### PR TITLE
build(deps): bump `certify` to incorporate security patches

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,8 +8,10 @@ alabaster==0.7.12
     # via sphinx
 babel==2.10.3
     # via sphinx
-certifi==2022.9.24
-    # via requests
+certifi==2022.12.7
+    # via
+    #   -r requirements/build.in
+    #   requests
 charset-normalizer==2.1.1
     # via requests
 docutils==0.17.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,10 @@ argilla==1.1.1
     # via unstructured (setup.py)
 backoff==2.2.1
     # via argilla
-certifi==2022.9.24
-    # via httpx
+certifi==2022.12.7
+    # via
+    #   httpx
+    #   unstructured (setup.py)
 click==8.1.3
     # via nltk
 deprecated==1.2.13

--- a/requirements/build.in
+++ b/requirements/build.in
@@ -1,2 +1,5 @@
 sphinx
 sphinx_rtd_theme
+
+# NOTE(robinson) - The following dependencies are pinned to address security scans
+certifi>=2022.12.07

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -8,8 +8,10 @@ alabaster==0.7.12
     # via sphinx
 babel==2.10.3
     # via sphinx
-certifi==2022.9.24
-    # via requests
+certifi==2022.12.7
+    # via
+    #   -r requirements/build.in
+    #   requests
 charset-normalizer==2.1.1
     # via requests
 docutils==0.17.1

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -8,10 +8,11 @@ argilla==1.1.1
     # via unstructured (setup.py)
 backoff==2.2.1
     # via argilla
-certifi==2022.9.24
+certifi==2022.12.7
     # via
     #   httpx
     #   requests
+    #   unstructured (setup.py)
 charset-normalizer==2.1.1
     # via requests
 click==8.1.3

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ setup(
         "lxml",
         "nltk",
         "argilla",
+        # NOTE(robinson) - The following dependencies are pinned
+        # to address security scans
+        "certifi>=2022.12.07",
     ],
     extras_require={
         "huggingface": [


### PR DESCRIPTION
### Summary

Bumps and pins the `certify` version to incorporate security patches in version `2022.12.07`.