### PR TITLE
feat: helper functions to identify and extract phone numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.5-dev4
+## 0.3.5-dev5
 
 * Add new pattern to recognize plain text dash bullets
 * Add test for bullet patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 0.3.5-dev3
+## 0.3.5-dev4
 
 * Add new pattern to recognize plain text dash bullets
 * Add test for bullet patterns
 * Fix for `partition_html` that allows for processing `div` tags that have both text and child
   elements
 * Add ability to extract document metadata from `.docx`, `.xlsx`, and `.jpg` files.
+* Helper functions for identifying and extracting phone numbers
 
 ## 0.3.4
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -162,19 +162,19 @@ Examples:
   is_possible_title(example_3, sentence_min_length=5)
 
 
-``contains_phone_number``
--------------------------
+``contains_us_phone_number``
+----------------------------
 
-Checks to see if a section of text containers a phone number.
+Checks to see if a section of text contains a US phone number.
 
 Examples:
 
 .. code:: python
 
-  from unstructured.partition.text_type import contains_phone_number
+  from unstructured.partition.text_type import contains_us_phone_number
 
   # Returns True because the text includes a phone number
-  contains_phone_number("Phone number: 215-867-5309")
+  contains_us_phone_number("Phone number: 215-867-5309")
 
 
 ``contains_verb``
@@ -486,19 +486,19 @@ Examples:
   extract_text_after(text, r"SPEAKER \d{1}:")
 
 
-``extract_phone_number``
-------------------------
+``extract_us_phone_number``
+---------------------------
 
-Extracts a phone number from a section of text
+Extracts a phone number from a section of text.
 
 Examples:
 
 .. code:: python
 
-  from unstructured.cleaners.extract import extract_phone_number
+  from unstructured.cleaners.extract import extract_us_phone_number
 
   # Returns "215-867-5309"
-  extract_phone_number("Phone number: 215-867-5309")
+  extract_us_phone_number("Phone number: 215-867-5309")
 
 
 ``translate_text``

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -162,6 +162,21 @@ Examples:
   is_possible_title(example_3, sentence_min_length=5)
 
 
+``contains_phone_number``
+-------------------------
+
+Checks to see if a section of text containers a phone number.
+
+Examples:
+
+.. code:: python
+
+  from unstructured.partition.text_type import contains_phone_number
+
+  # Returns True because the text includes a phone number
+  contains_phone_number("Phone number: 215-867-5309")
+
+
 ``contains_verb``
 -----------------
 
@@ -469,6 +484,21 @@ Examples:
 
   # Returns "Look at me, I'm flying!"
   extract_text_after(text, r"SPEAKER \d{1}:")
+
+
+``extract_phone_number``
+------------------------
+
+Extracts a phone number from a section of text
+
+Examples:
+
+.. code:: python
+
+  from unstructured.cleaners.extract import extract_phone_number
+
+  # Returns "215-867-5309"
+  extract_phone_number("Phone number: 215-867-5309")
 
 
 ``translate_text``

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -21,3 +21,16 @@ def test_extract_text_before():
 def test_extract_text_after():
     text = "Teacher: BLAH BLAH BLAH; Student: BLAH BLAH BLAH!"
     assert extract.extract_text_after(text, "BLAH;", 0) == "Student: BLAH BLAH BLAH!"
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("215-867-5309", "215-867-5309"),
+        ("Phone Number: +1 215.867.5309", "+1 215.867.5309"),
+        ("Phone Number: Just Kidding", ""),
+    ],
+)
+def test_extract_phone_number(text, expected):
+    phone_number = extract.extract_phone_number(text)
+    assert phone_number == expected

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -31,6 +31,6 @@ def test_extract_text_after():
         ("Phone Number: Just Kidding", ""),
     ],
 )
