### PR TITLE
chore: Fix parse received data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1-dev0
+
+* Fix bug in `_parse_received_data`.
+
 ## 0.4.0
 
 * Added generic `partition` brick that detects the file type and routes a file to the appropriate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
   elements
 * Add ability to extract document metadata from `.docx`, `.xlsx`, and `.jpg` files.
 * Helper functions for identifying and extracting phone numbers
-* Add new function `extract_attachment_info` that extracts and decode the attachment
+* Add new function `extract_attachment_info` that extracts and decodes the attachment
 of an email.
 * Staging brick to convert a list of `Element`s to a `pandas` dataframe.
 * Add plain text functionality to `partition_email`

--- a/example-docs/fake-email-header.eml
+++ b/example-docs/fake-email-header.eml
@@ -1,0 +1,28 @@
+Received: from ABCDEFG-000.ABC.guide (00.0.0.00) by ABCDEFG-000.ABC.guide
+ ([ba23::58b5:2236:45g2:88h2]) with Unstructured TTTT Server (version=ABC0_0,
+ cipher=ABC_ABCDE_ABC_NOPE_ABC_000_ABC_ABC000) id 00.0.000.0 via Techbox
+ Transport; Wed, 20 Feb 2023 10:03:18 +1200
+MIME-Version: 1.0
+Date: Fri, 16 Dec 2022 17:04:16 -0500
+Message-ID: <CADc-_xaLB2FeVQ7mNsoX+NJb_7hAJhBKa_zet-rtgPGenj0uVw@mail.gmail.com>
+Subject: Test Email
+From: Matthew Robinson <mrobinson@unstructured.io>
+To: Matthew Robinson <mrobinson@unstructured.io>
+Content-Type: multipart/alternative; boundary="00000000000095c9b205eff92630"
+
+--00000000000095c9b205eff92630
+Content-Type: text/plain; charset="UTF-8"
+
+This is a test email to use for unit tests.
+
+Important points:
+
+   - Roses are red
+   - Violets are blue
+
+--00000000000095c9b205eff92630
+Content-Type: text/html; charset="UTF-8"
+
+<div dir="ltr"><div>This is a test email to use for unit tests.</div><div><br></div><div>Important points:</div><div><ul><li>Roses are red</li><li>Violets are blue</li></ul></div></div>
+
+--00000000000095c9b205eff92630--

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -1,7 +1,9 @@
+import datetime
 import email
 import os
 import pathlib
 import pytest
