### PR TITLE
fix: titles and narrative text need at least one english word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.5-dev1
+## 0.4.5-dev2
 
 * Loosen the default cap threshold to `0.5`.
 * Add a `NARRATIVE_TEXT_CAP_THRESHOLD` environment variable for controlling the cap ratio threshold.
@@ -7,7 +7,8 @@
   is insufficient to determine that the text is narrative.
 * Upper cased text is lower cased before checking for verbs. This helps avoid some missed verbs.
 * Adds an `Address` element for capturing elements that only contain an address.
-* Suppress the `UserWarning` when detectron is called
+* Suppress the `UserWarning` when detectron is called.
+* Checks that titles and narrative test have at least one English word.
 
 ## 0.4.4
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ install-huggingface:
 install-nltk-models:
 	python -c "import nltk; nltk.download('punkt')"
 	python -c "import nltk; nltk.download('averaged_perceptron_tagger')"
+	python -c "import nltk; nltk.download('words')"
 
 .PHONY: install-test
 install-test:

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -244,6 +244,7 @@ for consideration as narrative text. The function performs the following checks 
 * Empty text cannot be narrative text
 * Text that is all numeric cannot be narrative text
 * Text that does not contain a verb cannot be narrative text
+* Narrative text must contain at least one English word (if ``language`` is set to "en")
 * Text that exceeds the specified caps ratio cannot be narrative text. The threshold
   is configurable with the ``cap_threshold`` kwarg. To ignore this check, you can set
   ``cap_threshold=1.0``. You can also set the threshold by using the
@@ -279,6 +280,7 @@ for consideration as a title. The function performs the following checks:
 
 * Empty text cannot be a title
 * Text that is all numeric cannot be a title
+* Narrative text must contain at least one English word (if ``language`` is set to "en")
 * If a title contains more than one sentence that exceeds a certain length, it cannot be a title. Sentence length threshold is controlled by the ``sentence_min_length`` kwarg and defaults to 5.
 * If a segment of text ends in a comma, it is not considered a potential title. This is to avoid salutations like "To My Dearest Friends," getting flagged as titles.
 

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -140,6 +140,8 @@ def test_contains_verb(text, expected, monkeypatch):
         ("parrot beak", True),
         ("parrot!", True),
         ("daljdf adlfajldj ajadfa", False),
+        ("BTAR ADFJA L", False),
+        ("Unstructured Technologies", True),
     ],
 )
 def test_contains_english_word(text, expected, monkeypatch):

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -37,7 +37,8 @@ def test_headings_are_not_narrative_text(text, expected):
         ("Ask Me About Intellectual Property", False),  # Exceeds the cap threshold
         ("7", False),  # Fails because it is numeric
         ("intellectual property", False),  # Fails because it does not contain a verb
-        ("", False),  # Fails because it is empty
+        ("Dal;kdjfal adawels adfjwalsdf. Addad jaja fjawlek", False),
+        ("", False),  # Doesn't have english words  # Fails because it is empty
     ],
 )
 def test_is_possible_narrative_text(text, expected, monkeypatch):
@@ -60,6 +61,7 @@ def test_is_possible_narrative_text(text, expected, monkeypatch):
         ("", False),  # Fails because it is empty
         ("ITEM 1A. RISK FACTORS", True),  # Two "sentences", but both are short
         ("To My Dearest Friends,", False),  # Ends with a comma
+        ("BTAR ADFJA L", False),  # Doesn't have english words
     ],
 )
 def test_is_possible_title(text, expected, monkeypatch):
@@ -127,6 +129,21 @@ def test_is_bulletized_text(text, expected):
 )
 def test_contains_verb(text, expected, monkeypatch):
     has_verb = text_type.contains_verb(text)
+    assert has_verb is expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("PARROT BEAK", True),
+        ("Parrot Beak", True),
+        ("parrot beak", True),
+        ("parrot!", True),
+        ("daljdf adlfajldj ajadfa", False),
+    ],
+)
+def test_contains_english_word(text, expected, monkeypatch):
+    has_verb = text_type.contains_english_word(text)
     assert has_verb is expected
 
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.5-dev1"  # pragma: no cover
+__version__ = "0.4.5-dev2"  # pragma: no cover

--- a/unstructured/nlp/english_words.py
+++ b/unstructured/nlp/english_words.py
@@ -1,0 +1,7 @@
+from nltk.corpus import words as nltk_words
+
+ADDITIONAL_ENGLISH_WORDS = [
+    "unstructured",
+    "technologies",
+]
+ENGLISH_WORDS = nltk_words.words() + ADDITIONAL_ENGLISH_WORDS

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -10,6 +10,7 @@ else:
     from typing import Final
 
 from unstructured.cleaners.core import remove_punctuation
