### PR TITLE
docs: add info about os dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ To install the library, run `pip install unstructured`.
 
 * Run `make install-project-local`
 
+* Optional
+  * For processing image files, `tesseract` is required. See [here](https://tesseract-ocr.github.io/tessdoc/Installation.html) for installation instructions.
+  * For processing PDF files, `tesseract` and `poppler` are required. The [pdf2image docs](https://pdf2image.readthedocs.io/en/latest/installation.html) have instructions on installing `poppler` across various platforms.
+
 ## :clap: Quick Tour
 
 You can run this [Colab notebook](https://colab.research.google.com/drive/1U8VCjY2-x8c6y5TYMbSFtQGlQVFHCVIW) to run the examples below.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To install the library, run `pip install unstructured`.
 
 * Run `make install-project-local`
 
-* Optional
+* Optional:
   * For processing image files, `tesseract` is required. See [here](https://tesseract-ocr.github.io/tessdoc/Installation.html) for installation instructions.
   * For processing PDF files, `tesseract` and `poppler` are required. The [pdf2image docs](https://pdf2image.readthedocs.io/en/latest/installation.html) have instructions on installing `poppler` across various platforms.
 


### PR DESCRIPTION
Added information about OS dependencies `poppler` and `tesseract`.