### PR TITLE
feat: Optionally include LabelStudio annotations in staging brick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.2.1-dev2
+## 0.2.1-dev3
 
 * Added staging brick for CSV format for Prodigy
 * Added staging brick for Prodigy
+* Added ability to upload LabelStudio annotations
 * Added text_field and id_field to stage_for_label_studio signature
 
 ## 0.2.0

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -361,6 +361,98 @@ Examples:
       json.dump(label_studio_data, f, indent=4)
 
 
+You can also include pre-annotations as part of your LabelStudio upload. The
+``annotations`` kwarg is a list of lists. If ``annotations`` is specified, there must be a list of
+annotations for each element in the ``elements`` list. If an element does not have any annotations,
+use an empty list.
+The following shows an example of how to upload annotations for the "Text Classification"
+task in LabelStudio:
+
+.. code:: python
+
+  import json
+
+  from unstructured.documents.elements import NarrativeText
+  from unstructured.staging.label_studio import (
+      stage_for_label_studio,
+      LabelStudioAnnotation,
+      LabelStudioResult,
+  )
+
+
+
+  elements = [NarrativeText(text="Narrative")]
+  annotations = [[
+    LabelStudioAnnotation(
+        result=[
+            LabelStudioResult(
+                type="choices",
+                value={"choices": ["Positive"]},
+                from_name="sentiment",
+                to_name="text",
+            )
+        ]
+    )
+  ]]
+  label_studio_data = stage_for_label_studio(
+      elements,
+      annotations=annotations,
+      text_field="my_text",
+      id_field="my_id"
+  )
+
+  # The resulting JSON file is ready to be uploaded to LabelStudio
+  # with annotations included
+  with open("label_studio.json", "w") as f:
+      json.dump(label_studio_data, f, indent=4)
+
+
+The following shows an example of how to upload annotations for the "Named Entity Recognition"
+task in LabelStudio:
+
+.. code:: python
+
+  import json
+
+  from unstructured.documents.elements import NarrativeText
+  from unstructured.staging.label_studio import (
+      stage_for_label_studio,
+      LabelStudioAnnotation,
+      LabelStudioResult,
+  )
+
+
+
+  elements = [NarrativeText(text="Narrative")]
+  annotations = [[
+    LabelStudioAnnotation(
+        result=[
+            LabelStudioResult(
+                type="labels",
+                value={"start": 0, "end": 9, "text": "Narrative", "labels": ["MISC"]},
+                from_name="label",
+                to_name="text",
+            )
+        ]
+    )
+  ]]
+  label_studio_data = stage_for_label_studio(
+      elements,
+      annotations=annotations,
+      text_field="my_text",
+      id_field="my_id"
+  )
+
+  # The resulting JSON file is ready to be uploaded to LabelStudio
+  # with annotations included
+  with open("label_studio.json", "w") as f:
+      json.dump(label_studio_data, f, indent=4)
+
+
+See the `LabelStudio docs` <https://labelstud.io/tags/labels.html>`_ for a fulle list of options
+for labels and annotations.
+
+
 ``stage_for_prodigy``
 --------------------------
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -449,7 +449,7 @@ task in LabelStudio:
       json.dump(label_studio_data, f, indent=4)
 
 
-See the `LabelStudio docs <https://labelstud.io/tags/labels.html>`_ for a fulle list of options
+See the `LabelStudio docs <https://labelstud.io/tags/labels.html>`_ for a full list of options
 for labels and annotations.
 
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -449,7 +449,7 @@ task in LabelStudio:
       json.dump(label_studio_data, f, indent=4)
 
 
-See the `LabelStudio docs` <https://labelstud.io/tags/labels.html>`_ for a fulle list of options
+See the `LabelStudio docs <https://labelstud.io/tags/labels.html>`_ for a fulle list of options
 for labels and annotations.
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Unstructured Technologies'
 author = 'Unstructured Technologies'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = '0.2.1-dev3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/test_unstructured/staging/test_label_studio.py
+++ b/test_unstructured/staging/test_label_studio.py
@@ -96,6 +96,44 @@ def test_stage_with_annotation():
     ]
 
 
