### PR TITLE
fix: Change the image src to an absolute link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <h3 align="center">
-  <img src="img/unstructured_logo.png" height="200">
+  <img
+    src="https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/img/unstructured_logo.png"
+    height="200"
+  >
 </h3>
 
 <h3 align="center">


### PR DESCRIPTION
### Summary

Changes the image `src` to an absolute link so it will render properly in the PyPI long description. Currently, the image doesn't appear, as shown below:

<img width="550" alt="image" src="https://user-images.githubusercontent.com/1635179/200685087-fe0eb73a-f7d8-4081-9adc-ba12a5608c5b.png">
