### PR TITLE
feat: `UNSTRUCTURED_LANGUAGE_CHECK` env var to control 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.5.4-dev 0
+
+### Enhancements
+
+* Adds an `UNSTRUCTURED_LANGUAGE_CHECKS` environment variable to control whether or not language
+  specific checks like vocabulary and POS tagging are applied. Set to `"true"` for higher
+  resolution partitioning and `"false"` for faster processing.
+
+### Features
+
+### Fixes
+
 ## 0.5.3
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.4-dev 0
+## 0.5.4-dev0
 
 ### Enhancements
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -1351,6 +1351,7 @@ for consideration as narrative text. The function performs the following checks 
   The environment variables takes precedence over the kwarg.
 * The cap ratio test does not apply to text that is all uppercase.
 * If you use the ``language=""`` kwarg or set the ``UNSTRUCTURED_LANGUAGE`` environment variable to ``""``, the function will skip the verb check and the English word check.
+* If you use the ``language_checks=True`` kwarg or set the ``UNSTRUCTURED_LANGUAGE_CHECKS`` environment variable to ``"true"``, the function will apply language specific checks such as vocab part of speech checks.
 
 
 Examples:
@@ -1392,6 +1393,8 @@ for consideration as a title. The function performs the following checks:
 * If a title contains more than one sentence that exceeds a certain length, it cannot be a title. Sentence length threshold is controlled by the ``sentence_min_length`` kwarg and defaults to 5.
 * If a segment of text ends in a comma, it is not considered a potential title. This is to avoid salutations like "To My Dearest Friends," getting flagged as titles.
 * If you use the ``language=""`` kwarg or set the ``UNSTRUCTURED_LANGUAGE`` environment variable to ``""``, the function will skip the English word check.
+* If you use the ``language_checks=True`` kwarg or set the ``UNSTRUCTURED_LANGUAGE_CHECKS`` environment variable to ``"true"``, the function will apply language specific checks such as vocab part of speech checks.
+
 
 
 

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -50,11 +50,13 @@ def test_is_possible_narrative_text(text, expected, monkeypatch):
     monkeypatch.setattr(text_type, "word_tokenize", mock_word_tokenize)
     monkeypatch.setattr(text_type, "pos_tag", mock_pos_tag)
     monkeypatch.setattr(text_type, "sent_tokenize", mock_sent_tokenize)
+    monkeypatch.setenv("UNSTRUCTURED_LANGUAGE_CHECKS", "true")
     is_possible_narrative = text_type.is_possible_narrative_text(text, cap_threshold=0.3)
     assert is_possible_narrative is expected
 
 
-def test_text_type_handles_non_english_examples():
+def test_text_type_handles_non_english_examples(monkeypatch):
+    monkeypatch.setenv("UNSTRUCTURED_LANGUAGE_CHECKS", "true")
     narrative_text = "Я говорю по-русски. Вы тоже?"
     title = "Риски"
 
@@ -102,6 +104,7 @@ def test_text_type_handles_non_english_examples_with_env_var(monkeypatch):
 def test_is_possible_title(text, expected, monkeypatch):
     monkeypatch.setattr(text_type, "sent_tokenize", mock_sent_tokenize)
     monkeypatch.setattr(text_type, "word_tokenize", mock_word_tokenize)
+    monkeypatch.setenv("UNSTRUCTURED_LANGUAGE_CHECKS", "true")
     assert text_type.is_possible_title(text) is expected
 
 

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -55,6 +55,13 @@ def test_is_possible_narrative_text(text, expected, monkeypatch):
     assert is_possible_narrative is expected
 
 
+def test_narrative_text_language_checks():
+    # NOTE(robinson) - This is true because we don't check english vocab if language checks
+    # are set to False
+    text = "Dal;kdjfal adawels adfjwalsdf. Addad jaja fjawlek"
+    text_type.is_possible_narrative_text(text, language_checks=False) is True
+
+
 def test_text_type_handles_non_english_examples(monkeypatch):
     monkeypatch.setenv("UNSTRUCTURED_LANGUAGE_CHECKS", "true")
     narrative_text = "Я говорю по-русски. Вы тоже?"
@@ -106,6 +113,13 @@ def test_is_possible_title(text, expected, monkeypatch):
     monkeypatch.setattr(text_type, "word_tokenize", mock_word_tokenize)
     monkeypatch.setenv("UNSTRUCTURED_LANGUAGE_CHECKS", "true")
     assert text_type.is_possible_title(text) is expected
