### PR TITLE
Resolve various style issues to improve overall code quality

### DIFF
--- a/examples/sec-sentiment-analysis/fetch.py
+++ b/examples/sec-sentiment-analysis/fetch.py
@@ -2,10 +2,10 @@
 import json
 import os
 import re
-import requests
-from typing import Final, List, Optional, Tuple, Union
 import webbrowser
+from typing import Final, List, Optional, Tuple, Union
 
+import requests
 from ratelimit import limits, sleep_and_retry
 
 SEC_ARCHIVE_URL: Final[str] = "https://www.sec.gov/Archives/edgar/data"

--- a/examples/sec-sentiment-analysis/fetch.py
+++ b/examples/sec-sentiment-analysis/fetch.py
@@ -23,7 +23,7 @@ VALID_FILING_TYPES: Final[List[str]] = [
 
 
 def get_filing(
-    cik: Union[str, int], accession_number: Union[str, int], company: str, email: str
+    cik: Union[str, int], accession_number: Union[str, int], company: str, email: str,
 ) -> str:
     """Fetches the specified filing from the SEC EDGAR Archives. Conforms to the rate
     limits specified on the SEC website.
@@ -35,7 +35,7 @@ def get_filing(
 @sleep_and_retry
 @limits(calls=10, period=1)
 def _get_filing(
-    session: requests.Session, cik: Union[str, int], accession_number: Union[str, int]
+    session: requests.Session, cik: Union[str, int], accession_number: Union[str, int],
 ) -> str:
     """Wrapped so filings can be retrieved with an existing session."""
     url = archive_url(cik, accession_number)
@@ -70,7 +70,7 @@ def get_forms_by_cik(session: requests.Session, cik: Union[str, int]) -> dict:
 
 
 def _get_recent_acc_num_by_cik(
-    session: requests.Session, cik: Union[str, int], form_types: List[str]
+    session: requests.Session, cik: Union[str, int], form_types: List[str],
 ) -> Tuple[str, str]:
     """Returns accession number and form type for the most recent filing for one of the
     given form_types (AKA filing types) for a given cik."""
@@ -120,7 +120,7 @@ def get_form_by_ticker(
     session = _get_session(company, email)
     cik = get_cik_by_ticker(session, ticker)
     return get_form_by_cik(
-        cik, form_type, allow_amended_filing=allow_amended_filing, company=company, email=email
+        cik, form_type, allow_amended_filing=allow_amended_filing, company=company, email=email,
     )
 
 
@@ -148,7 +148,7 @@ def get_form_by_cik(
     """
     session = _get_session(company, email)
     acc_num, _ = _get_recent_acc_num_by_cik(
-        session, cik, _form_types(form_type, allow_amended_filing)
+        session, cik, _form_types(form_type, allow_amended_filing),
     )
     text = _get_filing(session, cik, acc_num)
     return text
@@ -173,7 +173,7 @@ def open_form_by_ticker(
     session = _get_session(company, email)
     cik = get_cik_by_ticker(session, ticker)
     acc_num, _ = _get_recent_acc_num_by_cik(
-        session, cik, _form_types(form_type, allow_amended_filing)
+        session, cik, _form_types(form_type, allow_amended_filing),
     )
     open_form(cik, acc_num)
 
@@ -219,7 +219,7 @@ def _get_session(company: Optional[str] = None, email: Optional[str] = None) -> 
         {
             "User-Agent": f"{company} {email}",
             "Content-Type": "text/html",
-        }
+        },
     )
     return session
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from unstructured.__version__ import __version__
 setup(
     name="unstructured",
     description="A library that prepares raw documents for downstream ML tasks.",
-    long_description=open("README.md", "r", encoding="utf-8").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     keywords="NLP PDF HTML CV XML parsing preprocessing",
     url="https://github.com/Unstructured-IO/unstructured",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 from unstructured.__version__ import __version__
 

--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -145,7 +145,15 @@ def test_clean_postfix(text, pattern, ignore_case, strip, expected):
 
 @pytest.mark.parametrize(
     # NOTE(yuming): Tests combined cleaners
-    ("text", "extra_whitespace", "dashes", "bullets", "lowercase", "trailing_punctuation", "expected"),
+    (
+        "text",
+        "extra_whitespace",
+        "dashes",
+        "bullets",
+        "lowercase",
+        "trailing_punctuation",
+        "expected",
+    ),
     [
         ("  Risk-factors ", True, True, False, False, False, "Risk factors"),
         ("● Point!  ●●● ", True, False, True, False, False, "Point! ●●●"),

--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -4,7 +4,7 @@ import unstructured.cleaners.core as core
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("● An excellent point!", "An excellent point!"),
         ("● An excellent point! ●●●", "An excellent point! ●●●"),
@@ -18,7 +18,7 @@ def test_clean_bullets(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("1. Introduction:", "Introduction:"),
         ("a. Introduction:", "Introduction:"),
@@ -43,7 +43,7 @@ def test_clean_ordered_bullets(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("\x93A lovely quote!\x94", "“A lovely quote!”"),
         ("\x91A lovely quote!\x92", "‘A lovely quote!’"),
@@ -55,7 +55,7 @@ def test_replace_unicode_quotes(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [("5 w=E2=80=99s", "5 w’s")],
 )
 def test_replace_mime_encodings(text, expected):
@@ -63,7 +63,7 @@ def test_replace_mime_encodings(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("“A lovely quote!”", "A lovely quote"),
         ("‘A lovely quote!’", "A lovely quote"),
@@ -75,7 +75,7 @@ def test_remove_punctuation(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("RISK\n\nFACTORS", "RISK FACTORS"),
         ("Item\xa01A", "Item 1A"),
@@ -89,7 +89,7 @@ def test_clean_extra_whitespace(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("Risk-factors", "Risk factors"),
         ("Risk – factors", "Risk   factors"),
@@ -103,7 +103,7 @@ def test_clean_dashes(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("Item 1A:", "Item 1A"),
         ("Item 1A;", "Item 1A"),
@@ -118,7 +118,7 @@ def test_clean_trailing_punctuation(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, pattern, ignore_case, strip, expected",
+    ("text", "pattern", "ignore_case", "strip", "expected"),
     [
         ("SUMMARY: A great SUMMARY", r"(SUMMARY|DESC):", False, True, "A great SUMMARY"),
         ("DESC: A great SUMMARY", r"(SUMMARY|DESC):", False, True, "A great SUMMARY"),
@@ -131,7 +131,7 @@ def test_clean_prefix(text, pattern, ignore_case, strip, expected):
 
 
 @pytest.mark.parametrize(
-    "text, pattern, ignore_case, strip, expected",
+    ("text", "pattern", "ignore_case", "strip", "expected"),
     [
         ("The END! END", r"(END|STOP)", False, True, "The END!"),
         ("The END! STOP", r"(END|STOP)", False, True, "The END!"),
@@ -145,7 +145,7 @@ def test_clean_postfix(text, pattern, ignore_case, strip, expected):
 
 @pytest.mark.parametrize(
     # NOTE(yuming): Tests combined cleaners
-    "text, extra_whitespace, dashes, bullets, lowercase, trailing_punctuation, expected",
+    ("text", "extra_whitespace", "dashes", "bullets", "lowercase", "trailing_punctuation", "expected"),
     [
         ("  Risk-factors ", True, True, False, False, False, "Risk factors"),
         ("● Point!  ●●● ", True, False, True, False, False, "Point! ●●●"),

--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -1,6 +1,6 @@
 import pytest
 
-import unstructured.cleaners.core as core
+from unstructured.cleaners import core
 
 
 @pytest.mark.parametrize(

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -1,5 +1,6 @@
-import pytest
 import datetime
+
+import pytest
 
 import unstructured.cleaners.extract as extract
 

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-import unstructured.cleaners.extract as extract
+from unstructured.cleaners import extract
 
 EMAIL_META_DATA_INPUT = """from ABC.DEF.local ([ba23::58b5:2236:45g2:88h2]) by
     \n ABC.DEF.local ([ba23::58b5:2236:45g2:88h2%25]) with mapi id\

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -54,7 +54,7 @@ def test_extract_mapi_id():
 
 def test_extract_datetimetz():
     assert extract.extract_datetimetz(EMAIL_META_DATA_INPUT) == datetime.datetime(
-        2021, 3, 26, 11, 4, 9, tzinfo=datetime.timezone(datetime.timedelta(seconds=43200))
+        2021, 3, 26, 11, 4, 9, tzinfo=datetime.timezone(datetime.timedelta(seconds=43200)),
     )
 
 

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -54,7 +54,13 @@ def test_extract_mapi_id():
 
 def test_extract_datetimetz():
     assert extract.extract_datetimetz(EMAIL_META_DATA_INPUT) == datetime.datetime(
-        2021, 3, 26, 11, 4, 9, tzinfo=datetime.timezone(datetime.timedelta(seconds=43200)),
+        2021,
+        3,
+        26,
+        11,
+        4,
+        9,
+        tzinfo=datetime.timezone(datetime.timedelta(seconds=43200)),
     )
 
 

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -59,7 +59,7 @@ def test_extract_datetimetz():
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("215-867-5309", "215-867-5309"),
         ("Phone Number: +1 215.867.5309", "+1 215.867.5309"),
@@ -72,7 +72,7 @@ def test_extract_us_phone_number(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("1. Introduction:", ("1", None, None)),
         ("a. Introduction:", ("a", None, None)),

--- a/test_unstructured/cleaners/test_translate.py
+++ b/test_unstructured/cleaners/test_translate.py
@@ -1,6 +1,6 @@
 import pytest
 
-import unstructured.cleaners.translate as translate
+from unstructured.cleaners import translate
 
 
 def test_get_opus_mt_model_name():

--- a/test_unstructured/documents/test_base.py
+++ b/test_unstructured/documents/test_base.py
@@ -1,4 +1,5 @@
 import pytest
+
 from unstructured.documents.base import Document, Page
 from unstructured.documents.elements import NarrativeText, Title
 

--- a/test_unstructured/documents/test_elements.py
+++ b/test_unstructured/documents/test_elements.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 import pytest
 
 from unstructured.cleaners.core import clean_prefix

--- a/test_unstructured/documents/test_email_elements.py
+++ b/test_unstructured/documents/test_email_elements.py
@@ -30,7 +30,7 @@ def test_name_element_apply_multiple_cleaners():
         partial(translate_text, target_lang="ru"),
     ]
     name_element = Name(
-        name="[1] A Textbook on Crocodile Habitats", text="[1] A Textbook on Crocodile Habitats"
+        name="[1] A Textbook on Crocodile Habitats", text="[1] A Textbook on Crocodile Habitats",
     )
     name_element.apply(*cleaners)
     assert (

--- a/test_unstructured/documents/test_email_elements.py
+++ b/test_unstructured/documents/test_email_elements.py
@@ -1,9 +1,10 @@
 from functools import partial
+
 import pytest
 
 from unstructured.cleaners.core import clean_prefix
 from unstructured.cleaners.translate import translate_text
-from unstructured.documents.email_elements import EmailElement, NoID, Name
+from unstructured.documents.email_elements import EmailElement, Name, NoID
 
 
 def test_text_id():

--- a/test_unstructured/documents/test_email_elements.py
+++ b/test_unstructured/documents/test_email_elements.py
@@ -30,7 +30,8 @@ def test_name_element_apply_multiple_cleaners():
         partial(translate_text, target_lang="ru"),
     ]
     name_element = Name(
-        name="[1] A Textbook on Crocodile Habitats", text="[1] A Textbook on Crocodile Habitats",
+        name="[1] A Textbook on Crocodile Habitats",
+        text="[1] A Textbook on Crocodile Habitats",
     )
     name_element.apply(*cleaners)
     assert (

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from lxml import etree
 
-import unstructured.documents.html as html
+from unstructured.documents import html
 from unstructured.documents.base import Page
 from unstructured.documents.elements import (
     Address,

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -48,12 +48,12 @@ def sample_doc():
         tag="p",
         ancestortags=("table", "tbody", "tr", "td"),
     )
-    narrative = HTMLNarrativeText("I'm some narrative text", tag="p", ancestortags=tuple())
+    narrative = HTMLNarrativeText("I'm some narrative text", tag="p", ancestortags=())
     page1 = Page(0)
     page1.elements = [table_element, narrative]
-    header = HTMLTitle("I'm a header", tag="header", ancestortags=tuple())
-    body = HTMLNarrativeText("Body text", tag="p", ancestortags=tuple())
-    footer = HTMLTitle("I'm a footer", tag="footer", ancestortags=tuple())
+    header = HTMLTitle("I'm a header", tag="header", ancestortags=())
+    body = HTMLNarrativeText("Body text", tag="p", ancestortags=())
+    footer = HTMLTitle("I'm a footer", tag="footer", ancestortags=())
     page2 = Page(1)
     page2.elements = [header, body, footer]
     doc = HTMLDocument.from_pages([page1, page2])

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -41,7 +41,7 @@ INCLUDED_TAGS = TEXT_TAGS + HEADING_TAGS + LIST_ITEM_TAGS + ["div"]
 EXCLUDED_TAGS = "tag", [tag for tag in TAGS if tag not in INCLUDED_TAGS]
 
 
-@pytest.fixture
+@pytest.fixture()
 def sample_doc():
     table_element = HTMLTitle(
         "I'm a title in a table.",
@@ -120,7 +120,7 @@ def test_read_without_skipping_table(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "doc, expected",
+    ("doc", "expected"),
     [
         (
             "<p>Hi there <span>my name is</span> <b><i>Matt</i></i></p>",

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -1,22 +1,27 @@
 import os
 
-from lxml import etree
 import pytest
+from lxml import etree
 
+import unstructured.documents.html as html
 from unstructured.documents.base import Page
-from unstructured.documents.elements import Address, ListItem, NarrativeText, Text, Title
+from unstructured.documents.elements import (
+    Address,
+    ListItem,
+    NarrativeText,
+    Text,
+    Title,
+)
 from unstructured.documents.html import (
+    HEADING_TAGS,
     LIST_ITEM_TAGS,
+    TABLE_TAGS,
+    TEXT_TAGS,
     HTMLDocument,
     HTMLNarrativeText,
     HTMLTitle,
-    TEXT_TAGS,
-    TABLE_TAGS,
-    HEADING_TAGS,
     TagsMixin,
 )
-import unstructured.documents.html as html
-
 
 TAGS = (
     "<a><abbr><acronym><address><applet><area><article><aside><audio><b><base><basefont><bdi>"

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -314,7 +314,7 @@ def test_read_html_doc(tmpdir, monkeypatch):
         f.write(doc)
 
     html_document = HTMLDocument.from_file(filename=filename).doc_after_cleaners(
-        skip_headers_and_footers=True, skip_table_text=True
+        skip_headers_and_footers=True, skip_table_text=True,
     )
     print("original pages: ", HTMLDocument.from_file(filename=filename).pages)
     print("filtered pages: ", html_document.pages)

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -314,7 +314,8 @@ def test_read_html_doc(tmpdir, monkeypatch):
         f.write(doc)
 
     html_document = HTMLDocument.from_file(filename=filename).doc_after_cleaners(
-        skip_headers_and_footers=True, skip_table_text=True,
+        skip_headers_and_footers=True,
+        skip_table_text=True,
     )
     print("original pages: ", HTMLDocument.from_file(filename=filename).pages)
     print("filtered pages: ", html_document.pages)

--- a/test_unstructured/documents/test_xml.py
+++ b/test_unstructured/documents/test_xml.py
@@ -9,7 +9,7 @@ from unstructured.documents.xml import XMLDocument
 FILEPATH = Path(__file__).absolute().parent
 
 
-@pytest.fixture
+@pytest.fixture()
 def sample_document():
     return """"<SEC-DOCUMENT>
     <TYPE>10-K

--- a/test_unstructured/documents/test_xml.py
+++ b/test_unstructured/documents/test_xml.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-import lxml.etree as etree
+from lxml import etree
 import pytest
 
 from unstructured.documents.xml import XMLDocument

--- a/test_unstructured/file_utils/test_exploration.py
+++ b/test_unstructured/file_utils/test_exploration.py
@@ -1,8 +1,8 @@
 import os
 import pathlib
-import pytest
 
 import pandas as pd
+import pytest
 
 import unstructured.file_utils.exploration as exploration
 from unstructured.file_utils.filetype import FileType

--- a/test_unstructured/file_utils/test_exploration.py
+++ b/test_unstructured/file_utils/test_exploration.py
@@ -74,7 +74,8 @@ def test_get_file_info_from_file_contents():
         file_contents = [f.read()]
 
     file_info = exploration.get_file_info_from_file_contents(
-        file_contents=file_contents, filenames=["test.eml"],
+        file_contents=file_contents,
+        filenames=["test.eml"],
     )
     assert file_info.filetype[0] == FileType.EML
 
@@ -86,5 +87,6 @@ def test_get_file_info_from_file_contents_raises_if_lists_no_equal():
 
     with pytest.raises(ValueError):
         exploration.get_file_info_from_file_contents(
-            file_contents=file_contents, filenames=["test.eml", "test2.eml"],
+            file_contents=file_contents,
+            filenames=["test.eml", "test2.eml"],
         )

--- a/test_unstructured/file_utils/test_exploration.py
+++ b/test_unstructured/file_utils/test_exploration.py
@@ -4,7 +4,7 @@ import pathlib
 import pandas as pd
 import pytest
 
-import unstructured.file_utils.exploration as exploration
+from unstructured.file_utils import exploration
 from unstructured.file_utils.filetype import FileType
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()

--- a/test_unstructured/file_utils/test_exploration.py
+++ b/test_unstructured/file_utils/test_exploration.py
@@ -70,7 +70,7 @@ def test_get_file_info(tmpdir):
 
 def test_get_file_info_from_file_contents():
     file_contents_filename = os.path.join(DIRECTORY, "test-file-contents.txt")
-    with open(file_contents_filename, "r") as f:
+    with open(file_contents_filename) as f:
         file_contents = [f.read()]
 
     file_info = exploration.get_file_info_from_file_contents(
@@ -81,7 +81,7 @@ def test_get_file_info_from_file_contents():
 
 def test_get_file_info_from_file_contents_raises_if_lists_no_equal():
     file_contents_filename = os.path.join(DIRECTORY, "test-file-contents.txt")
-    with open(file_contents_filename, "r") as f:
+    with open(file_contents_filename) as f:
         file_contents = [f.read()]
 
     with pytest.raises(ValueError):

--- a/test_unstructured/file_utils/test_exploration.py
+++ b/test_unstructured/file_utils/test_exploration.py
@@ -74,7 +74,7 @@ def test_get_file_info_from_file_contents():
         file_contents = [f.read()]
 
     file_info = exploration.get_file_info_from_file_contents(
-        file_contents=file_contents, filenames=["test.eml"]
+        file_contents=file_contents, filenames=["test.eml"],
     )
     assert file_info.filetype[0] == FileType.EML
 
@@ -86,5 +86,5 @@ def test_get_file_info_from_file_contents_raises_if_lists_no_equal():
 
     with pytest.raises(ValueError):
         exploration.get_file_info_from_file_contents(
-            file_contents=file_contents, filenames=["test.eml", "test2.eml"]
+            file_contents=file_contents, filenames=["test.eml", "test2.eml"],
         )

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -1,16 +1,16 @@
 import os
 import pathlib
-import pytest
 import zipfile
 
 import magic
+import pytest
 
 import unstructured.file_utils.filetype as filetype
 from unstructured.file_utils.filetype import (
-    detect_filetype,
-    FileType,
     DOCX_MIME_TYPES,
     XLSX_MIME_TYPES,
+    FileType,
+    detect_filetype,
 )
 
 FILE_DIRECTORY = pathlib.Path(__file__).parent.resolve()

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -5,7 +5,7 @@ import zipfile
 import magic
 import pytest
 
-import unstructured.file_utils.filetype as filetype
+from unstructured.file_utils import filetype
 from unstructured.file_utils.filetype import (
     DOCX_MIME_TYPES,
     XLSX_MIME_TYPES,

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -18,7 +18,7 @@ EXAMPLE_DOCS_DIRECTORY = os.path.join(FILE_DIRECTORY, "..", "..", "example-docs"
 
 
 @pytest.mark.parametrize(
-    "file, expected",
+    ("file", "expected"),
     [
         ("layout-parser-paper-fast.pdf", FileType.PDF),
         ("fake.docx", FileType.DOCX),
@@ -38,7 +38,7 @@ def test_detect_filetype_from_filename(file, expected):
 
 
 @pytest.mark.parametrize(
-    "file, expected",
+    ("file", "expected"),
     [
         ("layout-parser-paper-fast.pdf", FileType.PDF),
         ("fake.docx", FileType.DOCX),
@@ -59,7 +59,7 @@ def test_detect_filetype_from_filename_with_extension(monkeypatch, file, expecte
 
 
 @pytest.mark.parametrize(
-    "file, expected",
+    ("file", "expected"),
     [
         ("layout-parser-paper-fast.pdf", FileType.PDF),
         ("fake.docx", FileType.DOCX),

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -85,9 +85,8 @@ def test_detect_filetype_from_file(file, expected):
 def test_detect_filetype_from_file_raises_without_libmagic(monkeypatch):
     monkeypatch.setattr(filetype, "LIBMAGIC_AVAILABLE", False)
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-text.txt")
-    with open(filename, "rb") as f:
-        with pytest.raises(ImportError):
-            detect_filetype(file=f)
+    with open(filename, "rb") as f, pytest.raises(ImportError):
+        detect_filetype(file=f)
 
 
 def test_detect_xml_application_xml(monkeypatch):
@@ -246,9 +245,8 @@ def test_detect_filetype_detects_unknown_text_types_as_txt(monkeypatch):
 
 def test_detect_filetype_raises_with_both_specified():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.eml")
-    with open(filename, "rb") as f:
-        with pytest.raises(ValueError):
-            detect_filetype(filename=filename, file=f)
+    with open(filename, "rb") as f, pytest.raises(ValueError):
+        detect_filetype(filename=filename, file=f)
 
 
 def test_detect_filetype_raises_with_none_specified():

--- a/test_unstructured/file_utils/test_metadata.py
+++ b/test_unstructured/file_utils/test_metadata.py
@@ -1,10 +1,10 @@
 import datetime
 import os
 import pathlib
-import pytest
 
 import docx
 import openpyxl
+import pytest
 
 import unstructured.file_utils.metadata as meta
 

--- a/test_unstructured/nlp/mock_nltk.py
+++ b/test_unstructured/nlp/mock_nltk.py
@@ -12,7 +12,7 @@ def mock_word_tokenize(text: str) -> List[str]:
 
 def mock_pos_tag(text: str) -> List[Tuple[str, str]]:
     tokens = mock_word_tokenize(text)
-    pos_tags: List[Tuple[str, str]] = list()
+    pos_tags: List[Tuple[str, str]] = []
     for token in tokens:
         if token.lower() == "ask":
             pos_tags.append((token, "VB"))

--- a/test_unstructured/nlp/test_tokenize.py
+++ b/test_unstructured/nlp/test_tokenize.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import nltk
 
-import unstructured.nlp.tokenize as tokenize
+from unstructured.nlp import tokenize
 from test_unstructured.nlp.mock_nltk import mock_sent_tokenize, mock_word_tokenize
 
 

--- a/test_unstructured/nlp/test_tokenize.py
+++ b/test_unstructured/nlp/test_tokenize.py
@@ -16,9 +16,8 @@ def test_nltk_packages_download_if_not_present():
 
 
 def test_nltk_packages_do_not_download_if():
-    with patch.object(nltk, "find"):
-        with patch.object(nltk, "download") as mock_download:
-            tokenize._download_nltk_package_if_not_present("fake_package", "tokenizers")
+    with patch.object(nltk, "find"), patch.object(nltk, "download") as mock_download:
+        tokenize._download_nltk_package_if_not_present("fake_package", "tokenizers")
 
     mock_download.assert_not_called()
 

--- a/test_unstructured/nlp/test_tokenize.py
+++ b/test_unstructured/nlp/test_tokenize.py
@@ -24,7 +24,7 @@ def test_nltk_packages_do_not_download_if():
 
 
 def mock_pos_tag(tokens: List[str]) -> List[Tuple[str, str]]:
-    pos_tags: List[Tuple[str, str]] = list()
+    pos_tags: List[Tuple[str, str]] = []
     for token in tokens:
         if token.lower() == "ask":
             pos_tags.append((token, "VB"))

--- a/test_unstructured/nlp/test_tokenize.py
+++ b/test_unstructured/nlp/test_tokenize.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import nltk
 
 import unstructured.nlp.tokenize as tokenize
-
 from test_unstructured.nlp.mock_nltk import mock_sent_tokenize, mock_word_tokenize
 
 

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -1,13 +1,20 @@
 import os
 import pathlib
-import pytest
 import warnings
 
 import docx
+import pytest
 
-from unstructured.documents.elements import Address, NarrativeText, PageBreak, Title, Text, ListItem
-from unstructured.partition.auto import partition
 import unstructured.partition.auto as auto
+from unstructured.documents.elements import (
+    Address,
+    ListItem,
+    NarrativeText,
+    PageBreak,
+    Text,
+    Title,
+)
+from unstructured.partition.auto import partition
 from unstructured.partition.common import convert_office_doc
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -52,7 +52,7 @@ def test_auto_partition_email_from_file_rb():
     assert elements == EXPECTED_EMAIL_OUTPUT
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_docx_document():
     document = docx.Document()
 
@@ -73,7 +73,7 @@ def mock_docx_document():
     return document
 
 
-@pytest.fixture
+@pytest.fixture()
 def expected_docx_elements():
     return [
         Title("These are a few of my favorite things:"),
@@ -117,7 +117,7 @@ def test_auto_partition_doc_with_filename(mock_docx_document, expected_docx_elem
 
 # NOTE(robinson) - the application/x-ole-storage mime type is not specific enough to
 # determine that the file is an .doc document
-@pytest.mark.xfail
+@pytest.mark.xfail()
 def test_auto_partition_doc_with_file(mock_docx_document, expected_docx_elements, tmpdir):
     docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -38,7 +38,7 @@ def test_auto_partition_email_from_filename():
 
 def test_auto_partition_email_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.eml")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         elements = partition(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_EMAIL_OUTPUT
@@ -138,7 +138,7 @@ def test_auto_partition_html_from_filename():
 
 def test_auto_partition_html_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-html.html")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         elements = partition(file=f)
     assert len(elements) > 0
 
@@ -170,7 +170,7 @@ def test_auto_partition_text_from_filename():
 
 def test_auto_partition_text_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-text.txt")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         elements = partition(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_TEXT_OUTPUT

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -5,7 +5,7 @@ import warnings
 import docx
 import pytest
 
-import unstructured.partition.auto as auto
+from unstructured.partition import auto
 from unstructured.documents.elements import (
     Address,
     ListItem,

--- a/test_unstructured/partition/test_common.py
+++ b/test_unstructured/partition/test_common.py
@@ -29,7 +29,8 @@ def test_normalize_layout_element_dict_caption():
     }
     element = common.normalize_layout_element(layout_element)
     assert element == FigureCaption(
-        text="Some lovely text", coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
+        text="Some lovely text",
+        coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
     )
 
 
@@ -51,7 +52,8 @@ def test_normalize_layout_element_layout_element():
     )
     element = common.normalize_layout_element(layout_element)
     assert element == NarrativeText(
-        text="Some lovely text", coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
+        text="Some lovely text",
+        coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
     )
 
 

--- a/test_unstructured/partition/test_common.py
+++ b/test_unstructured/partition/test_common.py
@@ -1,6 +1,6 @@
 from unstructured_inference.inference.layout import LayoutElement
 
-import unstructured.partition.common as common
+from unstructured.partition import common
 from unstructured.documents.elements import (
     CheckBox,
     FigureCaption,

--- a/test_unstructured/partition/test_common.py
+++ b/test_unstructured/partition/test_common.py
@@ -1,5 +1,6 @@
 from unstructured_inference.inference.layout import LayoutElement
 
+import unstructured.partition.common as common
 from unstructured.documents.elements import (
     CheckBox,
     FigureCaption,
@@ -8,7 +9,6 @@ from unstructured.documents.elements import (
     Text,
     Title,
 )
-import unstructured.partition.common as common
 
 
 def test_normalize_layout_element_dict():

--- a/test_unstructured/partition/test_common.py
+++ b/test_unstructured/partition/test_common.py
@@ -29,7 +29,7 @@ def test_normalize_layout_element_dict_caption():
     }
     element = common.normalize_layout_element(layout_element)
     assert element == FigureCaption(
-        text="Some lovely text", coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]]
+        text="Some lovely text", coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
     )
 
 
@@ -51,7 +51,7 @@ def test_normalize_layout_element_layout_element():
     )
     element = common.normalize_layout_element(layout_element)
     assert element == NarrativeText(
-        text="Some lovely text", coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]]
+        text="Some lovely text", coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
     )
 
 

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -1,9 +1,15 @@
 import os
-import pytest
 
 import docx
+import pytest
 
-from unstructured.documents.elements import Address, ListItem, NarrativeText, Title, Text
+from unstructured.documents.elements import (
+    Address,
+    ListItem,
+    NarrativeText,
+    Text,
+    Title,
+)
 from unstructured.partition.common import convert_office_doc
 from unstructured.partition.doc import partition_doc
 from unstructured.partition.docx import partition_docx

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -99,9 +99,8 @@ def test_partition_doc_raises_with_both_specified(mock_document, tmpdir):
     mock_document.save(docx_filename)
     convert_office_doc(docx_filename, tmpdir.dirname, "doc")
 
-    with open(doc_filename, "rb") as f:
-        with pytest.raises(ValueError):
-            partition_doc(filename=doc_filename, file=f)
+    with open(doc_filename, "rb") as f, pytest.raises(ValueError):
+        partition_doc(filename=doc_filename, file=f)
 
 
 def test_partition_doc_raises_with_neither():

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -15,7 +15,7 @@ from unstructured.partition.doc import partition_doc
 from unstructured.partition.docx import partition_docx
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_document():
     document = docx.Document()
 
@@ -42,7 +42,7 @@ def mock_document():
     return document
 
 
-@pytest.fixture
+@pytest.fixture()
 def expected_elements():
     return [
         Title("These are a few of my favorite things:"),

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -13,7 +13,7 @@ from unstructured.documents.elements import (
 from unstructured.partition.docx import partition_docx
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_document():
     document = docx.Document()
 
@@ -40,7 +40,7 @@ def mock_document():
     return document
 
 
-@pytest.fixture
+@pytest.fixture()
 def expected_elements():
     return [
         Title("These are a few of my favorite things:"),

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -1,9 +1,15 @@
 import os
-import pytest
 
 import docx
+import pytest
 
-from unstructured.documents.elements import Address, ListItem, NarrativeText, Title, Text
+from unstructured.documents.elements import (
+    Address,
+    ListItem,
+    NarrativeText,
+    Text,
+    Title,
+)
 from unstructured.partition.docx import partition_docx
 
 

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -75,9 +75,8 @@ def test_partition_docx_raises_with_both_specified(mock_document, tmpdir):
     filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     mock_document.save(filename)
 
-    with open(filename, "rb") as f:
-        with pytest.raises(ValueError):
-            partition_docx(filename=filename, file=f)
+    with open(filename, "rb") as f, pytest.raises(ValueError):
+        partition_docx(filename=filename, file=f)
 
 
 def test_partition_docx_raises_with_neither():

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -45,7 +45,7 @@ RECEIVED_HEADER_OUTPUT = [
         name="received_datetimetz",
         text="2023-02-20 10:03:18+12:00",
         datestamp=datetime.datetime(
-            2023, 2, 20, 10, 3, 18, tzinfo=datetime.timezone(datetime.timedelta(seconds=43200))
+            2023, 2, 20, 10, 3, 18, tzinfo=datetime.timezone(datetime.timedelta(seconds=43200)),
         ),
     ),
     MetaData(name="MIME-Version", text="1.0"),
@@ -58,7 +58,7 @@ RECEIVED_HEADER_OUTPUT = [
     Sender(name="Matthew Robinson", text="mrobinson@unstructured.io"),
     Recipient(name="Matthew Robinson", text="mrobinson@unstructured.io"),
     MetaData(
-        name="Content-Type", text='multipart/alternative; boundary="00000000000095c9b205eff92630"'
+        name="Content-Type", text='multipart/alternative; boundary="00000000000095c9b205eff92630"',
     ),
 ]
 
@@ -73,14 +73,14 @@ HEADER_EXPECTED_OUTPUT = [
     Sender(name="Matthew Robinson", text="mrobinson@unstructured.io"),
     Recipient(name="Matthew Robinson", text="mrobinson@unstructured.io"),
     MetaData(
-        name="Content-Type", text='multipart/alternative; boundary="00000000000095c9b205eff92630"'
+        name="Content-Type", text='multipart/alternative; boundary="00000000000095c9b205eff92630"',
     ),
 ]
 
 ALL_EXPECTED_OUTPUT = HEADER_EXPECTED_OUTPUT + EXPECTED_OUTPUT
 
 ATTACH_EXPECTED_OUTPUT = [
-    {"filename": "fake-attachment.txt", "payload": b"Hey this is a fake attachment!"}
+    {"filename": "fake-attachment.txt", "payload": b"Hey this is a fake attachment!"},
 ]
 
 

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -45,7 +45,13 @@ RECEIVED_HEADER_OUTPUT = [
         name="received_datetimetz",
         text="2023-02-20 10:03:18+12:00",
         datestamp=datetime.datetime(
-            2023, 2, 20, 10, 3, 18, tzinfo=datetime.timezone(datetime.timedelta(seconds=43200)),
+            2023,
+            2,
+            20,
+            10,
+            3,
+            18,
+            tzinfo=datetime.timezone(datetime.timedelta(seconds=43200)),
         ),
     ),
     MetaData(name="MIME-Version", text="1.0"),
@@ -58,7 +64,8 @@ RECEIVED_HEADER_OUTPUT = [
     Sender(name="Matthew Robinson", text="mrobinson@unstructured.io"),
     Recipient(name="Matthew Robinson", text="mrobinson@unstructured.io"),
     MetaData(
-        name="Content-Type", text='multipart/alternative; boundary="00000000000095c9b205eff92630"',
+        name="Content-Type",
+        text='multipart/alternative; boundary="00000000000095c9b205eff92630"',
     ),
 ]
 
@@ -73,7 +80,8 @@ HEADER_EXPECTED_OUTPUT = [
     Sender(name="Matthew Robinson", text="mrobinson@unstructured.io"),
     Recipient(name="Matthew Robinson", text="mrobinson@unstructured.io"),
     MetaData(
-        name="Content-Type", text='multipart/alternative; boundary="00000000000095c9b205eff92630"',
+        name="Content-Type",
+        text='multipart/alternative; boundary="00000000000095c9b205eff92630"',
     ),
 ]
 

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -2,23 +2,22 @@ import datetime
 import email
 import os
 import pathlib
+
 import pytest
 
-
-from unstructured.documents.elements import NarrativeText, Title, ListItem, Image
+from unstructured.documents.elements import Image, ListItem, NarrativeText, Title
 from unstructured.documents.email_elements import (
     MetaData,
+    ReceivedInfo,
     Recipient,
     Sender,
     Subject,
-    ReceivedInfo,
 )
 from unstructured.partition.email import (
     extract_attachment_info,
     partition_email,
     partition_email_header,
 )
-
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -93,7 +93,7 @@ def test_partition_email_from_filename():
 
 def test_partition_email_from_file():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         elements = partition_email(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
@@ -109,7 +109,7 @@ def test_partition_email_from_file_rb():
 
 def test_partition_email_from_text_file():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.txt")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         elements = partition_email(file=f, content_source="text/plain")
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
@@ -117,7 +117,7 @@ def test_partition_email_from_text_file():
 
 def test_partition_email_from_text_file_with_headers():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.txt")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         elements = partition_email(file=f, content_source="text/plain", include_headers=True)
     assert len(elements) > 0
     assert elements == ALL_EXPECTED_OUTPUT
@@ -125,7 +125,7 @@ def test_partition_email_from_text_file_with_headers():
 
 def test_partition_email_from_text():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         text = f.read()
     elements = partition_email(text=text)
     assert len(elements) > 0
@@ -141,7 +141,7 @@ def test_partition_email_from_filename_with_embedded_image():
 
 def test_partition_email_header():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email-header.eml")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         msg = email.message_from_file(f)
     elements = partition_email_header(msg)
     assert len(elements) > 0
@@ -162,7 +162,7 @@ def test_extract_email_text_matches_html():
 
 def test_extract_attachment_info():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email-attachment.eml")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         msg = email.message_from_file(f)
     attachment_info = extract_attachment_info(msg)
     assert len(attachment_info) > 0
@@ -176,7 +176,7 @@ def test_partition_email_raises_with_none_specified():
 
 def test_partition_email_raises_with_too_many_specified():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         text = f.read()
 
     with pytest.raises(ValueError):

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -1,13 +1,12 @@
 import os
 import pathlib
-import pytest
 from unittest.mock import patch
 
+import pytest
 import requests
 
 from unstructured.documents.elements import PageBreak
 from unstructured.partition.html import partition_html
-
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -77,7 +77,9 @@ def test_partition_html_from_url_raises_with_bad_content_type():
         text = f.read()
 
     response = MockResponse(
-        text=text, status_code=200, headers={"Content-Type": "application/json"},
+        text=text,
+        status_code=200,
+        headers={"Content-Type": "application/json"},
     )
     with patch.object(requests, "get", return_value=response) as _:
         with pytest.raises(ValueError):

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -77,7 +77,7 @@ def test_partition_html_from_url_raises_with_bad_content_type():
         text = f.read()
 
     response = MockResponse(
-        text=text, status_code=200, headers={"Content-Type": "application/json"}
+        text=text, status_code=200, headers={"Content-Type": "application/json"},
     )
     with patch.object(requests, "get", return_value=response) as _:
         with pytest.raises(ValueError):

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -27,14 +27,14 @@ def test_partition_html_with_page_breaks():
 
 def test_partition_html_from_file():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         elements = partition_html(file=f)
     assert len(elements) > 0
 
 
 def test_partition_html_from_text():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         text = f.read()
     elements = partition_html(text=text)
     assert len(elements) > 0
@@ -50,7 +50,7 @@ class MockResponse:
 
 def test_partition_html_from_url():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         text = f.read()
 
     response = MockResponse(text=text, status_code=200, headers={"Content-Type": "text/html"})
@@ -62,7 +62,7 @@ def test_partition_html_from_url():
 
 def test_partition_html_from_url_raises_with_bad_status_code():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         text = f.read()
 
     response = MockResponse(text=text, status_code=500, headers={"Content-Type": "text/html"})
@@ -73,7 +73,7 @@ def test_partition_html_from_url_raises_with_bad_status_code():
 
 def test_partition_html_from_url_raises_with_bad_content_type():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         text = f.read()
 
     response = MockResponse(
@@ -91,7 +91,7 @@ def test_partition_html_raises_with_none_specified():
 
 def test_partition_html_raises_with_too_many_specified():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         text = f.read()
 
     with pytest.raises(ValueError):

--- a/test_unstructured/partition/test_image.py
+++ b/test_unstructured/partition/test_image.py
@@ -93,13 +93,19 @@ def test_partition_image_api_page_break(monkeypatch, filename="example-docs/exam
     assert partition_image_response[2]["text"] == "A Charlie Brown Christmas"
 
 
-@pytest.mark.parametrize(("filename", "file"), [("example-docs/example.jpg", None), (None, b"0000")])
+@pytest.mark.parametrize(
+    ("filename", "file"), [("example-docs/example.jpg", None), (None, b"0000")]
+)
 def test_partition_image_local(monkeypatch, filename, file):
     monkeypatch.setattr(
-        layout, "process_data_with_model", lambda *args, **kwargs: MockDocumentLayout(),
+        layout,
+        "process_data_with_model",
+        lambda *args, **kwargs: MockDocumentLayout(),
     )
     monkeypatch.setattr(
-        layout, "process_file_with_model", lambda *args, **kwargs: MockDocumentLayout(),
+        layout,
+        "process_file_with_model",
+        lambda *args, **kwargs: MockDocumentLayout(),
     )
 
     partition_image_response = pdf._partition_pdf_or_image_local(filename, file, is_image=True)
@@ -114,7 +120,8 @@ def test_partition_image_local_raises_with_no_filename():
 
 
 def test_partition_image_api_raises_with_failed_healthcheck(
-    monkeypatch, filename="example-docs/example.jpg",
+    monkeypatch,
+    filename="example-docs/example.jpg",
 ):
     monkeypatch.setattr(requests, "post", mock_successful_post)
     monkeypatch.setattr(requests, "get", mock_unhealthy_get)
@@ -124,7 +131,8 @@ def test_partition_image_api_raises_with_failed_healthcheck(
 
 
 def test_partition_image_api_raises_with_failed_api_call(
-    monkeypatch, filename="example-docs/example.jpg",
+    monkeypatch,
+    filename="example-docs/example.jpg",
 ):
     monkeypatch.setattr(requests, "post", mock_unsuccessful_post)
     monkeypatch.setattr(requests, "get", mock_healthy_get)
@@ -134,11 +142,14 @@ def test_partition_image_api_raises_with_failed_api_call(
 
 
 @pytest.mark.parametrize(
-    ("url", "api_called", "local_called"), [("fakeurl", True, False), (None, False, True)],
+    ("url", "api_called", "local_called"),
+    [("fakeurl", True, False), (None, False, True)],
 )
 def test_partition_image(url, api_called, local_called):
     with mock.patch.object(
-        pdf, attribute="_partition_via_api", new=mock.MagicMock(),
+        pdf,
+        attribute="_partition_via_api",
+        new=mock.MagicMock(),
     ), mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
         image.partition_image(filename="fake.pdf", url=url)
         assert pdf._partition_via_api.called == api_called

--- a/test_unstructured/partition/test_image.py
+++ b/test_unstructured/partition/test_image.py
@@ -1,10 +1,11 @@
-import pytest
-import requests
 from unittest import mock
 
-import unstructured.partition.pdf as pdf
-import unstructured.partition.image as image
+import pytest
+import requests
 import unstructured_inference.inference.layout as layout
+
+import unstructured.partition.image as image
+import unstructured.partition.pdf as pdf
 
 
 class MockResponse:

--- a/test_unstructured/partition/test_image.py
+++ b/test_unstructured/partition/test_image.py
@@ -2,10 +2,10 @@ from unittest import mock
 
 import pytest
 import requests
-import unstructured_inference.inference.layout as layout
+from unstructured_inference.inference import layout
 
-import unstructured.partition.image as image
-import unstructured.partition.pdf as pdf
+from unstructured.partition import image
+from unstructured.partition import pdf
 
 
 class MockResponse:

--- a/test_unstructured/partition/test_image.py
+++ b/test_unstructured/partition/test_image.py
@@ -40,7 +40,7 @@ def mock_successful_post(url, **kwargs):
                 "number": 1,
                 "elements": [{"type": "Title", "text": "A Charlie Brown Christmas"}],
             },
-        ]
+        ],
     }
     return MockResponse(status_code=200, response=response)
 
@@ -56,7 +56,7 @@ class MockPageLayout(layout.PageLayout):
                 type="Title",
                 coordinates=[(0, 0), (2, 2)],
                 text="Charlie Brown and the Great Pumpkin",
-            )
+            ),
         ]
 
 
@@ -66,7 +66,7 @@ class MockDocumentLayout(layout.DocumentLayout):
         return [
             MockPageLayout(
                 number=0,
-            )
+            ),
         ]
 
 
@@ -96,10 +96,10 @@ def test_partition_image_api_page_break(monkeypatch, filename="example-docs/exam
 @pytest.mark.parametrize("filename, file", [("example-docs/example.jpg", None), (None, b"0000")])
 def test_partition_image_local(monkeypatch, filename, file):
     monkeypatch.setattr(
-        layout, "process_data_with_model", lambda *args, **kwargs: MockDocumentLayout()
+        layout, "process_data_with_model", lambda *args, **kwargs: MockDocumentLayout(),
     )
     monkeypatch.setattr(
-        layout, "process_file_with_model", lambda *args, **kwargs: MockDocumentLayout()
+        layout, "process_file_with_model", lambda *args, **kwargs: MockDocumentLayout(),
     )
 
     partition_image_response = pdf._partition_pdf_or_image_local(filename, file, is_image=True)
@@ -114,7 +114,7 @@ def test_partition_image_local_raises_with_no_filename():
 
 
 def test_partition_image_api_raises_with_failed_healthcheck(
-    monkeypatch, filename="example-docs/example.jpg"
+    monkeypatch, filename="example-docs/example.jpg",
 ):
     monkeypatch.setattr(requests, "post", mock_successful_post)
     monkeypatch.setattr(requests, "get", mock_unhealthy_get)
@@ -124,7 +124,7 @@ def test_partition_image_api_raises_with_failed_healthcheck(
 
 
 def test_partition_image_api_raises_with_failed_api_call(
-    monkeypatch, filename="example-docs/example.jpg"
+    monkeypatch, filename="example-docs/example.jpg",
 ):
     monkeypatch.setattr(requests, "post", mock_unsuccessful_post)
     monkeypatch.setattr(requests, "get", mock_healthy_get)
@@ -134,11 +134,11 @@ def test_partition_image_api_raises_with_failed_api_call(
 
 
 @pytest.mark.parametrize(
-    "url, api_called, local_called", [("fakeurl", True, False), (None, False, True)]
+    "url, api_called, local_called", [("fakeurl", True, False), (None, False, True)],
 )
 def test_partition_image(url, api_called, local_called):
     with mock.patch.object(
-        pdf, attribute="_partition_via_api", new=mock.MagicMock()
+        pdf, attribute="_partition_via_api", new=mock.MagicMock(),
     ), mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
         image.partition_image(filename="fake.pdf", url=url)
         assert pdf._partition_via_api.called == api_called

--- a/test_unstructured/partition/test_image.py
+++ b/test_unstructured/partition/test_image.py
@@ -93,7 +93,7 @@ def test_partition_image_api_page_break(monkeypatch, filename="example-docs/exam
     assert partition_image_response[2]["text"] == "A Charlie Brown Christmas"
 
 
-@pytest.mark.parametrize("filename, file", [("example-docs/example.jpg", None), (None, b"0000")])
+@pytest.mark.parametrize(("filename", "file"), [("example-docs/example.jpg", None), (None, b"0000")])
 def test_partition_image_local(monkeypatch, filename, file):
     monkeypatch.setattr(
         layout, "process_data_with_model", lambda *args, **kwargs: MockDocumentLayout(),
@@ -134,7 +134,7 @@ def test_partition_image_api_raises_with_failed_api_call(
 
 
 @pytest.mark.parametrize(
-    "url, api_called, local_called", [("fakeurl", True, False), (None, False, True)],
+    ("url", "api_called", "local_called"), [("fakeurl", True, False), (None, False, True)],
 )
 def test_partition_image(url, api_called, local_called):
     with mock.patch.object(

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -82,7 +82,8 @@ def test_partition_pdf_api(monkeypatch, filename="example-docs/layout-parser-pap
 
 
 def test_partition_pdf_api_page_breaks(
-    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf",
+    monkeypatch,
+    filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     monkeypatch.setattr(requests, "post", mock_successful_post)
     monkeypatch.setattr(requests, "get", mock_healthy_get)
@@ -96,14 +97,19 @@ def test_partition_pdf_api_page_breaks(
 
 
 @pytest.mark.parametrize(
-    ("filename", "file"), [("example-docs/layout-parser-paper-fast.pdf", None), (None, b"0000")],
+    ("filename", "file"),
+    [("example-docs/layout-parser-paper-fast.pdf", None), (None, b"0000")],
 )
 def test_partition_pdf_local(monkeypatch, filename, file):
     monkeypatch.setattr(
-        layout, "process_data_with_model", lambda *args, **kwargs: MockDocumentLayout(),
+        layout,
+        "process_data_with_model",
+        lambda *args, **kwargs: MockDocumentLayout(),
     )
     monkeypatch.setattr(
-        layout, "process_file_with_model", lambda *args, **kwargs: MockDocumentLayout(),
+        layout,
+        "process_file_with_model",
+        lambda *args, **kwargs: MockDocumentLayout(),
     )
 
     partition_pdf_response = pdf._partition_pdf_or_image_local(filename, file)
@@ -125,7 +131,8 @@ def test_partition_pdf_local_raises_with_no_filename():
 
 
 def test_partition_pdf_api_raises_with_failed_healthcheck(
-    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf",
+    monkeypatch,
+    filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     monkeypatch.setattr(requests, "post", mock_successful_post)
     monkeypatch.setattr(requests, "get", mock_unhealthy_get)
@@ -135,7 +142,8 @@ def test_partition_pdf_api_raises_with_failed_healthcheck(
 
 
 def test_partition_pdf_api_raises_with_failed_api_call(
-    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf",
+    monkeypatch,
+    filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     monkeypatch.setattr(requests, "post", mock_unsuccessful_post)
     monkeypatch.setattr(requests, "get", mock_healthy_get)
@@ -145,11 +153,14 @@ def test_partition_pdf_api_raises_with_failed_api_call(
 
 
 @pytest.mark.parametrize(
-    ("url", "api_called", "local_called"), [("fakeurl", True, False), (None, False, True)],
+    ("url", "api_called", "local_called"),
+    [("fakeurl", True, False), (None, False, True)],
 )
 def test_partition_pdf(url, api_called, local_called):
     with mock.patch.object(
-        pdf, attribute="_partition_via_api", new=mock.MagicMock(),
+        pdf,
+        attribute="_partition_via_api",
+        new=mock.MagicMock(),
     ), mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
         pdf.partition_pdf(filename="fake.pdf", url=url)
         assert pdf._partition_via_api.called == api_called
@@ -157,11 +168,14 @@ def test_partition_pdf(url, api_called, local_called):
 
 
 @pytest.mark.parametrize(
-    ("url", "api_called", "local_called"), [("fakeurl", True, False), (None, False, True)],
+    ("url", "api_called", "local_called"),
+    [("fakeurl", True, False), (None, False, True)],
 )
 def test_partition_pdf_with_template(url, api_called, local_called):
     with mock.patch.object(
-        pdf, attribute="_partition_via_api", new=mock.MagicMock(),
+        pdf,
+        attribute="_partition_via_api",
+        new=mock.MagicMock(),
     ), mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
         pdf.partition_pdf(filename="fake.pdf", url=url, template="checkbox")
         assert pdf._partition_via_api.called == api_called

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -1,10 +1,11 @@
-import pytest
-import requests
 from unittest import mock
 
-from unstructured.documents.elements import PageBreak
-import unstructured.partition.pdf as pdf
+import pytest
+import requests
 import unstructured_inference.inference.layout as layout
+
+import unstructured.partition.pdf as pdf
+from unstructured.documents.elements import PageBreak
 
 
 class MockResponse:

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -96,7 +96,7 @@ def test_partition_pdf_api_page_breaks(
 
 
 @pytest.mark.parametrize(
-    "filename, file", [("example-docs/layout-parser-paper-fast.pdf", None), (None, b"0000")],
+    ("filename", "file"), [("example-docs/layout-parser-paper-fast.pdf", None), (None, b"0000")],
 )
 def test_partition_pdf_local(monkeypatch, filename, file):
     monkeypatch.setattr(
@@ -145,7 +145,7 @@ def test_partition_pdf_api_raises_with_failed_api_call(
 
 
 @pytest.mark.parametrize(
-    "url, api_called, local_called", [("fakeurl", True, False), (None, False, True)],
+    ("url", "api_called", "local_called"), [("fakeurl", True, False), (None, False, True)],
 )
 def test_partition_pdf(url, api_called, local_called):
     with mock.patch.object(
@@ -157,7 +157,7 @@ def test_partition_pdf(url, api_called, local_called):
 
 
 @pytest.mark.parametrize(
-    "url, api_called, local_called", [("fakeurl", True, False), (None, False, True)],
+    ("url", "api_called", "local_called"), [("fakeurl", True, False), (None, False, True)],
 )
 def test_partition_pdf_with_template(url, api_called, local_called):
     with mock.patch.object(

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -2,9 +2,9 @@ from unittest import mock
 
 import pytest
 import requests
-import unstructured_inference.inference.layout as layout
+from unstructured_inference.inference import layout
 
-import unstructured.partition.pdf as pdf
+from unstructured.partition import pdf
 from unstructured.documents.elements import PageBreak
 
 

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -40,7 +40,7 @@ def mock_successful_post(url, **kwargs):
                 "number": 1,
                 "elements": [{"type": "Title", "text": "A Charlie Brown Christmas"}],
             },
-        ]
+        ],
     }
     return MockResponse(status_code=200, response=response)
 
@@ -56,7 +56,7 @@ class MockPageLayout(layout.PageLayout):
                 type="Title",
                 coordinates=[(0, 0), (2, 2)],
                 text="Charlie Brown and the Great Pumpkin",
-            )
+            ),
         ]
 
 
@@ -66,7 +66,7 @@ class MockDocumentLayout(layout.DocumentLayout):
         return [
             MockPageLayout(
                 number=0,
-            )
+            ),
         ]
 
 
@@ -82,7 +82,7 @@ def test_partition_pdf_api(monkeypatch, filename="example-docs/layout-parser-pap
 
 
 def test_partition_pdf_api_page_breaks(
-    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf"
+    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     monkeypatch.setattr(requests, "post", mock_successful_post)
     monkeypatch.setattr(requests, "get", mock_healthy_get)
@@ -96,14 +96,14 @@ def test_partition_pdf_api_page_breaks(
 
 
 @pytest.mark.parametrize(
-    "filename, file", [("example-docs/layout-parser-paper-fast.pdf", None), (None, b"0000")]
+    "filename, file", [("example-docs/layout-parser-paper-fast.pdf", None), (None, b"0000")],
 )
 def test_partition_pdf_local(monkeypatch, filename, file):
     monkeypatch.setattr(
-        layout, "process_data_with_model", lambda *args, **kwargs: MockDocumentLayout()
+        layout, "process_data_with_model", lambda *args, **kwargs: MockDocumentLayout(),
     )
     monkeypatch.setattr(
-        layout, "process_file_with_model", lambda *args, **kwargs: MockDocumentLayout()
+        layout, "process_file_with_model", lambda *args, **kwargs: MockDocumentLayout(),
     )
 
     partition_pdf_response = pdf._partition_pdf_or_image_local(filename, file)
@@ -125,7 +125,7 @@ def test_partition_pdf_local_raises_with_no_filename():
 
 
 def test_partition_pdf_api_raises_with_failed_healthcheck(
-    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf"
+    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     monkeypatch.setattr(requests, "post", mock_successful_post)
     monkeypatch.setattr(requests, "get", mock_unhealthy_get)
@@ -135,7 +135,7 @@ def test_partition_pdf_api_raises_with_failed_healthcheck(
 
 
 def test_partition_pdf_api_raises_with_failed_api_call(
-    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf"
+    monkeypatch, filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     monkeypatch.setattr(requests, "post", mock_unsuccessful_post)
     monkeypatch.setattr(requests, "get", mock_healthy_get)
@@ -145,11 +145,11 @@ def test_partition_pdf_api_raises_with_failed_api_call(
 
 
 @pytest.mark.parametrize(
-    "url, api_called, local_called", [("fakeurl", True, False), (None, False, True)]
+    "url, api_called, local_called", [("fakeurl", True, False), (None, False, True)],
 )
 def test_partition_pdf(url, api_called, local_called):
     with mock.patch.object(
-        pdf, attribute="_partition_via_api", new=mock.MagicMock()
+        pdf, attribute="_partition_via_api", new=mock.MagicMock(),
     ), mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
         pdf.partition_pdf(filename="fake.pdf", url=url)
         assert pdf._partition_via_api.called == api_called
@@ -157,11 +157,11 @@ def test_partition_pdf(url, api_called, local_called):
 
 
 @pytest.mark.parametrize(
-    "url, api_called, local_called", [("fakeurl", True, False), (None, False, True)]
+    "url, api_called, local_called", [("fakeurl", True, False), (None, False, True)],
 )
 def test_partition_pdf_with_template(url, api_called, local_called):
     with mock.patch.object(
-        pdf, attribute="_partition_via_api", new=mock.MagicMock()
+        pdf, attribute="_partition_via_api", new=mock.MagicMock(),
     ), mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
         pdf.partition_pdf(filename="fake.pdf", url=url, template="checkbox")
         assert pdf._partition_via_api.called == api_called

--- a/test_unstructured/partition/test_ppt.py
+++ b/test_unstructured/partition/test_ppt.py
@@ -1,9 +1,10 @@
 import os
 import pathlib
+
 import pytest
 
-from unstructured.partition.ppt import partition_ppt
 from unstructured.documents.elements import ListItem, NarrativeText, Title
+from unstructured.partition.ppt import partition_ppt
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 EXAMPLE_DOCS_DIRECTORY = os.path.join(DIRECTORY, "..", "..", "example-docs")

--- a/test_unstructured/partition/test_ppt.py
+++ b/test_unstructured/partition/test_ppt.py
@@ -40,9 +40,8 @@ def test_partition_ppt_from_file():
 
 def test_partition_ppt_raises_with_both_specified():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.ppt")
-    with open(filename, "rb") as f:
-        with pytest.raises(ValueError):
-            partition_ppt(filename=filename, file=f)
+    with open(filename, "rb") as f, pytest.raises(ValueError):
+        partition_ppt(filename=filename, file=f)
 
 
 def test_partition_ppt_raises_with_neither():

--- a/test_unstructured/partition/test_pptx.py
+++ b/test_unstructured/partition/test_pptx.py
@@ -41,9 +41,8 @@ def test_partition_pptx_from_file():
 
 def test_partition_pptx_raises_with_both_specified():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.pptx")
-    with open(filename, "rb") as f:
-        with pytest.raises(ValueError):
-            partition_pptx(filename=filename, file=f)
+    with open(filename, "rb") as f, pytest.raises(ValueError):
+        partition_pptx(filename=filename, file=f)
 
 
 def test_partition_pptx_raises_with_neither():

--- a/test_unstructured/partition/test_pptx.py
+++ b/test_unstructured/partition/test_pptx.py
@@ -1,11 +1,17 @@
 import os
 import pathlib
-import pytest
 
 import pptx
+import pytest
 
+from unstructured.documents.elements import (
+    ListItem,
+    NarrativeText,
+    PageBreak,
+    Text,
+    Title,
+)
 from unstructured.partition.pptx import partition_pptx
-from unstructured.documents.elements import ListItem, NarrativeText, PageBreak, Text, Title
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 EXAMPLE_DOCS_DIRECTORY = os.path.join(DIRECTORY, "..", "..", "example-docs")

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -1,8 +1,9 @@
 import os
 import pathlib
+
 import pytest
 
-from unstructured.documents.elements import Address, NarrativeText, Title, ListItem
+from unstructured.documents.elements import Address, ListItem, NarrativeText, Title
 from unstructured.partition.text import partition_text
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -27,7 +27,7 @@ def test_partition_text_from_filename():
 
 def test_partition_text_from_file():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         elements = partition_text(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
@@ -35,7 +35,7 @@ def test_partition_text_from_file():
 
 def test_partition_text_from_text():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         text = f.read()
     elements = partition_text(text=text)
     assert len(elements) > 0
@@ -49,7 +49,7 @@ def test_partition_text_raises_with_none_specified():
 
 def test_partition_text_raises_with_too_many_specified():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
-    with open(filename, "r") as f:
+    with open(filename) as f:
         text = f.read()
 
     with pytest.raises(ValueError):

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -11,7 +11,7 @@ from test_unstructured.nlp.mock_nltk import (
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         (
             "ITEM 5(a).: MARKET FOR REGISTRANT’S COMMON EQUITY, RELATED STOCKHOLDER MATTERS AND "
@@ -35,7 +35,7 @@ def test_headings_are_not_narrative_text(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("Ask the teacher for an apple.", True),
         ("Ask Me About Intellectual Property", False),  # Exceeds the cap threshold
@@ -80,7 +80,7 @@ def test_text_type_handles_non_english_examples_with_env_var(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("Intellectual Property", True),  # Fails because it exceeds the cap threshold
         (
@@ -106,7 +106,7 @@ def test_is_possible_title(text, expected, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("8675309", True),
         ("+1 867-5309", True),
@@ -124,7 +124,7 @@ def test_contains_us_phone_number(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("• This is a fine point!", True),
         (" • This is a fine point!", True),  # Has an extra space in front of the bullet
@@ -154,7 +154,7 @@ def test_is_bulletized_text(text, expected):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("Ask the teacher for an apple", True),
         ("Intellectual property", False),
@@ -167,7 +167,7 @@ def test_contains_verb(text, expected, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("PARROT BEAK", True),
         ("Parrot Beak", True),
@@ -185,7 +185,7 @@ def test_contains_english_word(text, expected, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("Intellectual Property in the United States", True),
         ("Intellectual property helps incentivize innovation.", False),
@@ -257,7 +257,7 @@ def test_item_titles():
 
 
 @pytest.mark.parametrize(
-    "text, expected",
+    ("text", "expected"),
     [
         ("Doylestown, PA 18901", True),
         ("DOYLESTOWN, PENNSYLVANIA, 18901", True),

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-import unstructured.partition.text_type as text_type
+from unstructured.partition import text_type
 from test_unstructured.nlp.mock_nltk import (
     mock_pos_tag,
     mock_sent_tokenize,

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -1,9 +1,13 @@
-import pytest
 from unittest.mock import patch
 
-import unstructured.partition.text_type as text_type
+import pytest
 
-from test_unstructured.nlp.mock_nltk import mock_pos_tag, mock_sent_tokenize, mock_word_tokenize
+import unstructured.partition.text_type as text_type
+from test_unstructured.nlp.mock_nltk import (
+    mock_pos_tag,
+    mock_sent_tokenize,
+    mock_word_tokenize,
+)
 
 
 @pytest.mark.parametrize(

--- a/test_unstructured/staging/test_argilla.py
+++ b/test_unstructured/staging/test_argilla.py
@@ -1,8 +1,8 @@
+import argilla as rg
 import pytest
 
-import argilla as rg
 import unstructured.staging.argilla as argilla
-from unstructured.documents.elements import Title, NarrativeText
+from unstructured.documents.elements import NarrativeText, Title
 
 
 @pytest.fixture

--- a/test_unstructured/staging/test_argilla.py
+++ b/test_unstructured/staging/test_argilla.py
@@ -5,13 +5,13 @@ import unstructured.staging.argilla as argilla
 from unstructured.documents.elements import NarrativeText, Title
 
 
-@pytest.fixture
+@pytest.fixture()
 def elements():
     return [Title(text="example"), NarrativeText(text="another example")]
 
 
 @pytest.mark.parametrize(
-    "task_name, dataset_type, extra_kwargs",
+    ("task_name", "dataset_type", "extra_kwargs"),
     [
         (
             "text_classification",
@@ -56,7 +56,7 @@ def test_stage_for_argilla(elements, task_name, dataset_type, extra_kwargs):
 
 
 @pytest.mark.parametrize(
-    "task_name, error, error_message, extra_kwargs",
+    ("task_name", "error", "error_message", "extra_kwargs"),
     [
         ("unknown_task", ValueError, "invalid value", {}),
         ("text_classification", ValueError, "invalid value", {"metadata": "invalid metadata"}),

--- a/test_unstructured/staging/test_argilla.py
+++ b/test_unstructured/staging/test_argilla.py
@@ -1,7 +1,7 @@
 import argilla as rg
 import pytest
 
-import unstructured.staging.argilla as argilla
+from unstructured.staging import argilla
 from unstructured.documents.elements import NarrativeText, Title
 
 

--- a/test_unstructured/staging/test_base_staging.py
+++ b/test_unstructured/staging/test_base_staging.py
@@ -6,7 +6,7 @@ import pathlib
 import pandas as pd
 import pytest
 
-import unstructured.staging.base as base
+from unstructured.staging import base
 from unstructured.documents.elements import (
     Address,
     CheckBox,

--- a/test_unstructured/staging/test_base_staging.py
+++ b/test_unstructured/staging/test_base_staging.py
@@ -60,7 +60,7 @@ def test_convert_to_csv(output_csv_file):
         isd_csv_string = base.convert_to_csv(elements)
         csv_file.write(isd_csv_string)
 
-    with open(output_csv_file, "r") as csv_file:
+    with open(output_csv_file) as csv_file:
         csv_rows = csv.DictReader(csv_file)
         assert all(set(row.keys()) == set(base.TABLE_FIELDNAMES) for row in csv_rows)
 

--- a/test_unstructured/staging/test_base_staging.py
+++ b/test_unstructured/staging/test_base_staging.py
@@ -2,23 +2,22 @@ import csv
 import json
 import os
 import pathlib
-import pytest
 
 import pandas as pd
+import pytest
 
 import unstructured.staging.base as base
-
 from unstructured.documents.elements import (
     Address,
     CheckBox,
     ElementMetadata,
     FigureCaption,
-    Title,
-    Text,
-    NarrativeText,
-    ListItem,
     Image,
+    ListItem,
+    NarrativeText,
     PageBreak,
+    Text,
+    Title,
 )
 
 

--- a/test_unstructured/staging/test_base_staging.py
+++ b/test_unstructured/staging/test_base_staging.py
@@ -21,7 +21,7 @@ from unstructured.documents.elements import (
 )
 
 
-@pytest.fixture
+@pytest.fixture()
 def output_csv_file(tmp_path):
     return os.path.join(tmp_path, "isd_data.csv")
 

--- a/test_unstructured/staging/test_base_staging.py
+++ b/test_unstructured/staging/test_base_staging.py
@@ -72,7 +72,7 @@ def test_convert_to_dataframe():
         {
             "type": ["Title", "NarrativeText"],
             "text": ["Title 1", "Narrative 1"],
-        }
+        },
     )
     assert df.type.equals(expected_df.type) is True
     assert df.text.equals(expected_df.text) is True

--- a/test_unstructured/staging/test_datasaur.py
+++ b/test_unstructured/staging/test_datasaur.py
@@ -1,6 +1,6 @@
 import pytest
 
-import unstructured.staging.datasaur as datasaur
+from unstructured.staging import datasaur
 from unstructured.documents.elements import Text
 
 

--- a/test_unstructured/staging/test_huggingface.py
+++ b/test_unstructured/staging/test_huggingface.py
@@ -1,7 +1,7 @@
 import pytest
 
-from unstructured.documents.elements import Text
 import unstructured.staging.huggingface as huggingface
+from unstructured.documents.elements import Text
 
 
 class MockTokenizer:

--- a/test_unstructured/staging/test_huggingface.py
+++ b/test_unstructured/staging/test_huggingface.py
@@ -1,6 +1,6 @@
 import pytest
 
-import unstructured.staging.huggingface as huggingface
+from unstructured.staging import huggingface
 from unstructured.documents.elements import Text
 
 

--- a/test_unstructured/staging/test_label_box.py
+++ b/test_unstructured/staging/test_label_box.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-import unstructured.staging.label_box as label_box
+from unstructured.staging import label_box
 from unstructured.documents.elements import NarrativeText, Title
 
 

--- a/test_unstructured/staging/test_label_box.py
+++ b/test_unstructured/staging/test_label_box.py
@@ -1,7 +1,9 @@
 import os
+
 import pytest
+
 import unstructured.staging.label_box as label_box
-from unstructured.documents.elements import Title, NarrativeText
+from unstructured.documents.elements import NarrativeText, Title
 
 
 @pytest.fixture

--- a/test_unstructured/staging/test_label_box.py
+++ b/test_unstructured/staging/test_label_box.py
@@ -55,7 +55,14 @@ attachment = {"type": "RAW_TEXT", "value": "Text description."}
 
 @pytest.mark.parametrize(
     (
-        ("external_ids", "attachments", "output_directory_fixture", "create_directory", "raises", "exception_class")
+        (
+            "external_ids",
+            "attachments",
+            "output_directory_fixture",
+            "create_directory",
+            "raises",
+            "exception_class",
+        )
     ),
     [
         (None, None, "output_directory", True, False, None),

--- a/test_unstructured/staging/test_label_box.py
+++ b/test_unstructured/staging/test_label_box.py
@@ -133,5 +133,5 @@ def test_stage_for_label_box(
             assert element_config["data"].endswith(f'{element_config["externalId"]}.txt')
 
             output_filepath = os.path.join(output_directory, f'{element_config["externalId"]}.txt')
-            with open(output_filepath, "r") as data_file:
+            with open(output_filepath) as data_file:
                 assert data_file.read().strip() == element.text.strip()

--- a/test_unstructured/staging/test_label_box.py
+++ b/test_unstructured/staging/test_label_box.py
@@ -6,28 +6,28 @@ import unstructured.staging.label_box as label_box
 from unstructured.documents.elements import NarrativeText, Title
 
 
-@pytest.fixture
+@pytest.fixture()
 def elements():
     return [Title(text="Title 1"), NarrativeText(text="Narrative 1")]
 
 
-@pytest.fixture
+@pytest.fixture()
 def output_directory(tmp_path):
     return str(tmp_path)
 
 
-@pytest.fixture
+@pytest.fixture()
 def nonexistent_output_directory(tmp_path):
     return os.path.join(str(tmp_path), "nonexistent_dir")
 
 
-@pytest.fixture
+@pytest.fixture()
 def url_prefix():
     return "https://storage.googleapis.com/labelbox-sample-datasets/nlp"
 
 
 @pytest.mark.parametrize(
-    "attachments, raises_error",
+    ("attachments", "raises_error"),
     [
         (
             [
@@ -55,8 +55,7 @@ attachment = {"type": "RAW_TEXT", "value": "Text description."}
 
 @pytest.mark.parametrize(
     (
-        "external_ids, attachments, output_directory_fixture, create_directory, "
-        "raises, exception_class"
+        ("external_ids", "attachments", "output_directory_fixture", "create_directory", "raises", "exception_class")
     ),
     [
         (None, None, "output_directory", True, False, None),

--- a/test_unstructured/staging/test_label_studio.py
+++ b/test_unstructured/staging/test_label_studio.py
@@ -5,7 +5,7 @@ import pytest
 import vcr
 from label_studio_sdk.client import Client
 
-import unstructured.staging.label_studio as label_studio
+from unstructured.staging import label_studio
 from unstructured.documents.elements import NarrativeText, Title
 
 

--- a/test_unstructured/staging/test_label_studio.py
+++ b/test_unstructured/staging/test_label_studio.py
@@ -94,8 +94,8 @@ def test_created_annotation():
                 value={"choices": ["Positive"]},
                 from_name="sentiment",
                 to_name="text",
-            )
-        ]
+            ),
+        ],
     )
 
     annotation.to_dict() == {
@@ -108,7 +108,7 @@ def test_created_annotation():
                 "to_name": "text",
                 "hidden": False,
                 "read_only": False,
-            }
+            },
         ],
         "was_canceled": False,
     }
@@ -132,7 +132,7 @@ def test_init_prediction(score, raises, exception):
             value={"choices": ["Positive"]},
             from_name="sentiment",
             to_name="text",
-        )
+        ),
     ]
 
     if raises:
@@ -150,7 +150,7 @@ def test_init_prediction(score, raises, exception):
                     "to_name": "text",
                     "hidden": False,
                     "read_only": False,
-                }
+                },
             ],
             "was_canceled": False,
             "score": score,
@@ -167,9 +167,9 @@ def test_stage_with_annotation():
                     value={"choices": ["Positive"]},
                     from_name="sentiment",
                     to_name="text",
-                )
-            ]
-        )
+                ),
+            ],
+        ),
     ]
     label_studio_data = label_studio.stage_for_label_studio([element], [annotations])
     assert label_studio_data == [
@@ -186,12 +186,12 @@ def test_stage_with_annotation():
                             "to_name": "text",
                             "hidden": False,
                             "read_only": False,
-                        }
+                        },
                     ],
                     "was_canceled": False,
-                }
+                },
             ],
-        }
+        },
     ]
 
 
@@ -205,10 +205,10 @@ def test_stage_with_prediction():
                     value={"choices": ["Positive"]},
                     from_name="sentiment",
                     to_name="text",
-                )
+                ),
             ],
             score=0.98,
-        )
+        ),
     ]
     label_studio_data = label_studio.stage_for_label_studio([element], predictions=[prediction])
     assert label_studio_data == [
@@ -225,13 +225,13 @@ def test_stage_with_prediction():
                             "to_name": "text",
                             "hidden": False,
                             "read_only": False,
-                        }
+                        },
                     ],
                     "was_canceled": False,
                     "score": 0.98,
-                }
+                },
             ],
-        }
+        },
     ]
 
 
@@ -245,9 +245,9 @@ def test_stage_with_annotation_for_ner():
                     value={"start": 12, "end": 16, "text": "bear", "labels": ["PER"]},
                     from_name="label",
                     to_name="text",
-                )
-            ]
-        )
+                ),
+            ],
+        ),
     ]
     label_studio_data = label_studio.stage_for_label_studio([element], [annotations])
     assert label_studio_data == [
@@ -264,12 +264,12 @@ def test_stage_with_annotation_for_ner():
                             "to_name": "text",
                             "hidden": False,
                             "read_only": False,
-                        }
+                        },
                     ],
                     "was_canceled": False,
-                }
+                },
             ],
-        }
+        },
     ]
 
 
@@ -283,9 +283,9 @@ def test_stage_with_annotation_raises_with_mismatched_lengths():
                     value={"choices": ["Positive"]},
                     from_name="sentiment",
                     to_name="text",
-                )
-            ]
-        )
+                ),
+            ],
+        ),
     ]
     with pytest.raises(ValueError):
         label_studio.stage_for_label_studio([element], [annotations, annotations])
@@ -301,10 +301,10 @@ def test_stage_with_prediction_raises_with_mismatched_lengths():
                     value={"choices": ["Positive"]},
                     from_name="sentiment",
                     to_name="text",
-                )
+                ),
             ],
             score=0.82,
