### PR TITLE
fix: add __init__.py to the partition module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Added \_\_init.py\_\_ to `partition`
+
 ## 0.3.0
 
 * Implement staging brick for Argilla. Converts lists of `Text` elements to `argilla` dataset classes.

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0"  # pragma: no cover
+__version__ = "0.3.1"  # pragma: no cover


### PR DESCRIPTION
### Summary

- Add `__init__.py` to the `partition` module so it can be imported.