### PR TITLE
feat: add `structlog` to replace `print`-statements and default `logging`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "python-magic",
         "markdown",
         "requests",
+        "structlog",
         # NOTE(robinson) - The following dependencies are pinned
         # to address security scans
         "certifi>=2022.12.07",

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -8,6 +8,7 @@ if sys.version_info < (3, 8):
 else:
     from typing import Final
 
+import structlog
 from lxml import etree
 
 from unstructured.cleaners.core import clean_bullets, replace_unicode_quotes
@@ -21,7 +22,6 @@ from unstructured.documents.elements import (
     Title,
 )
 from unstructured.documents.xml import XMLDocument
-from unstructured.logger import logger
 from unstructured.partition.text_type import (
     is_bulleted_text,
     is_possible_narrative_text,
@@ -35,6 +35,9 @@ HEADING_TAGS: Final[List[str]] = ["h1", "h2", "h3", "h4", "h5", "h6"]
 TABLE_TAGS: Final[List[str]] = ["table", "tbody", "td", "tr"]
 PAGEBREAK_TAGS: Final[List[str]] = ["hr"]
 HEADER_OR_FOOTER_TAGS: Final[List[str]] = ["header", "footer"]
+
+
+logger = structlog.get_logger(__name__)
 
 
 class TagsMixin:
@@ -95,7 +98,6 @@ class HTMLDocument(XMLDocument):
         """
         if self._pages:
             return self._pages
-        logger.info("Reading document ...")
         pages: List[Page] = []
         root = _find_main(self.document_tree)
 

--- a/unstructured/documents/xml.py
+++ b/unstructured/documents/xml.py
@@ -1,11 +1,13 @@
 from typing import List, Optional, Union
 
+import structlog
 from lxml import etree
 
 from unstructured.documents.base import Document, Page
-from unstructured.logger import logger
 
 VALID_PARSERS = Union[etree.HTMLParser, etree.XMLParser, None]
+
+logger = structlog.get_logger(__name__)
 
 
 class XMLDocument(Document):
@@ -84,6 +86,7 @@ class XMLDocument(Document):
 
     @classmethod
     def from_file(cls, filename, parser: VALID_PARSERS = None, stylesheet: Optional[str] = None):
+        logger.info("Reading document from file ...")
         with open(filename, "r+", encoding="utf8") as f:
             content = f.read()
         return cls.from_string(content, parser=parser, stylesheet=stylesheet)

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -11,8 +11,11 @@ except ImportError:  # pragma: nocover
     LIBMAGIC_AVAILABLE = False  # pragma: nocover
 
 
-from unstructured.logger import logger
+import structlog
+
 from unstructured.nlp.patterns import EMAIL_HEAD_RE
+
+logger = structlog.get_logger(__name__)
 
 DOCX_MIME_TYPES = [
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -2,9 +2,14 @@
 through Unstructured."""
 
 from abc import ABC, abstractmethod
+from time import perf_counter
+
+import structlog
 
 from unstructured.partition.auto import partition
 from unstructured.staging.base import convert_to_dict
+
+logger = structlog.get_logger(__name__)
 
 
 class BaseConnector(ABC):
@@ -86,7 +91,8 @@ class BaseIngestDoc(ABC):
         pass
 
     def process_file(self):
-        print(f"Processing {self.filename}")
+        logger.info("Processing document...")
+        start_time = perf_counter()
 
         elements = partition(filename=str(self.filename))
         isd_elems = convert_to_dict(elements)
@@ -97,5 +103,7 @@ class BaseIngestDoc(ABC):
             elem["metadata"].pop("filename", None)  # type: ignore[attr-defined]
             elem.pop("coordinates")  # type: ignore[attr-defined]
             self.isd_elems_no_filename.append(elem)
+
+        logger.info(f"Document processed in {perf_counter() - start_time:.3f} seconds.")
 
         return self.isd_elems_no_filename

--- a/unstructured/logger.py
+++ b/unstructured/logger.py
@@ -1,3 +1,0 @@
-import logging
-
-logger = logging.getLogger("unstructured")

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -9,8 +9,9 @@ if sys.version_info < (3, 8):
 else:
     from typing import Final
 
+import structlog
+
 from unstructured.cleaners.core import remove_punctuation
-from unstructured.logger import logger
 from unstructured.nlp.english_words import ENGLISH_WORDS
 from unstructured.nlp.patterns import (
     UNICODE_BULLETS_RE,
@@ -21,6 +22,8 @@ from unstructured.nlp.tokenize import pos_tag, sent_tokenize, word_tokenize
 
 POS_VERB_TAGS: Final[List[str]] = ["VB", "VBG", "VBD", "VBN", "VBP", "VBZ"]
 ENGLISH_WORD_SPLIT_RE = re.compile(r"[\s|\.|-|_|\/]")
+
+logger = structlog.get_logger(__name__)
 
 
 def is_possible_narrative_text(


### PR DESCRIPTION
## What's in this PR?

Basically the idea is to introduce `structlog` to replace the default `logging` used as well as the `print`-statements used along the codebase, to rely on a more standardized logging interface such as `structlog`. More information on `structlog` at https://www.structlog.org/en/stable/

## What's missing in this PR?

To identify which `contextvars` can be useful, make sure that the `structlog` logging messages are not annoying, make sure that the information is representative and accurate, ideantify more possible logging messages, etc.