+from unstructured.nlp.english_words import ENGLISH_WORDS
 from unstructured.nlp.patterns import US_PHONE_NUMBERS_RE, UNICODE_BULLETS_RE, US_CITY_STATE_ZIP_RE
 from unstructured.nlp.tokenize import pos_tag, sent_tokenize, word_tokenize
 from unstructured.logger import logger
@@ -18,7 +19,7 @@ from unstructured.logger import logger
 POS_VERB_TAGS: Final[List[str]] = ["VB", "VBG", "VBD", "VBN", "VBP", "VBZ"]
 
 
-def is_possible_narrative_text(text: str, cap_threshold: float = 0.5) -> bool:
+def is_possible_narrative_text(text: str, cap_threshold: float = 0.5, language: str = "en") -> bool:
     """Checks to see if the text passes all of the checks for a narrative text section.
     You can change the cap threshold using the cap_threshold kwarg or the
     NARRATIVE_TEXT_CAP_THRESHOLD environment variable. The environment variable takes
@@ -30,6 +31,8 @@ def is_possible_narrative_text(text: str, cap_threshold: float = 0.5) -> bool:
         the input text
     cap_threshold
         the percentage of capitalized words necessary to disqualify the segment as narrative
+    language
+        the two letter language code for the text. defaults to "en" for English
     """
     if len(text) == 0:
         logger.debug("Not narrative. Text is empty.")
@@ -37,6 +40,9 @@ def is_possible_narrative_text(text: str, cap_threshold: float = 0.5) -> bool:
 
     if text.isnumeric():
         logger.debug(f"Not narrative. Text is all numeric:\n\n{text}")
+        return False
+
+    if language == "en" and not contains_english_word(text):
         return False
 
     # NOTE(robinson): it gets read in from the environment as a string so we need to
@@ -53,15 +59,17 @@ def is_possible_narrative_text(text: str, cap_threshold: float = 0.5) -> bool:
     return True
 
 
-def is_possible_title(text: str, sentence_min_length: int = 5) -> bool:
+def is_possible_title(text: str, sentence_min_length: int = 5, language: str = "en") -> bool:
     """Checks to see if the text passes all of the checks for a valid title.
 
     Parameters
     ----------
     text
         the input text
-    setence_min_length
+    sentence_min_length
         the minimum number of words required to consider a section of text a sentence
+    language
+        the two letter language code for the text. defaults to "en" for English
     """
     if len(text) == 0:
         logger.debug("Not a title. Text is empty.")
@@ -69,6 +77,9 @@ def is_possible_title(text: str, sentence_min_length: int = 5) -> bool:
 
     # NOTE(robinson) - Prevent flagging salutations like "To My Dearest Friends," as titles
     if text.endswith(","):
+        return False
+
+    if language == "en" and not contains_english_word(text):
         return False
 
     if text.isnumeric():
@@ -110,6 +121,19 @@ def contains_verb(text: str) -> bool:
     for _, tag in pos_tags:
         if tag in POS_VERB_TAGS:
             return True
+    return False
+
+
+def contains_english_word(text: str) -> bool:
+    """Checks to see if the text contains an English word."""
+    text = text.lower()
+    words = text.split(" ")
+    for word in words:
+        # NOTE(robinson) - to ignore punctuation at the ends of words like "best."
+        word = "".join([character for character in word if character.isalpha()])
+        if word in ENGLISH_WORDS:
+            return True
+
     return False
 
 

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -131,7 +131,7 @@ def contains_english_word(text: str) -> bool:
     for word in words:
         # NOTE(robinson) - to ignore punctuation at the ends of words like "best."
         word = "".join([character for character in word if character.isalpha()])
-        if word in ENGLISH_WORDS:
+        if len(word) > 1 and word in ENGLISH_WORDS:
             return True
 
     return False


### PR DESCRIPTION
### Summary

Adds a check that requires narrative text and titles to have at least one English words. Prevents office symbols like `ASDF-JQL` and similar items from being flagged as titles.

### Testing

```python
from unstructured.partition.text_type import is_possible_narrative_text, is_possible_title

is_possible_title("PARROT BEAK") # should be True
is_possible_title("ASDF-JQL") # should be False

is_possible_narrative_text("The parrot is squawking!") # should be True
is_possible_narrative_text("ASDJ JQL; QWER. TUSP AHSAD.") # should be False
```