### PR TITLE
feat: Allow option to specify predictions in LabelStudio staging brick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.2.1-dev4
+## 0.2.1-dev5
 
+* Added ability to upload LabelStudio predictions
 * Added utility function for JSONL reading and writing
 * Added staging brick for CSV format for Prodigy
 * Added staging brick for Prodigy

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -361,8 +361,9 @@ Examples:
       json.dump(label_studio_data, f, indent=4)
 
 
-You can also include pre-annotations as part of your LabelStudio upload. The
-``annotations`` kwarg is a list of lists. If ``annotations`` is specified, there must be a list of
+You can also include pre-annotations and predictions as part of your LabelStudio upload. 
+
+The ``annotations`` kwarg is a list of lists. If ``annotations`` is specified, there must be a list of
 annotations for each element in the ``elements`` list. If an element does not have any annotations,
 use an empty list.
 The following shows an example of how to upload annotations for the "Text Classification"
@@ -397,6 +398,52 @@ task in LabelStudio:
   label_studio_data = stage_for_label_studio(
       elements,
       annotations=annotations,
+      text_field="my_text",
+      id_field="my_id"
+  )
+
+  # The resulting JSON file is ready to be uploaded to LabelStudio
+  # with annotations included
+  with open("label_studio.json", "w") as f:
+      json.dump(label_studio_data, f, indent=4)
+
+
+Similar to annotations, the ``predictions`` kwarg is also a list of lists. A ``prediction`` is an annotation with
+the addition of a ``score`` value. If ``predictions`` is specified, there must be a list of
+predictions for each element in the ``elements`` list. If an element does not have any predictions, use an empty list. 
+The following shows an example of how to upload predictions for the "Text Classification"
+task in LabelStudio:
+
+.. code:: python
+
+  import json
+
+  from unstructured.documents.elements import NarrativeText
+  from unstructured.staging.label_studio import (
+      stage_for_label_studio,
+      LabelStudioPrediction,
+      LabelStudioResult,
+  )
+
+
+
+  elements = [NarrativeText(text="Narrative")]
+  predictions = [[
+    LabelStudioPrediction(
+        result=[
+            LabelStudioResult(
+                type="choices",
+                value={"choices": ["Positive"]},
+                from_name="sentiment",
+                to_name="text",
+            )
+        ],
+        score=0.68
+    )
+  ]]
+  label_studio_data = stage_for_label_studio(
+      elements,
+      predictions=predictions,
       text_field="my_text",
       id_field="my_id"
   )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.1-dev4"  # pragma: no cover
+__version__ = "0.2.1-dev5"  # pragma: no cover

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -98,9 +98,22 @@ class LabelStudioAnnotation:
         return _annotation_dict
 
 
+@dataclass
+class LabelStudioPrediction(LabelStudioAnnotation):
+    score: float = 0
+
+    def __post_init__(self):
+        if not isinstance(self.score, (int, float)) or (self.score < 0 or self.score > 1):
+            raise ValueError(
+                f"{self.score} is not a valid score value. "
+                f"Score value must be a number between 0 and 1."
+            )
+
+
 def stage_for_label_studio(
     elements: List[Text],
     annotations: Optional[List[List[LabelStudioAnnotation]]] = None,
+    predictions: Optional[List[List[LabelStudioPrediction]]] = None,
     text_field: str = "text",
     id_field: str = "ref_id",
 ) -> LABEL_STUDIO_TYPE:
@@ -109,6 +122,9 @@ def stage_for_label_studio(
     if annotations is not None:
         if len(elements) != len(annotations):
             raise ValueError("The length of elements and annotations must match.")
+    if predictions is not None:
+        if len(elements) != len(predictions):
+            raise ValueError("The length of elements and predictions must match.")
 
     label_studio_data: LABEL_STUDIO_TYPE = list()
     for i, element in enumerate(elements):
@@ -121,6 +137,8 @@ def stage_for_label_studio(
         labeling_example["data"] = data
         if annotations is not None:
             labeling_example["annotations"] = [a.to_dict() for a in annotations[i]]
+        if predictions is not None:
+            labeling_example["predictions"] = [a.to_dict() for a in predictions[i]]
         label_studio_data.append(labeling_example)
 
     return label_studio_data


### PR DESCRIPTION
Resolves https://github.com/Unstructured-IO/community-tasks/issues/6

**Summary of changes**
- [x] Implemented `LabelStudioPrediction` dataclass and allow the option to specify `predictions` keyword argument.
- [x] Unit tests added to ensure 100% coverage.
   <img width="739" alt="image" src="https://user-images.githubusercontent.com/20739674/194134294-ccf0d303-7466-436f-a0bb-1312e85876e3.png">
- [x] Docs updated to include a prediction loading example.
   <img width="1406" alt="image" src="https://user-images.githubusercontent.com/20739674/194134404-36f90717-8ba9-4569-91bb-1a64b34e2fee.png">
- [x] `CHANGELOG.md` and `__version__.py` updated.

**Code included in example:**
```python
import json

from unstructured.documents.elements import NarrativeText
from unstructured.staging.label_studio import (
    stage_for_label_studio,
    LabelStudioPrediction,
    LabelStudioResult,
)



elements = [NarrativeText(text="Narrative")]
predictions = [[
  LabelStudioPrediction(
      result=[
          LabelStudioResult(
              type="choices",
              value={"choices": ["Positive"]},
              from_name="sentiment",
              to_name="text",
          )
      ],
      score=0.68
  )
]]
label_studio_data = stage_for_label_studio(
    elements,
    predictions=predictions,
    text_field="my_text",
    id_field="my_id"
)

# The resulting JSON file is ready to be uploaded to LabelStudio
# with annotations included
with open("label_studio.json", "w") as f:
    json.dump(label_studio_data, f, indent=4)
```