+
 
 from unstructured.documents.elements import NarrativeText, Title, ListItem, Image
 from unstructured.documents.email_elements import (
@@ -9,6 +11,7 @@ from unstructured.documents.email_elements import (
     Recipient,
     Sender,
     Subject,
+    ReceivedInfo,
 )
 from unstructured.partition.email import (
     extract_attachment_info,
@@ -34,6 +37,30 @@ IMAGE_EXPECTED_OUTPUT = [
     Image(text="unstructured_logo.png"),
     ListItem(text="Roses are red"),
     ListItem(text="Violets are blue"),
+]
+
+RECEIVED_HEADER_OUTPUT = [
+    ReceivedInfo(name="ABCDEFG-000.ABC.guide", text="00.0.0.00"),
+    ReceivedInfo(name="ABCDEFG-000.ABC.guide", text="ba23::58b5:2236:45g2:88h2"),
+    ReceivedInfo(
+        name="received_datetimetz",
+        text="2023-02-20 10:03:18+12:00",
+        datestamp=datetime.datetime(
+            2023, 2, 20, 10, 3, 18, tzinfo=datetime.timezone(datetime.timedelta(seconds=43200))
+        ),
+    ),
+    MetaData(name="MIME-Version", text="1.0"),
+    MetaData(name="Date", text="Fri, 16 Dec 2022 17:04:16 -0500"),
+    MetaData(
+        name="Message-ID",
+        text="<CADc-_xaLB2FeVQ7mNsoX+NJb_7hAJhBKa_zet-rtgPGenj0uVw@mail.gmail.com>",
+    ),
+    Subject(text="Test Email"),
+    Sender(name="Matthew Robinson", text="mrobinson@unstructured.io"),
+    Recipient(name="Matthew Robinson", text="mrobinson@unstructured.io"),
+    MetaData(
+        name="Content-Type", text='multipart/alternative; boundary="00000000000095c9b205eff92630"'
+    ),
 ]
 
 HEADER_EXPECTED_OUTPUT = [
@@ -114,12 +141,12 @@ def test_partition_email_from_filename_with_embedded_image():
 
 
 def test_partition_email_header():
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email-header.eml")
     with open(filename, "r") as f:
         msg = email.message_from_file(f)
     elements = partition_email_header(msg)
     assert len(elements) > 0
-    assert elements == HEADER_EXPECTED_OUTPUT
+    assert elements == RECEIVED_HEADER_OUTPUT
 
 
 def test_extract_attachment_info():

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.0"  # pragma: no cover
+__version__ = "0.4.1-dev0"  # pragma: no cover

--- a/unstructured/documents/email_elements.py
+++ b/unstructured/documents/email_elements.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from datetime import datetime
 import hashlib
-from typing import Callable, List, Union, Optional
+from typing import Callable, List, Union
 from unstructured.documents.elements import Element, Text, NoID
 
 
@@ -20,7 +20,7 @@ class Name(EmailElement):
         self,
         name: str,
         text: str,
-        datestamp: Optional[datetime] = None,
+        datestamp: Union[datetime, None] = None,
         element_id: Union[str, NoID] = NoID(),
     ):
         self.name: str = name

--- a/unstructured/documents/email_elements.py
+++ b/unstructured/documents/email_elements.py
@@ -5,6 +5,12 @@ from typing import Callable, List, Union
 from unstructured.documents.elements import Element, Text, NoID
 
 
+class NoDatestamp(ABC):
+    """Class to indicate that an element do not have a datetime stamp."""
+
+    pass
+
+
 class EmailElement(Element):
     """An email element is a section of the email."""
 
@@ -20,7 +26,7 @@ class Name(EmailElement):
         self,
         name: str,
         text: str,
-        datestamp: Union[datetime, None] = None,
+        datestamp: Union[datetime, NoDatestamp] = NoDatestamp(),
         element_id: Union[str, NoID] = NoID(),
     ):
         self.name: str = name

--- a/unstructured/documents/email_elements.py
+++ b/unstructured/documents/email_elements.py
@@ -42,7 +42,7 @@ class Name(EmailElement):
             self.datestamp: datetime = datestamp
 
     def has_datestamp(self):
-        return self.datestamp is not None
+        return "self.datestamp" in globals()
 
     def __str__(self):
         return f"{self.name}: {self.text}"

--- a/unstructured/documents/email_elements.py
+++ b/unstructured/documents/email_elements.py
@@ -31,13 +31,15 @@ class Name(EmailElement):
     ):
         self.name: str = name
         self.text: str = text
-        self.datestamp: datetime = datestamp
 
         if isinstance(element_id, NoID):
             # NOTE(robinson) - Cut the SHA256 hex in half to get the first 128 bits
             element_id = hashlib.sha256(text.encode()).hexdigest()[:32]
 
         super().__init__(element_id=element_id)
+
+        if isinstance(datestamp, datetime):
+            self.datestamp: datetime = datestamp
 
     def has_datestamp(self):
         return self.datestamp is not None

--- a/unstructured/documents/email_elements.py
+++ b/unstructured/documents/email_elements.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from datetime import datetime
 import hashlib
-from typing import Callable, List, Union
+from typing import Callable, List, Union, Optional
 from unstructured.documents.elements import Element, Text, NoID
 
 
@@ -20,12 +20,12 @@ class Name(EmailElement):
         self,
         name: str,
         text: str,
+        datestamp: Optional[datetime] = None,
         element_id: Union[str, NoID] = NoID(),
     ):
         self.name: str = name
         self.text: str = text
-        self.datestamp: datetime
-        self.has_datestamp: bool = False
+        self.datestamp: datetime = datestamp
 
         if isinstance(element_id, NoID):
             # NOTE(robinson) - Cut the SHA256 hex in half to get the first 128 bits
@@ -33,15 +33,14 @@ class Name(EmailElement):
 
         super().__init__(element_id=element_id)
 
-    def set_datestamp(self, datestamp: datetime):
-        self.datestamp = datestamp
-        self.has_datestamp = True
+    def has_datestamp(self):
+        return self.datestamp is not None
 
     def __str__(self):
         return f"{self.name}: {self.text}"
 
     def __eq__(self, other):
