### PR TITLE
feat: new bricks for removing and extracting ordered bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.5-dev6
+
+* Add new cleaning brick for ordered bullets.
+* Add new extract method for ordered bullets.
+* Add test for cleaning ordered bullets.
+* Add test for extracting ordered bullets.
+
 ## 0.3.5-dev5
 
 * Add new pattern to recognize plain text dash bullets

--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -35,15 +35,15 @@ def test_clean_bullets(text, expected):
         ("2,3. Morse code 3. ●●●", "2,3. Morse code 3. ●●●"),
         ("1..2.3 four", "1..2.3 four"),
         ("Fig. 2: The relationship", "Fig. 2: The relationship"),
-        ("23 is everywhere", "23 is everywhere")
+        ("23 is everywhere", "23 is everywhere"),
     ],
 )
 def test_clean_ordered_bullets(text, expected):
     assert (
-            core.clean_ordered_bullets(
-                text=text,
-            )
-            == expected
+        core.clean_ordered_bullets(
+            text=text,
+        )
+        == expected
     )
 
 
@@ -166,13 +166,13 @@ def test_clean_postfix(text, pattern, ignore_case, strip, expected):
 )
 def test_clean(text, extra_whitespace, dashes, bullets, lowercase, trailing_punctuation, expected):
     assert (
-            core.clean(
-                text=text,
-                extra_whitespace=extra_whitespace,
-                dashes=dashes,
-                bullets=bullets,
-                trailing_punctuation=trailing_punctuation,
-                lowercase=lowercase,
-            )
-            == expected
+        core.clean(
+            text=text,
+            extra_whitespace=extra_whitespace,
+            dashes=dashes,
+            bullets=bullets,
+            trailing_punctuation=trailing_punctuation,
+            lowercase=lowercase,
+        )
+        == expected
     )

--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -20,6 +20,36 @@ def test_clean_bullets(text, expected):
 @pytest.mark.parametrize(
     "text, expected",
     [
+        ("1. Introduction:", "Introduction:"),
+        ("a. Introduction:", "Introduction:"),
+        ("20.3 Morse code ●●●", "Morse code ●●●"),
+        ("5.3.1 Convolutional Networks ", "Convolutional Networks"),
+        ("D.b.C Recurrent Neural Networks", "Recurrent Neural Networks"),
+        ("2.b.1 Recurrent Neural Networks", "Recurrent Neural Networks"),
+        ("eins. Neural Networks", "eins. Neural Networks"),
+        ("bb.c Feed Forward Neural Networks", "Feed Forward Neural Networks"),
+        ("aaa.ccc Metrics", "aaa.ccc Metrics"),
+        (" version = 3.8", " version = 3.8"),
+        ("1 2. 3 4", "1 2. 3 4"),
+        ("1) 2. 3 4", "1) 2. 3 4"),
+        ("2,3. Morse code 3. ●●●", "2,3. Morse code 3. ●●●"),
+        ("1..2.3 four", "1..2.3 four"),
+        ("Fig. 2: The relationship", "Fig. 2: The relationship"),
+        ("23 is everywhere", "23 is everywhere")
+    ],
+)
+def test_clean_ordered_bullets(text, expected):
+    assert (
+            core.clean_ordered_bullets(
+                text=text,
+            )
+            == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
         ("\x93A lovely quote!\x94", "“A lovely quote!”"),
         ("\x91A lovely quote!\x92", "‘A lovely quote!’"),
         ("Our dog&apos;s bowl.", "Our dog's bowl."),
@@ -136,13 +166,13 @@ def test_clean_postfix(text, pattern, ignore_case, strip, expected):
 )
 def test_clean(text, extra_whitespace, dashes, bullets, lowercase, trailing_punctuation, expected):
     assert (
-        core.clean(
-            text=text,
-            extra_whitespace=extra_whitespace,
-            dashes=dashes,
-            bullets=bullets,
-            trailing_punctuation=trailing_punctuation,
-            lowercase=lowercase,
-        )
-        == expected
+            core.clean(
+                text=text,
+                extra_whitespace=extra_whitespace,
+                dashes=dashes,
+                bullets=bullets,
+                trailing_punctuation=trailing_punctuation,
+                lowercase=lowercase,
+            )
+            == expected
     )

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -54,13 +54,13 @@ def test_extract_us_phone_number(text, expected):
         ("2,3. Morse code 3. ●●●", (None, None, None)),
         ("1..2.3 four", (None, None, None)),
         ("Fig. 2: The relationship", (None, None, None)),
-        ("23 is everywhere", (None, None, None))
+        ("23 is everywhere", (None, None, None)),
     ],
 )
 def test_extract_ordered_bullets(text, expected):
     assert (
-            extract.extract_ordered_bullets(
-                text=text,
-            )
-            == expected
+        extract.extract_ordered_bullets(
+            text=text,
+        )
+        == expected
     )

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -34,3 +34,33 @@ def test_extract_text_after():
 def test_extract_us_phone_number(text, expected):
     phone_number = extract.extract_us_phone_number(text)
     assert phone_number == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("1. Introduction:", ("1", None, None)),
