### PR TITLE
feat: text2text and token classification for argilla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.0-dev6
 
-* Implement staging brick for Argilla. Converts `Text` elements to `argilla` dataset classes.
+* Implement staging brick for Argilla. Converts lists of `Text` elements to `argilla` dataset classes.
 * Removing the local PDF parsing code and any dependencies and tests.
 * Reorganizes the staging bricks in the unstructured.partition module
 * Allow entities to be passed into the Datasaur staging brick

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.3.0-dev5
+## 0.3.0-dev6
 
-* Implement staging brick for Argilla.
+* Implement staging brick for Argilla. Converts `Text` elements to `argilla` dataset classes.
 * Removing the local PDF parsing code and any dependencies and tests.
 * Reorganizes the staging bricks in the unstructured.partition module
 * Allow entities to be passed into the Datasaur staging brick

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -904,7 +904,7 @@ Convert a list of ``Text`` elements to an `Argilla Dataset <https://docs.argilla
 The type of Argilla dataset to be generated can be specified with ``argilla_task``
 parameter. Valid values for ``argilla_task`` are ``"text_classification"``,
 ``"token_classification"``, and ``"text2text"``. If ``"token_classification"`` is selected
-and ``tokens`` is not included in the optional recrod kwargs, the ``nltk`` word tokenizer
+and ``tokens`` is not included in the optional kwargs, the ``nltk`` word tokenizer
 is used by default.
 
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -920,5 +920,4 @@ Examples:
   elements = [Title(text="Title"), NarrativeText(text="Narrative")]
   metadata = [{"type": "title"}, {"type": "text"}]
 
-  # The resulting Argilla dataset is ready to be used with Argilla for training or labelling, etc.
   argilla_dataset = stage_for_argilla(elements, "text_classification", metadata=metadata)

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -901,8 +901,11 @@ Example:
 --------------------------
 
 Convert a list of ``Text`` elements to an `Argilla Dataset <https://docs.argilla.io/en/latest/reference/python/python_client.html#python-ref-datasets>`_.
-The type of Argilla dataset to be generated can be specified with `argilla_task` parameter. Currently, only ``text_classification``
-task type is supported.
+The type of Argilla dataset to be generated can be specified with ``argilla_task``
+parameter. Valid values for ``argilla_task`` are ``"text_classification"``,
+``"token_classification"``, and ``"text2text"``. If ``"token_classification"`` is selected
+and ``tokens`` is not included in the optional recrod kwargs, the ``nltk`` word tokenizer
+is used by default.
 
 
 Examples:

--- a/test_unstructured/staging/test_argilla.py
+++ b/test_unstructured/staging/test_argilla.py
@@ -23,16 +23,16 @@ def elements():
             rg.DatasetForTextClassification,
             {},
         ),
-        # (
-        #     "token_classification",
-        #     rg.DatasetForTokenClassification,
-        #     {"metadata": [{"type": "text1"}, {"type": "text2"}]},
-        # ),
-        # (
-        #     "token_classification",
-        #     rg.DatasetForTokenClassification,
-        #     {},
-        # ),
+        (
+            "token_classification",
+            rg.DatasetForTokenClassification,
+            {"metadata": [{"type": "text1"}, {"type": "text2"}]},
+        ),
+        (
+            "token_classification",
+            rg.DatasetForTokenClassification,
+            {},
+        ),
         (
             "text2text",
             rg.DatasetForText2Text,

--- a/test_unstructured/staging/test_argilla.py
+++ b/test_unstructured/staging/test_argilla.py
@@ -23,6 +23,26 @@ def elements():
             rg.DatasetForTextClassification,
             {},
         ),
+        # (
+        #     "token_classification",
+        #     rg.DatasetForTokenClassification,
+        #     {"metadata": [{"type": "text1"}, {"type": "text2"}]},
+        # ),
+        # (
+        #     "token_classification",
+        #     rg.DatasetForTokenClassification,
+        #     {},
+        # ),
+        (
+            "text2text",
+            rg.DatasetForText2Text,
+            {"metadata": [{"type": "text1"}, {"type": "text2"}]},
+        ),
+        (
+            "text2text",
+            rg.DatasetForText2Text,
+            {},
+        ),
     ],
 )
 def test_stage_for_argilla(elements, task_name, dataset_type, extra_kwargs):
@@ -39,8 +59,6 @@ def test_stage_for_argilla(elements, task_name, dataset_type, extra_kwargs):
     "task_name, error, error_message, extra_kwargs",
     [
         ("unknown_task", ValueError, "invalid value", {}),
-        ("token_classification", NotImplementedError, None, {}),
-        ("text2text", NotImplementedError, None, {}),
         ("text_classification", ValueError, "invalid value", {"metadata": "invalid metadata"}),
     ],
 )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0-dev5"  # pragma: no cover
+__version__ = "0.3.0-dev6"  # pragma: no cover

--- a/unstructured/staging/argilla.py
+++ b/unstructured/staging/argilla.py
@@ -1,11 +1,13 @@
 from typing import List, Union
-from unstructured.documents.elements import Text
 import argilla
 from argilla.client.models import (
     TextClassificationRecord,
     TokenClassificationRecord,
     Text2TextRecord,
 )
+
+from unstructured.documents.elements import Text
+from unstructured.nlp.tokenize import word_tokenize
 
 
 def stage_for_argilla(
@@ -45,6 +47,12 @@ def stage_for_argilla(
         arguments = dict(**element_kwargs, text=element.text)
         if isinstance(element.id, str):
             arguments["id"] = element.id
+
+        # NOTE(robinson) - TokenClassificationRecord raises and error if tokens are not
+        # provided as part of the input for the record. Default to the nltk word tokenizer
+        if argilla_task == "token_classification" and "tokens" not in arguments:
+            tokens = word_tokenize(arguments["text"])
+            arguments["tokens"] = tokens
 
         results.append(argilla_record_class(**arguments))
 

--- a/unstructured/staging/argilla.py
+++ b/unstructured/staging/argilla.py
@@ -31,9 +31,6 @@ def stage_for_argilla(
             "Must be one of: {', '.join(ARGILLA_TASKS.keys())}."
         )
 
-    if argilla_task in {"token_classification", "text2text"}:
-        raise NotImplementedError()  # TODO: Implement token_classification and text2text tasks
-
     for record_kwarg_key, record_kwarg_value in record_kwargs.items():
         if type(record_kwarg_value) is not list or len(record_kwarg_value) != len(elements):
             raise ValueError(


### PR DESCRIPTION
### Summary

Closes Unstructured-IO/community#27 and Unstructured-IO/community#28. Adds support for `text2text` and `token_classification` tasks to the `stage_for_argilla` brick. For token classification tasks, if `tokens` is not specified as an optional kwarg, then the `nltk` word tokenizer is used by default.

### Testing

#### Token Classification

```python
  import json

  from unstructured.documents.elements import Title, NarrativeText
  from unstructured.staging.argilla import stage_for_argilla

  elements = [Title(text="Title"), NarrativeText(text="Narrative")]
  metadata = [{"type": "title"}, {"type": "text"}]

  argilla_dataset = stage_for_argilla(elements, "token_classification", metadata=metadata)
```

#### Text2Text

```python
  import json

  from unstructured.documents.elements import Title, NarrativeText
  from unstructured.staging.argilla import stage_for_argilla

  elements = [Title(text="Title"), NarrativeText(text="Narrative")]
  metadata = [{"type": "title"}, {"type": "text"}]

  argilla_dataset = stage_for_argilla(elements, "text2text", metadata=metadata)
```