### PR TITLE
docs: update the link for colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To install the library, run `pip install unstructured`.
 
 ## :clap: Quick Tour
 
-You can run this [Colab notebook](https://colab.research.google.com/drive/1RnXEiSTUaru8vZSGbh1U2T2P9aUa5tQD#scrollTo=E_WN7p3JGcLJ) to run the examples below.
+You can run this [Colab notebook](https://colab.research.google.com/drive/1U8VCjY2-x8c6y5TYMbSFtQGlQVFHCVIW) to run the examples below.
 
 The following examples show how to get started with the `unstructured` library.
 You can parse **TXT**, **HTML**, **PDF**, **EML** and **DOCX** documents with one line of code!


### PR DESCRIPTION
Colab Notebooks have been moved and updated. This PR updates the link for [`Unstructured_Quick_Tour.ipynb`](https://colab.research.google.com/drive/1U8VCjY2-x8c6y5TYMbSFtQGlQVFHCVIW) in the README.md