### PR TITLE
fix: `partition_html` should process container divs that include text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 0.3.5-dev0
+## 0.3.5-dev1
 
 * Add new pattern to recognize plain text dash bullets
 * Add test for bullet patterns
+* Fix for `partition_html` that allows for processing `div` tags that have both text and child
+  elements
 
 ## 0.3.4
 

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -475,6 +475,34 @@ def test_nested_text_tags():
     assert len(html_document.pages[0].elements) == 1
 
 
+def test_containers_with_text_are_processed():
+    html_str = """<div dir=3D"ltr">Hi All,<div><br></div>
+   <div>Get excited for our first annual family day!</div>
+   <div>Best.<br clear=3D"all">
+      <div><br></div>
+      -- <br>
+      <div dir=3D"ltr">
+         <div dir=3D"ltr">Dino the Datasaur<div>Unstructured Technologies<br><div>Data Scientist
+                </div>
+               <div><br></div>
+            </div>
+         </div>
+      </div>
+   </div>
+</div>"""
+    html_document = HTMLDocument.from_string(html_str)
+    html_document._read()
+
+    assert html_document.elements == [
+        Title(text="Hi All,"),
+        NarrativeText(text="Get excited for our first annual family day!"),
+        Title(text="Best."),
+        Title(text="Dino the Datasaur"),
+        Title(text="Unstructured Technologies"),
+        Title(text="Data Scientist"),
+    ]
+
+
 def test_html_grabs_bulleted_text_in_tags():
     html_str = """<html>
     <body>

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.5-dev0"  # pragma: no cover
+__version__ = "0.3.5-dev1"  # pragma: no cover

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -97,7 +97,7 @@ class HTMLDocument(XMLDocument):
                         descendanttag_elems = tuple(tag_elem.iterdescendants())
 
                 elif _is_container_with_text(tag_elem):
-                    element = _text_to_element(tag_elem.text, "div", [])
+                    element = _text_to_element(tag_elem.text, "div", ())
                     if element is not None:
                         page.elements.append(element)
 


### PR DESCRIPTION
### Summary

Fixes an issue with `partition_html` that caused `div` tags that were both containers and included to text to be skipped. For example:

```html
<div>My name is Matt
    <div>This is my message</div>
</div>
```

would previously include `This is my message` but not `My name is Matt`. With the fix, all of the text is included.

### Testing

Using the sample doc from the `pipeline-email` repo:

```python
from unstructured.partition.email import partition_email

filename = "sample-docs/family_day.eml"
elements = partition_email(filename=filename)
print("\n\n".join([str(el) for el in elements]))
```

The output should look like:

```python
Hi All,

Get excited for our first annual family day!

They'll be face painting, a petting zoo, funnel cake and more.

Make sure to RSVP!

Best.

Mallori Harrell

Unstructured Technologies

Data Scientist
```