### PR TITLE
chore: default to local inference for `partition_pdf` and `partition_image`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.4.9-dev0
+## 0.4.9-dev1
 
 * Added ingest modules and s3 connector
+* Default to `url=None` for `partition_pdf` and `partition_image`
 
 ## 0.4.8
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -142,7 +142,7 @@ Examples:
   from unstructured.partition.pdf import partition_pdf
 
   # Returns a List[Element] present in the pages of the parsed pdf document
-  elements = partition_pdf("example-docs/layout-parser-paper-fast.pdf", url=None)
+  elements = partition_pdf("example-docs/layout-parser-paper-fast.pdf")
 
 
 ``partition_image``
@@ -159,7 +159,7 @@ Examples:
   from unstructured.partition.image import partition_image
 
   # Returns a List[Element] present in the pages of the parsed image document
-  elements = partition_image("example-docs/layout-parser-paper-fast.jpg", url=None)
+  elements = partition_image("example-docs/layout-parser-paper-fast.jpg")
 
 
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.9-dev0"  # pragma: no cover
+__version__ = "0.4.9-dev1"  # pragma: no cover

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -7,7 +7,7 @@ from unstructured.partition.pdf import partition_pdf_or_image
 def partition_image(
     filename: str = "",
     file: Optional[bytes] = None,
-    url: Optional[str] = "https://ml.unstructured.io/",
+    url: Optional[str] = None,
     template: Optional[str] = None,
     token: Optional[str] = None,
     include_page_breaks: bool = False,

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -9,7 +9,7 @@ from unstructured.partition.common import normalize_layout_element, document_to_
 def partition_pdf(
     filename: str = "",
     file: Optional[bytes] = None,
-    url: Optional[str] = "https://ml.unstructured.io/",
+    url: Optional[str] = None,
     template: Optional[str] = None,
     token: Optional[str] = None,
     include_page_breaks: bool = False,


### PR DESCRIPTION
### Summary

Updates `partition_pdf` and `partition_image` to use local inference by default since the hosted model inference endpoint is no longer running and most of our users are running inference locally.

### Testing

The following snippets should run in local inference mode (if they run at all at the moment, that means the changes work).

```python
 from unstructured.partition.pdf import partition_pdf
 elements = partition_pdf("example-docs/layout-parser-paper-fast.pdf")
```