### PR TITLE
build(deps): Bump certifi to address security scans

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -9,3 +9,7 @@ mypy
 pytest-cov
 label_studio_sdk
 vcrpy
+
+# NOTE(robinson) - The following pins are to address
+# vulernabilities in dependency scans
+certifi>=2022.12.07

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,8 +8,10 @@ attrs==22.1.0
     # via pytest
 black==22.10.0
     # via -r requirements/test.in
-certifi==2022.9.24
-    # via requests
+certifi==2022.12.7
+    # via
+    #   -r requirements/test.in
+    #   requests
 charset-normalizer==2.1.1
     # via requests
 click==8.1.3


### PR DESCRIPTION
### Summary

Bumps and pins the `certifi` version to address vulnerabilities from the dependabot scans.