-        )
+        ),
     ]
     with pytest.raises(ValueError):
         label_studio.stage_for_label_studio([element], predictions=[prediction, prediction])
@@ -330,10 +330,10 @@ def test_stage_with_reviewed_annotation():
                     value={"choices": ["Positive"]},
                     from_name="sentiment",
                     to_name="text",
-                )
+                ),
             ],
             reviews=[label_studio.LabelStudioReview(created_by={"user_id": 1}, accepted=True)],
-        )
+        ),
     ]
     label_studio_data = label_studio.stage_for_label_studio([element], [annotations])
     assert label_studio_data == [
@@ -350,11 +350,11 @@ def test_stage_with_reviewed_annotation():
                             "id": None,
                             "hidden": False,
                             "read_only": False,
-                        }
+                        },
                     ],
                     "reviews": [{"created_by": {"user_id": 1}, "accepted": True, "id": None}],
                     "was_canceled": False,
-                }
+                },
             ],
-        }
+        },
     ]

--- a/test_unstructured/staging/test_label_studio.py
+++ b/test_unstructured/staging/test_label_studio.py
@@ -9,7 +9,7 @@ import unstructured.staging.label_studio as label_studio
 from unstructured.documents.elements import NarrativeText, Title
 
 
-@pytest.fixture
+@pytest.fixture()
 def elements():
     return [Title(text="Title 1"), NarrativeText(text="Narrative 1")]
 
