### PR TITLE
feat: Add html escape quotes to cleaning brick

### DIFF
--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -22,6 +22,7 @@ def test_clean_bullets(text, expected):
     [
         ("\x93A lovely quote!\x94", "“A lovely quote!”"),
         ("\x91A lovely quote!\x92", "‘A lovely quote!’"),
+        ("Our dog&apos;s bowl.", "Our dog's bowl."),
     ],
 )
 def test_replace_unicode_quotes(text, expected):

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -33,6 +33,7 @@ def replace_unicode_quotes(text) -> str:
     text = text.replace("\x92", "’")
     text = text.replace("\x93", "“")
     text = text.replace("\x94", "”")
+    text = text.replace("&apos;", "'")
     return text
 
 


### PR DESCRIPTION
### Summary

Adds the `&apos;` HTML quote escape to the `replace_unicode_quotes` cleaning brick. 

### Testing

```python
from unstructured.cleaners.core import replace_unicode_quotes

# The output should be "My dog's bowl"
replace_unicode_quotes("My dog&apos;s bowl")
```