### PR TITLE
Fix: Resolve several issues with the require dependencies decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
+## 0.5.1-dev1
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* Fix several issues with the `requires_dependencies` decorator, including the error message
+  and how it was used.
+
 ## 0.5.0
 
 ### Enhancements
 
 * Add `requires_dependencies` Python decorator to check dependencies are installed before
-instantiating a class or running a function
+  instantiating a class or running a function
 
 ### Features
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.0"  # pragma: no cover
+__version__ = "0.5.1-dev1"  # pragma: no cover

--- a/unstructured/ingest/connector/github.py
+++ b/unstructured/ingest/connector/github.py
@@ -125,7 +125,7 @@ class GitHubIngestDoc(BaseIngestDoc):
         print(f"Wrote {output_filename}")
 
 
-@requires_dependencies(["pygithub"], extras="github")
+@requires_dependencies(["github"], extras="github")
 class GitHubConnector(BaseConnector):
     def __init__(self, config: SimpleGitHubConfig):
         from github import Github

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -29,7 +29,7 @@ def requires_dependencies(dependencies: Union[str, List[str]], extras: Optional[
                     missing_deps.append(dep)
             if len(missing_deps) > 0:
                 raise ImportError(
-                    f"Following dependencies are missing: {', '.join(missing_deps)}."
+                    f"Following dependencies are missing: {', '.join(missing_deps)}. "
                     + f"Please install them using `pip install unstructured[{extras}]`."
                     if extras
                     else f"Please install them using `pip install {' '.join(missing_deps)}`.",

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -14,7 +14,10 @@ def read_from_jsonl(filename: str) -> List[Dict]:
         return [json.loads(line) for line in input_file]
 
 
-def requires_dependencies(dependencies: Union[str, List[str]], extras: Optional[str] = None):
+def requires_dependencies(
+    dependencies: Union[str, List[str]],
+    extras: Optional[str] = None,
+):
     if isinstance(dependencies, str):
         dependencies = [dependencies]
 
@@ -30,9 +33,11 @@ def requires_dependencies(dependencies: Union[str, List[str]], extras: Optional[
             if len(missing_deps) > 0:
                 raise ImportError(
                     f"Following dependencies are missing: {', '.join(missing_deps)}. "
-                    + f"Please install them using `pip install unstructured[{extras}]`."
-                    if extras
-                    else f"Please install them using `pip install {' '.join(missing_deps)}`.",
+                    + (
+                        f"Please install them using `pip install unstructured[{extras}]`."
+                        if extras
+                        else f"Please install them using `pip install {' '.join(missing_deps)}`."
+                    ),
                 )
             return func(*args, **kwargs)
 


### PR DESCRIPTION
Hello!

## Pull Request overview
* Fix several issues re. the `requires_dependencies` decorator:
  1. There was a missing space between the sentences.
  2. Crucial brackets were missing in making the error message.
  3. "pygithub" was used where "github" should have been used.

## Details
### Issue 1
The output of the `requires_dependencies` error was e.g.:
```
ImportError: Following dependencies are missing: pygithub.Please install them using `pip install unstructured[github]`.
```
I.e., no space between the sentences.

### Issue 2
If `extras` was not provided, then the first part of the error message was not included, e.g.
```
ImportError: Please install them using `pip install uninstalled_test_module`.
```
This was due to missing brackets.

### Issue 3
The `GitHubConnector` was decorated with
```
@requires_dependencies(["pygithub"], extras="github")
```
Which attempts to import `pygithub`, which does not exist. Instead, `github` must be imported.

---

This all was causing test failures on some CI runs. For example [here](https://github.com/Unstructured-IO/unstructured/actions/runs/4295225741/jobs/7485389440) and [here](https://github.com/Unstructured-IO/unstructured/actions/runs/4296693510/jobs/7488768442).
It is causing failures for my other PRs, e.g. #313 and #312.
Interestingly, the CI didn't fail every single time - I'm not quite sure why.

cc: @alvarobartt I believe these issues may negatively impact your PRs too.

- Tom Aarsen