-def test_extract_phone_number(text, expected):
-    phone_number = extract.extract_phone_number(text)
+def test_extract_us_phone_number(text, expected):
+    phone_number = extract.extract_us_phone_number(text)
     assert phone_number == expected

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -70,6 +70,24 @@ def test_is_possible_title(text, expected, monkeypatch):
 @pytest.mark.parametrize(
     "text, expected",
     [
+        ("8675309", True),
+        ("+1 867-5309", True),
+        ("2158675309", True),
+        ("+12158675309", True),
+        ("867.5309", True),
+        ("1-800-867-5309", True),
+        ("1(800)-867-5309", True),
+        ("Tel: 1(800)-867-5309", True),
+    ],
+)
+def test_contains_phone_number(text, expected):
+    has_phone_number = text_type.contains_phone_number(text)
+    assert has_phone_number is expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
         ("• This is a fine point!", True),
         (" • This is a fine point!", True),  # Has an extra space in front of the bullet
         ("‣ This is a fine point!", True),

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -80,8 +80,8 @@ def test_is_possible_title(text, expected, monkeypatch):
         ("Tel: 1(800)-867-5309", True),
     ],
 )
-def test_contains_phone_number(text, expected):
-    has_phone_number = text_type.contains_phone_number(text)
+def test_contains_us_phone_number(text, expected):
+    has_phone_number = text_type.contains_us_phone_number(text)
     assert has_phone_number is expected
 
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.5-dev3"  # pragma: no cover
+__version__ = "0.3.5-dev4"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.5-dev4"  # pragma: no cover
+__version__ = "0.3.5-dev5"  # pragma: no cover

--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -1,5 +1,7 @@
 import re
 
+from unstructured.nlp.patterns import PHONE_NUMBERS_RE
+
 
 def _get_indexed_match(text: str, pattern: str, index: int = 0) -> re.Match:
     if not isinstance(index, int) or index < 0:
