### PR TITLE
docs: add quotes to `unstructured[local-inference]` install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ about. Bricks in the library fall into three categories:
 Use the following instructions to get up and running with `unstructured` and test your
 installation.
 
-- Install the Python SDK with `pip install unstructured[local-inference]`
+- Install the Python SDK with `pip install "unstructured[local-inference]"`
 		- If you do not need to process PDFs or images, you can run `pip install unstructured`
 - Install the following system dependencies if they are not already available on your system.
   Depending on what document types you're parsing, you may not need all of these.

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -7,8 +7,8 @@ Quick Start
 Use the following instructions to get up and running with ``unstructured`` and test your
 installation.
 
-* Install the Python SDK with ``pip install unstructured[local-inference]``
-  * If you do not need to process PDFs or images, you can run ``pip install unstructured``
+* Install the Python SDK with ``"pip install unstructured[local-inference]"``
+	* If you do not need to process PDFs or images, you can run ``pip install unstructured``
 
 * Install the following system dependencies if they are not already available on your system. Depending on what document types you're parsing, you may not need all of these.
 	* ``libmagic-dev`` (filetype detection)


### PR DESCRIPTION
### Summary

Corrects the install instruction for local inference to `pip install "unstructured[local-inference]"`