### PR TITLE
feat: `Final` Compatibility with Python 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+* Add alternative way of importing `Final` to support google colab
+
 ## 0.2.3
 
 * Add cleaning bricks for removing prefixes and postfixes

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.3"  # pragma: no cover
+__version__ = "0.2.4"  # pragma: no cover

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
-from typing import Final, List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple
+import sys
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Final
+else:
+    from typing import Final
 
 from lxml import etree
 

--- a/unstructured/logger.py
+++ b/unstructured/logger.py
@@ -1,6 +1,11 @@
 import logging
 import os
-from typing import Final
+import sys
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Final
+else:
+    from typing import Final
 
 DEFAULT_LOG_LEVEL: Final[str] = "WARNING"
 

--- a/unstructured/models/layout/detectron2.py
+++ b/unstructured/models/layout/detectron2.py
@@ -1,4 +1,9 @@
-from typing import Final
+import sys
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Final
+else:
+    from typing import Final
 
 from layoutparser.models.detectron2.layoutmodel import (
     is_detectron2_available,

--- a/unstructured/nlp/partition.py
+++ b/unstructured/nlp/partition.py
@@ -1,5 +1,11 @@
 """parition.py implements logic for partining plain text documents into sections."""
-from typing import Final, List, Optional
+from typing import List, Optional
+import sys
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Final
+else:
+    from typing import Final
 
 from unstructured.cleaners.core import remove_punctuation
 from unstructured.nlp.patterns import UNICODE_BULLETS_RE

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -1,4 +1,11 @@
-from typing import Final, List
+from typing import List
+import sys
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Final
+else:
+    from typing import Final
+
 import re
 
 UNICODE_BULLETS: Final[List[str]] = [

--- a/unstructured/nlp/tokenize.py
+++ b/unstructured/nlp/tokenize.py
@@ -1,5 +1,11 @@
 from functools import lru_cache
-from typing import Final, List, Tuple
+from typing import List, Tuple
+import sys
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Final
+else:
+    from typing import Final
 
 from nltk import (
     pos_tag as _pos_tag,


### PR DESCRIPTION
Addresses https://github.com/Unstructured-IO/unstructured/issues/57 that support an alternative way of importing `Final` if the python version is less than 3.8.

Will publish `unstructured` to version `0.2.4` once merged.