@@ -44,3 +46,20 @@ def extract_text_after(text: str, pattern: str, index: int = 0, strip: bool = Tr
     _, end = regex_match.span()
     before_text = text[end:]
     return before_text.lstrip() if strip else before_text
+
+
+def extract_phone_number(text: str):
+    """Extracts a phone number from a section of text that includes a phone number. If there
+    is no phone number present, the result will be an empty string.
+
+    Example
+    -------
+    extract_phone_number("Phone Number: 215-867-5309") -> "215-867-5309"
+    """
+    regex_match = PHONE_NUMBERS_RE.search(text)
+    if regex_match is None:
+        return ""
+
+    start, end = regex_match.span()
+    phone_number = text[start:end]
+    return phone_number.strip()

--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -1,6 +1,6 @@
 import re
 
-from unstructured.nlp.patterns import PHONE_NUMBERS_RE
+from unstructured.nlp.patterns import US_PHONE_NUMBERS_RE
 
 
 def _get_indexed_match(text: str, pattern: str, index: int = 0) -> re.Match:
@@ -48,15 +48,15 @@ def extract_text_after(text: str, pattern: str, index: int = 0, strip: bool = Tr
     return before_text.lstrip() if strip else before_text
 
 
-def extract_phone_number(text: str):
-    """Extracts a phone number from a section of text that includes a phone number. If there
+def extract_us_phone_number(text: str):
+    """Extracts a US phone number from a section of text that includes a phone number. If there
     is no phone number present, the result will be an empty string.
 
     Example
     -------
     extract_phone_number("Phone Number: 215-867-5309") -> "215-867-5309"
     """
-    regex_match = PHONE_NUMBERS_RE.search(text)
+    regex_match = US_PHONE_NUMBERS_RE.search(text)
     if regex_match is None:
         return ""
 

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -11,10 +11,10 @@ import re
 # NOTE(robinson) - Modified from answers found on this stackoverflow post
 # ref: https://stackoverflow.com/questions/16699007/
 # regular-expression-to-match-standard-10-digit-phone-number
-PHONE_NUMBERS_PATTERN = (
+US_PHONE_NUMBERS_PATTERN = (
     r"(?:\+?(\d{1,3}))?[-. (]*(\d{3})?[-. )]*(\d{3})[-. ]*(\d{4})(?: *x(\d+))?\s*$"
 )
-PHONE_NUMBERS_RE = re.compile(PHONE_NUMBERS_PATTERN)
+US_PHONE_NUMBERS_RE = re.compile(US_PHONE_NUMBERS_PATTERN)
 
 UNICODE_BULLETS: Final[List[str]] = [
     "\u0095",

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -8,6 +8,14 @@ else:
 
 import re
 
+# NOTE(robinson) - Modified from answers found on this stackoverflow post
+# ref: https://stackoverflow.com/questions/16699007/
+# regular-expression-to-match-standard-10-digit-phone-number
+PHONE_NUMBERS_PATTERN = (
+    r"(?:\+?(\d{1,3}))?[-. (]*(\d{3})?[-. )]*(\d{3})[-. ]*(\d{4})(?: *x(\d+))?\s*$"
+)
+PHONE_NUMBERS_RE = re.compile(PHONE_NUMBERS_PATTERN)
+
 UNICODE_BULLETS: Final[List[str]] = [
     "\u0095",
     "\u2022",

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -9,7 +9,7 @@ else:
     from typing import Final
 
 from unstructured.cleaners.core import remove_punctuation
-from unstructured.nlp.patterns import PHONE_NUMBERS_RE, UNICODE_BULLETS_RE
+from unstructured.nlp.patterns import US_PHONE_NUMBERS_RE, UNICODE_BULLETS_RE
 from unstructured.nlp.tokenize import pos_tag, sent_tokenize, word_tokenize
 from unstructured.logger import logger
 
@@ -63,14 +63,14 @@ def is_bulleted_text(text: str) -> bool:
     return UNICODE_BULLETS_RE.match(text.strip()) is not None
 
 
-def contains_phone_number(text: str) -> bool:
-    """Checks to see if a section of text contains a phone number.
+def contains_us_phone_number(text: str) -> bool:
+    """Checks to see if a section of text contains a US phone number.
 
     Example
     -------
-    contains_phone_number("867-5309") -> True
+    contains_us_phone_number("867-5309") -> True
     """
-    return PHONE_NUMBERS_RE.search(text.strip()) is not None
+    return US_PHONE_NUMBERS_RE.search(text.strip()) is not None
 
 
 def contains_verb(text: str) -> bool:

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -9,7 +9,7 @@ else:
     from typing import Final
 
 from unstructured.cleaners.core import remove_punctuation
-from unstructured.nlp.patterns import UNICODE_BULLETS_RE
+from unstructured.nlp.patterns import PHONE_NUMBERS_RE, UNICODE_BULLETS_RE
 from unstructured.nlp.tokenize import pos_tag, sent_tokenize, word_tokenize
 from unstructured.logger import logger
 
@@ -61,6 +61,16 @@ def is_possible_title(text: str, sentence_min_length: int = 5) -> bool:
 def is_bulleted_text(text: str) -> bool:
     """Checks to see if the section of text is part of a bulleted list."""
     return UNICODE_BULLETS_RE.match(text.strip()) is not None
+
+
+def contains_phone_number(text: str) -> bool:
+    """Checks to see if a section of text contains a phone number.
+
+    Example
+    -------
+    contains_phone_number("867-5309") -> True
+    """
+    return PHONE_NUMBERS_RE.search(text.strip()) is not None
 
 
 def contains_verb(text: str) -> bool:


### PR DESCRIPTION
### Summary

Adds a `contains_phone_number` function to identify if a section of text contains a phone number and an `extract_phone_number` cleaning brick for extracting the phone numbers.

### Testing

```python
  from unstructured.cleaners.extract import extract_phone_number
  # Returns "215-867-5309"
  extract_phone_number("Phone number: 215-867-5309")
```

```python
  from unstructured.partition.text_type import contains_phone_number
  # Returns True because the text includes a phone number
  contains_phone_number("Phone number: 215-867-5309")
```