### PR TITLE
fix: fix abstract class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.6-dev0
 
-* Typing corrections
+* Small change to how _read is placed within the inheritance structure since it doesn't really apply to pdf
 
 ## 0.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.6-dev0
+
+* Typing corrections
+
 ## 0.2.5
 
 * Update python requirement to >=3.7

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ check: check-src check-tests check-version
 check-src:
 	black --line-length 100 ${PACKAGE_NAME} --check
 	flake8 ${PACKAGE_NAME}
-	mypy ${PACKAGE_NAME} --ignore-missing-imports
+	mypy ${PACKAGE_NAME} --ignore-missing-imports --check-untyped-defs
 
 .PHONY: check-tests
 check-tests:

--- a/test_unstructured/documents/test_base.py
+++ b/test_unstructured/documents/test_base.py
@@ -4,7 +4,8 @@ from unstructured.documents.elements import NarrativeText, Title
 
 
 class MockDocument(Document):
-    def _read(self):
+    def __init__(self):
+        super().__init__()
         elements = [
             Title(text="This is a narrative."),
             NarrativeText(text="This is a narrative."),
@@ -12,7 +13,7 @@ class MockDocument(Document):
         ]
         page = Page(number=0)
         page.elements = elements
-        return [page]
+        self._pages = [page]
 
 
 def test_get_narrative():

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.5"  # pragma: no cover
+__version__ = "0.2.6-dev0"  # pragma: no cover

--- a/unstructured/documents/base.py
+++ b/unstructured/documents/base.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import List, Optional
 
 from unstructured.documents.elements import Element, NarrativeText
@@ -15,10 +15,6 @@ class Document(ABC):
     def __str__(self) -> str:
         return "\n\n".join([str(page) for page in self.pages])
 
-    @abstractmethod
-    def _read(self) -> List[Page]:  # pragma: no cover
-        pass
-
     def get_narrative(self) -> List[NarrativeText]:
         """Pulls out all of the narrative text sections from the document."""
         narrative: List[NarrativeText] = list()
@@ -32,7 +28,10 @@ class Document(ABC):
     def pages(self) -> List[Page]:
         """Gets all elements from pages in sequential order."""
         if self._pages is None:
-            self._pages = self._read()
+            raise NotImplementedError(
+                "When subclassing, _pages should always be populated before "
+                "using the pages property."
+            )
         return self._pages
 
     @property

--- a/unstructured/documents/base.py
+++ b/unstructured/documents/base.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import List, Optional
 
 from unstructured.documents.elements import Element, NarrativeText
@@ -15,6 +15,7 @@ class Document(ABC):
     def __str__(self) -> str:
         return "\n\n".join([str(page) for page in self.pages])
 
+    @abstractmethod
     def _read(self) -> List[Page]:  # pragma: no cover
         pass
 

--- a/unstructured/documents/xml.py
+++ b/unstructured/documents/xml.py
@@ -1,9 +1,9 @@
-from typing import Optional, Union
+from typing import Optional, Union, List
 
 import lxml.etree as etree
 
 from unstructured.logger import get_logger
-from unstructured.documents.base import Document
+from unstructured.documents.base import Document, Page
 
 logger = get_logger()
 
@@ -42,6 +42,13 @@ class XMLDocument(Document):
 
     def _read(self):
         raise NotImplementedError
+
+    @property
+    def pages(self) -> List[Page]:
+        """Gets all elements from pages in sequential order."""
+        if self._pages is None:
+            self._pages = self._read()
+        return super().pages
 
     def _read_xml(self, content):
         """Reads in an XML file and converts it to an lxml element tree object."""


### PR DESCRIPTION
Changed where `_read` sits in the inheritance structure since `PDFDocument` doesn't really need lazy document processing and it was causing a typing issue with the new version of `mypy`.

#### Testing

- In `requirements/test.txt`, change the `mypy` version to 0.990
- In your `unstructured` environment, run `pip install -r requirements/test.txt`
- run `make check`
- There should be no errors