### PR TITLE
fix: avoid divide by zero in `exceeds_cap_ratio`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3-dev0
+
+* Fix in `exceeds_cap_ratio` so the function doesn't break with empty text
+
 ## 0.4.2
 
 * Added `partition_image` to process documents in an image format.

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -135,6 +135,7 @@ def test_contains_verb(text, expected, monkeypatch):
         ("Intellectual Property in the United States", True),
         ("Intellectual property helps incentivize innovation.", False),
         ("THIS IS ALL CAPS. BUT IT IS TWO SENTENCES.", False),
+        ("", False),
     ],
 )
 def test_contains_exceeds_cap_ratio(text, expected, monkeypatch):

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.2"  # pragma: no cover
+__version__ = "0.4.3-dev0"  # pragma: no cover

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -119,6 +119,8 @@ def exceeds_cap_ratio(text: str, threshold: float = 0.3) -> bool:
         return False
 
     tokens = word_tokenize(text)
+    if len(tokens) == 0:
+        return False
     capitalized = sum([word.istitle() or word.isupper() for word in tokens])
     ratio = capitalized / len(tokens)
     return ratio > threshold


### PR DESCRIPTION
### Summarize

Closes #159. Fixes a divide by zero error that occurs in `exceeds_cap_ratio` if the input is empty.

### Testing

The following should return `False`.

```python
from unstructured.partition.text_type import exceeds_cap_ratio

exceeds_cap_ratio("")
```