### PR TITLE
test: mock model api calls; full coverage for partition_pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-dev6
+## 0.3.0-dev7
 
 * Implement staging brick for Argilla. Converts lists of `Text` elements to `argilla` dataset classes.
 * Removing the local PDF parsing code and any dependencies and tests.

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -1,10 +1,77 @@
+import pytest
+
+import requests
+
 import unstructured.partition.pdf as pdf
 
 
-def test_partition_pdf(filename="example-docs/layout-parser-paper-fast.pdf"):
+class MockResponse:
+    def __init__(self, status_code, response):
+        self.status_code = status_code
+        self.response = response
+
+    def json(self):
+        return self.response
+
+
+def mock_healthy_get(url, **kwargs):
+    return MockResponse(status_code=200, response={})
+
+
+def mock_unhealthy_get(url, **kwargs):
+    return MockResponse(status_code=500, response={})
+
+
+def mock_unsuccessful_post(url, **kwargs):
+    return MockResponse(status_code=500, response={})
+
+
+def mock_successful_post(url, **kwargs):
+    response = {
+        "pages": [
+            {
+                "number": 0,
+                "elements": [{"type": "Title", "text": "Charlie Brown and the Great Pumpkin"}],
+            }
+        ]
+    }
+    return MockResponse(status_code=200, response=response)
+
+
+def test_partition_pdf(monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf"):
+    monkeypatch.setattr(requests, "post", mock_successful_post)
+    monkeypatch.setattr(requests, "get", mock_healthy_get)
+
     partition_pdf_response = pdf.partition_pdf(filename)
     assert partition_pdf_response[0]["type"] == "Title"
-    assert (
-        partition_pdf_response[0]["text"]
-        == "LayoutParser : A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis"
-    )
+    assert partition_pdf_response[0]["text"] == "Charlie Brown and the Great Pumpkin"
+
+
+def test_partition_pdf_raises_with_no_filename(
+    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf"
+):
+    monkeypatch.setattr(requests, "post", mock_successful_post)
+    monkeypatch.setattr(requests, "get", mock_healthy_get)
+
+    with pytest.raises(FileNotFoundError):
+        pdf.partition_pdf(filename=None, file=None)
+
+
+def test_partition_pdf_raises_with_failed_healthcheck(
+    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf"
+):
+    monkeypatch.setattr(requests, "post", mock_successful_post)
+    monkeypatch.setattr(requests, "get", mock_unhealthy_get)
+
+    with pytest.raises(ValueError):
+        pdf.partition_pdf(filename=filename)
+
+
+def test_partition_pdf_raises_with_failed_api_call(
+    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf"
+):
+    monkeypatch.setattr(requests, "post", mock_unsuccessful_post)
+    monkeypatch.setattr(requests, "get", mock_healthy_get)
+
+    with pytest.raises(ValueError):
+        pdf.partition_pdf(filename=filename)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0-dev6"  # pragma: no cover
+__version__ = "0.3.0-dev7"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -3,9 +3,9 @@ import requests  # type: ignore
 import sys
 
 if sys.version_info < (3, 8):
-    from typing_extensions import List, Optional
+    from typing_extensions import List, Optional  # pragma: no cover
 else:
-    from typing import List, Optional
+    from typing import List, Optional  # pragma: no cover
 
 from unstructured.documents.elements import Element
 
@@ -48,6 +48,7 @@ def partition_pdf(
         headers={"Authorization": f"Bearer {token}" if token else ""},
         files={"file": file_},
     )
+
     if response.status_code == 200:
         pages = response.json()["pages"]
         return [element for page in pages for element in page["elements"]]


### PR DESCRIPTION
### Summary

- Updates the `partition_pdf` tests to use mock API calls instead of calling the live API.
- Expands `partition_pdf` tests to achieve 100% test coverage

### Testing

`make test` should work with the updated tests and show 100% coverage