### PR TITLE
fix: Ingest main: actually initialize the connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.16-dev1
+## 0.4.16-dev2
 
 ### Enhancements
 
@@ -7,6 +7,10 @@
 ### Features
 
 * Added setup script for Ubuntu
+
+### Fixes
+
+* Initializes connector properly in ingest.main::MainProcess
 
 ## 0.4.15
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.16-dev1"  # pragma: no cover
+__version__ = "0.4.16-dev2"  # pragma: no cover

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -20,6 +20,7 @@ class MainProcess:
 
     def initialize(self):
         """Slower initialization things: check connections, load things into memory, etc."""
+        self.doc_connector.initialize()
         initialize()
 
     def cleanup(self):


### PR DESCRIPTION
This brings back the connector initialization as was intended and got lost in a refactor.

Thanks @tomaarsen for catching this.