### PR TITLE
refactor: break up logic from one line to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.4.12-dev0
+## 0.4.12-dev1
 
-* Adds console_entrypoint for unstructured-ingest
+* Adds console_entrypoint for unstructured-ingest and more structure/docs related to ingest.
 
 ## 0.4.11
 

--- a/unstructured/ingest/doc_processor/generalized.py
+++ b/unstructured/ingest/doc_processor/generalized.py
@@ -28,7 +28,8 @@ def process_document(doc):
         # accessing the .filename property could lazily call .get_file(), but
         # keeping them as two distinct calls for end-user transparency for now
         print(f"Processing {doc.filename}")
-        isd_elems = convert_to_isd(partition(filename=doc.filename))
+        elements = partition(filename=doc.filename)
+        isd_elems = convert_to_isd(elements)
 
         isd_elems_no_filename = []
         for elem in isd_elems:

--- a/unstructured/ingest/doc_processor/generalized.py
+++ b/unstructured/ingest/doc_processor/generalized.py
@@ -28,7 +28,9 @@ def process_document(doc):
         # accessing the .filename property could lazily call .get_file(), but
         # keeping them as two distinct calls for end-user transparency for now
         print(f"Processing {doc.filename}")
+
         elements = partition(filename=doc.filename)
+
         isd_elems = convert_to_isd(elements)
 
         isd_elems_no_filename = []


### PR DESCRIPTION
Separate `elements` out into separate variable to more naturally allow for conditional logic based on the instance type of the `doc` (or other properties).

E.g.

```
elements = partition(filename=doc.filename)
if isinstance(doc, SubstackIngestDoc):
    from unstructured.ingests.doc_processor import substack
    elements = substack.process_html_elements(elements)
```