### PR TITLE
build(deps): bump `unstructured_inference` version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.4.1-dev0
+## 0.4.1
 
 * Added support for text files in the `partition` function
+* Pinned `opencv-python` for easier installation on Linux
 
 ## 0.4.0
 

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,6 @@ setup(
             "torch",
             "transformers",
         ],
-        "local-inference": ["unstructured-inference>=0.2.1"],
+        "local-inference": ["unstructured-inference>=0.2.3"],
     },
 )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.1-dev0"  # pragma: no cover
+__version__ = "0.4.1"  # pragma: no cover


### PR DESCRIPTION
### Summary 

Bumps `unstructured-inference` to pull in an `opencv-dependency` pin that is required to install `unstructured` on Linux.