### PR TITLE
chore: add new pattern for dash bullet

### DIFF
--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -26,6 +26,7 @@ UNICODE_BULLETS: Final[List[str]] = [
     "\u2767",
     "\u29BE",
     "\u29BF",
+    "\u002D",
     "",
     "\*",  # noqa: W605 NOTE(robinson) - skipping qa because we need the escape for the regex
     "\x95",


### PR DESCRIPTION
This PR adds a new unicode character for dash `-` bullets, so the `is_bulleted_text` method can recognize plain text dashes.