+        ("a. Introduction:", ("a", None, None)),
+        ("20.3 Morse code ●●●", ("20", "3", None)),
+        ("5.3.1 Convolutional Networks ", ("5", "3", "1")),
+        ("D.b.C Recurrent Neural Networks", ("D", "b", "C")),
+        ("2.b.1 Recurrent Neural Networks", ("2", "b", "1")),
+        ("eins. Neural Networks", (None, None, None)),
+        ("bb.c Feed Forward Neural Networks", ("bb", "c", None)),
+        ("aaa.ccc Metrics", (None, None, None)),
+        (" version = 3.8", (None, None, None)),
+        ("1 2. 3 4", (None, None, None)),
+        ("1) 2. 3 4", (None, None, None)),
+        ("2,3. Morse code 3. ●●●", (None, None, None)),
+        ("1..2.3 four", (None, None, None)),
+        ("Fig. 2: The relationship", (None, None, None)),
+        ("23 is everywhere", (None, None, None))
+    ],
+)
+def test_extract_ordered_bullets(text, expected):
+    assert (
+            extract.extract_ordered_bullets(
+                text=text,
+            )
+            == expected
+    )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.5-dev5"  # pragma: no cover
+__version__ = "0.3.5-dev6"  # pragma: no cover

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -21,8 +21,32 @@ def clean_bullets(text) -> str:
     return cleaned_text.strip()
 
 
+def clean_ordered_bullets(text) -> str:
+    """Cleans the start of bulleted text sections up to three “sub-section”
+    bullets accounting numeric and alpha-numeric types.
+
+    Example
+    -------
+    1.1 This is a very important point -> This is a very important point
+    a.b This is a very important point -> This is a very important point
+    """
+    text_sp = text.split()
+    text_cl = " ".join(text_sp[1:])
+    if any(['.' not in text_sp[0], '..' in text_sp[0]]):
+        return text
+
+    bullet = text_sp[0].split('.')
+    if not bullet[-1]:
+        del bullet[-1]
+
+    if len(bullet[0]) > 2:
+        return text
+
+    return text_cl
+
+
 # TODO(robinson) - There's likely a cleaner was to accomplish this and get all of the
-# unicode chracters instead of just the quotes. Doing this for now since quotes are
+# unicode characters instead of just the quotes. Doing this for now since quotes are
 # an issue that are popping up in the SEC filings tests
 def replace_unicode_quotes(text) -> str:
     """Replaces unicode bullets in text with the expected character

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -32,10 +32,10 @@ def clean_ordered_bullets(text) -> str:
     """
     text_sp = text.split()
     text_cl = " ".join(text_sp[1:])
-    if any(['.' not in text_sp[0], '..' in text_sp[0]]):
+    if any(["." not in text_sp[0], ".." in text_sp[0]]):
         return text
 
-    bullet = text_sp[0].split('.')
+    bullet = text_sp[0].split(".")
     if not bullet[-1]:
         del bullet[-1]
 

--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -65,7 +65,7 @@ def extract_us_phone_number(text: str):
     return phone_number.strip()
 
 
-def extract_ordered_bullets(text) -> str:
+def extract_ordered_bullets(text) -> tuple:
     """Extracts the start of bulleted text sections up to three “sub-section”
     bullets accounting numeric and alpha-numeric types.
 
@@ -76,10 +76,10 @@ def extract_ordered_bullets(text) -> str:
     a.b This is a very important point -> ("a", "b", None)
     """
     text_sp = text.split()
-    if any(['.' not in text_sp[0], '..' in text_sp[0]]):
+    if any(["." not in text_sp[0], ".." in text_sp[0]]):
         return None, None, None
 
-    bullet = text_sp[0].split('.')
+    bullet = text_sp[0].split(".")
     if not bullet[-1]:
         del bullet[-1]
 

--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -63,3 +63,34 @@ def extract_us_phone_number(text: str):
     start, end = regex_match.span()
     phone_number = text[start:end]
     return phone_number.strip()
+
+
+def extract_ordered_bullets(text) -> str:
+    """Extracts the start of bulleted text sections up to three “sub-section”
+    bullets accounting numeric and alpha-numeric types.
+
+    Example
+    -------
+    This is a very important point -> (None, None, None)
+    1.1 This is a very important point -> ("1", "1", None)
+    a.b This is a very important point -> ("a", "b", None)
+    """
+    text_sp = text.split()
+    if any(['.' not in text_sp[0], '..' in text_sp[0]]):
+        return None, None, None
+
+    bullet = text_sp[0].split('.')
+    if not bullet[-1]:
+        del bullet[-1]
+
+    if len(bullet[0]) > 2:
+        return None, None, None
+
+    a, *temp = bullet
+    b, c = None, None
+    if temp:
+        b, *c = temp
+        b = "".join(b)
+        c = "".join(c)
+    c = None if not c else c
+    return a, b, c


### PR DESCRIPTION
New cleaning brick to remove alpha numeric bullets up to three “sub-sections", and additional method to extract them separately:
- `clean_ordered_bullets(text) -> str`
- `extract_ordered_bullets(text) -> tuple`