### PR TITLE
fix: handle xml filetype detection on amazon linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.4
+## 0.4.4-dev3
 
 * Updated `partition_pdf` and `partition_image` to return `unstructured` `Element` objects
 * Fixed the healthcheck url path when partitioning images and PDFs via API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.4-dev2
+## 0.4.4
 
 * Updated `partition_pdf` and `partition_image` to return `unstructured` `Element` objects
 * Fixed the healthcheck url path when partitioning images and PDFs via API
@@ -6,6 +6,7 @@
 * Adds `FigureCaption` and `CheckBox` document elements
 * Added ability to split lists detected in `LayoutElement` objects
 * Adds `partition_pptx` for partitioning PowerPoint documents
+* Fixed file type detection for XML and HTML files on Amazone Linux
 
 ## 0.4.3
 

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -45,16 +45,19 @@ def test_detect_filetype_from_filename(file, expected):
         ("fake-text.txt", FileType.TXT),
         ("fake-email.eml", FileType.EML),
         ("factbook.xml", FileType.XML),
-        ("example-10k.html", FileType.XML),
+        # NOTE(robinson) - For the document, some operating systems return
+        # */xml and some return */html. Either could be acceptable depending on the OS
+        ("example-10k.html", [FileType.HTML, FileType.XML]),
         ("fake-html.html", FileType.HTML),
         ("fake-excel.xlsx", FileType.XLSX),
         ("fake-power-point.pptx", FileType.PPTX),
     ],
 )
 def test_detect_filetype_from_file(file, expected):
+    expected = expected if isinstance(expected, list) else [expected]
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, file)
     with open(filename, "rb") as f:
-        assert detect_filetype(file=f) == expected
+        assert detect_filetype(file=f) in expected
 
 
 def test_detect_xml_application_xml(monkeypatch):

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -57,6 +57,34 @@ def test_detect_filetype_from_file(file, expected):
         assert detect_filetype(file=f) == expected
 
 
+def test_detect_xml_application_xml(monkeypatch):
+    monkeypatch.setattr(magic, "from_file", lambda *args, **kwargs: "application/xml")
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.xml")
+    filetype = detect_filetype(filename=filename)
+    assert filetype == FileType.XML
+
+
+def test_detect_xml_text_xml(monkeypatch):
+    monkeypatch.setattr(magic, "from_file", lambda *args, **kwargs: "text/xml")
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.xml")
+    filetype = detect_filetype(filename=filename)
+    assert filetype == FileType.XML
+
+
+def test_detect_html_application_xml(monkeypatch):
+    monkeypatch.setattr(magic, "from_file", lambda *args, **kwargs: "application/xml")
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.html")
+    filetype = detect_filetype(filename=filename)
+    assert filetype == FileType.HTML
+
+
+def test_detect_html_text_xml(monkeypatch):
+    monkeypatch.setattr(magic, "from_file", lambda *args, **kwargs: "text/xml")
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.html")
+    filetype = detect_filetype(filename=filename)
+    assert filetype == FileType.HTML
+
+
 def test_detect_docx_filetype_application_octet_stream(monkeypatch):
     monkeypatch.setattr(magic, "from_buffer", lambda *args, **kwargs: "application/octet-stream")
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.docx")

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.4-dev2"  # pragma: no cover
+__version__ = "0.4.4"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.4"  # pragma: no cover
+__version__ = "0.4.4-dev3"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -153,7 +153,7 @@ def detect_filetype(
         else:
             return FileType.TXT
 
-    elif mime_type == "text/xml":
+    elif mime_type.endswith("xml"):
         if extension and extension == ".html":
             return FileType.HTML
         else:

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -121,7 +121,7 @@ def detect_filetype(
     elif file is not None:
         extension = None
         # NOTE(robinson) - the python-magic docs recommend reading at least the first 2048 bytes
-        # Increased to 4096 because otherwise .xlsx files get detected as a zip fle
+        # Increased to 4096 because otherwise .xlsx files get detected as a zip file
         # ref: https://github.com/ahupp/python-magic#usage
         mime_type = magic.from_buffer(file.read(4096), mime=True)
     else:


### PR DESCRIPTION
### Summary

Updates `detect_filetype` to properly detect `.xml` and `.html` files on Amazon Linux systems. On Amazon linux, the MIME type is `application/xml` instead of `text/xml`. The logic now treats any MIME type that ends in `.xml` as an XML file. Also updates the tests to account for different operating systems potentially returning different MIME types from buffer.

### Testing

Tests pass on an Amazon Linux instance.

![image](https://user-images.githubusercontent.com/1635179/214399637-24b44b9a-defe-4aff-ab20-fc1c003f235a.png)
