### PR TITLE
Skip failing posix_path test on Windows

### DIFF
--- a/test_unstructured/staging/test_base_staging.py
+++ b/test_unstructured/staging/test_base_staging.py
@@ -2,6 +2,7 @@ import csv
 import json
 import os
 import pathlib
+import platform
 import pytest
 
 import pandas as pd
@@ -79,6 +80,9 @@ def test_convert_to_dataframe():
     assert df.text.equals(expected_df.text) is True
 
 
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="Posix Paths are not available on Windows"
+)
 def test_convert_to_isd_serializes_with_posix_paths():
     metadata = ElementMetadata(filename=pathlib.PosixPath("../../fake-file.txt"))
     elements = [


### PR DESCRIPTION
Hello!

## Pull Request overview
* Skip failing posix_path test on Windows.

## Details
See https://github.com/Unstructured-IO/unstructured/issues/234#issuecomment-1445026548 for details. 
In short, the following test fails on Windows:
https://github.com/Unstructured-IO/unstructured/blob/a79b365ab47856b891dd77363ade95ccb76ec2f4/test_unstructured/staging/test_base_staging.py#L82-L90
```
FAILED test_unstructured/staging/test_base_staging.py::test_convert_to_isd_serializes_with_posix_paths - NotImplementedError: cannot instantiate 'PosixPath' on your system
```
I've added a [`platform.system()`](https://docs.python.org/3/library/platform.html#platform.system) conditional to skip this test.

## Note
I've again not updated the CHANGELOG. I primarily see user-facing changes there, so I'm not sure if a test suite fix should result in me updating that file. Let me know!

- Tom Aarsen