+def test_stage_with_annotation_for_ner():
+    element = NarrativeText(text="A big brown bear")
+    annotations = [
+        label_studio.LabelStudioAnnotation(
+            result=[
+                label_studio.LabelStudioResult(
+                    type="labels",
+                    value={"start": 12, "end": 16, "text": "bear", "labels": ["PER"]},
+                    from_name="label",
+                    to_name="text",
+                )
+            ]
+        )
+    ]
+    label_studio_data = label_studio.stage_for_label_studio([element], [annotations])
+    assert label_studio_data == [
+        {
+            "data": {"text": "A big brown bear", "ref_id": "8f458d5d0635df3975ceb9109cef9e12"},
+            "annotations": [
+                {
+                    "result": [
+                        {
+                            "type": "labels",
+                            "value": {"start": 12, "end": 16, "text": "bear", "labels": ["PER"]},
+                            "from_name": "label",
+                            "id": None,
+                            "to_name": "text",
+                            "hidden": False,
+                            "read_only": False,
+                        }
+                    ],
+                    "was_canceled": False,
+                }
+            ],
+        }
+    ]
+
+
 def test_stage_with_annotation_raises_with_mismatched_lengths():
     element = NarrativeText(text="A big brown bear")
     annotations = [
@@ -111,9 +149,7 @@ def test_stage_with_annotation_raises_with_mismatched_lengths():
         )
     ]
     with pytest.raises(ValueError):
-        label_studio_data = label_studio.stage_for_label_studio(
-            [element], [annotations, annotations]
-        )
+        label_studio.stage_for_label_studio([element], [annotations, annotations])
 
 
 def test_stage_with_annotation_raises_with_invalid_type():

--- a/test_unstructured/staging/test_label_studio.py
+++ b/test_unstructured/staging/test_label_studio.py
@@ -28,3 +28,69 @@ def test_specify_text_name(elements):
 def test_specify_id_name(elements):
     label_studio_data = label_studio.stage_for_label_studio(elements, id_field="random_id")
     assert "random_id" in label_studio_data[0]["data"]
+
+
+def test_created_annotation():
+    annotation = label_studio.LabelStudioAnnotation(
+        result=[
+            label_studio.LabelStudioResult(
+                type="choices",
+                value={"choices": ["Positive"]},
+                from_name="sentiment",
+                to_name="text",
+            )
+        ]
+    )
+
+    annotation.to_dict() == {
+        "result": [
+            {
+                "type": "choices",
+                "value": {"choices": ["Positive"]},
+                "from_name": "sentiment",
+                "id": None,
+                "to_name": "text",
+                "hidden": False,
+                "read_only": False,
+            }
+        ],
+        "was_canceled": False,
+    }
+
+
+def test_stage_with_annotation():
+    element = NarrativeText(text="A big brown bear")
+    annotations = [
+        label_studio.LabelStudioAnnotation(
+            result=[
+                label_studio.LabelStudioResult(
+                    type="choices",
+                    value={"choices": ["Positive"]},
+                    from_name="sentiment",
+                    to_name="text",
+                )
+            ]
+        )
+    ]
+    label_studio_data = label_studio.stage_for_label_studio([element], [annotations])
+    assert label_studio_data == [
+        {
+            "data": {"text": "A big brown bear", "ref_id": "8f458d5d0635df3975ceb9109cef9e12"},
+            "annotations": [
+                {
+                    "result": [
+                        {
+                            "type": "choices",
+                            "value": {"choices": ["Positive"]},
+                            "from_name": "sentiment",
+                            "id": None,
+                            "to_name": "text",
+                            "hidden": False,
+                            "read_only": False,
+                        }
+                    ],
+                    "was_canceled": False,
+                }
+            ],
+        }
+    ]

--- a/test_unstructured/staging/test_label_studio.py
+++ b/test_unstructured/staging/test_label_studio.py
@@ -94,3 +94,73 @@ def test_stage_with_annotation():
             ],
         }
     ]