@@ -115,7 +115,7 @@ def test_created_annotation():
 
 
 @pytest.mark.parametrize(
-    "score, raises, exception",
+    ("score", "raises", "exception"),
     [
         (None, True, ValueError),
         (-0.25, True, ValueError),

--- a/test_unstructured/staging/test_label_studio.py
+++ b/test_unstructured/staging/test_label_studio.py
@@ -1,13 +1,12 @@
-import pytest
-import unstructured.staging.label_studio as label_studio
-
-from unstructured.documents.elements import Title, NarrativeText
-
-from label_studio_sdk.client import Client
-
 import logging
 import re
+
+import pytest
 import vcr
+from label_studio_sdk.client import Client
+
+import unstructured.staging.label_studio as label_studio
+from unstructured.documents.elements import NarrativeText, Title
 
 
 @pytest.fixture

--- a/test_unstructured/staging/test_prodigy.py
+++ b/test_unstructured/staging/test_prodigy.py
@@ -54,7 +54,7 @@ def test_validate_prodigy_metadata_with_valid_metadata(elements, valid_metadata)
     ],
 )
 def test_validate_prodigy_metadata_with_invalid_metadata(
-    elements, invalid_metadata_fixture, exception_message, request
+    elements, invalid_metadata_fixture, exception_message, request,
 ):
     invalid_metadata = request.getfixturevalue(invalid_metadata_fixture)
     with pytest.raises(ValueError) as validation_exception:

