### PR TITLE
fix: Adds missing __init__.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.13
+
+* Fixes unstructured-ingest cli.
+
 ## 0.4.12
 
 * Adds console_entrypoint for unstructured-ingest, other structure/doc updates related to ingest.

--- a/Ingest.md
+++ b/Ingest.md
@@ -20,6 +20,8 @@ Installation note: make sure to install the following extras when installing uns
 
     pip install "unstructured[s3,local-inference]"
 
+See the [Quick Start](https://github.com/Unstructured-IO/unstructured#eight_pointed_black_star-quick-start) which documents how to pip install `dectectron2` and other OS dependencies, necessary for the parsing of .PDF files.
+
 # Developers' Guide
 
 ## Local testing

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.12"  # pragma: no cover
+__version__ = "0.4.13"  # pragma: no cover


### PR DESCRIPTION
Fixes an issue where the packaged CLI `unstructured-ingest` was failing due to:

    ModuleNotFoundError: No module named 'unstructured.ingest'

Also updates the Ingest documentation to make clear that detectron and other OS dependencies are needed when processing PDF's.

Tested locally in a fresh virtual env where the `unstructured` package was installed from the local checkout with `pip install -e .`