### PR TITLE
Enhancement: improve `detect_filetype` warning to include filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
-## 0.5.4-dev1
+## 0.5.4-dev2
 
 ### Enhancements
-
 
 * Add `FsspecConnector` to easily integrate any existing `fsspec` filesystem as a connector.
 * Rename `s3_connector.py` to `s3.py` for readability and consistency with the
@@ -11,6 +10,7 @@
 * Adds an `UNSTRUCTURED_LANGUAGE_CHECKS` environment variable to control whether or not language
   specific checks like vocabulary and POS tagging are applied. Set to `"true"` for higher
   resolution partitioning and `"false"` for faster processing.
+* Improves `detect_filetype` warning to include filename when provided.
 
 ### Features
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.4-dev1"  # pragma: no cover
+__version__ = "0.5.4-dev2"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -229,7 +229,8 @@ def detect_filetype(
             return EXT_TO_FILETYPE.get(extension.lower(), filetype)
 
     logger.warning(
-        f"MIME type was {mime_type}. This file type is not currently supported in unstructured.",
+        f"The MIME type{f' of {filename!r}' if filename else ''} is {mime_type!r}. "
+        "This file type is not currently supported in unstructured.",
     )
     return FileType.UNK
 


### PR DESCRIPTION
Closes #208

Hello!

## Pull Request overview
* Improved `detect_filetype` warning to include filename if provided.

## Details
See #208 for details on the desired improvement.

## Reproduction
Consider the following script to reproduce the warning:
```python
from unstructured.file_utils.filetype import detect_filetype

print(detect_filetype(filename="example-docs/fake-email-header.eml"))
```
I've used the already-available [`example-docs/fake-email-header.eml`](https://github.com/Unstructured-IO/unstructured/blob/main/example-docs/fake-email-header.eml) as libmagic responds with an unknown mime type for it. This makes it a good target file to test out these changes with.

On the `main` branch, the output of this script is:
```
MIME type was message/rfc822. This file type is not currently supported in unstructured.
FileType.UNK
```
After this PR, the output will be:
```
The MIME type of 'example-docs/fake-email-header.eml' is 'message/rfc822'. This file type is not currently supported in unstructured.
FileType.UNK
```

---

I'm open to feedback, as always. And feel free to let me know if I need to handle any merge conflicts.

- Tom Aarsen
