### PR TITLE
doc: bump to newer version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.3-dev2
+## 0.3.3
 
 * Removes BasicConfig from logger configuration
 * Adds the `partition_email` partitioning brick

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.3-dev2"  # pragma: no cover
+__version__ = "0.3.3"  # pragma: no cover


### PR DESCRIPTION
### Summary
Bump library to `0.3.3` and will be published later.