### PR TITLE
fix: track narrative text and figure captions in HTML documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.17-dev1
+## 0.5.0
 
 ### Enhancements
 
@@ -9,6 +9,8 @@
 ### Fixes
 
 * Fix `process_document` file cleaning on failure
+* Fixes an error introduced in the metadata tracking commit that caused `NarrativeText`
+  and `FigureCaption` elements to be represented as `Text` in HTML documents.
 
 ## 0.4.16
 

--- a/test_unstructured/partition/test_common.py
+++ b/test_unstructured/partition/test_common.py
@@ -34,6 +34,19 @@ def test_normalize_layout_element_dict_caption():
     )
 
 
+def test_normalize_layout_element_dict_figure_caption():
+    layout_element = {
+        "type": "FigureCaption",
+        "coordinates": [[1, 2], [3, 4], [5, 6], [7, 8]],
+        "text": "Some lovely text",
+    }
+    element = common.normalize_layout_element(layout_element)
+    assert element == FigureCaption(
+        text="Some lovely text",
+        coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
+    )
+
+
 def test_normalize_layout_element_dict_misc():
     layout_element = {
         "type": "Misc",
@@ -47,6 +60,19 @@ def test_normalize_layout_element_dict_misc():
 def test_normalize_layout_element_layout_element():
     layout_element = LayoutElement(
         type="Text",
+        coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
+        text="Some lovely text",
+    )
+    element = common.normalize_layout_element(layout_element)
+    assert element == NarrativeText(
+        text="Some lovely text",
+        coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
+    )
+
+
+def test_normalize_layout_element_layout_element_narrative_text():
+    layout_element = LayoutElement(
+        type="NarrativeText",
         coordinates=[[1, 2], [3, 4], [5, 6], [7, 8]],
         text="Some lovely text",
     )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.17-dev1"  # pragma: no cover
+__version__ = "0.5.0"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -201,6 +201,8 @@ class PageBreak(Text):
 TYPE_TO_TEXT_ELEMENT_MAP: Dict[str, Any] = {
     "UncategorizedText": Text,
     "FigureCaption": FigureCaption,
+    "Figure": FigureCaption,
+    "Text": NarrativeText,
     "NarrativeText": NarrativeText,
     "ListItem": ListItem,
     "BulletedText": ListItem,

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -2,15 +2,13 @@ import subprocess
 from typing import List, Optional, Union
 
 from unstructured.documents.elements import (
+    TYPE_TO_TEXT_ELEMENT_MAP,
     CheckBox,
     Element,
     ElementMetadata,
-    FigureCaption,
     ListItem,
-    NarrativeText,
     PageBreak,
     Text,
-    Title,
 )
 from unstructured.nlp.patterns import ENUMERATED_BULLETS_RE, UNICODE_BULLETS_RE
 
@@ -31,20 +29,13 @@ def normalize_layout_element(layout_element) -> Union[Element, List[Element]]:
     coordinates = layout_dict.get("coordinates")
     element_type = layout_dict.get("type")
 
-    if element_type == "Title":
-        return Title(text=text, coordinates=coordinates)
-    elif element_type == "Text":
-        return NarrativeText(text=text, coordinates=coordinates)
-    elif element_type == "Figure":
-        return FigureCaption(text=text, coordinates=coordinates)
-    elif element_type == "List":
-        return layout_list_to_list_items(text, coordinates)
+    if element_type in TYPE_TO_TEXT_ELEMENT_MAP:
+        _element_class = TYPE_TO_TEXT_ELEMENT_MAP[element_type]
+        return _element_class(text=text, coordinates=coordinates)
     elif element_type == "Checked":
         return CheckBox(checked=True, coordinates=coordinates)
     elif element_type == "Unchecked":
         return CheckBox(checked=False, coordinates=coordinates)
-    elif element_type == "PageBreak":
-        return PageBreak()
     else:
         return Text(text=text, coordinates=coordinates)
 

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -29,7 +29,9 @@ def normalize_layout_element(layout_element) -> Union[Element, List[Element]]:
     coordinates = layout_dict.get("coordinates")
     element_type = layout_dict.get("type")
 
-    if element_type in TYPE_TO_TEXT_ELEMENT_MAP:
+    if element_type == "List":
+        return layout_list_to_list_items(text, coordinates)
+    elif element_type in TYPE_TO_TEXT_ELEMENT_MAP:
         _element_class = TYPE_TO_TEXT_ELEMENT_MAP[element_type]
         return _element_class(text=text, coordinates=coordinates)
     elif element_type == "Checked":


### PR DESCRIPTION
### Summary

Fixes an issue introduced in [this commit](https://github.com/Unstructured-IO/unstructured/commit/74e6b84b41ff5456ba8f87958a2c7cde73d3c8d1#diff-9eb4b1248793302fa3b6bc9db25756503ea28f53ca556417c27f0be85d7a709b) that caused `NarrativeText` and `FigureCaption` elements to get represented as `Text` in HTML documents.

### Testing

The following previously showed no `NarrativeText` elements, but should now display `NarrativeText`.

```python
from unstructured.partition.html import partition_html
from unstructured.documents.elements import NarrativeText

url = "https://www.understandingwar.org/backgrounder/russian-offensive-campaign-assessment-february-8-2023"
elements = partition_html(url=url)

narrative_text = [el for el in elements if isinstance(el, NarrativeText)][2:]
for element in narrative_text:
    print(element)
```