### PR TITLE
bump: release commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.1-dev2
+## 0.5.1
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * Fixes an error causing JavaScript to appear in the output of `partition_html` sometimes.
 * Fix several issues with the `requires_dependencies` decorator, including the error message
-  and how it was used.
+  and how it was used, which had caused an error for `unstructured-ingest --github-url ...`.
 
 ## 0.5.0
 

--- a/test_unstructured_ingest/expected-structured-output/github-downloadify/test.html.json
+++ b/test_unstructured_ingest/expected-structured-output/github-downloadify/test.html.json
@@ -8,8 +8,8 @@
     }
   },
   {
-    "element_id": "d551bbfc9477547e4dce6264d8196c7b",
-    "text": "More info available at the Github Project Page",
+    "element_id": "4300054a3c2601f905282a7bc7199044",
+    "text": "More info available at the \n\t\tGithub Project Page",
     "type": "Title",
     "metadata": {
       "page_number": 1
@@ -24,9 +24,9 @@
     }
   },
   {
-    "element_id": "43f65b1c5bd47774b25c72e2f96de300",
-    "text": "File Contents\n\nWhatever you put in this text box will be downloaded and saved in the file. If you leave it blank, no file will be downloaded",
-    "type": "UncategorizedText",
+    "element_id": "a309823c9d508290682a198270b84bca",
+    "text": "File Contents\nWhatever you put in this text box will be downloaded and saved in the file. If you leave it blank, no file will be downloaded",
+    "type": "NarrativeText",
     "metadata": {
       "page_number": 1
     }
@@ -34,7 +34,7 @@
   {
     "element_id": "53a4db70c6d40ed5206711ed8a255e03",
     "text": "You must have Flash 10 installed to download this file.",
-    "type": "UncategorizedText",
+    "type": "NarrativeText",
     "metadata": {
       "page_number": 1
     }

--- a/test_unstructured_ingest/test-ingest-github.sh
+++ b/test_unstructured_ingest/test-ingest-github.sh
@@ -3,10 +3,12 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"/.. || exit 1
 
-if [[ "$CI" == "true" && "$(( RANDOM % 10))" != "1" ]]; then
-    # NOTE(crag): proper fix is being tracked here: https://github.com/Unstructured-IO/unstructured/issues/306
-    echo "Skipping ingest 90% of github ingest tests to avoid rate limiting issue."
-    exit 0
+if [[ "$CI" == "true" ]]; then
+    if [ "$(( RANDOM % 10))" -lt 2 ] ; then
+        # NOTE(crag): proper fix is being tracked here: https://github.com/Unstructured-IO/unstructured/issues/306
+        echo "Skipping ingest 80% of github ingest tests to avoid rate limiting issue."
+        exit 0
+    fi
 fi
 
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.1-dev2"  # pragma: no cover
+__version__ = "0.5.1"  # pragma: no cover


### PR DESCRIPTION
Updates the github-ingest test's expected output, which is a result of https://github.com/Unstructured-IO/unstructured/pull/309 .
Includes tweaks so that the github ingest test script now runs 20% of the time. The above would have been caught sooner if this ran 100% of the time. Related issue: https://github.com/Unstructured-IO/unstructured/issues/306 .