-        if self.has_datestamp:
+        if self.has_datestamp():
             return (
                 self.name == other.name
                 and self.text == other.text

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -24,6 +24,7 @@ from unstructured.documents.email_elements import (
     ReceivedInfo,
     MetaData,
 )
+
 from unstructured.documents.elements import Element, Text, Image, NarrativeText, Title
 from unstructured.partition.html import partition_html
 from unstructured.partition.text import split_by_paragraph, partition_text
@@ -46,11 +47,9 @@ def _parse_received_data(data: str) -> List[Element]:
     if mapi_id:
         elements.append(ReceivedInfo(name="mapi_id", text=mapi_id[0]))
     if datetimetz:
-        elements.append(
-            ReceivedInfo(name="received_datetimetz", text=str(datetimetz)).set_datestamp(
-                datestamp=datetimetz
-            )
-        )
+        datetimestamp = ReceivedInfo(name="received_datetimetz", text=str(datetimetz))
+        datetimestamp.set_datestamp(datestamp=datetimetz)
+        elements.append(datetimestamp)
 
     return elements
 
@@ -207,12 +206,12 @@ def partition_email(
     elif content_source == "text/plain":
         elements = partition_text(text=content)
 
-    for idx, element in enumerate(elements):
-        indices = has_embedded_image(element)
-        if (isinstance(element, NarrativeText) or isinstance(element, Title)) and indices:
-            image_info, clean_element = find_embedded_image(element, indices)
-            elements[idx] = clean_element
-            elements.insert(idx + 1, image_info)
+    # for idx, element in enumerate(elements):
+    #     indices = has_embedded_image(element)
+    #     if (isinstance(element, NarrativeText) or isinstance(element, Title)) and indices:
+    #         image_info, clean_element = find_embedded_image(element, indices)
+    #         elements[idx] = clean_element
+    #         elements.insert(idx + 1, image_info)
 
     header: List[Element] = list()
     if include_headers:

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -24,7 +24,6 @@ from unstructured.documents.email_elements import (
     ReceivedInfo,
     MetaData,
 )
-
 from unstructured.documents.elements import Element, Text, Image, NarrativeText, Title
 from unstructured.partition.html import partition_html
 from unstructured.partition.text import split_by_paragraph, partition_text
@@ -47,9 +46,11 @@ def _parse_received_data(data: str) -> List[Element]:
     if mapi_id:
         elements.append(ReceivedInfo(name="mapi_id", text=mapi_id[0]))
     if datetimetz:
-        datetimestamp = ReceivedInfo(name="received_datetimetz", text=str(datetimetz))
-        datetimestamp.set_datestamp(datestamp=datetimetz)
-        elements.append(datetimestamp)
+        elements.append(
+            ReceivedInfo(name="received_datetimetz", text=str(datetimetz)).set_datestamp(
+                datestamp=datetimetz
+            )
+        )
 
     return elements
 
@@ -206,12 +207,12 @@ def partition_email(
     elif content_source == "text/plain":
         elements = partition_text(text=content)
 
-    # for idx, element in enumerate(elements):
-    #     indices = has_embedded_image(element)
-    #     if (isinstance(element, NarrativeText) or isinstance(element, Title)) and indices:
-    #         image_info, clean_element = find_embedded_image(element, indices)
-    #         elements[idx] = clean_element
-    #         elements.insert(idx + 1, image_info)
+    for idx, element in enumerate(elements):
+        indices = has_embedded_image(element)
+        if (isinstance(element, NarrativeText) or isinstance(element, Title)) and indices:
+            image_info, clean_element = find_embedded_image(element, indices)
+            elements[idx] = clean_element
+            elements.insert(idx + 1, image_info)
 
     header: List[Element] = list()
     if include_headers:

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -46,10 +46,9 @@ def _parse_received_data(data: str) -> List[Element]:
     if mapi_id:
         elements.append(ReceivedInfo(name="mapi_id", text=mapi_id[0]))
     if datetimetz:
-        datetimetz_element = ReceivedInfo(name="received_datetimetz", text=str(datetimetz))
-        datetimetz_element.set_datestamp(datestamp=datetimetz)
-        elements.append(datetimetz_element)
-
+        elements.append(
+            ReceivedInfo(name="received_datetimetz", text=str(datetimetz), datestamp=datetimetz)
+        )
     return elements
 
 

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -46,11 +46,9 @@ def _parse_received_data(data: str) -> List[Element]:
     if mapi_id:
         elements.append(ReceivedInfo(name="mapi_id", text=mapi_id[0]))
     if datetimetz:
-        elements.append(
-            ReceivedInfo(name="received_datetimetz", text=str(datetimetz)).set_datestamp(
-                datestamp=datetimetz
-            )
-        )
+        datetimetz_element = ReceivedInfo(name="received_datetimetz", text=str(datetimetz))
+        datetimetz_element.set_datestamp(datestamp=datetimetz)
+        elements.append(datetimetz_element)
 
     return elements
 


### PR DESCRIPTION
The `_parse_received_data` function current returns `None` when the `datetimestamp` variable is set. This PR fixes this bug.