### PR TITLE
feat: Expose Wikipedia `auto_suggest` argument to the ingest CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.5.3-dev0
+
+### Enhancements
+
+### Features
+
+* Add `--wikipedia-auto-suggest` argument to the ingest CLI to disable automatic redirection
+  to pages with similar names.
+
+### Fixes
+
 ## 0.5.2
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.2"  # pragma: no cover
+__version__ = "0.5.3-dev0"  # pragma: no cover

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 @dataclass
 class SimpleWikipediaConfig(BaseConnectorConfig):
     title: str
+    auto_suggest: bool
 
     # Standard Connector options
     download_dir: str
@@ -155,7 +156,7 @@ class WikipediaConnector(BaseConnector):
     def get_ingest_docs(self):
         import wikipedia
 
-        page = wikipedia.page(self.config.title)
+        page = wikipedia.page(self.config.title, auto_suggest=self.config.auto_suggest)
         return [
             WikipediaIngestTextDoc(self.config, page),
             WikipediaIngestHTMLDoc(self.config, page),

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -90,6 +90,12 @@ class MainProcess:
     help='Title of a Wikipedia page, e.g. "Open source software".',
 )
 @click.option(
+    "--wikipedia-auto-suggest",
+    default=True,
+    help="Whether to automatically suggest a page if the exact page was not found."
+    " Set to False if the wrong Wikipedia page is fetched.",
+)
+@click.option(
     "--github-url",
     default=None,
     help='URL to GitHub repository, e.g. "https://github.com/Unstructured-IO/unstructured",'
@@ -182,6 +188,7 @@ class MainProcess:
 def main(
     s3_url,
     wikipedia_page_title,
+    wikipedia_auto_suggest,
     github_url,
     github_access_token,
     github_branch,
@@ -278,6 +285,7 @@ def main(
         doc_connector = WikipediaConnector(  # type: ignore
             config=SimpleWikipediaConfig(
                 title=wikipedia_page_title,
+                auto_suggest=wikipedia_auto_suggest,
                 # defaults params:
                 download_dir=download_dir,
                 preserve_downloads=preserve_downloads,


### PR DESCRIPTION
Closes #330

Hello!

## Pull Request overview
* Introduce the `--wikipedia-auto-suggest` CLI argument, defaulting to `True`.

## Details
The `auto_suggest` parameter from [`wikipedia.page`](https://wikipedia.readthedocs.io/en/latest/code.html#wikipedia.page) is now exposed to others, allowing users to prevent the wikipedia API from redirecting "Mango" to "Manga".

@cragwolfe I know you're very passionate about Mangos, so this one's for you:
```
unstructured-ingest --wikipedia-page-title "Mango" --wikipedia-auto-suggest False
```
The resulting summary file:
```json
[
  {
    "element_id": "abf8cf7754f228105897c717c95a1ab4",
    "text": "A mango is an edible stone fruit produced by the tropical tree Mangifera indica. It is believed to have originated between northwestern Myanmar, Bangladesh, and northeastern India. M. indica has been cultivated in South and Southeast Asia since ancient times resulting in two types of modern mango cultivars: the \"Indian type\" and the \"Southeast Asian type\". Other species in the genus Mangifera also produce edible fruits that are also called \"mangoes\", the majority of which are found in the Malesian ecoregion.Worldwide, there are several hundred cultivars of mango. Depending on the cultivar, mango fruit varies in size, shape, sweetness, skin color, and flesh color, which may be pale yellow, gold, green, or orange. Mango is the national fruit of India, Pakistan and the Philippines, while the mango tree is the national tree of Bangladesh.",
    "type": "NarrativeText",
    "metadata": {}
  }
]
```
As expected! The other two files I won't include in this PR description, as they're quite big.

<details><summary>Fluff</summary>
Although I'm pretty sure this still isn't quite the Mango that you were originally referring to, haha. That was Mango Capital, right? 😉 
</details>

## Alternative options
1. I can set the default to `False`.
2. If we like `False` as a default, I could also modify the argument to be more like `--verbose`, i.e. with `is_flag=True`, allowing for `--wikipedia-auto-suggest` rather than `--wikipedia-auto-suggest True`. I think this may be a tad unintuitive however.


- Tom Aarsen