--- a/test_unstructured/staging/test_prodigy.py
+++ b/test_unstructured/staging/test_prodigy.py
@@ -7,27 +7,27 @@ import unstructured.staging.prodigy as prodigy
 from unstructured.documents.elements import NarrativeText, Title
 
 
-@pytest.fixture
+@pytest.fixture()
 def elements():
     return [Title(text="Title 1"), NarrativeText(text="Narrative 1")]
 
 
-@pytest.fixture
+@pytest.fixture()
 def valid_metadata():
     return [{"score": 0.1}, {"category": "paragraph"}]
 
 
-@pytest.fixture
+@pytest.fixture()
 def metadata_with_id():
     return [{"score": 0.1}, {"id": 1, "category": "paragraph"}]
 
 
-@pytest.fixture
+@pytest.fixture()
 def metadata_with_invalid_length():
     return [{"score": 0.1}, {"category": "paragraph"}, {"type": "text"}]
 
 
-@pytest.fixture
+@pytest.fixture()
 def output_csv_file(tmp_path):
     return os.path.join(tmp_path, "prodigy_data.csv")
 
@@ -44,7 +44,7 @@ def test_validate_prodigy_metadata_with_valid_metadata(elements, valid_metadata)
 
 
 @pytest.mark.parametrize(
-    "invalid_metadata_fixture, exception_message",
+    ("invalid_metadata_fixture", "exception_message"),
     [
         ("metadata_with_id", 'The key "id" is not allowed with metadata parameter at index: 1'),
         (

--- a/test_unstructured/staging/test_prodigy.py
+++ b/test_unstructured/staging/test_prodigy.py
@@ -98,7 +98,7 @@ def test_stage_csv_for_prodigy(elements, output_csv_file):
         csv_file.write(prodigy_csv_string)
 
     fieldnames = ["text", "id"]
-    with open(output_csv_file, "r") as csv_file:
+    with open(output_csv_file) as csv_file:
         csv_rows = csv.DictReader(csv_file)
         assert all(set(row.keys()) == set(fieldnames) for row in csv_rows)
 
@@ -110,6 +110,6 @@ def test_stage_csv_for_prodigy_with_metadata(elements, valid_metadata, output_cs
 
     fieldnames = set(["text", "id"]).union(*(data.keys() for data in valid_metadata))
     fieldnames = [fieldname.lower() for fieldname in fieldnames]
-    with open(output_csv_file, "r") as csv_file:
+    with open(output_csv_file) as csv_file:
         csv_rows = csv.DictReader(csv_file)
         assert all(set(row.keys()) == set(fieldnames) for row in csv_rows)

--- a/test_unstructured/staging/test_prodigy.py
+++ b/test_unstructured/staging/test_prodigy.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-import unstructured.staging.prodigy as prodigy
+from unstructured.staging import prodigy
 from unstructured.documents.elements import NarrativeText, Title
 
 

--- a/test_unstructured/staging/test_prodigy.py
+++ b/test_unstructured/staging/test_prodigy.py
@@ -54,7 +54,10 @@ def test_validate_prodigy_metadata_with_valid_metadata(elements, valid_metadata)
     ],
 )
 def test_validate_prodigy_metadata_with_invalid_metadata(
-    elements, invalid_metadata_fixture, exception_message, request,
+    elements,
+    invalid_metadata_fixture,
+    exception_message,
+    request,
 ):
     invalid_metadata = request.getfixturevalue(invalid_metadata_fixture)
     with pytest.raises(ValueError) as validation_exception:

--- a/test_unstructured/staging/test_prodigy.py
+++ b/test_unstructured/staging/test_prodigy.py
@@ -1,9 +1,10 @@
-import pytest
 import csv
 import os
 
+import pytest
+
 import unstructured.staging.prodigy as prodigy
-from unstructured.documents.elements import Title, NarrativeText
+from unstructured.documents.elements import NarrativeText, Title
 
 
 @pytest.fixture

--- a/test_unstructured/staging/test_prodigy.py
+++ b/test_unstructured/staging/test_prodigy.py
@@ -108,7 +108,7 @@ def test_stage_csv_for_prodigy_with_metadata(elements, valid_metadata, output_cs
         prodigy_csv_string = prodigy.stage_csv_for_prodigy(elements, valid_metadata)
         csv_file.write(prodigy_csv_string)
 
-    fieldnames = set(["text", "id"]).union(*(data.keys() for data in valid_metadata))
+    fieldnames = {"text", "id"}.union(*(data.keys() for data in valid_metadata))
     fieldnames = [fieldname.lower() for fieldname in fieldnames]
     with open(output_csv_file) as csv_file:
         csv_rows = csv.DictReader(csv_file)

--- a/test_unstructured/test_utils.py
+++ b/test_unstructured/test_utils.py
@@ -1,5 +1,6 @@
-import os
 import json
+import os
+
 import pytest
 
 import unstructured.utils as utils

--- a/test_unstructured/test_utils.py
+++ b/test_unstructured/test_utils.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-import unstructured.utils as utils
+from unstructured import utils
 
 
 @pytest.fixture()

--- a/test_unstructured/test_utils.py
+++ b/test_unstructured/test_utils.py
@@ -29,7 +29,7 @@ def input_jsonl_file(tmp_path, input_data):
 
 def test_save_as_jsonl(input_data, output_jsonl_file):
     utils.save_as_jsonl(input_data, output_jsonl_file)
-    with open(output_jsonl_file, "r") as output_file:
+    with open(output_jsonl_file) as output_file:
         file_data = [json.loads(line) for line in output_file]
     assert file_data == input_data
 

--- a/test_unstructured/test_utils.py
+++ b/test_unstructured/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 import unstructured.utils as utils
 
 
-@pytest.fixture
+@pytest.fixture()
 def input_data():
     return [
         {"text": "This is a sentence."},
@@ -14,12 +14,12 @@ def input_data():
     ]
 
 
-@pytest.fixture
+@pytest.fixture()
 def output_jsonl_file(tmp_path):
     return os.path.join(tmp_path, "output.jsonl")
 
 
-@pytest.fixture
+@pytest.fixture()
 def input_jsonl_file(tmp_path, input_data):
     file_path = os.path.join(tmp_path, "input.jsonl")
     with open(file_path, "w+") as input_file:

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -1,7 +1,7 @@
+import quopri
 import re
 import sys
 import unicodedata
-import quopri
 
 from unstructured.nlp.patterns import UNICODE_BULLETS_RE
 

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -149,7 +149,7 @@ def clean_prefix(text: str, pattern: str, ignore_case: bool = False, strip: bool
     strip: If True, removes leading whitespace from the cleaned string.
     """
     flags = re.IGNORECASE if ignore_case else 0
-    clean_text = re.sub(fr"^{pattern}", "", text, flags=flags)
+    clean_text = re.sub(rf"^{pattern}", "", text, flags=flags)
     clean_text = clean_text.lstrip() if strip else clean_text
     return clean_text
 
@@ -166,7 +166,7 @@ def clean_postfix(text: str, pattern: str, ignore_case: bool = False, strip: boo
     strip: If True, removes trailing whitespace from the cleaned string.
     """
     flags = re.IGNORECASE if ignore_case else 0
-    clean_text = re.sub(fr"{pattern}$", "", text, flags=flags)
+    clean_text = re.sub(rf"{pattern}$", "", text, flags=flags)
     clean_text = clean_text.rstrip() if strip else clean_text
     return clean_text
 

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -149,7 +149,7 @@ def clean_prefix(text: str, pattern: str, ignore_case: bool = False, strip: bool
     strip: If True, removes leading whitespace from the cleaned string.
     """
     flags = re.IGNORECASE if ignore_case else 0
-    clean_text = re.sub(r"^{0}".format(pattern), "", text, flags=flags)
+    clean_text = re.sub(fr"^{pattern}", "", text, flags=flags)
     clean_text = clean_text.lstrip() if strip else clean_text
     return clean_text
 
@@ -166,7 +166,7 @@ def clean_postfix(text: str, pattern: str, ignore_case: bool = False, strip: boo
     strip: If True, removes trailing whitespace from the cleaned string.
     """
     flags = re.IGNORECASE if ignore_case else 0
-    clean_text = re.sub(r"{0}$".format(pattern), "", text, flags=flags)
+    clean_text = re.sub(fr"{pattern}$", "", text, flags=flags)
     clean_text = clean_text.rstrip() if strip else clean_text
     return clean_text
 

--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -1,15 +1,15 @@
-import re
 import datetime
+import re
 from typing import List
-from unstructured.nlp.patterns import (
-    IP_ADDRESS_PATTERN_RE,
-    IP_ADDRESS_NAME_PATTERN,
-    MAPI_ID_PATTERN,
-    EMAIL_DATETIMETZ_PATTERN,
-    EMAIL_ADDRESS_PATTERN,
-)
 
-from unstructured.nlp.patterns import US_PHONE_NUMBERS_RE
+from unstructured.nlp.patterns import (
+    EMAIL_ADDRESS_PATTERN,
+    EMAIL_DATETIMETZ_PATTERN,
+    IP_ADDRESS_NAME_PATTERN,
+    IP_ADDRESS_PATTERN_RE,
+    MAPI_ID_PATTERN,
+    US_PHONE_NUMBERS_RE,
+)
 
 
 def _get_indexed_match(text: str, pattern: str, index: int = 0) -> re.Match:

--- a/unstructured/cleaners/translate.py
+++ b/unstructured/cleaners/translate.py
@@ -64,7 +64,7 @@ def translate_text(text, source_lang: Optional[str] = None, target_lang: str = "
 
     chunks: List[str] = chunk_by_attention_window(text, tokenizer, split_function=sent_tokenize)
 
-    translated_chunks: List[str] = list()
+    translated_chunks: List[str] = []
     for chunk in chunks:
         translated_chunks.append(_translate_text(text, model, tokenizer))
 

--- a/unstructured/cleaners/translate.py
+++ b/unstructured/cleaners/translate.py
@@ -1,11 +1,11 @@
-from typing import List, Optional
 import warnings
+from typing import List, Optional
 
 import langdetect
 from transformers import MarianMTModel, MarianTokenizer
 
-from unstructured.staging.huggingface import chunk_by_attention_window
 from unstructured.nlp.tokenize import sent_tokenize
+from unstructured.staging.huggingface import chunk_by_attention_window
 
 
 def _get_opus_mt_model_name(source_lang: str, target_lang: str):

--- a/unstructured/cleaners/translate.py
+++ b/unstructured/cleaners/translate.py
@@ -17,7 +17,7 @@ def _get_opus_mt_model_name(source_lang: str, target_lang: str):
 def _validate_language_code(language_code: str):
     if not isinstance(language_code, str) or len(language_code) != 2:
         raise ValueError(
-            f"Invalid language code: {language_code}. Language codes must be two letter strings."
+            f"Invalid language code: {language_code}. Language codes must be two letter strings.",
         )
 
 
@@ -59,7 +59,7 @@ def translate_text(text, source_lang: Optional[str] = None, target_lang: str = "
     except OSError:
         raise ValueError(
             f"Transformers could not find the translation model {model_name}. "
-            "The requested source/target language combo is not suppored."
+            "The requested source/target language combo is not suppored.",
         )
 
     chunks: List[str] = chunk_by_attention_window(text, tokenizer, split_function=sent_tokenize)
@@ -79,7 +79,7 @@ def _translate_text(text, model, tokenizer):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         translated = model.generate(
-            **tokenizer([text], return_tensors="pt", padding="max_length", max_length=512)
+            **tokenizer([text], return_tensors="pt", padding="max_length", max_length=512),
         )
     return [tokenizer.decode(t, max_new_tokens=512, skip_special_tokens=True) for t in translated][
         0

--- a/unstructured/documents/base.py
+++ b/unstructured/documents/base.py
@@ -18,7 +18,7 @@ class Document(ABC):
 
     def get_narrative(self) -> List[NarrativeText]:
         """Pulls out all of the narrative text sections from the document."""
-        narrative: List[NarrativeText] = list()
+        narrative: List[NarrativeText] = []
         for page in self.pages:
             for element in page.elements:
                 if isinstance(element, NarrativeText):
@@ -85,7 +85,7 @@ class Page(ABC):
 
     def __init__(self, number: int):
         self.number: int = number
-        self.elements: List[Element] = list()
+        self.elements: List[Element] = []
 
     def __str__(self):
         return "\n\n".join([str(element) for element in self.elements])

--- a/unstructured/documents/base.py
+++ b/unstructured/documents/base.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from abc import ABC
 from typing import List, Optional
 

--- a/unstructured/documents/base.py
+++ b/unstructured/documents/base.py
@@ -31,7 +31,7 @@ class Document(ABC):
         if self._pages is None:
             raise NotImplementedError(
                 "When subclassing, _pages should always be populated before "
-                "using the pages property."
+                "using the pages property.",
             )
         return self._pages
 

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -109,7 +109,7 @@ class Text(Element):
                 (self.text == other.text),
                 (self.coordinates == other.coordinates),
                 (self.category == other.category),
-            ]
+            ],
         )
 
     def to_dict(self) -> dict:

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -1,8 +1,8 @@
+import hashlib
+import pathlib
 from abc import ABC
 from dataclasses import dataclass
-import hashlib
 from typing import Any, Callable, Dict, List, Optional, Union
-import pathlib
 
 
 class NoID(ABC):

--- a/unstructured/documents/email_elements.py
+++ b/unstructured/documents/email_elements.py
@@ -3,7 +3,7 @@ from abc import ABC
 from datetime import datetime
 from typing import Callable, List, Union
 
-from unstructured.documents.elements import Element, Text, NoID
+from unstructured.documents.elements import Element, NoID, Text
 
 
 class NoDatestamp(ABC):

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -145,7 +145,7 @@ class HTMLDocument(XMLDocument):
         return pages
 
     def doc_after_cleaners(
-        self, skip_headers_and_footers=False, skip_table_text=False, inplace=False
+        self, skip_headers_and_footers=False, skip_table_text=False, inplace=False,
     ) -> HTMLDocument:
         """Filters the elements and returns a new instance of the class based on the criteria
         specified. Note that the number of pages can change in the case that all elements on a
@@ -177,7 +177,7 @@ class HTMLDocument(XMLDocument):
                     raise ValueError(
                         f"elements of class {self.__class__} should be of type HTMLTitle "
                         f"HTMLNarrativeText, or HTMLListItem but "
-                        f"object has an element of type {type(el)}"
+                        f"object has an element of type {type(el)}",
                     )
                 if not any(excluder(el) for excluder in excluders):
                     elements.append(el)
@@ -296,7 +296,7 @@ def _is_text_tag(tag_elem: etree.Element, max_predecessor_len: int = 5) -> bool:
 
 
 def _process_list_item(
-    tag_elem: etree.Element, max_predecessor_len: int = 5
+    tag_elem: etree.Element, max_predecessor_len: int = 5,
 ) -> Tuple[Optional[Element], etree.Element]:
     """If an etree element contains bulleted text, extracts the relevant bulleted text
     and converts it to ListItem objects. Also returns the next html elements so that

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -44,7 +44,7 @@ class TagsMixin:
         self,
         *args,
         tag: Optional[str] = None,
-        ancestortags: Sequence[str] = tuple(),
+        ancestortags: Sequence[str] = (),
         **kwargs,
     ):
         if tag is None:
@@ -96,14 +96,14 @@ class HTMLDocument(XMLDocument):
         if self._pages:
             return self._pages
         logger.info("Reading document ...")
-        pages: List[Page] = list()
+        pages: List[Page] = []
         root = _find_main(self.document_tree)
 
         articles = _find_articles(root)
         page_number = 0
         page = Page(number=page_number)
         for article in articles:
-            descendanttag_elems: Tuple[etree.Element, ...] = tuple()
+            descendanttag_elems: Tuple[etree.Element, ...] = ()
             for tag_elem in article.iter():
                 if tag_elem in descendanttag_elems:
                     # Prevent repeating something that's been flagged as text as we chase it
@@ -322,7 +322,7 @@ def _process_list_item(
 
 
 def _get_bullet_descendants(element, next_element) -> Tuple[etree.Element, ...]:
-    descendants = list()
+    descendants = []
     if element is not None:
         if next_element is not None:
             descendants += list(next_element.iterdescendants())
@@ -346,7 +346,7 @@ def _bulleted_text_from_table(table) -> List[Element]:
     NOTE: if a table has mixed bullets and non-bullets, only bullets are extracted.
     I.e., _read() will drop non-bullet narrative text in the table.
     """
-    bulleted_text: List[Element] = list()
+    bulleted_text: List[Element] = []
     rows = table.findall(".//tr")
     for row in rows:
         text = _construct_text(row)

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -145,7 +145,10 @@ class HTMLDocument(XMLDocument):
         return pages
 
     def doc_after_cleaners(
-        self, skip_headers_and_footers=False, skip_table_text=False, inplace=False,
+        self,
+        skip_headers_and_footers=False,
+        skip_table_text=False,
+        inplace=False,
     ) -> HTMLDocument:
         """Filters the elements and returns a new instance of the class based on the criteria
         specified. Note that the number of pages can change in the case that all elements on a
@@ -296,7 +299,8 @@ def _is_text_tag(tag_elem: etree.Element, max_predecessor_len: int = 5) -> bool:
 
 
 def _process_list_item(
-    tag_elem: etree.Element, max_predecessor_len: int = 5,
+    tag_elem: etree.Element,
+    max_predecessor_len: int = 5,
 ) -> Tuple[Optional[Element], etree.Element]:
     """If an etree element contains bulleted text, extracts the relevant bulleted text
     and converts it to ListItem objects. Also returns the next html elements so that

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -323,9 +323,8 @@ def _process_list_item(
 
 def _get_bullet_descendants(element, next_element) -> Tuple[etree.Element, ...]:
     descendants = []
-    if element is not None:
-        if next_element is not None:
-            descendants += list(next_element.iterdescendants())
+    if element is not None and next_element is not None:
+        descendants += list(next_element.iterdescendants())
     descendanttag_elems = tuple(descendants)
     return descendanttag_elems
 
@@ -334,9 +333,8 @@ def is_list_item_tag(tag_elem: etree.Element) -> bool:
     """Checks to see if a tag contains bulleted text."""
     if tag_elem.tag in LIST_ITEM_TAGS:
         return True
-    elif tag_elem.tag == "div":
-        if is_bulleted_text(_construct_text(tag_elem)):
-            return True
+    elif tag_elem.tag == "div" and is_bulleted_text(_construct_text(tag_elem)):
+        return True
     return False
 
 
@@ -383,10 +381,7 @@ def _has_adjacent_bulleted_spans(tag_elem: etree.Element, children: List[etree.E
 def has_table_ancestor(element: TagsMixin) -> bool:
     """Checks to see if an element has ancestors that are table elements. If so, we consider
     it to be a table element rather than a section of narrative text."""
-    for ancestor in element.ancestortags:
-        if ancestor in TABLE_TAGS:
-            return True
-    return False
+    return any(ancestor in TABLE_TAGS for ancestor in element.ancestortags)
 
 
 def in_header_or_footer(element: TagsMixin) -> bool:

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from typing import List, Optional, Sequence, Tuple
+
 import sys
+from typing import List, Optional, Sequence, Tuple
 
 if sys.version_info < (3, 8):
     from typing_extensions import Final
@@ -9,12 +10,18 @@ else:
 
 from lxml import etree
 
-from unstructured.logger import logger
-
 from unstructured.cleaners.core import clean_bullets, replace_unicode_quotes
 from unstructured.documents.base import Page
-from unstructured.documents.elements import Address, ListItem, Element, NarrativeText, Text, Title
+from unstructured.documents.elements import (
+    Address,
+    Element,
+    ListItem,
+    NarrativeText,
+    Text,
+    Title,
+)
 from unstructured.documents.xml import XMLDocument
+from unstructured.logger import logger
 from unstructured.partition.text_type import (
     is_bulleted_text,
     is_possible_narrative_text,

--- a/unstructured/documents/xml.py
+++ b/unstructured/documents/xml.py
@@ -1,10 +1,9 @@
-from typing import Optional, Union, List
+from typing import List, Optional, Union
 
 import lxml.etree as etree
 
-from unstructured.logger import logger
 from unstructured.documents.base import Document, Page
-
+from unstructured.logger import logger
 
 VALID_PARSERS = Union[etree.HTMLParser, etree.XMLParser, None]
 

--- a/unstructured/documents/xml.py
+++ b/unstructured/documents/xml.py
@@ -64,7 +64,7 @@ class XMLDocument(Document):
                         "Stylesheets are more commonly parsed with the "
                         "XMLParser. If your HTML does not display properly, try "
                         "`import lxml.etree as etree` and setting "
-                        "`parser=etree.XMLParser()` instead."
+                        "`parser=etree.XMLParser()` instead.",
                     )
                 xslt = etree.parse(self.stylesheet)
                 transform = etree.XSLT(xslt)

--- a/unstructured/documents/xml.py
+++ b/unstructured/documents/xml.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union
 
-import lxml.etree as etree
+from lxml import etree
 
 from unstructured.documents.base import Document, Page
 from unstructured.logger import logger

--- a/unstructured/file_utils/exploration.py
+++ b/unstructured/file_utils/exploration.py
@@ -44,7 +44,7 @@ def get_file_info(filenames: List[str]) -> pd.DataFrame:
 
 
 def get_file_info_from_file_contents(
-    file_contents: List[str], filenames: Optional[List[str]] = None
+    file_contents: List[str], filenames: Optional[List[str]] = None,
 ) -> pd.DataFrame:
     data: Dict[str, List[Any]] = {
         "filesize": [],
@@ -55,7 +55,7 @@ def get_file_info_from_file_contents(
         if len(filenames) != len(file_contents):
             raise ValueError(
                 f"There are {len(filenames)} filenames and {len(file_contents)} "
-                "file_contents. Both inputs must be the same length."
+                "file_contents. Both inputs must be the same length.",
             )
         data["filename"] = []
 

--- a/unstructured/file_utils/exploration.py
+++ b/unstructured/file_utils/exploration.py
@@ -44,7 +44,8 @@ def get_file_info(filenames: List[str]) -> pd.DataFrame:
 
 
 def get_file_info_from_file_contents(
-    file_contents: List[str], filenames: Optional[List[str]] = None,
+    file_contents: List[str],
+    filenames: Optional[List[str]] = None,
 ) -> pd.DataFrame:
     data: Dict[str, List[Any]] = {
         "filesize": [],

--- a/unstructured/file_utils/exploration.py
+++ b/unstructured/file_utils/exploration.py
@@ -11,7 +11,7 @@ from unstructured.file_utils.filetype import detect_filetype
 def get_directory_file_info(directory: str) -> pd.DataFrame:
     """Recursively walks a directory and extracts key file information to support initial
     exploration of text data sets. Returns a pandas DataFrame."""
-    filenames: List[str] = list()
+    filenames: List[str] = []
     for path, _, files in os.walk(directory):
         for filename_no_path in files:
             filenames.append(os.path.join(path, filename_no_path))

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -114,7 +114,8 @@ EXT_TO_FILETYPE = {
 
 
 def detect_filetype(
-    filename: Optional[str] = None, file: Optional[IO] = None,
+    filename: Optional[str] = None,
+    file: Optional[IO] = None,
 ) -> Optional[FileType]:
     """Use libmagic to determine a file's type. Helps determine which partition brick
     to use for a given file. A return value of None indicates a non-supported file type."""

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -1,7 +1,7 @@
-from enum import Enum
 import os
-from typing import IO, Optional
 import zipfile
+from enum import Enum
+from typing import IO, Optional
 
 try:
     import magic
@@ -13,7 +13,6 @@ except ImportError:  # pragma: nocover
 
 from unstructured.logger import logger
 from unstructured.nlp.patterns import EMAIL_HEAD_RE
-
 
 DOCX_MIME_TYPES = [
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -114,7 +114,7 @@ EXT_TO_FILETYPE = {
 
 
 def detect_filetype(
-    filename: Optional[str] = None, file: Optional[IO] = None
+    filename: Optional[str] = None, file: Optional[IO] = None,
 ) -> Optional[FileType]:
     """Use libmagic to determine a file's type. Helps determine which partition brick
     to use for a given file. A return value of None indicates a non-supported file type."""
@@ -140,7 +140,7 @@ def detect_filetype(
             raise ImportError(
                 "libmagic is unavailable. "
                 "Filetype detection on file-like objects requires libmagic. "
-                "Please install libmagic and try again."
+                "Please install libmagic and try again.",
             )
     else:
         raise ValueError("No filename nor file were specified.")
@@ -215,7 +215,7 @@ def detect_filetype(
             return filetype
 
     logger.warn(
-        f"MIME type was {mime_type}. This file type is not currently supported in unstructured."
+        f"MIME type was {mime_type}. This file type is not currently supported in unstructured.",
     )
     return FileType.UNK
 

--- a/unstructured/file_utils/metadata.py
+++ b/unstructured/file_utils/metadata.py
@@ -119,7 +119,7 @@ def get_jpg_metadata(
         raise FileNotFoundError("No filename nor file were specified")
 
     exif_data = image.getexif()
-    exif_dict: Dict[str, Any] = dict()
+    exif_dict: Dict[str, Any] = {}
     for tag_id in exif_data:
         tag = TAGS.get(tag_id, tag_id)
         data = exif_data.get(tag_id)

--- a/unstructured/file_utils/metadata.py
+++ b/unstructured/file_utils/metadata.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass, field
 import datetime
 import io
-from typing import Any, Dict, IO, Final, Optional
+from dataclasses import dataclass, field
+from typing import IO, Any, Dict, Final, Optional
 
 import docx
 import openpyxl

--- a/unstructured/ingest/connector/s3_connector.py
+++ b/unstructured/ingest/connector/s3_connector.py
@@ -51,7 +51,7 @@ class SimpleS3Config(BaseConnectorConfig):
         if not match:
             raise ValueError(
                 f"s3_url {self.s3_url} does not look like a valid path. "
-                "Expected s3://<bucket-name or s3://<bucket-name/path"
+                "Expected s3://<bucket-name or s3://<bucket-name/path",
             )
         self.s3_bucket = match.group(1)
         self.s3_path = match.group(2) or ""
@@ -172,7 +172,7 @@ class S3Connector(BaseConnector):
         response = self.s3_cli.list_objects_v2(**self._list_objects_kwargs, MaxKeys=1)
         if response["KeyCount"] < 1:
             raise ValueError(
-                f"No objects found in {self.config.s3_url} -- response list object is {response}"
+                f"No objects found in {self.config.s3_url} -- response list object is {response}",
             )
         os.mkdir(self.config.download_dir)
 
@@ -185,7 +185,7 @@ class S3Connector(BaseConnector):
                 break
             next_token = response.get("NextContinuationToken")
             response = self.s3_cli.list_objects_v2(
-                **self._list_objects_kwargs, ContinuationToken=next_token
+                **self._list_objects_kwargs, ContinuationToken=next_token,
             )
         return s3_keys
 

--- a/unstructured/ingest/connector/s3_connector.py
+++ b/unstructured/ingest/connector/s3_connector.py
@@ -1,10 +1,14 @@
-from dataclasses import dataclass, field
-from pathlib import Path
 import json
 import os
 import re
+from dataclasses import dataclass, field
+from pathlib import Path
 
-from unstructured.ingest.interfaces import BaseConnector, BaseConnectorConfig, BaseIngestDoc
+from unstructured.ingest.interfaces import (
+    BaseConnector,
+    BaseConnectorConfig,
+    BaseIngestDoc,
+)
 
 
 @dataclass

--- a/unstructured/ingest/connector/s3_connector.py
+++ b/unstructured/ingest/connector/s3_connector.py
@@ -185,7 +185,8 @@ class S3Connector(BaseConnector):
                 break
             next_token = response.get("NextContinuationToken")
             response = self.s3_cli.list_objects_v2(
-                **self._list_objects_kwargs, ContinuationToken=next_token,
+                **self._list_objects_kwargs,
+                ContinuationToken=next_token,
             )
         return s3_keys
 

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -31,14 +31,14 @@ class MainProcess:
         num_docs_to_process = len(docs)
         if num_docs_to_process == 0:
             print(
-                "All docs have structured outputs, nothing to do. Use --reprocess to process all."
+                "All docs have structured outputs, nothing to do. Use --reprocess to process all.",
             )
             return None
         elif num_docs_to_process != num_docs_all:
             print(
                 f"Skipping processing for {num_docs_all - num_docs_to_process} docs out of "
                 f"{num_docs_all} since their structured outputs already exist, use --reprocess to "
-                "reprocess those in addition to the unprocessed ones."
+                "reprocess those in addition to the unprocessed ones.",
             )
         return docs
 

--- a/unstructured/nlp/english_words.py
+++ b/unstructured/nlp/english_words.py
@@ -9,7 +9,7 @@ DIRECTORY = pathlib.Path(__file__).parent.resolve()
 # ref: https://github.com/jeremy-rifkin/Wordlist
 ENGLISH_WORDS_FILE = os.path.join(DIRECTORY, "english-words.txt")
 
-with open(ENGLISH_WORDS_FILE, "r") as f:
+with open(ENGLISH_WORDS_FILE) as f:
     BASE_ENGLISH_WORDS = f.read().split("\n")
 
 # NOTE(robinson) - add new words that we want to pass for the English check in here

--- a/unstructured/nlp/english_words.py
+++ b/unstructured/nlp/english_words.py
@@ -1,5 +1,5 @@
-import pathlib
 import os
+import pathlib
 from typing import List
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -1,5 +1,5 @@
-from typing import List
 import sys
+from typing import List
 
 if sys.version_info < (3, 8):
     from typing_extensions import Final

--- a/unstructured/nlp/tokenize.py
+++ b/unstructured/nlp/tokenize.py
@@ -51,7 +51,7 @@ def pos_tag(text: str) -> List[Tuple[str, str]]:
     # situations like "ITEM 1A. PROPERTIES" where "PROPERTIES" can be mistaken
     # for a verb because it looks like it's in verb form an "ITEM 1A." looks like the subject.
     sentences = _sent_tokenize(text)
-    parts_of_speech = list()
+    parts_of_speech = []
     for sentence in sentences:
         tokens = _word_tokenize(sentence)
         parts_of_speech.extend(_pos_tag(tokens))

--- a/unstructured/nlp/tokenize.py
+++ b/unstructured/nlp/tokenize.py
@@ -1,6 +1,6 @@
+import sys
 from functools import lru_cache
 from typing import List, Tuple
-import sys
 
 if sys.version_info < (3, 8):
     from typing_extensions import Final
@@ -8,11 +8,9 @@ else:
     from typing import Final
 
 import nltk
-from nltk import (
-    pos_tag as _pos_tag,
-    sent_tokenize as _sent_tokenize,
-    word_tokenize as _word_tokenize,
-)
+from nltk import pos_tag as _pos_tag
+from nltk import sent_tokenize as _sent_tokenize
+from nltk import word_tokenize as _word_tokenize
 
 CACHE_MAX_SIZE: Final[int] = 128
 

--- a/unstructured/partition/__init__.py
+++ b/unstructured/partition/__init__.py
@@ -1,6 +1,7 @@
-import requests  # type: ignore
-from typing import BinaryIO, List, Optional, Union, Tuple, Mapping
+from typing import BinaryIO, List, Mapping, Optional, Tuple, Union
 from urllib.parse import urlsplit
+
+import requests  # type: ignore
 
 from unstructured.documents.elements import Element
 

--- a/unstructured/partition/__init__.py
+++ b/unstructured/partition/__init__.py
@@ -31,7 +31,7 @@ def _partition_via_api(
         "file": (
             filename,
             file if file else open(filename, "rb"),
-        )
+        ),
     }
     response = requests.post(
         url=url,

--- a/unstructured/partition/__init__.py
+++ b/unstructured/partition/__init__.py
@@ -43,7 +43,7 @@ def _partition_via_api(
     if response.status_code == 200:
         pages = response.json()["pages"]
         num_pages = len(pages)
-        elements = list()
+        elements = []
         for i, page in enumerate(pages):
             for element in page["elements"]:
                 elements.append(element)

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -1,14 +1,14 @@
 from typing import IO, Optional
 
-from unstructured.file_utils.filetype import detect_filetype, FileType
+from unstructured.file_utils.filetype import FileType, detect_filetype
 from unstructured.partition.doc import partition_doc
 from unstructured.partition.docx import partition_docx
 from unstructured.partition.email import partition_email
 from unstructured.partition.html import partition_html
+from unstructured.partition.image import partition_image
 from unstructured.partition.pdf import partition_pdf
 from unstructured.partition.ppt import partition_ppt
 from unstructured.partition.pptx import partition_pptx
-from unstructured.partition.image import partition_image
 from unstructured.partition.text import partition_text
 
 

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -2,9 +2,9 @@ import subprocess
 from typing import List, Optional, Union
 
 from unstructured.documents.elements import (
+    CheckBox,
     Element,
     ElementMetadata,
-    CheckBox,
     FigureCaption,
     ListItem,
     NarrativeText,
@@ -12,7 +12,7 @@ from unstructured.documents.elements import (
     Text,
     Title,
 )
-from unstructured.nlp.patterns import UNICODE_BULLETS_RE, ENUMERATED_BULLETS_RE
+from unstructured.nlp.patterns import ENUMERATED_BULLETS_RE, UNICODE_BULLETS_RE
 
 
 def normalize_layout_element(layout_element) -> Union[Element, List[Element]]:

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -56,7 +56,7 @@ def layout_list_to_list_items(text: str, coordinates: List[float]) -> List[Eleme
     if len(split_items) == 1:
         split_items = UNICODE_BULLETS_RE.split(text)
 
-    list_items: List[Element] = list()
+    list_items: List[Element] = []
     for text_segment in split_items:
         if len(text_segment.strip()) > 0:
             list_items.append(ListItem(text=text_segment.strip(), coordinates=coordinates))
@@ -66,7 +66,7 @@ def layout_list_to_list_items(text: str, coordinates: List[float]) -> List[Eleme
 
 def document_to_element_list(document, include_page_breaks: bool = False) -> List[Element]:
     """Converts a DocumentLayout object to a list of unstructured elements."""
-    elements: List[Element] = list()
+    elements: List[Element] = []
     num_pages = len(document.pages)
     for i, page in enumerate(document.pages):
         for element in page.elements:
@@ -85,7 +85,7 @@ def add_element_metadata(
 ) -> List[Element]:
     """Adds document metadata to the document element. Document metadata includes information
     like the filename, source url, and page number."""
-    elements: List[Element] = list()
+    elements: List[Element] = []
     page_number: int = 1
     for layout_element in layout_elements:
         element = normalize_layout_element(layout_element)

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -120,7 +120,7 @@ def convert_office_doc(input_filename: str, output_directory: str, target_format
                 "--outdir",
                 output_directory,
                 input_filename,
-            ]
+            ],
         )
     except FileNotFoundError:
         raise FileNotFoundError(
@@ -129,5 +129,5 @@ on your system and try again.
 
 - Install instructions: https://www.libreoffice.org/get-help/install-howto/
 - Mac: https://formulae.brew.sh/cask/libreoffice
-- Debian: https://wiki.debian.org/LibreOffice"""
+- Debian: https://wiki.debian.org/LibreOffice""",
         )

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -214,7 +214,7 @@ def partition_email(
 
     for idx, element in enumerate(elements):
         indices = has_embedded_image(element)
-        if (isinstance(element, NarrativeText) or isinstance(element, Title)) and indices:
+        if (isinstance(element, (NarrativeText, Title))) and indices:
             image_info, clean_element = find_embedded_image(element, indices)
             elements[idx] = clean_element
             elements.insert(idx + 1, image_info)

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -162,7 +162,7 @@ def partition_email(
         raise ValueError("One of filename, file, or text must be specified.")
 
     if filename is not None and not file and not text:
-        with open(filename, "r") as f:
+        with open(filename) as f:
             msg = email.message_from_file(f)
 
     elif file is not None and not filename and not text:

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -86,7 +86,8 @@ def partition_email_header(msg: Message) -> List[Element]:
 
 
 def extract_attachment_info(
-    message: Message, output_dir: Optional[str] = None,
+    message: Message,
+    output_dir: Optional[str] = None,
 ) -> List[Dict[str, str]]:
     list_attachments = []
     attachment_info = {}
@@ -121,7 +122,8 @@ def has_embedded_image(element):
 
 
 def find_embedded_image(
-    element: Union[NarrativeText, Title], indices: re.Match,
+    element: Union[NarrativeText, Title],
+    indices: re.Match,
 ) -> Tuple[Element, Element]:
     start, end = indices.start(), indices.end()
 

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -1,40 +1,39 @@
 import email
-import sys
 import re
+import sys
 from email.message import Message
-from typing import Dict, IO, List, Optional, Tuple, Union
+from typing import IO, Dict, List, Optional, Tuple, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Final
 else:
     from typing import Final
 
-from unstructured.cleaners.core import replace_mime_encodings, clean_extra_whitespace
+from unstructured.cleaners.core import clean_extra_whitespace, replace_mime_encodings
 from unstructured.cleaners.extract import (
+    extract_datetimetz,
+    extract_email_address,
     extract_ip_address,
     extract_ip_address_name,
     extract_mapi_id,
-    extract_datetimetz,
-    extract_email_address,
-)
-from unstructured.documents.email_elements import (
-    Recipient,
-    Sender,
-    Subject,
-    ReceivedInfo,
-    MetaData,
 )
 from unstructured.documents.elements import (
     Element,
     ElementMetadata,
-    Text,
     Image,
     NarrativeText,
+    Text,
     Title,
 )
+from unstructured.documents.email_elements import (
+    MetaData,
+    ReceivedInfo,
+    Recipient,
+    Sender,
+    Subject,
+)
 from unstructured.partition.html import partition_html
-from unstructured.partition.text import split_by_paragraph, partition_text
-
+from unstructured.partition.text import partition_text, split_by_paragraph
 
 VALID_CONTENT_SOURCES: Final[List[str]] = ["text/html", "text/plain"]
 

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -52,7 +52,7 @@ def _parse_received_data(data: str) -> List[Element]:
         elements.append(ReceivedInfo(name="mapi_id", text=mapi_id[0]))
     if datetimetz:
         elements.append(
-            ReceivedInfo(name="received_datetimetz", text=str(datetimetz), datestamp=datetimetz)
+            ReceivedInfo(name="received_datetimetz", text=str(datetimetz), datestamp=datetimetz),
         )
     return elements
 
@@ -86,7 +86,7 @@ def partition_email_header(msg: Message) -> List[Element]:
 
 
 def extract_attachment_info(
-    message: Message, output_dir: Optional[str] = None
+    message: Message, output_dir: Optional[str] = None,
 ) -> List[Dict[str, str]]:
     list_attachments = []
     attachment_info = {}
@@ -121,7 +121,7 @@ def has_embedded_image(element):
 
 
 def find_embedded_image(
-    element: Union[NarrativeText, Title], indices: re.Match
+    element: Union[NarrativeText, Title], indices: re.Match,
 ) -> Tuple[Element, Element]:
     start, end = indices.start(), indices.end()
 
@@ -155,7 +155,7 @@ def partition_email(
     if content_source not in VALID_CONTENT_SOURCES:
         raise ValueError(
             f"{content_source} is not a valid value for content_source. "
-            f"Valid content sources are: {VALID_CONTENT_SOURCES}"
+            f"Valid content sources are: {VALID_CONTENT_SOURCES}",
         )
 
     if not any([filename, file, text]):

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -44,7 +44,7 @@ def _parse_received_data(data: str) -> List[Element]:
     mapi_id = extract_mapi_id(data)
     datetimetz = extract_datetimetz(data)
 
-    elements: List[Element] = list()
+    elements: List[Element] = []
     if ip_address_names and ip_addresses:
         for name, ip in zip(ip_address_names, ip_addresses):
             elements.append(ReceivedInfo(name=name, text=ip))
@@ -67,7 +67,7 @@ def _parse_email_address(data: str) -> Tuple[str, str]:
 
 
 def partition_email_header(msg: Message) -> List[Element]:
-    elements: List[Element] = list()
+    elements: List[Element] = []
     for item in msg.raw_items():
         if item[0] == "To":
             text = _parse_email_address(item[1])
@@ -219,7 +219,7 @@ def partition_email(
             elements[idx] = clean_element
             elements.insert(idx + 1, image_info)
 
-    header: List[Element] = list()
+    header: List[Element] = []
     if include_headers:
         header = partition_email_header(msg)
     all_elements = header + elements

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -73,7 +73,10 @@ def partition_html(
     layout_elements = document_to_element_list(document, include_page_breaks=include_page_breaks)
     if include_metadata:
         return add_element_metadata(
-            layout_elements, include_page_breaks=include_page_breaks, filename=filename, url=url,
+            layout_elements,
+            include_page_breaks=include_page_breaks,
+            filename=filename,
+            url=url,
         )
     else:
         return layout_elements

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -73,7 +73,7 @@ def partition_html(
     layout_elements = document_to_element_list(document, include_page_breaks=include_page_breaks)
     if include_metadata:
         return add_element_metadata(
-            layout_elements, include_page_breaks=include_page_breaks, filename=filename, url=url
+            layout_elements, include_page_breaks=include_page_breaks, filename=filename, url=url,
         )
     else:
         return layout_elements

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -1,5 +1,5 @@
-from typing import List, Optional
 import warnings
+from typing import List, Optional
 
 from unstructured.documents.elements import Element
 from unstructured.partition import _partition_via_api

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -94,7 +94,7 @@ def partition_pdf_or_image(
         )
 
     return add_element_metadata(
-        layout_elements, include_page_breaks=include_page_breaks, filename=filename
+        layout_elements, include_page_breaks=include_page_breaks, filename=filename,
     )
 
 
@@ -116,14 +116,14 @@ def _partition_pdf_or_image_local(
             "unstructured_inference module not found... try running pip install "
             "unstructured[local-inference] if you installed the unstructured library as a package. "
             "If you cloned the unstructured repository, try running make install-local-inference "
-            "from the root directory of the repository."
+            "from the root directory of the repository.",
         ) from e
     except ImportError as e:
         raise Exception(
             "There was a problem importing unstructured_inference module - it may not be installed "
             "correctly... try running pip install unstructured[local-inference] if you installed "
             "the unstructured library as a package. If you cloned the unstructured repository, try "
-            "running make install-local-inference from the root directory of the repository."
+            "running make install-local-inference from the root directory of the repository.",
         ) from e
 
     layout = (

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -94,7 +94,9 @@ def partition_pdf_or_image(
         )
 
     return add_element_metadata(
-        layout_elements, include_page_breaks=include_page_breaks, filename=filename,
+        layout_elements,
+        include_page_breaks=include_page_breaks,
+        filename=filename,
     )
 
 

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -8,7 +8,9 @@ from unstructured.partition.pptx import partition_pptx
 
 
 def partition_ppt(
-    filename: Optional[str] = None, file: Optional[IO] = None, include_page_breaks: bool = False,
+    filename: Optional[str] = None,
+    file: Optional[IO] = None,
+    include_page_breaks: bool = False,
 ) -> List[Element]:
     """Partitions Microsoft PowerPoint Documents in .ppt format into their document elements.
 

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -8,7 +8,7 @@ from unstructured.partition.pptx import partition_pptx
 
 
 def partition_ppt(
-    filename: Optional[str] = None, file: Optional[IO] = None, include_page_breaks: bool = False
+    filename: Optional[str] = None, file: Optional[IO] = None, include_page_breaks: bool = False,
 ) -> List[Element]:
     """Partitions Microsoft PowerPoint Documents in .ppt format into their document elements.
 

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -51,7 +51,7 @@ def partition_pptx(
     else:
         raise ValueError("Only one of filename or file can be specified.")
 
-    elements: List[Element] = list()
+    elements: List[Element] = []
     metadata_filename = metadata_filename or filename
     metadata = ElementMetadata(filename=metadata_filename)
     num_slides = len(presentation.slides)

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -16,7 +16,6 @@ from unstructured.partition.text_type import (
     is_possible_title,
 )
 
-
 OPENXML_SCHEMA_NAME = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
 
 

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -44,7 +44,7 @@ def partition_text(
         raise ValueError("One of filename, file, or text must be specified.")
 
     if filename is not None and not file and not text:
-        with open(filename, "r") as f:
+        with open(filename) as f:
             file_text = f.read()
 
     elif file is not None and not filename and not text:

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -1,6 +1,7 @@
 import re
 from typing import IO, List, Optional
 
+from unstructured.cleaners.core import clean_bullets
 from unstructured.documents.elements import (
     Address,
     Element,
@@ -10,13 +11,11 @@ from unstructured.documents.elements import (
     Text,
     Title,
 )
-
-from unstructured.cleaners.core import clean_bullets
 from unstructured.nlp.patterns import PARAGRAPH_PATTERN
 from unstructured.partition.text_type import (
+    is_bulleted_text,
     is_possible_narrative_text,
     is_possible_title,
-    is_bulleted_text,
     is_us_city_state_zip,
 )
 

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -58,7 +58,7 @@ def partition_text(
 
     file_content = split_by_paragraph(file_text)
 
-    elements: List[Element] = list()
+    elements: List[Element] = []
     metadata = ElementMetadata(filename=filename)
     for ctext in file_content:
         ctext = ctext.strip()

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -2,7 +2,6 @@
 import os
 import re
 import sys
-
 from typing import List, Optional
 
 if sys.version_info < (3, 8):
@@ -11,11 +10,14 @@ else:
     from typing import Final
 
 from unstructured.cleaners.core import remove_punctuation
-from unstructured.nlp.english_words import ENGLISH_WORDS
-from unstructured.nlp.patterns import US_PHONE_NUMBERS_RE, UNICODE_BULLETS_RE, US_CITY_STATE_ZIP_RE
-from unstructured.nlp.tokenize import pos_tag, sent_tokenize, word_tokenize
 from unstructured.logger import logger
-
+from unstructured.nlp.english_words import ENGLISH_WORDS
+from unstructured.nlp.patterns import (
+    UNICODE_BULLETS_RE,
+    US_CITY_STATE_ZIP_RE,
+    US_PHONE_NUMBERS_RE,
+)
+from unstructured.nlp.tokenize import pos_tag, sent_tokenize, word_tokenize
 
 POS_VERB_TAGS: Final[List[str]] = ["VB", "VBG", "VBD", "VBN", "VBP", "VBZ"]
 ENGLISH_WORD_SPLIT_RE = re.compile(r"[\s|\.|-|_|\/]")

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -24,7 +24,7 @@ ENGLISH_WORD_SPLIT_RE = re.compile(r"[\s|\.|-|_|\/]")
 
 
 def is_possible_narrative_text(
-    text: str, cap_threshold: float = 0.5, non_alpha_threshold: float = 0.5, language: str = "en"
+    text: str, cap_threshold: float = 0.5, non_alpha_threshold: float = 0.5, language: str = "en",
 ) -> bool:
     """Checks to see if the text passes all of the checks for a narrative text section.
     You can change the cap threshold using the cap_threshold kwarg or the
@@ -58,14 +58,14 @@ def is_possible_narrative_text(
     # NOTE(robinson): it gets read in from the environment as a string so we need to
     # cast it to a float
     cap_threshold = float(
-        os.environ.get("UNSTRUCTURED_NARRATIVE_TEXT_CAP_THRESHOLD", cap_threshold)
+        os.environ.get("UNSTRUCTURED_NARRATIVE_TEXT_CAP_THRESHOLD", cap_threshold),
     )
     if exceeds_cap_ratio(text, threshold=cap_threshold):
         logger.debug(f"Not narrative. Text exceeds cap ratio {cap_threshold}:\n\n{text}")
         return False
 
     non_alpha_threshold = float(
-        os.environ.get("UNSTRUCTURED_NARRATIVE_TEXT_NON_ALPHA_THRESHOLD", non_alpha_threshold)
+        os.environ.get("UNSTRUCTURED_NARRATIVE_TEXT_NON_ALPHA_THRESHOLD", non_alpha_threshold),
     )
     if under_non_alpha_ratio(text, threshold=non_alpha_threshold):
         return False
@@ -104,7 +104,7 @@ def is_possible_title(
         return False
 
     title_max_word_length = int(
-        os.environ.get("UNSTRUCTURED_TITLE_MAX_WORD_LENGTH", title_max_word_length)
+        os.environ.get("UNSTRUCTURED_TITLE_MAX_WORD_LENGTH", title_max_word_length),
     )
     # NOTE(robinson) - splitting on spaces here instead of word tokenizing because it
     # is less expensive and actual tokenization doesn't add much value for the length check
@@ -112,7 +112,7 @@ def is_possible_title(
         return False
 
     non_alpha_threshold = float(
-        os.environ.get("UNSTRUCTURED_TITLE_NON_ALPHA_THRESHOLD", non_alpha_threshold)
+        os.environ.get("UNSTRUCTURED_TITLE_NON_ALPHA_THRESHOLD", non_alpha_threshold),
     )
     if under_non_alpha_ratio(text, threshold=non_alpha_threshold):
         return False
@@ -199,7 +199,7 @@ def sentence_count(text: str, min_length: Optional[int] = None) -> int:
         if min_length and len(words) < min_length:
             logger.debug(
                 f"Skipping sentence because does not exceed {min_length} word tokens\n"
-                f"{sentence}"
+                f"{sentence}",
             )
             continue
         count += 1

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -24,7 +24,10 @@ ENGLISH_WORD_SPLIT_RE = re.compile(r"[\s|\.|-|_|\/]")
 
 
 def is_possible_narrative_text(
-    text: str, cap_threshold: float = 0.5, non_alpha_threshold: float = 0.5, language: str = "en",
+    text: str,
+    cap_threshold: float = 0.5,
+    non_alpha_threshold: float = 0.5,
+    language: str = "en",
 ) -> bool:
     """Checks to see if the text passes all of the checks for a narrative text section.
     You can change the cap threshold using the cap_threshold kwarg or the

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -161,10 +161,7 @@ def contains_verb(text: str) -> bool:
         text = text.lower()
 
     pos_tags = pos_tag(text)
-    for _, tag in pos_tags:
-        if tag in POS_VERB_TAGS:
-            return True
-    return False
+    return any(tag in POS_VERB_TAGS for _, tag in pos_tags)
 
 
 def contains_english_word(text: str) -> bool:

--- a/unstructured/staging/argilla.py
+++ b/unstructured/staging/argilla.py
@@ -1,9 +1,10 @@
 from typing import List, Union
+
 import argilla
 from argilla.client.models import (
+    Text2TextRecord,
     TextClassificationRecord,
     TokenClassificationRecord,
-    Text2TextRecord,
 )
 
 from unstructured.documents.elements import Text

--- a/unstructured/staging/argilla.py
+++ b/unstructured/staging/argilla.py
@@ -31,14 +31,14 @@ def stage_for_argilla(
     except KeyError as e:
         raise ValueError(
             f'Invalid value "{e.args[0]}" specified for argilla_task. '
-            "Must be one of: {', '.join(ARGILLA_TASKS.keys())}."
+            "Must be one of: {', '.join(ARGILLA_TASKS.keys())}.",
         )
 
     for record_kwarg_key, record_kwarg_value in record_kwargs.items():
         if type(record_kwarg_value) is not list or len(record_kwarg_value) != len(elements):
             raise ValueError(
                 f'Invalid value specified for "{record_kwarg_key}" keyword argument.'
-                " Must be of type list and same length as elements list."
+                " Must be of type list and same length as elements list.",
             )
 
     results: List[Union[TextClassificationRecord, TokenClassificationRecord, Text2TextRecord]] = []

--- a/unstructured/staging/base.py
+++ b/unstructured/staging/base.py
@@ -1,16 +1,16 @@
-import io
 import csv
+import io
 import json
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
 from unstructured.documents.elements import (
+    TYPE_TO_TEXT_ELEMENT_MAP,
     CheckBox,
-    NoID,
     Element,
     ElementMetadata,
-    TYPE_TO_TEXT_ELEMENT_MAP,
+    NoID,
 )
 
 TABLE_FIELDNAMES: List[str] = [

--- a/unstructured/staging/base.py
+++ b/unstructured/staging/base.py
@@ -26,7 +26,7 @@ TABLE_FIELDNAMES: List[str] = [
 
 def convert_to_isd(elements: List[Element]) -> List[Dict[str, str]]:
     """Represents the document elements as an Initial Structured Document (ISD)."""
-    isd: List[Dict[str, str]] = list()
+    isd: List[Dict[str, str]] = []
     for element in elements:
         section = element.to_dict()
         isd.append(section)
@@ -47,7 +47,7 @@ def elements_to_json(elements: List[Element], filename: str, indent: int = 4):
 
 def isd_to_elements(isd: List[Dict[str, Any]]) -> List[Element]:
     """Converts an Initial Structured Data (ISD) dictionary to a list of elements."""
-    elements: List[Element] = list()
+    elements: List[Element] = []
 
     for item in isd:
         element_id: str = item.get("element_id", NoID())

--- a/unstructured/staging/base.py
+++ b/unstructured/staging/base.py
@@ -88,7 +88,7 @@ def dict_to_elements(element_dict: List[Dict[str, Any]]) -> List[Element]:
 
 def elements_from_json(filename: str) -> List[Element]:
     """Loads a list of elements from a JSON file."""
-    with open(filename, "r") as f:
+    with open(filename) as f:
         element_dict = json.load(f)
     return dict_to_elements(element_dict)
 

--- a/unstructured/staging/base.py
+++ b/unstructured/staging/base.py
@@ -66,7 +66,7 @@ def isd_to_elements(isd: List[Dict[str, Any]]) -> List[Element]:
                     element_id=element_id,
                     metadata=metadata,
                     coordinates=coordinates,
-                )
+                ),
             )
         elif item["type"] == "CheckBox":
             elements.append(
@@ -75,7 +75,7 @@ def isd_to_elements(isd: List[Dict[str, Any]]) -> List[Element]:
                     element_id=element_id,
                     metadata=metadata,
                     coordinates=coordinates,
-                )
+                ),
             )
 
     return elements

--- a/unstructured/staging/datasaur.py
+++ b/unstructured/staging/datasaur.py
@@ -8,7 +8,7 @@ def stage_for_datasaur(
     entities: Optional[List[List[Dict[str, Any]]]] = None,
 ) -> List[Dict[str, Any]]:
     """Convert a list of elements into a list of dictionaries for use in Datasaur"""
-    result: List[Dict[str, Any]] = list()
+    result: List[Dict[str, Any]] = []
 
     _entities: List[List[Dict[str, Any]]] = [[] for _ in range(len(elements))]
     if entities is not None:
@@ -22,7 +22,7 @@ def stage_for_datasaur(
         _entities = entities
 
     for i, item in enumerate(elements):
-        data = dict(text=item.text, entities=_entities[i])
+        data = {"text": item.text, "entities": _entities[i]}
         result.append(data)
 
     return result

--- a/unstructured/staging/datasaur.py
+++ b/unstructured/staging/datasaur.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+
 from unstructured.documents.elements import Text
 
 

--- a/unstructured/staging/huggingface.py
+++ b/unstructured/staging/huggingface.py
@@ -51,7 +51,7 @@ def chunk_by_attention_window(
     num_splits = len(split_text)
 
     chunks: List[str] = list()
-    chunk_text = str()
+    chunk_text = ""
     chunk_size = 0
 
     for i, segment in enumerate(split_text):
@@ -68,7 +68,7 @@ def chunk_by_attention_window(
 
         if chunk_size + num_tokens > max_chunk_size or i == (num_splits - 1):
             chunks.append(chunk_text)
-            chunk_text = str()
+            chunk_text = ""
             chunk_size = 0
 
         # NOTE(robinson) - To avoid the separator appearing at the beginning of the string

--- a/unstructured/staging/huggingface.py
+++ b/unstructured/staging/huggingface.py
@@ -6,7 +6,7 @@ from unstructured.documents.elements import Text
 
 
 def stage_for_transformers(
-    elements: List[Text], tokenizer: PreTrainedTokenizer, **chunk_kwargs
+    elements: List[Text], tokenizer: PreTrainedTokenizer, **chunk_kwargs,
 ) -> List[str]:
     """Stages text elements for transformers pipelines by chunking them into sections that can
     fit into the attention window for the model associated with the tokenizer."""
@@ -42,7 +42,7 @@ def chunk_by_attention_window(
     if buffer < 0 or buffer >= max_input_size:
         raise ValueError(
             f"buffer is set to {buffer}. Must be greater than zero and smaller than "
-            f"max_input_size, which is {max_input_size}."
+            f"max_input_size, which is {max_input_size}.",
         )
 
     max_chunk_size = max_input_size - buffer
@@ -63,7 +63,7 @@ def chunk_by_attention_window(
                 f"The maximum number of tokens is {max_chunk_size}. "
                 "Consider using a different split_function to reduce the size "
                 "of the segments under consideration. The text that caused the "
-                "error is: \n\n{segment}"
+                "error is: \n\n{segment}",
             )
 
         if chunk_size + num_tokens > max_chunk_size or i == (num_splits - 1):

--- a/unstructured/staging/huggingface.py
+++ b/unstructured/staging/huggingface.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, List
+from typing import Callable, List, Optional
 
 from transformers import PreTrainedTokenizer
 

--- a/unstructured/staging/huggingface.py
+++ b/unstructured/staging/huggingface.py
@@ -50,7 +50,7 @@ def chunk_by_attention_window(
     split_text: List[str] = split_function(text)
     num_splits = len(split_text)
 
-    chunks: List[str] = list()
+    chunks: List[str] = []
     chunk_text = ""
     chunk_size = 0
 

--- a/unstructured/staging/huggingface.py
+++ b/unstructured/staging/huggingface.py
@@ -6,7 +6,9 @@ from unstructured.documents.elements import Text
 
 
 def stage_for_transformers(
-    elements: List[Text], tokenizer: PreTrainedTokenizer, **chunk_kwargs,
+    elements: List[Text],
+    tokenizer: PreTrainedTokenizer,
+    **chunk_kwargs,
 ) -> List[str]:
     """Stages text elements for transformers pipelines by chunking them into sections that can
     fit into the attention window for the model associated with the tokenizer."""

--- a/unstructured/staging/label_box.py
+++ b/unstructured/staging/label_box.py
@@ -28,12 +28,12 @@ def _validate_attachments(attachment_list: List[Dict[str, str]], element_index: 
         ):
             raise ValueError(
                 f"{error_message_prefix}. Invalid value specified for attachment.type. "
-                f"Must be one of: {', '.join(VALID_ATTACHMENT_TYPES)}"
+                f"Must be one of: {', '.join(VALID_ATTACHMENT_TYPES)}",
             )
         if not isinstance(attachment_value, str):
             raise ValueError(
                 f"{error_message_prefix}. Invalid value specified for attachment.value. "
-                "Must be of type string."
+                "Must be of type string.",
             )
 
 
@@ -53,7 +53,7 @@ def stage_for_label_box(
     if (external_ids is not None) and len(external_ids) != len(elements):
         raise ValueError(
             "The external_ids parameter must be a list and the length of external_ids parameter "
-            "must be the same as the length of elements parameter."
+            "must be the same as the length of elements parameter.",
         )
     elif external_ids is None:
         ids = [element.id for element in elements]
@@ -63,7 +63,7 @@ def stage_for_label_box(
     if (attachments is not None) and len(attachments) != len(elements):
         raise ValueError(
             "The attachments parameter must be a list and the length of attachments parameter "
-            "must be the same as the length of elements parameter."
+            "must be the same as the length of elements parameter.",
         )
     elif attachments is None:
         attachments = [[] for _ in elements]

--- a/unstructured/staging/label_box.py
+++ b/unstructured/staging/label_box.py
@@ -1,8 +1,7 @@
 import os
+from typing import Any, Dict, List, Optional, Sequence, Union
 
-from typing import Any, Dict, List, Optional, Union, Sequence
-from unstructured.documents.elements import Text, NoID
-
+from unstructured.documents.elements import NoID, Text
 
 VALID_ATTACHMENT_TYPES: List[str] = ["IMAGE", "VIDEO", "RAW_TEXT", "TEXT_URL", "HTML"]
 

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -49,7 +49,7 @@ class LabelStudioResult:
         if self.type not in VALID_LABEL_TYPES:
             raise ValueError(
                 f"{self.type} is not a valid label type. "
-                f"Valid label types are: {VALID_LABEL_TYPES}"
+                f"Valid label types are: {VALID_LABEL_TYPES}",
             )
 
     def to_dict(self):
@@ -105,7 +105,7 @@ class LabelStudioPrediction(LabelStudioAnnotation):
         if not isinstance(self.score, (int, float)) or (self.score < 0 or self.score > 1):
             raise ValueError(
                 f"{self.score} is not a valid score value. "
-                f"Score value must be a number between 0 and 1."
+                f"Score value must be a number between 0 and 1.",
             )
 
 

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Union
 
 from unstructured.documents.elements import Text
 
-
 LABEL_STUDIO_TYPE = List[Dict[str, Dict[str, str]]]
 
 # NOTE(robinson) - ref: https://labelstud.io/tags/labels.html

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -118,12 +118,10 @@ def stage_for_label_studio(
 ) -> LABEL_STUDIO_TYPE:
     """Converts the document to the format required for upload to LabelStudio.
     ref: https://labelstud.io/guide/tasks.html#Example-JSON-format"""
-    if annotations is not None:
-        if len(elements) != len(annotations):
-            raise ValueError("The length of elements and annotations must match.")
-    if predictions is not None:
-        if len(elements) != len(predictions):
-            raise ValueError("The length of elements and predictions must match.")
+    if annotations is not None and len(elements) != len(annotations):
+        raise ValueError("The length of elements and annotations must match.")
+    if predictions is not None and len(elements) != len(predictions):
+        raise ValueError("The length of elements and predictions must match.")
 
     label_studio_data: LABEL_STUDIO_TYPE = []
     for i, element in enumerate(elements):

--- a/unstructured/staging/label_studio.py
+++ b/unstructured/staging/label_studio.py
@@ -125,14 +125,14 @@ def stage_for_label_studio(
         if len(elements) != len(predictions):
             raise ValueError("The length of elements and predictions must match.")
 
-    label_studio_data: LABEL_STUDIO_TYPE = list()
+    label_studio_data: LABEL_STUDIO_TYPE = []
     for i, element in enumerate(elements):
-        data: Dict[str, str] = dict()
+        data: Dict[str, str] = {}
         data[text_field] = element.text
         if isinstance(element.id, str):
             data[id_field] = element.id
 
-        labeling_example: Dict[str, Any] = dict()
+        labeling_example: Dict[str, Any] = {}
         labeling_example["data"] = data
         if annotations is not None:
             labeling_example["annotations"] = [a.to_dict() for a in annotations[i]]

--- a/unstructured/staging/prodigy.py
+++ b/unstructured/staging/prodigy.py
@@ -32,7 +32,7 @@ def _validate_prodigy_metadata(
             )
         validated_metadata = metadata
     else:
-        validated_metadata = [dict() for _ in elements]
+        validated_metadata = [{} for _ in elements]
     return validated_metadata
 
 
@@ -47,11 +47,11 @@ def stage_for_prodigy(
 
     validated_metadata: Iterable[Dict[str, str]] = _validate_prodigy_metadata(elements, metadata)
 
-    prodigy_data: PRODIGY_TYPE = list()
+    prodigy_data: PRODIGY_TYPE = []
     for element, metadatum in zip(elements, validated_metadata):
         if isinstance(element.id, str):
             metadatum["id"] = element.id
-        data: Dict[str, Union[str, Dict[str, str]]] = dict(text=element.text, meta=metadatum)
+        data: Dict[str, Union[str, Dict[str, str]]] = {"text": element.text, "meta": metadatum}
         prodigy_data.append(data)
 
     return prodigy_data

--- a/unstructured/staging/prodigy.py
+++ b/unstructured/staging/prodigy.py
@@ -19,7 +19,8 @@ def _validate_prodigy_metadata(
     if metadata:
         if len(metadata) != len(elements):
             raise ValueError(
-                "The length of metadata parameter does not match with length of elements parameter.",
+                "The length of the metadata parameter does not match with"
+                " the length of the elements parameter.",
             )
         id_error_index: Optional[int] = next(
             (index for index, metadatum in enumerate(metadata) if "id" in metadatum),

--- a/unstructured/staging/prodigy.py
+++ b/unstructured/staging/prodigy.py
@@ -22,7 +22,8 @@ def _validate_prodigy_metadata(
                 "The length of metadata parameter does not match with length of elements parameter.",
             )
         id_error_index: Optional[int] = next(
-            (index for index, metadatum in enumerate(metadata) if "id" in metadatum), None,
+            (index for index, metadatum in enumerate(metadata) if "id" in metadatum),
+            None,
         )
         if isinstance(id_error_index, int):
             raise ValueError(

--- a/unstructured/staging/prodigy.py
+++ b/unstructured/staging/prodigy.py
@@ -70,7 +70,7 @@ def stage_csv_for_prodigy(
     csv_fieldnames = ["text", "id"]
     csv_fieldnames += list(
         set().union(
-            *((key.lower() for key in metadata_item.keys()) for metadata_item in validated_metadata),
+            *((key.lower() for key in metadata_item) for metadata_item in validated_metadata),
         ),
     )
 

--- a/unstructured/staging/prodigy.py
+++ b/unstructured/staging/prodigy.py
@@ -19,16 +19,16 @@ def _validate_prodigy_metadata(
     if metadata:
         if len(metadata) != len(elements):
             raise ValueError(
-                "The length of metadata parameter does not match with length of elements parameter."
+                "The length of metadata parameter does not match with length of elements parameter.",
             )
         id_error_index: Optional[int] = next(
-            (index for index, metadatum in enumerate(metadata) if "id" in metadatum), None
+            (index for index, metadatum in enumerate(metadata) if "id" in metadatum), None,
         )
         if isinstance(id_error_index, int):
             raise ValueError(
                 'The key "id" is not allowed with metadata parameter at index: {index}'.format(
-                    index=id_error_index
-                )
+                    index=id_error_index,
+                ),
             )
         validated_metadata = metadata
     else:
@@ -70,8 +70,8 @@ def stage_csv_for_prodigy(
     csv_fieldnames = ["text", "id"]
     csv_fieldnames += list(
         set().union(
-            *((key.lower() for key in metadata_item.keys()) for metadata_item in validated_metadata)
-        )
+            *((key.lower() for key in metadata_item.keys()) for metadata_item in validated_metadata),
+        ),
     )
 
     def _get_rows() -> Generator[Dict[str, str], None, None]:

--- a/unstructured/staging/prodigy.py
+++ b/unstructured/staging/prodigy.py
@@ -1,9 +1,8 @@
-import io
-from typing import Generator, Iterable, List, Dict, Optional, Union
 import csv
+import io
+from typing import Dict, Generator, Iterable, List, Optional, Union
 
 from unstructured.documents.elements import Text
-
 
 PRODIGY_TYPE = List[Dict[str, Union[str, Dict[str, str]]]]
 

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -1,6 +1,5 @@
-from typing import List, Dict
-
 import json
+from typing import Dict, List
 
 
 def save_as_jsonl(data: List[Dict], filename: str) -> None:

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -8,5 +8,5 @@ def save_as_jsonl(data: List[Dict], filename: str) -> None:
 
 
 def read_from_jsonl(filename: str) -> List[Dict]:
-    with open(filename, "r") as input_file:
+    with open(filename) as input_file:
         return [json.loads(line) for line in input_file]

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 def save_as_jsonl(data: List[Dict], filename: str) -> None:
     with open(filename, "w+") as output_file:
-        output_file.writelines((json.dumps(datum) + "\n" for datum in data))
+        output_file.writelines(json.dumps(datum) + "\n" for datum in data)
 
 
 def read_from_jsonl(filename: str) -> List[Dict]:


### PR DESCRIPTION
Hello!

## Pull Request overview
* Rely on detailed and careful use of [`ruff`](https://github.com/charliermarsh/ruff) and `black` to improve the code style used in Unstructured.

## Preface
I realise that this is quite a big PR in terms of changes, and that changes to style are not always welcome. Consequently, I only applied changes that are generally believed to indeed be improvements. In doing so, I purposefully separated types of changes between commits, allowing us to cherry-pick commits that we do like, or revert ones that we don't.
With other words, I understand if you would like to see some commits reverted. Please let me know, and I'll make it happen. Together we can improve the code quality of unstructured :)

I would heavily recommend browsing through each commit separately, rather than looking at the whole PR diff at once!

## Details
As mentioned, I've split up this PR into separate commits. The majority of these changes are made using [`ruff`](https://github.com/charliermarsh/ruff), a linter that is able to both find and fix style errors. I have applied each of the various linters from ruff, and selectively applied the fixes whenever I felt like certain changes would indeed improve code quality notably.

Here is the list of changes, including the commit hashes for easily viewing the changes separate from each other, and optionally with the commands that were used to apply the changes:
  1. Sorting imports (3a3d8907ab94df1d1606c95bc55639d809475b93) - `ruff . --select I --fix`
  2. Removing unnecessary `open` parameter ("r") (1e09df9679b8482c3ea5415bead2a1c57a1e1a0d) - `ruff . --select UP015 --fix`
  3. Using f-strings rather than .format (254578452edd0a9ec0258a367baa11a761ead234) - `ruff . --select UP032 --fix`
  4. Removing extraneous parentheses (f350add684745c10bcb0aec19b38bbf87f678b67) `ruff . --select UP034 --fix`
  5. Replacing `str()` with `""` (f350add684745c10bcb0aec19b38bbf87f678b67) - `ruff . --select UP018 --fix`
  6. Introduce missing trailing commas (7aff4296fd66b54f5e1285861a08f12b6fca6d83) - `ruff . --select COM --fix`
  7. Replace `dict()` with `{}`, `list()` with `[]`, `tuple` with `()` (80d45e6a138343974bed433cf25b9a12607f2ed5) - `ruff . --select C4 --fix`
  8. Correctly format pytest fixtures and pytest.mark.parametrize arguments (f3c96b92f32f5407df37c3571b87cb9d6ea1ec6a) - `ruff . --select PT --fix`
  9. Simplify code, e.g. merging of conditionals (2066d5a18b6aaf6d81f58b6d1af26c2300c30d02) - `ruff . --select SIM --fix`
  10. Avoid imports with unnecessary aliases (76af0bb762e592c724d72db6a2bbd6275491e791) - `ruff . --select PLR0402 --fix`
  11. Format with black (eeb81306428c8e8bcc81374e316f39a699476330, b8325ef2f8b3b90ffd10d4947e9966fc68d846ac) - `black --line-length 100 unstructured` & `black --line-length 100 test_unstructured`

## Note
I've not modified the CHANGELOG. I am unsure whether I should be doing this on PRs that do not affect the code. Please let me know so I may do it correctly for future PRs!

---

I've also resolved a merge conflict with main. Let me know if any more pop up! A PR like this one picks up merge conflicts quickly, but I can fix them.

Let me know if there's anything else you need from me now!

- Tom Aarsen