### PR TITLE
feat: Add staging brick for Datasaur token-based tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2-dev0
+
+* Add staging brick for Datasaur
+
 ## 0.2.1
 
 * Added brick to convert an ISD dictionary to a list of elements

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -750,3 +750,26 @@ files to an S3 bucket.
 
   upload_staged_files()
 
+``stage_for_datasaur``
+--------------------------
+Formats a list of Text elements as input to Datasaur.
+
+For example, if input looks like:
+
+.. code:: python
+  input  = [Text("Text1"),Text("Text2")]
+  output = (stage_for_datasaur(input))
+The output should look like:
+
+.. code:: python
+
+  [
+    {
+      "text": "Text1",
+      "entities": []
+    }, 
+    {
+      "text": "Text2",
+      "entities": []
+    }
+  ]

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -759,9 +759,9 @@ Example:
 .. code:: python
 
   from unstructured.staging.datasaur import stage_for_datasaur
-  input  = [Text("Text1"),Text("Text2")]
-  output = stage_for_datasaur(input)
+  elements  = [Text("Text1"),Text("Text2")]
+  datasaur_data = stage_for_datasaur(elements)
 
-  # output is a list of dictionaries, each one with two keys:
-  # "text" with the content of the element and 
-  # "entities" with an empty list.
+output is a list of dictionaries, each one with two keys:
+"text" with the content of the element and 
+"entities" with an empty list.

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -752,24 +752,16 @@ files to an S3 bucket.
 
 ``stage_for_datasaur``
 --------------------------
-Formats a list of Text elements as input to Datasaur.
+Formats a list of ``Text`` elements as input to token based tasks in Datasaur.
 
-For example, if input looks like:
+Example: 
 
 .. code:: python
+
+  from unstructured.staging.datasaur import stage_for_datasaur
   input  = [Text("Text1"),Text("Text2")]
-  output = (stage_for_datasaur(input))
-The output should look like:
+  output = stage_for_datasaur(input)
 
-.. code:: python
-
-  [
-    {
-      "text": "Text1",
-      "entities": []
-    }, 
-    {
-      "text": "Text2",
-      "entities": []
-    }
-  ]
+  # output is a list of dictionaries, each one with two keys:
+  # "text" with the content of the element and 
+  # "entities" with an empty list.

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -762,6 +762,6 @@ Example:
   elements  = [Text("Text1"),Text("Text2")]
   datasaur_data = stage_for_datasaur(elements)
 
-output is a list of dictionaries, each one with two keys:
+The output is a list of dictionaries, each one with two keys:
 "text" with the content of the element and 
 "entities" with an empty list.

--- a/test_unstructured/staging/test_datasaur.py
+++ b/test_unstructured/staging/test_datasaur.py
@@ -1,0 +1,16 @@
+import pytest
+
+import unstructured.staging.datasaur as datasaur
+
+from unstructured.documents.elements import Text
+
+
+def test_stage_for_datasaur():
+    elements = [Text("Text 1"),Text("Text 2"),Text("Text 3")]
+    result = datasaur.stage_for_datasaur(elements)
+    assert result[0]["text"] == "Text 1"
+    assert result[0]["entities"] == []
+    assert result[1]["text"] == "Text 2"
+    assert result[1]["entities"] == []    
+    assert result[2]["text"] == "Text 3"
+    assert result[2]["entities"] == []

--- a/test_unstructured/staging/test_datasaur.py
+++ b/test_unstructured/staging/test_datasaur.py
@@ -1,16 +1,14 @@
-import pytest
-
 import unstructured.staging.datasaur as datasaur
 
 from unstructured.documents.elements import Text
 
 
 def test_stage_for_datasaur():
-    elements = [Text("Text 1"),Text("Text 2"),Text("Text 3")]
+    elements = [Text("Text 1"), Text("Text 2"), Text("Text 3")]
     result = datasaur.stage_for_datasaur(elements)
     assert result[0]["text"] == "Text 1"
     assert result[0]["entities"] == []
     assert result[1]["text"] == "Text 2"
-    assert result[1]["entities"] == []    
+    assert result[1]["entities"] == []
     assert result[2]["text"] == "Text 3"
     assert result[2]["entities"] == []

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.1"  # pragma: no cover
+__version__ = "0.2.2-dev0"  # pragma: no cover

--- a/unstructured/staging/datasaur.py
+++ b/unstructured/staging/datasaur.py
@@ -1,7 +1,9 @@
 from typing import Dict, List, Any
 from unstructured.documents.elements import Text
 
-def stage_for_datasaur( elements: List[Text] ) -> List[Dict[str, Any]]:
+
+def stage_for_datasaur(elements: List[Text]) -> List[Dict[str, Any]]:
+    """Convert a list of elements into a list of dictionaries for use in Datasaur"""
     result: List[Dict[str, Any]] = list()
     for item in elements:
         data = dict(text=item.text, entities=[])

--- a/unstructured/staging/datasaur.py
+++ b/unstructured/staging/datasaur.py
@@ -1,0 +1,10 @@
+from typing import Dict, List, Any
+from unstructured.documents.elements import Text
+
+def stage_for_datasaur( elements: List[Text] ) -> List[Dict[str, Any]]:
+    result: List[Dict[str, Any]] = list()
+    for item in elements:
+        data = dict(text=item.text, entities=[])
+        result.append(data)
+
+    return result


### PR DESCRIPTION
In this pull request I add staging bick for Datasaur.

Changed files:
- unstructured/staging/datasaur.py
- docs/source/bricks.rst 

Definition of Done:

Was added a staging brick with this signature:

```
stage_for_datasaur(  elements: List[Text] ) -> List[Dict[str, Any]]:
```
Formats a list of ``Text`` elements as input to token based tasks in Datasaur, the output has
the next format:  

```
[
  {
    "text": "The new series Narcos created by Chris Brancato , Eric Newman and Carlo Bernard , represents a pretty ambitious step for Netflix .",
    "entities": []
  }, ...
]
```

Example of usage:

```
from unstructured.staging.datasaur import stage_for_datasaur
input  = [Text("Text1"),Text("Text2")]

# output according to below example
output = stage_for_datasaur(input)
```
