### PR TITLE
feat: `partition_html` directly from a url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.7-dev1
 
-* Added the ability to pull and HTML document from a url in `partition_html`.
+* Added the ability to pull an HTML document from a url in `partition_html`.
 
 ## 0.4.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.4.7-dev0
+## 0.4.7-dev1
+
+* Added the ability to pull and HTML document from a url in `partition_html`.
 
 ## 0.4.6
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -11,6 +11,7 @@ pytest-cov
 # issue to address
 # ref: https://github.com/Unstructured-IO/unstructured/issues/200
 label_studio_sdk==0.0.17
+types-requests
 vcrpy
 
 # NOTE(robinson) - The following pins are to address

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -78,6 +78,10 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
+types-requests==2.28.11.8
+    # via -r requirements/test.in
+types-urllib3==1.26.25.4
+    # via types-requests
 typing-extensions==4.4.0
     # via
     #   black

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.7-dev0"  # pragma: no cover
+__version__ = "0.4.7-dev1"  # pragma: no cover

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -1,11 +1,16 @@
 from typing import IO, List, Optional
 
+import requests
+
 from unstructured.documents.elements import Element
 from unstructured.documents.html import HTMLDocument
 
 
 def partition_html(
-    filename: Optional[str] = None, file: Optional[IO] = None, text: Optional[str] = None
+    filename: Optional[str] = None,
+    file: Optional[IO] = None,
+    text: Optional[str] = None,
+    url: Optional[str] = None,
 ) -> List[Element]:
     """Partitions an HTML document into its constituent elements.
 
@@ -17,15 +22,17 @@ def partition_html(
         A file-like object using "r" mode --> open(filename, "r").
     text
         The string representation of the HTML document.
+    url
+        The URL of a webpage to parse. Only for URLs that return an HTML document.
     """
-    if not any([filename, file, text]):
+    if not any([filename, file, text, url]):
         raise ValueError("One of filename, file, or text must be specified.")
 
-    if filename is not None and not file and not text:
+    if filename is not None and not file and not text and not url:
         document = HTMLDocument.from_file(filename)
         elements = document.elements
 
-    elif file is not None and not filename and not text:
+    elif file is not None and not filename and not text and not url:
         file_content = file.read()
         if isinstance(file_content, bytes):
             file_text = file_content.decode("utf-8")
@@ -35,9 +42,21 @@ def partition_html(
         document = HTMLDocument.from_string(file_text)
         elements = document.elements
 
-    elif text is not None and not filename and not file:
+    elif text is not None and not filename and not file and not url:
         _text: str = str(text)
         document = HTMLDocument.from_string(_text)
+        elements = document.elements
+
+    elif url is not None and not filename and not file and not text:
+        response = requests.get(url)
+        if not response.ok:
+            raise ValueError(f"URL return an error: {response.status_code} {response.text}")
+
+        content_type = response.headers.get("Content-Type", "")
+        if not content_type.startswith("text/html"):
+            raise ValueError(f"Expected content type text/html. Got {content_type}.")
+
+        document = HTMLDocument.from_string(response.text)
         elements = document.elements
 
     else:


### PR DESCRIPTION
### Summary

Adds the ability to pass a URL into the `partition_html` function. Will raise an error if the status code is bad, or if the content type is not `text/html`.

### Testing

```python
from unstructured.partition.html import partition_html

elements = partition_html(url="https://www.understandingwar.org/backgrounder/russian-offensive-campaign-update-february-5-2023")
```