### PR TITLE
docs: Add developer quick start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,22 @@ about. Bricks in the library fall into three categories:
 
 ## Installation
 
-You can install the `unstructured` library with `pip install unstructured`. We also provide
-`make` commands to install the library for local development. The `make install-project-local`
-command installs `unstructured` into your local Python environment in editable mode. Run
-`make help` for a full list of install options.
+To install the library, run `pip install unstructured`.
+
+## Developer Quick Start
+
+* Using `pyenv` to manage virtualenv's is recommended
+	* Mac install instructions. See [here](https://github.com/Unstructured-IO/community#mac--homebrew) for more detailed instructions.
+		* `brew install pyenv-virtualenv`
+	  * `pyenv install 3.8.13`
+  * Linux instructions are available [here](https://github.com/Unstructured-IO/community#linux).
+
+* Create a virtualenv to work in and activate it, e.g. for one named `unstructured`:
+
+	`pyenv  virtualenv 3.8.13 unstructured` <br />
+	`pyenv activate unstructured`
+
+* Run `make install-project-local`
 
 ## Quick Tour
 


### PR DESCRIPTION
### Summary

Adds a developer quick start section to the README, following the same format as in `pipeline-sec-filings`.