+
+
+def test_stage_with_annotation_raises_with_mismatched_lengths():
+    element = NarrativeText(text="A big brown bear")
+    annotations = [
+        label_studio.LabelStudioAnnotation(
+            result=[
+                label_studio.LabelStudioResult(
+                    type="choices",
+                    value={"choices": ["Positive"]},
+                    from_name="sentiment",
+                    to_name="text",
+                )
+            ]
+        )
+    ]
+    with pytest.raises(ValueError):
+        label_studio_data = label_studio.stage_for_label_studio(
+            [element], [annotations, annotations]
+        )
+
+
+def test_stage_with_annotation_raises_with_invalid_type():
+    with pytest.raises(ValueError):
+        label_studio.LabelStudioResult(
+            type="bears",
+            value={"bears": ["Positive"]},
+            from_name="sentiment",
+            to_name="text",
+        )
+
+
+def test_stage_with_reviewed_annotation():
+    element = NarrativeText(text="A big brown bear")
+    annotations = [
+        label_studio.LabelStudioAnnotation(
+            result=[
+                label_studio.LabelStudioResult(
+                    type="choices",
+                    value={"choices": ["Positive"]},
+                    from_name="sentiment",
+                    to_name="text",
+                )
+            ],
+            reviews=[label_studio.LabelStudioReview(created_by={"user_id": 1}, accepted=True)],
+        )
+    ]
+    label_studio_data = label_studio.stage_for_label_studio([element], [annotations])
+    assert label_studio_data == [
+        {
+            "data": {"text": "A big brown bear", "ref_id": "8f458d5d0635df3975ceb9109cef9e12"},
+            "annotations": [
+                {
+                    "result": [
+                        {
+                            "type": "choices",
+                            "value": {"choices": ["Positive"]},
+                            "from_name": "sentiment",
+                            "to_name": "text",
+                            "id": None,
+                            "hidden": False,
+                            "read_only": False,
+                        }
+                    ],
+                    "reviews": [{"created_by": {"user_id": 1}, "accepted": True, "id": None}],
+                    "was_canceled": False,
+                }
+            ],
+        }
+    ]

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.1-dev2"  # pragma: no cover
+__version__ = "0.2.1-dev3"  # pragma: no cover

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -8,19 +8,46 @@ from unstructured.documents.elements import Text
 LABEL_STUDIO_TYPE = List[Dict[str, Dict[str, str]]]
 
 
+VALID_TYPE = [
+    "labels",
+    "hypertextlabels",
+    "paragraphlabels",
+    "rectangle",
+    "keypoint",
+    "polygon",
+    "brush",
+    "ellipse",
+    "rectanglelabels",
+    "keypointlabels",
+    "polygonlabels",
+    "brushlabels",
+    "ellipselabels",
+    "timeserieslabels",
+    "choices",
+    "number",
+    "taxonomy",
+    "textarea",
+    "rating",
+    "pairwise",
+    "videorectangle",
+]
+
+
 @dataclass
 class LabelStudioResult:
     """Class for representing a LabelStudio annotation result.
     ref: https://labelstud.io/guide/export.html#Label-Studio-JSON-format-of-annotated-tasks"""
 
-    id: str
     type: str  # The type of tag used to annotate the task
     value: Dict[str, Any]  # The values for
+    from_name: str  # Name of the source object tag (i.e. "sentiment" for the sentiment template)
+    id: Optional[str] = None
     # NOTE(robinson) - See here for a list of object and control tags. Also provides the formats
     # for the value parameter
     # ref: https://labelstud.io/tags/
-    from_name: str = "tag"  # Name of the source object tag
     to_name: str = "text"  # Name of the destination control tag
+    hidden: bool = False
+    read_only: bool = False
 
     def to_dict(self):
         return self.__dict__
@@ -47,24 +74,30 @@ class LabelStudioAnnotation:
     """Class for representing LabelStudio annotations.
     ref: https://labelstud.io/guide/export.html#Label-Studio-JSON-format-of-annotated-tasks"""
 