+
+
+def test_title_language_checks():
+    # NOTE(robinson) - This is true because we don't check english vocab if language checks
+    # are set to False
+    text = "BTAR ADFJA L"
+    text_type.is_possible_narrative_text(text, language_checks=False) is True
 
 
 @pytest.mark.parametrize(

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -59,7 +59,7 @@ def test_narrative_text_language_checks():
     # NOTE(robinson) - This is true because we don't check english vocab if language checks
     # are set to False
     text = "Dal;kdjfal adawels adfjwalsdf. Addad jaja fjawlek"
-    text_type.is_possible_narrative_text(text, language_checks=False) is True
+    assert text_type.is_possible_narrative_text(text, language_checks=True) is False
 
 
 def test_text_type_handles_non_english_examples(monkeypatch):
@@ -119,7 +119,7 @@ def test_title_language_checks():
     # NOTE(robinson) - This is true because we don't check english vocab if language checks
     # are set to False
     text = "BTAR ADFJA L"
-    text_type.is_possible_narrative_text(text, language_checks=False) is True
+    assert text_type.is_possible_narrative_text(text, language_checks=True) is False
 
 
 @pytest.mark.parametrize(

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.3"  # pragma: no cover
+__version__ = "0.5.4-dev0"  # pragma: no cover

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -47,7 +47,7 @@ def is_possible_narrative_text(
     language
         The two letter language code for the text. defaults to "en" for English
     language_checks
-        If True, conducts checks that are language to the specified language. Turn on for more
+        If True, conducts checks that are specific to the chosen language. Turn on for more
         accurate partitioning and off for faster processing.
     """
     _language_checks = os.environ.get("UNSTRUCTURED_LANGUAGE_CHECKS")
@@ -111,7 +111,7 @@ def is_possible_title(
     language
         The two letter language code for the text. defaults to "en" for English
     language_checks
-        If True, conducts checks that are language to the specified language. Turn on for more
+        If True, conducts checks that are specific to the chosen language. Turn on for more
         accurate partitioning and off for faster processing.
     """
     _language_checks = os.environ.get("UNSTRUCTURED_LANGUAGE_CHECKS")

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -47,7 +47,8 @@ def is_possible_narrative_text(
     language
         The two letter language code for the text. defaults to "en" for English
     language_checks
-        If True, conducts checks that are language to the specified language.
+        If True, conducts checks that are language to the specified language. Turn on for more
+        accurate partitioning and off for faster processing.
     """
     _language_checks = os.environ.get("UNSTRUCTURED_LANGUAGE_CHECKS")
     if _language_checks is not None:
@@ -110,7 +111,8 @@ def is_possible_title(
     language
         The two letter language code for the text. defaults to "en" for English
     language_checks
-        If True, conducts checks that are language to the specified language.
+        If True, conducts checks that are language to the specified language. Turn on for more
+        accurate partitioning and off for faster processing.
     """
     _language_checks = os.environ.get("UNSTRUCTURED_LANGUAGE_CHECKS")
     if _language_checks is not None:

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -28,6 +28,7 @@ def is_possible_narrative_text(
     cap_threshold: float = 0.5,
     non_alpha_threshold: float = 0.5,
     language: str = "en",
+    language_checks: bool = False,
 ) -> bool:
     """Checks to see if the text passes all of the checks for a narrative text section.
     You can change the cap threshold using the cap_threshold kwarg or the
@@ -45,7 +46,13 @@ def is_possible_narrative_text(
         narrative text
     language
         The two letter language code for the text. defaults to "en" for English
+    language_checks
+        If True, conducts checks that are language to the specified language.
     """
+    _language_checks = os.environ.get("UNSTRUCTURED_LANGUAGE_CHECKS")
+    if _language_checks is not None:
+        language_checks = _language_checks.lower() == "true"
+
     if len(text) == 0:
         logger.debug("Not narrative. Text is empty.")
         return False
@@ -55,7 +62,7 @@ def is_possible_narrative_text(
         return False
 
     language = os.environ.get("UNSTRUCTURED_LANGUAGE", language)
-    if language == "en" and not contains_english_word(text):
+    if language == "en" and language_checks and not contains_english_word(text):
         return False
 
     # NOTE(robinson): it gets read in from the environment as a string so we need to
@@ -86,6 +93,7 @@ def is_possible_title(
     title_max_word_length: int = 12,
     non_alpha_threshold: float = 0.5,
     language: str = "en",
+    language_checks: bool = False,
 ) -> bool:
     """Checks to see if the text passes all of the checks for a valid title.
 
@@ -101,7 +109,13 @@ def is_possible_title(
         The minimum number of alpha characters the text needs to be considered a title
     language
         The two letter language code for the text. defaults to "en" for English
+    language_checks
+        If True, conducts checks that are language to the specified language.
     """
+    _language_checks = os.environ.get("UNSTRUCTURED_LANGUAGE_CHECKS")
+    if _language_checks is not None:
+        language_checks = _language_checks.lower() == "true"
+
     if len(text) == 0:
         logger.debug("Not a title. Text is empty.")
         return False
@@ -125,7 +139,7 @@ def is_possible_title(
         return False
 
     language = os.environ.get("UNSTRUCTURED_LANGUAGE", language)
-    if language == "en" and not contains_english_word(text):
+    if language == "en" and not contains_english_word(text) and language_checks:
         return False
 
     if text.isnumeric():


### PR DESCRIPTION
### Summary

Adds an `UNSTRUCTURED_LANGUAGE_CHECK` environment variable that controls whether language specific checks such as vocab and part of speech checks are applied. Users can set this to `"true"` for more accurate partitioning or `"false"` for faster processing.

### Testing

The following shows how to apply this language checks with both the kwarg and the environment variable.

```python
from unstructured.partition.text_type import is_possible_title

is_possible_title("BLI BLA BLARG") # should be True
is_possible_title("BLI BLA BLARG", language_checks=True) # should be False

os.environ["UNSTRUCTURED_LANGUAGE_CHECKS"] = "true"
is_possible_title("BLI BLA BLARG") # should be False
```

We should also observe a speed up when `partition_html` is applied on the feature branch relative to `main`. My tests locally show a ~3x speedup.

On the feature branch
```python
In [5]: %timeit partition_html(filename="example-docs/example-10k.html")
1.62 s ± 17.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each
```

On `main`:
```python
In [6]: %timeit partition_html(filename="example-docs/example-10k.html")
3.49 s ± 13.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```