### PR TITLE
chore: add type hint to requests.post arg

### DIFF
--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -3,10 +3,16 @@ import requests  # type: ignore
 import sys
 
 if sys.version_info < (3, 8):
-    from typing_extensions import List, Optional, Union, Tuple, Mapping  # pragma: no cover
+    from typing_extensions import (
+        List,
+        Optional,
+        Union,
+        Tuple,
+        Mapping,
+        BinaryIO,
+    )  # pragma: no cover
 else:
-    from typing import List, Optional, Union, Tuple, Mapping  # pragma: no cover
-from _typeshed import SupportsRead
+    from typing import List, Optional, Union, Tuple, Mapping, BinaryIO  # pragma: no cover
 
 from unstructured.documents.elements import Element
 
@@ -44,7 +50,7 @@ def partition_pdf(
 
     url = f"{url}layout/pdf" if template == "base-model" else f"{url}/{template}"
 
-    file_: Mapping[str, Tuple[str, Union[SupportsRead[bytes], bytes]]] = {
+    file_: Mapping[str, Tuple[str, Union[BinaryIO, bytes]]] = {
         "file": (
             filename,
             file if file else open(filename, "rb"),

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -3,9 +3,10 @@ import requests  # type: ignore
 import sys
 
 if sys.version_info < (3, 8):
-    from typing_extensions import List, Optional  # pragma: no cover
+    from typing_extensions import List, Optional, Union, Tuple, Mapping  # pragma: no cover
 else:
-    from typing import List, Optional  # pragma: no cover
+    from typing import List, Optional, Union, Tuple, Mapping  # pragma: no cover
+from _typeshed import SupportsRead
 
 from unstructured.documents.elements import Element
 
@@ -42,11 +43,17 @@ def partition_pdf(
         raise ValueError("endpoint api healthcheck has failed!")
 
     url = f"{url}layout/pdf" if template == "base-model" else f"{url}/{template}"
-    file_ = (filename, file if file else open(filename, "rb"))
+
+    file_: Mapping[str, Tuple[str, Union[SupportsRead[bytes], bytes]]] = {
+        "file": (
+            filename,
+            file if file else open(filename, "rb"),
+        )
+    }
     response = requests.post(
         url=url,
         headers={"Authorization": f"Bearer {token}" if token else ""},
-        files={"file": file_},
+        files=file_,
     )
 
     if response.status_code == 200:


### PR DESCRIPTION
In cases where the `types-requests` package was installed, `mypy` would throw an error on the `files` argument of `requests.post` in `unstructured/partition/pdf.py`. This PR fixes that without any functional change to the code by providing a type hint to the argument passed to `requests.post`.

#### Testing:
Verify the error from the `main` branch by installing `types-requests` in your environment and running `make check`.

Verify the fix from this branch in the same manner. With `types-requests` installed, `make check` should find no errors.