### PR TITLE
chore: Add long description content type; bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.2-dev0
+## 0.2.2
 
 * Add staging brick for Datasaur
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     name="unstructured",
     description="A library that prepares raw documents for downstream ML tasks.",
     long_description=open("README.md", "r", encoding="utf-8").read(),
+    long_description_content_type="text/markdown",
     keywords="NLP PDF HTML CV XML parsing preprocessing",
     url="https://github.com/Unstructured-IO/unstructured",
     python_requires=">=3.8.0",

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.2-dev0"  # pragma: no cover
+__version__ = "0.2.2"  # pragma: no cover


### PR DESCRIPTION
### Summary

Adds `long_description_content_type` to `setup.py` to ensure the `README` renders properly. Bumps the version so we can publish the long description updates to PyPI.