### PR TITLE
fix: `ElementMetadata` serializes when the filename is a `Path` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.10
+
+* Fixes `ElementMetadata` so that it's JSON serializable when the filename is a `Path` object.
+
 ## 0.4.9
 
 * Added ingest modules and s3 connector

--- a/test_unstructured/staging/test_base_staging.py
+++ b/test_unstructured/staging/test_base_staging.py
@@ -1,12 +1,14 @@
 import csv
+import json
 import os
+import pathlib
 import pytest
 
 import pandas as pd
 
 import unstructured.staging.base as base
 
-from unstructured.documents.elements import Title, NarrativeText, ListItem
+from unstructured.documents.elements import ElementMetadata, Title, NarrativeText, ListItem
 
 
 @pytest.fixture
@@ -64,3 +66,14 @@ def test_convert_to_dataframe():
     )
     assert df.type.equals(expected_df.type) is True
     assert df.text.equals(expected_df.text) is True
+
+
+def test_convert_to_isd_serializes_with_posix_paths():
+    metadata = ElementMetadata(filename=pathlib.PosixPath("../../fake-file.txt"))
+    elements = [
+        Title(text="Title 1", metadata=metadata),
+        NarrativeText(text="Narrative 1", metadata=metadata),
+    ]
+    output = base.convert_to_isd(elements)
+    # NOTE(robinson) - json.dumps should run without raising an exception
+    json.dumps(output)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.9"  # pragma: no cover
+__version__ = "0.4.10"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -2,6 +2,7 @@ from abc import ABC
 from dataclasses import dataclass
 import hashlib
 from typing import Callable, List, Optional, Union
+import pathlib
 
 
 class NoID(ABC):
@@ -15,6 +16,10 @@ class ElementMetadata:
     filename: Optional[str] = None
     page_number: Optional[int] = None
     url: Optional[str] = None
+
+    def __post_init__(self):
+        if isinstance(self.filename, pathlib.Path):
+            self.filename = str(self.filename)
 
     def to_dict(self):
         return {key: value for key, value in self.__dict__.items() if value is not None}


### PR DESCRIPTION
### Summary

Closes #232. Ensures ISD dictionaries are JSON serializable when the filename is a `Path` object.

### Testing

The following code should work. Previously you'd get a `JSONDecode` error.

```python
    import pathlib
    import json

    from unstructured.documents.elements import ElementMetadata, Title, NarrativeText
    from unstructured.staging.base import convert_to_isd
    

    metadata = ElementMetadata(filename=pathlib.PosixPath("../../fake-file.txt"))
    elements = [
        Title(text="Title 1", metadata=metadata),
        NarrativeText(text="Narrative 1", metadata=metadata),
    ]
    output = convert_to_isd(elements)
    json.dumps(output)
```