### PR TITLE
fix: set through env to avoid interpretation as command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.2-dev0
+## 0.5.2-dev1
 
 ### Enhancements
 
@@ -9,6 +9,8 @@ rather than a "tmp-ingest-" dir in the working directory.
 
 ### Fixes
 
+* 'setup_ubuntu.sh` no longer fails in some contexts by interpreting 
+`DEBIAN_FRONTEND=noninteractive` as a command
 * `unstructured-ingest` no longer re-downloads files when --preserve-downloads
 is used without --download-dir.
 

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -32,7 +32,7 @@ fi
 $sudo $pac update -y
 if [[ -d /etc/needrestart/conf.d ]]; then
     # shellcheck disable=SC2016
-    echo '$nrconf{restart} = '"'a';" | $sudo tee /etc/needrestart/conf.d/99z_temp_disable.conf 
+    echo '$nrconf{restart} = '"'a';" | $sudo tee /etc/needrestart/conf.d/99z_temp_disable.conf
 fi
 $sudo $pac upgrade -y
 
@@ -42,7 +42,7 @@ $sudo $pac install -y git
 
 #### Python
 # Install tools needed to build python
-$sudo DEBIAN_FRONTEND=noninteractive $pac install -y curl gcc bzip2 sqlite zlib1g-dev libreadline-dev libsqlite3-dev libssl-dev tk-dev libffi-dev xz-utils make build-essential libbz2-dev wget llvm libncursesw5-dev libxml2-dev libxmlsec1-dev liblzma-dev
+$sudo env DEBIAN_FRONTEND="noninteractive" $pac install -y curl gcc bzip2 sqlite zlib1g-dev libreadline-dev libsqlite3-dev libssl-dev tk-dev libffi-dev xz-utils make build-essential libbz2-dev wget llvm libncursesw5-dev libxml2-dev libxmlsec1-dev liblzma-dev
 # Install pyenv
 if [[ ! -d $USER_ACCOUNT_HOME/.pyenv ]]; then
     sudo -u "$USER_ACCOUNT" -i <<'EOF'

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.2-dev0"  # pragma: no cover
+__version__ = "0.5.2-dev1"  # pragma: no cover


### PR DESCRIPTION
When I took the changes to the Ubuntu setup script and propagated them to other scripts that run in slightly different contexts, the script failed at line 45 as `DEBIAN_FRONTEND=noninteractive` was interpreted as a command rather than a variable assignment.

Added the `env` command so there's no misinterpretation. Tested in docker as both root and user.

#### Testing:
A good test is @cragwolfe 's [gist](https://gist.github.com/cragwolfe/e230fea5491ce2704356ee17857ee73c) although lines 9-17 should be removed from [setup-deps-and-test-user.sh](https://gist.github.com/cragwolfe/e230fea5491ce2704356ee17857ee73c#file-setup-deps-and-test-user-sh) for the most thorough check, as the script is set up to avoid halting at an interactive prompt when `tzdata` is being installed. Also the `wget` line will get the old version of the script, so injecting the script into the container should be done a different way (either create a custom `Dockerfile` or change the `wget` to get the file from this branch).