### PR TITLE
fix: partition pdf bad responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Reorganizes the staging bricks in the unstructured.partition module
 * Allow entities to be passed into the Datasaur staging brick
 * Added HTML escapes to the `replace_unicode_quotes` brick
+* Fix bad responses in partition_pdf to raise ValueError
 
 ## 0.2.6
 

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -7,7 +7,7 @@ if sys.version_info < (3, 8):
 else:
     from typing import List, Optional
 
-from unstructured.documents.elements import Element, Text
+from unstructured.documents.elements import Element
 
 
 def partition_pdf(

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -39,7 +39,7 @@ def partition_pdf(
         healthcheck_response = requests.get(url=f"{url}healthcheck")
 
     if healthcheck_response.status_code != 200:
-        return [Text(text="error: endpoint api healthcheck has failed!")]
+        raise ValueError("endpoint api healthcheck has failed!")
 
     url = f"{url}layout/pdf" if template == "base-model" else f"{url}/{template}"
     file_ = (filename, file if file else open(filename, "rb"))
@@ -52,4 +52,4 @@ def partition_pdf(
         pages = response.json()["pages"]
         return [element for page in pages for element in page["elements"]]
     else:
-        return [Text(text=f"error: response status code = {response.status_code}")]
+        raise ValueError(f"response status code = {response.status_code}")


### PR DESCRIPTION
- raise ValueError for bad responses in `partition_pdf`
- remove unused dependency Text from imports