### PR TITLE
feat: `apply` method to apply cleaning bricks to elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.3.2-dev0
+## 0.3.2
 
 * Added `translate_text` brick for translating text between languages
+* Add an `apply` method to make it easier to apply cleaners to elements
 
 ## 0.3.1
 

--- a/docs/source/elements.rst
+++ b/docs/source/elements.rst
@@ -39,7 +39,7 @@ Examples:
   ]
 
   item = ListItem(text="[1] A Textbook on Crocodile Habitats")
-  item.apply(cleaners)
+  item.apply(*cleaners)
 
   # The output will be: Учебник по крокодильным средам обитания
   print(item)

--- a/docs/source/elements.rst
+++ b/docs/source/elements.rst
@@ -11,3 +11,35 @@ elements.
 * ``NarrativeText`` - Sections of a document that include well-formed prose. Sub-class of ``Text``.
 * ``Title`` - Headings and sub-headings wtihin a document. Sub-class of ``Text``.
 * ``ListItem`` - A text element that is part of an ordered or unordered list. Sub-class of ``Text``.
+
+
+#########################################
+Applying Cleaning Bricks to Text Elements
+#########################################
+
+You can apply cleaning bricks to a text element by using the ``apply`` method. The
+apply method accepts any function that takes a string as input and produces a string
+as output. Use the `partial` function from `functools` if you need to set additional
+args or kwargs for your cleaning brick. The `apply` method will accept either a single
+cleaner or a list of cleaners.
+
+Examples:
+
+.. code:: python
+
+  from functools import partial
+
+  from unstructured.cleaners.core import clean_prefix
+  from unstructured.cleaners.translate import translate_text
+  from unstructured.documents.elements import ListItem
+
+  cleaners = [
+    partial(clean_prefix, pattern=r"\[\d{1,2}\]"),
+    partial(translate_text, target_lang="ru"),
+  ]
+
+  item = ListItem(text="[1] A Textbook on Crocodile Habitats")
+  item.apply(cleaners)
+
+  # The output will be: Учебник по крокодильным средам обитания
+  print(item)

--- a/test_unstructured/documents/test_elements.py
+++ b/test_unstructured/documents/test_elements.py
@@ -29,7 +29,7 @@ def test_text_element_apply_multiple_cleaners():
         partial(translate_text, target_lang="ru"),
     ]
     text_element = Text(text="[1] A Textbook on Crocodile Habitats")
-    text_element.apply(cleaners)
+    text_element.apply(*cleaners)
     assert str(text_element) == "Учебник по крокодильным средам обитания"
 
 

--- a/test_unstructured/documents/test_elements.py
+++ b/test_unstructured/documents/test_elements.py
@@ -1,3 +1,7 @@
+from functools import partial
+
+from unstructured.cleaners.core import clean_prefix
+from unstructured.cleaners.translate import translate_text
 from unstructured.documents.elements import Element, NoID, Text
 
 
@@ -9,3 +13,20 @@ def test_text_id():
 def test_element_defaults_to_blank_id():
     element = Element()
     assert isinstance(element.id, NoID)
+
+
+def test_text_element_apply_cleaners():
+    text_element = Text(text="[1] A Textbook on Crocodile Habitats")
+
+    text_element.apply(partial(clean_prefix, pattern=r"\[\d{1,2}\]"))
+    assert str(text_element) == "A Textbook on Crocodile Habitats"
+
+
+def test_text_element_apply_multiple_cleaners():
+    cleaners = [
+        partial(clean_prefix, pattern=r"\[\d{1,2}\]"),
+        partial(translate_text, target_lang="ru"),
+    ]
+    text_element = Text(text="[1] A Textbook on Crocodile Habitats")
+    text_element.apply(cleaners)
+    assert str(text_element) == "Учебник по крокодильным средам обитания"

--- a/test_unstructured/documents/test_elements.py
+++ b/test_unstructured/documents/test_elements.py
@@ -1,4 +1,5 @@
 from functools import partial
+import pytest
 
 from unstructured.cleaners.core import clean_prefix
 from unstructured.cleaners.translate import translate_text
@@ -30,3 +31,9 @@ def test_text_element_apply_multiple_cleaners():
     text_element = Text(text="[1] A Textbook on Crocodile Habitats")
     text_element.apply(cleaners)
     assert str(text_element) == "Учебник по крокодильным средам обитания"
+
+
+def test_apply_raises_if_func_does_not_produce_string():
+    text_element = Text(text="[1] A Textbook on Crocodile Habitats")
+    with pytest.raises(ValueError):
+        text_element.apply(lambda s: 1)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.2-dev0"  # pragma: no cover
+__version__ = "0.3.2"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -1,6 +1,6 @@
 from abc import ABC
 import hashlib
-from typing import Callable, List, Union
+from typing import Callable, Union
 
 
 class NoID(ABC):
@@ -36,12 +36,9 @@ class Text(Element):
     def __eq__(self, other):
         return self.text == other.text
 
-    def apply(self, cleaners: Union[Callable, List[Callable]]):
+    def apply(self, *cleaners: Callable):
         """Applies a cleaning brick to the text element. The function that's passed in
         should take a string as input and produce a string as output."""
-        if callable(cleaners):
-            cleaners = [cleaners]
-
         cleaned_text = self.text
         for cleaner in cleaners:
             cleaned_text = cleaner(cleaned_text)

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -46,6 +46,9 @@ class Text(Element):
         for cleaner in cleaners:
             cleaned_text = cleaner(cleaned_text)
 
+        if not isinstance(cleaned_text, str):
+            raise ValueError("Cleaner produced a non-string output.")
+
         self.text = cleaned_text
 
 

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -1,6 +1,6 @@
 from abc import ABC
 import hashlib
-from typing import Union
+from typing import Callable, List, Union
 
 
 class NoID(ABC):
@@ -35,6 +35,18 @@ class Text(Element):
 
     def __eq__(self, other):
         return self.text == other.text
+
+    def apply(self, cleaners: Union[Callable, List[Callable]]):
+        """Applies a cleaning brick to the text element. The function that's passed in
+        should take a string as input and produce a string as output."""
+        if callable(cleaners):
+            cleaners = [cleaners]
+
+        cleaned_text = self.text
+        for cleaner in cleaners:
+            cleaned_text = cleaner(cleaned_text)
+
+        self.text = cleaned_text
 
 
 class NarrativeText(Text):


### PR DESCRIPTION
### Summary

Adds an `apply` method to `Text` elements to make it easier to apply cleaning bricks after partitioning. Previously, users would need to either create a new element or modify the text element in place to apply a cleaning brick. The `apply` method accepts either a single cleaner or a list of cleaners.


### Testing

```python
  from functools import partial

  from unstructured.cleaners.core import clean_prefix
  from unstructured.cleaners.translate import translate_text
  from unstructured.documents.elements import ListItem

  cleaners = [
    partial(clean_prefix, pattern=r"\[\d{1,2}\]"),
    partial(translate_text, target_lang="ru"),
  ]

  item = ListItem(text="[1] A Textbook on Crocodile Habitats")
  item.apply(*cleaners)

  # The output will be: Учебник по крокодильным средам обитания
  print(item)
```