### PR TITLE
feat: Implement stage_for_prodigy brick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.2.1-dev0
+## 0.2.1-dev1
 
+* Added staging brick for Prodigy
 * Added text_field and id_field to stage_for_label_studio signature
 
 ## 0.2.0

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -359,3 +359,27 @@ Examples:
   # The resulting JSON file is ready to be uploaded to LabelStudio
   with open("label_studio.json", "w") as f:
       json.dump(label_studio_data, f, indent=4)
+
+
+``stage_for_prodigy``
+--------------------------
+
+Formats outputs for use with `Prodigy <https://prodi.gy/docs/api-loaders>`_. After running ``stage_for_prodigy``, you can
+write the results to a JSON file that is ready to be used with Prodigy.
+
+Examples:
+
+.. code:: python
+
+  import json
+
+  from unstructured.documents.elements import Title, NarrativeText
+  from unstructured.staging.prodigy import stage_for_prodigy
+
+  elements = [Title(text="Title"), NarrativeText(text="Narrative")]
+  metadata = [{"type": "title"}, {"type": "text"}]
+  prodigy_data = stage_for_prodigy(elements, metadata)
+
+  # The resulting JSON file is ready to be used with Prodigy
+  with open("prodigy.json", "w") as f:
+      json.dump(prodigy_data, f, indent=4)

--- a/prodigy.json
+++ b/prodigy.json
@@ -1,0 +1,15 @@
+[
+    {
+        "text": "Title",
+        "meta": {
+            "type": "text",
+            "id": "7e8cd2056da73a7fefb6cd91f4e5d199"
+        }
+    },
+    {
+        "text": "Narrative",
+        "meta": {
+            "id": "ed2e59c337d01185f388a4e9334d6f2e"
+        }
+    }
+]

--- a/test_unstructured/staging/test_prodigy.py
+++ b/test_unstructured/staging/test_prodigy.py
@@ -1,0 +1,73 @@
+import pytest
+
+import unstructured.staging.prodigy as prodigy
+from unstructured.documents.elements import Title, NarrativeText
+
+
+@pytest.fixture
+def elements():
+    return [Title(text="Title 1"), NarrativeText(text="Narrative 1")]
+
+
+@pytest.fixture
+def valid_metadata():
+    return [{"score": 0.1}, {"category": "paragraph"}]
+
+
+@pytest.fixture
+def metadata_with_id():
+    return [{"score": 0.1}, {"id": 1, "category": "paragraph"}]
+
+
+@pytest.fixture
+def metadata_with_invalid_length():
+    return [{"score": 0.1}, {"category": "paragraph"}, {"type": "text"}]
+
+
+def test_convert_to_prodigy_data(elements):
+    prodigy_data = prodigy.stage_for_prodigy(elements)
+
+    assert len(prodigy_data) == len(elements)
+
+    assert prodigy_data[0]["text"] == "Title 1"
+    assert "meta" in prodigy_data[0]
+    assert "id" in prodigy_data[0]["meta"]
+    assert prodigy_data[0]["meta"]["id"] == elements[0].id
+
+    assert prodigy_data[1]["text"] == "Narrative 1"
+    assert "meta" in prodigy_data[1]
+    assert "id" in prodigy_data[1]["meta"]
+    assert prodigy_data[1]["meta"]["id"] == elements[1].id
+
+
+def test_convert_to_prodigy_data_with_valid_metadata(elements, valid_metadata):
+    prodigy_data = prodigy.stage_for_prodigy(elements, valid_metadata)
+
+    assert len(prodigy_data) == len(elements)
+
+    assert prodigy_data[0]["text"] == "Title 1"
+    assert "meta" in prodigy_data[0]
+    assert prodigy_data[0]["meta"] == {"id": elements[0].id, **valid_metadata[0]}
+
+    assert prodigy_data[1]["text"] == "Narrative 1"
+    assert "meta" in prodigy_data[1]
+    assert prodigy_data[1]["meta"] == {"id": elements[1].id, **valid_metadata[1]}
+
+
+@pytest.mark.parametrize(
+    "invalid_metadata_fixture, exception_message",
+    [
+        ("metadata_with_id", 'The key "id" is not allowed with metadata parameter at index: 1'),
+        (
+            "metadata_with_invalid_length",
+            "The length of metadata parameter does not match with length of elements parameter.",
+        ),
+    ],
+)
+def test_convert_to_prodigy_data_with_invalid_metadata(
+    elements, invalid_metadata_fixture, exception_message, request
+):
+    invalid_metadata = request.getfixturevalue(invalid_metadata_fixture)
+    with pytest.raises(ValueError) as validation_exception:
+        prodigy.stage_for_prodigy(elements, invalid_metadata)
+    assert str(validation_exception.value) == exception_message

--- a/unstructured/staging/prodigy.py
+++ b/unstructured/staging/prodigy.py
@@ -1,0 +1,44 @@
+from typing import Iterable, List, Dict, Optional, Union
+
+from unstructured.documents.elements import Text
+
+
+PRODIGY_TYPE = List[Dict[str, Union[str, Dict[str, str]]]]
+
+
+def stage_for_prodigy(
+    elements: List[Text],
+    metadata: Optional[List[Dict[str, str]]] = None,
+) -> PRODIGY_TYPE:
+    """
+    Converts the document to the format required for use with Prodigy.
+    ref: https://prodi.gy/docs/api-loaders#input
+    """
+
+    validated_metadata: Iterable[Dict[str, str]]
+    if metadata:
+        if len(metadata) != len(elements):
+            raise ValueError(
+                "The length of metadata parameter does not match with length of elements parameter."
+            )
+        id_error_index: Optional[int] = next(
+            (index for index, metadatum in enumerate(metadata) if "id" in metadatum), None
+        )
+        if isinstance(id_error_index, int):
+            raise ValueError(
+                'The key "id" is not allowed with metadata parameter at index: {index}'.format(
+                    index=id_error_index
+                )
+            )
+        validated_metadata = metadata
+    else:
+        validated_metadata = [dict() for _ in elements]
+
+    prodigy_data: PRODIGY_TYPE = list()
+    for element, metadatum in zip(elements, validated_metadata):
+        if isinstance(element.id, str):
+            metadatum["id"] = element.id
+        data: Dict[str, Union[str, Dict[str, str]]] = dict(text=element.text, meta=metadatum)
+        prodigy_data.append(data)
+
+    return prodigy_data


### PR DESCRIPTION
Resolves https://github.com/Unstructured-IO/community-tasks/issues/1

Summary of changes:
- [x] Implement `stage_for_prodigy` brick in `prodigy.py`
- [x] Add unit tests in `test_prodigy.py` and ensure 100% line coverage:
   <img width="924" alt="image" src="https://user-images.githubusercontent.com/20739674/193300985-8591dc30-9700-4ce6-93b9-52a1ffef8d11.png">
- [x] Add brick description and example to docs:
   <img width="1788" alt="image" src="https://user-images.githubusercontent.com/20739674/193301472-ada488b7-f69a-4433-8946-f43c7ff275f9.png">

Example:
```python
import json

from unstructured.documents.elements import Title, NarrativeText
from unstructured.staging.prodigy import stage_for_prodigy

elements = [Title(text="Title"), NarrativeText(text="Narrative")]
metadata = [{"type": "title"}, {"type": "text"}]
prodigy_data = stage_for_prodigy(elements, metadata)

# The resulting JSON file is ready to be used with Prodigy
with open("prodigy.json", "w") as f:
    json.dump(prodigy_data, f, indent=4)
```