### PR TITLE
fix: remove response text when the HTML status code is an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.7-dev4
+## 0.4.7
 
 * Added the ability to pull an HTML document from a url in `partition_html`.
 * Added the the ability to get file summary info from lists of filenames and lists

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.7-dev4"  # pragma: no cover
+__version__ = "0.4.7"  # pragma: no cover

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -51,7 +51,7 @@ def partition_html(
     elif url is not None and not filename and not file and not text:
         response = requests.get(url)
         if not response.ok:
-            raise ValueError(f"URL return an error: {response.status_code} {response.text}")
+            raise ValueError(f"URL return an error: {response.status_code}")
 
         content_type = response.headers.get("Content-Type", "")
         if not content_type.startswith("text/html"):


### PR DESCRIPTION
### Summary

Removes the response text from the exception if the HTML status code is an error. The error message is too long if it's a 404 html page. Also bumps the version for the `0.4.7` release.