### PR TITLE
fix: Change the Dependabot ecosystem from pip-compile to pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip-compile"
+  - package-ecosystem: "pip"
     directory: "/requirements"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
### Summary

Fixes [this build failure](https://github.com/Unstructured-IO/unstructured/runs/8577828844). Corrects the ecosystem name by updating it to `pip` from `pip-compile`.