### PR TITLE
docs: add links to linkedin and slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@
 
 </div>
 
+<div>
+  <p align="center">
+  <a
+  href="https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-1nlh1ot5d-dfY7zCRlhFboZrIWLA4Qgw">
+    <img src="https://img.shields.io/badge/JOIN US ON SLACK-4A154B?style=for-the-badge&logo=slack&logoColor=white" />
+  </a>
+  <a href="https://www.linkedin.com/company/unstructuredio/">
+    <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" />
+  </a>
+</div>
+
 <div align="center">
 <img src="https://user-images.githubusercontent.com/38184042/205945013-99670127-0bf3-4851-b4ac-0bc23e357476.gif" title="unstructured in action!">
 </div>


### PR DESCRIPTION
### Summary

Adds links to the community Slack and our LinkedIn page to the README.

### Testing

Click the links to make sure they work.