### PR TITLE
fix: preserve the order of shapes in `partition_pptx` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.5-dev5
+## 0.4.6
 
 * Loosen the default cap threshold to `0.5`.
 * Add a `UNSTRUCTURED_NARRATIVE_TEXT_CAP_THRESHOLD` environment variable for controlling
@@ -13,6 +13,7 @@
 * Checks that titles and narrative text are at least 50% alpha characters.
 * Restricts titles to a maximum word length. Adds a `UNSTRUCTURED_TITLE_MAX_WORD_LENGTH`
   environment variable for controlling the max number of words in a title.
+* Updated `partition_pptx` to order the elementso n the page
 
 ## 0.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Checks that titles and narrative text are at least 50% alpha characters.
 * Restricts titles to a maximum word length. Adds a `UNSTRUCTURED_TITLE_MAX_WORD_LENGTH`
   environment variable for controlling the max number of words in a title.
-* Updated `partition_pptx` to order the elementso n the page
+* Updated `partition_pptx` to order the elements on the page
 
 ## 0.4.4
 

--- a/test_unstructured/partition/test_pptx.py
+++ b/test_unstructured/partition/test_pptx.py
@@ -5,7 +5,7 @@ import pytest
 import pptx
 
 from unstructured.partition.pptx import partition_pptx
-from unstructured.documents.elements import ListItem, NarrativeText, Title
+from unstructured.documents.elements import ListItem, NarrativeText, Text, Title
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 EXAMPLE_DOCS_DIRECTORY = os.path.join(DIRECTORY, "..", "..", "example-docs")
@@ -57,21 +57,33 @@ def test_partition_pptx_orders_elements(tmpdir):
     tf = txBox.text_frame
     tf.text = "This is lower and should come second"
 
-    width = height = pptx.util.Inches(1)
-    left = top = pptx.util.Inches(-1)
+    left = top = width = height = pptx.util.Inches(1)
+    left = top = pptx.util.Inches(-10)
     txBox = slide.shapes.add_textbox(left, top, width, height)
     tf = txBox.text_frame
     tf.text = "This is off the page and shouldn't appear"
+
+    left = top = width = height = pptx.util.Inches(2)
+    txBox = slide.shapes.add_textbox(left, top, width, height)
+    tf = txBox.text_frame
+    tf.text = ""
 
     left = top = width = height = pptx.util.Inches(1)
     txBox = slide.shapes.add_textbox(left, top, width, height)
     tf = txBox.text_frame
     tf.text = "This is higher and should come first"
 
+    top = width = height = pptx.util.Inches(1)
+    left = pptx.util.Inches(0.5)
+    txBox = slide.shapes.add_textbox(left, top, width, height)
+    tf = txBox.text_frame
+    tf.text = "-------------TOP-------------"
+
     presentation.save(filename)
 
     elements = partition_pptx(filename=filename)
     assert elements == [
+        Text("-------------TOP-------------"),
         NarrativeText("This is higher and should come first"),
         NarrativeText("This is lower and should come second"),
     ]

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.5-dev5"  # pragma: no cover
+__version__ = "0.4.6"  # pragma: no cover

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -34,7 +34,7 @@ def partition_pptx(filename: Optional[str] = None, file: Optional[IO] = None) ->
         raise ValueError("Only one of filename or file can be specified.")
 
     elements: List[Element] = list()
-    for i, slide in enumerate(presentation.slides):
+    for slide in presentation.slides:
         for shape in _order_shapes(slide.shapes):
             # NOTE(robinson) - we don't deal with tables yet, but so future humans can find
             # it again, here are docs on how to deal with tables. The check for tables should


### PR DESCRIPTION
### Summary

Orders the elements extracted from `.pptx` files based on their position on the page. Proceeds from top to bottom and left to right. Previously the elements were not in the correct order.

### Testing

Run the following using the filename Matt provides you. The outputs should go top to bottom and left to right based on the position of the shapes.

```python
from unstructured.partition.auto import partition

partition(filename=filename)
```