### PR TITLE
build: Configure dependabot scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip-compile"
+    directory: "/requirements"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    # NOTE(robinson) - Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Summary

Addresses [CORE-53](https://unstructured-ai.atlassian.net/browse/CORE-53). Configures dependabot scans for the repo. Dependabot is set up to check for `pip-compile` and GitHub actions updates once a week.