-    id: str
-    lead_time: float  # Time in seconds to label the task
-    result: LabelStudioResult  # The result of the annotation
-    reviews: List[LabelStudioReview]  # An array consisting of the review results
-    completed_by: int  # User ID for the user who completed the task
+    result: List[LabelStudioResult]  # The result of the annotation
+    id: Optional[str] = None
+    lead_time: Optional[float] = None  # Time in seconds to label the task
+    completed_by: Optional[int] = None  # User ID for the user who completed the task
+    reviews: Optional[List[LabelStudioReview]] = None  # An array of the review results
     was_canceled: bool = False  # Indicates whether or not the annotation was canceled
 
     def to_dict(self):
         annotation_dict = deepcopy(self.__dict__)
-        annotation_dict["result"] = annotation_dict["result"].to_dict()
-        if "reviews" in annotation_dict:
+        annotation_dict["result"] = [r.to_dict() for r in annotation_dict["result"]]
+        if "reviews" in annotation_dict and annotation_dict["reviews"] is not None:
             annotation_dict["reviews"] = [r.to_dict() for r in annotation_dict["reviews"]]
-        return annotation_dict
+
+        _annotation_dict = deepcopy(annotation_dict)
+        for key, value in annotation_dict.items():
+            if value is None:
+                _annotation_dict.pop(key)
+
+        return _annotation_dict
 
 
 def stage_for_label_studio(
     elements: List[Text],
-    annotations: Optional[List[Optional[LabelStudioAnnotation]]] = None,
+    annotations: Optional[List[LabelStudioAnnotation]] = None,
     text_field: str = "text",
     id_field: str = "ref_id",
 ) -> LABEL_STUDIO_TYPE:
@@ -75,10 +108,17 @@ def stage_for_label_studio(
             raise ValueError("The length of elements and annotations must match.")
 
     label_studio_data: LABEL_STUDIO_TYPE = list()
-    for element in elements:
+    for i, element in enumerate(elements):
         data: Dict[str, str] = dict()
         data[text_field] = element.text
         if isinstance(element.id, str):
             data[id_field] = element.id
-        label_studio_data.append({"data": data})
+
+        labeling_example: Dict[str, Any] = dict()
+        labeling_example["data"] = data
+        if annotations is not None:
+            annotation: LabelStudioAnnotation = annotations[i]
+            labeling_example["annotations"] = [annotation.to_dict()]
+        label_studio_data.append(labeling_example)
+
     return label_studio_data

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from unstructured.documents.elements import Text
 
@@ -63,10 +63,17 @@ class LabelStudioAnnotation:
 
 
 def stage_for_label_studio(
-    elements: List[Text], text_field: str = "text", id_field: str = "ref_id"
+    elements: List[Text],
+    annotations: Optional[List[Optional[LabelStudioAnnotation]]] = None,
+    text_field: str = "text",
+    id_field: str = "ref_id",
 ) -> LABEL_STUDIO_TYPE:
     """Converts the document to the format required for upload to LabelStudio.
     ref: https://labelstud.io/guide/tasks.html#Example-JSON-format"""
+    if annotations is not None:
+        if len(elements) != len(annotations):
+            raise ValueError("The length of elements and annotations must match.")
+
     label_studio_data: LABEL_STUDIO_TYPE = list()
     for element in elements:
         data: Dict[str, str] = dict()

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -8,7 +8,7 @@ from unstructured.documents.elements import Text
 LABEL_STUDIO_TYPE = List[Dict[str, Dict[str, str]]]
 
 
-VALID_TYPE = [
+VALID_LABEL_TYPES = [
     "labels",
     "hypertextlabels",
     "paragraphlabels",
@@ -48,6 +48,13 @@ class LabelStudioResult:
     to_name: str = "text"  # Name of the destination control tag
     hidden: bool = False
     read_only: bool = False
+
+    def post_init(self):
+        if self.type not in VALID_LABEL_TYPES:
+            raise ValueError(
+                f"{self.type} is not a valid label type. "
+                f"Valid label types are: {VALID_LABEL_TYPES}"
+            )
 
     def to_dict(self):
         return self.__dict__

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -104,7 +104,7 @@ class LabelStudioAnnotation:
 
 def stage_for_label_studio(
     elements: List[Text],
-    annotations: Optional[List[LabelStudioAnnotation]] = None,
+    annotations: Optional[List[List[LabelStudioAnnotation]]] = None,
     text_field: str = "text",
     id_field: str = "ref_id",
 ) -> LABEL_STUDIO_TYPE:
@@ -124,8 +124,7 @@ def stage_for_label_studio(
         labeling_example: Dict[str, Any] = dict()
         labeling_example["data"] = data
         if annotations is not None:
-            annotation: LabelStudioAnnotation = annotations[i]
-            labeling_example["annotations"] = [annotation.to_dict()]
+            labeling_example["annotations"] = [a.to_dict() for a in annotations[i]]
         label_studio_data.append(labeling_example)
 
     return label_studio_data

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -41,11 +41,8 @@ class LabelStudioResult:
     type: str  # The type of tag used to annotate the task
     value: Dict[str, Any]  # The values for
     from_name: str  # Name of the source object tag (i.e. "sentiment" for the sentiment template)
+    to_name: str  # Name of the destination control tag
     id: Optional[str] = None
-    # NOTE(robinson) - See here for a list of object and control tags. Also provides the formats
-    # for the value parameter
-    # ref: https://labelstud.io/tags/
-    to_name: str = "text"  # Name of the destination control tag
     hidden: bool = False
     read_only: bool = False
 
@@ -66,11 +63,9 @@ class LabelStudioReview:
     Enterprise offering.
     ref: https://labelstud.io/guide/export.html#Label-Studio-JSON-format-of-annotated-tasks"""
 
-    id: str
-    # NOTE(robinson) - created_by is a dictionary containing the user ID, email, first name,
-    # and last name of the reviewer
     created_by: Dict[str, Union[str, int]]
     accepted: bool
+    id: Optional[str] = None
 
     def to_dict(self):
         return self.__dict__
@@ -94,6 +89,7 @@ class LabelStudioAnnotation:
         if "reviews" in annotation_dict and annotation_dict["reviews"] is not None:
             annotation_dict["reviews"] = [r.to_dict() for r in annotation_dict["reviews"]]
 
+        # NOTE(robinson) - Removes keys for any fields that defaulted to None
         _annotation_dict = deepcopy(annotation_dict)
         for key, value in annotation_dict.items():
             if value is None:

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -7,7 +7,7 @@ from unstructured.documents.elements import Text
 
 LABEL_STUDIO_TYPE = List[Dict[str, Dict[str, str]]]
 
-
+# NOTE(robinson) - ref: https://labelstud.io/tags/labels.html
 VALID_LABEL_TYPES = [
     "labels",
     "hypertextlabels",
@@ -46,7 +46,7 @@ class LabelStudioResult:
     hidden: bool = False
     read_only: bool = False
 
-    def post_init(self):
+    def __post_init__(self):
         if self.type not in VALID_LABEL_TYPES:
             raise ValueError(
                 f"{self.type} is not a valid label type. "

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Dict, List, Union
 
@@ -21,6 +22,9 @@ class LabelStudioResult:
     from_name: str = "tag"  # Name of the source object tag
     to_name: str = "text"  # Name of the destination control tag
 
+    def to_dict(self):
+        return self.__dict__
+
 
 @dataclass
 class LabelStudioReview:
@@ -34,6 +38,9 @@ class LabelStudioReview:
     created_by: Dict[str, Union[str, int]]
     accepted: bool
 
+    def to_dict(self):
+        return self.__dict__
+
 
 @dataclass
 class LabelStudioAnnotation:
@@ -42,9 +49,17 @@ class LabelStudioAnnotation:
 
     id: str
     lead_time: float  # Time in seconds to label the task
-    result: List[LabelStudioResult]  # An array consisting of the annotation results
+    result: LabelStudioResult  # The result of the annotation
+    reviews: List[LabelStudioReview]  # An array consisting of the review results
     completed_by: int  # User ID for the user who completed the task
     was_canceled: bool = False  # Indicates whether or not the annotation was canceled
+
+    def to_dict(self):
+        annotation_dict = deepcopy(self.__dict__)
+        annotation_dict["result"] = annotation_dict["result"].to_dict()
+        if "reviews" in annotation_dict:
+            annotation_dict["reviews"] = [r.to_dict() for r in annotation_dict["reviews"]]
+        return annotation_dict
 
 
 def stage_for_label_studio(

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -1,9 +1,50 @@
-from typing import Dict, List
+from dataclasses import dataclass
+from typing import Any, Dict, List, Union
 
 from unstructured.documents.elements import Text
 
 
 LABEL_STUDIO_TYPE = List[Dict[str, Dict[str, str]]]
+
+
+@dataclass
+class LabelStudioResult:
+    """Class for representing a LabelStudio annotation result.
+    ref: https://labelstud.io/guide/export.html#Label-Studio-JSON-format-of-annotated-tasks"""
+
+    id: str
+    type: str  # The type of tag used to annotate the task
+    value: Dict[str, Any]  # The values for
+    # NOTE(robinson) - See here for a list of object and control tags. Also provides the formats
+    # for the value parameter
+    # ref: https://labelstud.io/tags/
+    from_name: str = "tag"  # Name of the source object tag
+    to_name: str = "text"  # Name of the destination control tag
+
+
+@dataclass
+class LabelStudioReview:
+    """Class for representing a LablStudio review. Reviews are only available in the
+    Enterprise offering.
+    ref: https://labelstud.io/guide/export.html#Label-Studio-JSON-format-of-annotated-tasks"""
+
+    id: str
+    # NOTE(robinson) - created_by is a dictionary containing the user ID, email, first name,
+    # and last name of the reviewer
+    created_by: Dict[str, Union[str, int]]
+    accepted: bool
+
+
+@dataclass
+class LabelStudioAnnotation:
+    """Class for representing LabelStudio annotations.
+    ref: https://labelstud.io/guide/export.html#Label-Studio-JSON-format-of-annotated-tasks"""
+
+    id: str
+    lead_time: float  # Time in seconds to label the task
+    result: List[LabelStudioResult]  # An array consisting of the annotation results
+    completed_by: int  # User ID for the user who completed the task
+    was_canceled: bool = False  # Indicates whether or not the annotation was canceled
 
 
 def stage_for_label_studio(


### PR DESCRIPTION
### Summary

Adds an optional `annotation` kwarg to the `stage_for_label_studio` function that uploads annotations along with the training examples. If `annotations` is specified, it must be the same length as `elements`. `annotations` is a list of lists, each element can have a list of annotations. If a given element does not have any annotations, use an empty list.

### Testing

Install LabelStudio in a virtual environment and then run `label-studio` to start it.

#### Text Classification

```python
import json
from unstructured.documents.elements import NarrativeText
import unstructured.staging.label_studio as label_studio

element = NarrativeText(text="A big brown bear")
annotations = [
    label_studio.LabelStudioAnnotation(
        result=[
            label_studio.LabelStudioResult(
                type="choices",
                value={"choices": ["Positive"]},
                from_name="sentiment",
                to_name="text",
            )
        ]
    )
]
label_studio_data = label_studio.stage_for_label_studio(
    elements=[element], 
    annotations=[annotations]
)

with open("label-studio.json", "w") as f:
    json.dump(label_studio_data, f, indent=4)
```

Next, go into LabelStudio and create a new project. Upload the data and then select "Text Classification" as the template. Once you create the new project, you should be able to go into the project and see the training example labeled as "Positive".


#### Named Entity Recognition

Repeat the same process as above, but with the following change:

```python
    annotations = [
        label_studio.LabelStudioAnnotation(
            result=[
                label_studio.LabelStudioResult(
                    type="labels",
                    value={"start": 12, "end": 16, "text": "bear", "labels": ["PER"]},
                    from_name="label",
                    to_name="text",
                )
            ]
        )
    ]
```

This time, select "Named Entity Recognition" as the task type. When you open your project, you should see "bear" highlighted as a `PER` entity.