### PR TITLE
feat: add --metadata-include and --metadata-exclude parameters to unstructured-ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Features
 
+* Add `--metadata-include` and `--metadata-exclude` parameters to `unstructured-ingest`
 * Add `clean_non_ascii_chars` to remove non-ascii characters from unicode string
 
 ### Fixes

--- a/test_unstructured_ingest/test-ingest-azure.sh
+++ b/test_unstructured_ingest/test-ingest-azure.sh
@@ -4,6 +4,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR"/.. || exit 1
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
+    --metadata-exclude filename \
     --remote-url abfs://container1/ \
     --azure-account-name azureunstructured1 \
     --structured-output-dir azure-ingest-output \

--- a/test_unstructured_ingest/test-ingest-biomed-api.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-api.sh
@@ -10,6 +10,7 @@ if [[ "$(find test_unstructured_ingest/expected-structured-output/biomed-ingest-
 fi
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
+   --metadata-exclude filename \
    --biomed-api-from "2019-01-02" \
    --biomed-api-until "2019-01-02+00:03:10" \
    --structured-output-dir biomed-ingest-output-api  \

--- a/test_unstructured_ingest/test-ingest-biomed-path.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-path.sh
@@ -10,6 +10,7 @@ if [[ "$(find test_unstructured_ingest/expected-structured-output/biomed-ingest-
 fi
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
+    --metadata-exclude filename \
     --biomed-path "oa_pdf/07/07/sbaa031.073.PMC7234218.pdf" \
     --structured-output-dir biomed-ingest-output-path \
     --num-processes 2 \

--- a/test_unstructured_ingest/test-ingest-github.sh
+++ b/test_unstructured_ingest/test-ingest-github.sh
@@ -12,7 +12,12 @@ if [[ "$CI" == "true" ]]; then
 fi
 
 
-PYTHONPATH=. ./unstructured/ingest/main.py --github-url dcneiner/Downloadify --git-file-glob '*.html,*.txt' --structured-output-dir github-downloadify-output --verbose
+PYTHONPATH=. ./unstructured/ingest/main.py \
+    --metadata-exclude filename \
+    --github-url dcneiner/Downloadify \
+    --git-file-glob '*.html,*.txt' \
+    --structured-output-dir github-downloadify-output \
+    --verbose
 
 if ! diff -ru test_unstructured_ingest/expected-structured-output/github-downloadify github-downloadify-output ; then
    echo

--- a/test_unstructured_ingest/test-ingest-gitlab.sh
+++ b/test_unstructured_ingest/test-ingest-gitlab.sh
@@ -4,6 +4,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"/.. || exit 1
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
+    --metadata-exclude filename \
     --gitlab-url https://gitlab.com/gitlab-com/content-sites/docsy-gitlab \
     --git-file-glob '*.md,*.txt' \
     --structured-output-dir gitlab-ingest-output \

--- a/test_unstructured_ingest/test-ingest-s3.sh
+++ b/test_unstructured_ingest/test-ingest-s3.sh
@@ -9,7 +9,11 @@ if [[ "$(find test_unstructured_ingest/expected-structured-output/s3-small-batch
     exit 1
 fi
 
-PYTHONPATH=. ./unstructured/ingest/main.py --s3-url s3://utic-dev-tech-fixtures/small-pdf-set/ --s3-anonymous --structured-output-dir s3-small-batch-output
+PYTHONPATH=. ./unstructured/ingest/main.py \
+    --metadata-exclude filename \
+    --s3-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
+    --s3-anonymous \
+    --structured-output-dir s3-small-batch-output \
 
 if ! diff -ru test_unstructured_ingest/expected-structured-output/s3-small-batch s3-small-batch-output ; then
     echo

--- a/test_unstructured_ingest/test-ingest-wikipedia.sh
+++ b/test_unstructured_ingest/test-ingest-wikipedia.sh
@@ -4,6 +4,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"/.. || exit 1
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
+    --metadata-exclude filename \
     --wikipedia-page-title "Open Source Software" \
     --structured-output-dir wikipedia-ingest-output \
     --num-processes 2 \

--- a/test_unstructured_ingest/test_interfaces.py
+++ b/test_unstructured_ingest/test_interfaces.py
@@ -1,0 +1,79 @@
+import os
+import pathlib
+
+import pytest
+
+from unstructured.ingest.connector.git import GitIngestDoc, SimpleGitConfig
+
+
+DIRECTORY = pathlib.Path(__file__).parent.resolve()
+EXAMPLE_DOCS_DIRECTORY = os.path.join(DIRECTORY, "..", "example-docs")
+
+test_files = [
+    "layout-parser-paper-fast.jpg",
+    "layout-parser-paper-fast.pdf",
+]
+
+
+@pytest.mark.parametrize("filename", test_files)
+def test_process_file_include_filename(filename: str):
+    ingest_doc = GitIngestDoc(
+        path=filename,
+        config=SimpleGitConfig(
+          download_dir=EXAMPLE_DOCS_DIRECTORY,
+          metadata_include="filename",
+        ),
+    )
+    isd_elems = ingest_doc.process_file()
+
+    for elem in isd_elems:
+        for k in elem["metadata"]:
+            assert k == "filename"
+
+
+@pytest.mark.parametrize("filename", test_files)
+def test_process_file_include_filename_pagenum(filename: str):
+    ingest_doc = GitIngestDoc(
+        path=filename,
+        config=SimpleGitConfig(
+          download_dir=EXAMPLE_DOCS_DIRECTORY,
+          metadata_include="filename,page_number",
+        ),
+    )
+    isd_elems = ingest_doc.process_file()
+
+    for elem in isd_elems:
+        for k in elem["metadata"]:
+            assert k in ["filename", "page_number"]
+
+
+@pytest.mark.parametrize("filename", test_files)
+def test_process_file_exclude_filename(filename: str):
+    ingest_doc = GitIngestDoc(
+        path=filename,
+        config=SimpleGitConfig(
+          download_dir=EXAMPLE_DOCS_DIRECTORY,
+          metadata_exclude="filename",
+        ),
+    )
+    isd_elems = ingest_doc.process_file()
+
+    for elem in isd_elems:
+        for k in elem["metadata"]:
+            assert k != "filename"
+
+
+@pytest.mark.parametrize("filename", test_files)
+def test_process_file_exclude_filename_pagenum(filename: str):
+    ingest_doc = GitIngestDoc(
+        path=filename,
+        config=SimpleGitConfig(
+          download_dir=EXAMPLE_DOCS_DIRECTORY,
+          metadata_exclude="filename,page_number",
+        ),
+    )
+    isd_elems = ingest_doc.process_file()
+
+    for elem in isd_elems:
+        for k in elem["metadata"]:
+            assert k not in ["filename", "page_number"]

--- a/test_unstructured_ingest/test_interfaces.py
+++ b/test_unstructured_ingest/test_interfaces.py
@@ -5,7 +5,6 @@ import pytest
 
 from unstructured.ingest.connector.git import GitIngestDoc, SimpleGitConfig
 
-
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 EXAMPLE_DOCS_DIRECTORY = os.path.join(DIRECTORY, "..", "example-docs")
 

--- a/unstructured/ingest/connector/biomed.py
+++ b/unstructured/ingest/connector/biomed.py
@@ -48,6 +48,8 @@ class SimpleBiomedConfig(BaseConnectorConfig):
     output_dir: str
     re_download: bool = False
     preserve_downloads: bool = False
+    metadata_include: str = ""
+    metadata_exclude: str = ""
 
     def _validate_date_args(self, date):
         date_formats = ["%Y-%m-%d", "%Y-%m-%d+%H:%M:%S"]

--- a/unstructured/ingest/connector/biomed.py
+++ b/unstructured/ingest/connector/biomed.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from ftplib import FTP, error_perm
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 import requests
 from bs4 import BeautifulSoup
@@ -48,8 +48,8 @@ class SimpleBiomedConfig(BaseConnectorConfig):
     output_dir: str
     re_download: bool = False
     preserve_downloads: bool = False
-    metadata_include: str = ""
-    metadata_exclude: str = ""
+    metadata_include: Optional[str] = None
+    metadata_exclude: Optional[str] = None
 
     def _validate_date_args(self, date):
         date_formats = ["%Y-%m-%d", "%Y-%m-%d+%H:%M:%S"]

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -29,6 +29,8 @@ class SimpleFsspecConfig(BaseConnectorConfig):
     output_dir: str
     preserve_downloads: bool = False
     re_download: bool = False
+    metadata_include: str = ""
+    metadata_exclude: str = ""
 
     # fsspec specific options
     access_kwargs: dict = field(default_factory=dict)

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -3,7 +3,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Type
+from typing import Optional, Type
 
 from unstructured.ingest.interfaces import (
     BaseConnector,
@@ -29,8 +29,8 @@ class SimpleFsspecConfig(BaseConnectorConfig):
     output_dir: str
     preserve_downloads: bool = False
     re_download: bool = False
-    metadata_include: str = ""
-    metadata_exclude: str = ""
+    metadata_include: Optional[str] = None
+    metadata_exclude: Optional[str] = None
 
     # fsspec specific options
     access_kwargs: dict = field(default_factory=dict)

--- a/unstructured/ingest/connector/git.py
+++ b/unstructured/ingest/connector/git.py
@@ -26,8 +26,8 @@ class SimpleGitConfig(BaseConnectorConfig):
     output_dir: str
     preserve_downloads: bool = False
     re_download: bool = False
-    metadata_include: str = ""
-    metadata_exclude: str = ""
+    metadata_include: Optional[str] = None
+    metadata_exclude: Optional[str] = None
 
     repo_path: str = field(init=False, repr=False)
 

--- a/unstructured/ingest/connector/git.py
+++ b/unstructured/ingest/connector/git.py
@@ -26,6 +26,8 @@ class SimpleGitConfig(BaseConnectorConfig):
     output_dir: str
     preserve_downloads: bool = False
     re_download: bool = False
+    metadata_include: str = ""
+    metadata_exclude: str = ""
 
     repo_path: str = field(init=False, repr=False)
 

--- a/unstructured/ingest/connector/google_drive.py
+++ b/unstructured/ingest/connector/google_drive.py
@@ -77,6 +77,8 @@ class SimpleGoogleDriveConfig(BaseConnectorConfig):
     output_dir: str
     re_download: bool = False
     preserve_downloads: bool = False
+    metadata_include: str = ""
+    metadata_exclude: str = ""
 
     recursive: bool = False
 

--- a/unstructured/ingest/connector/google_drive.py
+++ b/unstructured/ingest/connector/google_drive.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass
 from mimetypes import guess_extension
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from unstructured.file_utils.filetype import EXT_TO_FILETYPE
 from unstructured.file_utils.google_filetype import GOOGLE_DRIVE_EXPORT_TYPES
@@ -77,8 +77,8 @@ class SimpleGoogleDriveConfig(BaseConnectorConfig):
     output_dir: str
     re_download: bool = False
     preserve_downloads: bool = False
-    metadata_include: str = ""
-    metadata_exclude: str = ""
+    metadata_include: Optional[str] = None
+    metadata_exclude: Optional[str] = None
 
     recursive: bool = False
 

--- a/unstructured/ingest/connector/reddit.py
+++ b/unstructured/ingest/connector/reddit.py
@@ -2,7 +2,7 @@ import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from unstructured.ingest.interfaces import (
     BaseConnector,
@@ -31,8 +31,8 @@ class SimpleRedditConfig(BaseConnectorConfig):
     output_dir: str
     preserve_downloads: bool = False
     re_download: bool = False
-    metadata_include: str = ""
-    metadata_exclude: str = ""
+    metadata_include: Optional[str] = None
+    metadata_exclude: Optional[str] = None
 
     def __post_init__(self):
         if self.num_posts <= 0:

--- a/unstructured/ingest/connector/reddit.py
+++ b/unstructured/ingest/connector/reddit.py
@@ -2,7 +2,7 @@ import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from unstructured.ingest.interfaces import (
     BaseConnector,

--- a/unstructured/ingest/connector/reddit.py
+++ b/unstructured/ingest/connector/reddit.py
@@ -31,6 +31,8 @@ class SimpleRedditConfig(BaseConnectorConfig):
     output_dir: str
     preserve_downloads: bool = False
     re_download: bool = False
+    metadata_include: str = ""
+    metadata_exclude: str = ""
 
     def __post_init__(self):
         if self.num_posts <= 0:

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -26,6 +26,8 @@ class SimpleWikipediaConfig(BaseConnectorConfig):
     output_dir: str
     preserve_downloads: bool = False
     re_download: bool = False
+    metadata_include: str = ""
+    metadata_exclude: str = ""
 
 
 @dataclass

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -2,7 +2,7 @@ import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from unstructured.ingest.interfaces import (
     BaseConnector,

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -29,6 +29,7 @@ class SimpleWikipediaConfig(BaseConnectorConfig):
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
 
+
 @dataclass
 class WikipediaIngestDoc(BaseIngestDoc):
     config: SimpleWikipediaConfig = field(repr=False)

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -2,7 +2,7 @@ import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from unstructured.ingest.interfaces import (
     BaseConnector,
@@ -26,9 +26,8 @@ class SimpleWikipediaConfig(BaseConnectorConfig):
     output_dir: str
     preserve_downloads: bool = False
     re_download: bool = False
-    metadata_include: str = ""
-    metadata_exclude: str = ""
-
+    metadata_include: Optional[str] = None
+    metadata_exclude: Optional[str] = None
 
 @dataclass
 class WikipediaIngestDoc(BaseIngestDoc):

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -1,6 +1,7 @@
 """Defines Abstract Base Classes (ABC's) core to batch processing documents
 through Unstructured."""
 
+import json
 from abc import ABC, abstractmethod
 
 from unstructured.ingest.logger import logger
@@ -98,16 +99,18 @@ class BaseIngestDoc(ABC):
         self.isd_elems_no_filename = []
         for elem in isd_elems:
             # type: ignore
+            metadata_dict = json.loads(elem["metadata"])
             if self.config.metadata_exclude:
                 ex_list = self.config.metadata_exclude.split(",")
                 for ex in ex_list:
-                    elem["metadata"].pop(ex, None)
+                    metadata_dict.pop(ex, None)
             elif self.config.metadata_include:
                 in_list = self.config.metadata_include.split(",")
                 for k in elem["metadata"]:
                     if k not in in_list:
-                        elem["metadata"].pop(k, None)
-
+                        metadata_dict.pop(k, None)
+            elem["metadata"] = str(metadata_dict)
+            
             elem.pop("coordinates")  # type: ignore[attr-defined]
             self.isd_elems_no_filename.append(elem)
 

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -59,7 +59,9 @@ class BaseIngestDoc(ABC):
 
     Crucially, it is not responsible for the actual processing of the raw document.
     """
+
     config: BaseConnectorConfig
+
     @property
     @abstractmethod
     def filename(self):
@@ -105,7 +107,7 @@ class BaseIngestDoc(ABC):
                 for k in elem["metadata"]:
                     if k not in in_list:
                         elem["metadata"].pop(k, None)
-            
+
             elem.pop("coordinates")  # type: ignore[attr-defined]
             self.isd_elems_no_filename.append(elem)
 

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -101,12 +101,12 @@ class BaseIngestDoc(ABC):
             if self.config.metadata_exclude:
                 ex_list = self.config.metadata_exclude.split(",")
                 for ex in ex_list:
-                    elem["metadata"].pop(ex, None)
+                    elem["metadata"].pop(ex, None) # type: ignore[attr-defined]
             elif self.config.metadata_include:
                 in_list = self.config.metadata_include.split(",")
                 for k in elem["metadata"]:
                     if k not in in_list:
-                        elem["metadata"].pop(k, None)
+                        elem["metadata"].pop(k, None) # type: ignore[attr-defined]
 
             elem.pop("coordinates")  # type: ignore[attr-defined]
             self.isd_elems_no_filename.append(elem)

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -101,12 +101,12 @@ class BaseIngestDoc(ABC):
             if self.config.metadata_exclude:
                 ex_list = self.config.metadata_exclude.split(",")
                 for ex in ex_list:
-                    elem["metadata"].pop(ex, None) # type: ignore[attr-defined]
+                    elem["metadata"].pop(ex, None)  # type: ignore[attr-defined]
             elif self.config.metadata_include:
                 in_list = self.config.metadata_include.split(",")
                 for k in elem["metadata"]:
                     if k not in in_list:
-                        elem["metadata"].pop(k, None) # type: ignore[attr-defined]
+                        elem["metadata"].pop(k, None)  # type: ignore[attr-defined]
 
             elem.pop("coordinates")  # type: ignore[attr-defined]
             self.isd_elems_no_filename.append(elem)

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -1,7 +1,6 @@
 """Defines Abstract Base Classes (ABC's) core to batch processing documents
 through Unstructured."""
 
-import ast
 from abc import ABC, abstractmethod
 
 from unstructured.ingest.logger import logger
@@ -99,18 +98,15 @@ class BaseIngestDoc(ABC):
         self.isd_elems_no_filename = []
         for elem in isd_elems:
             # type: ignore
-            metadata_dict = ast.literal_eval(elem["metadata"])
-
             if self.config.metadata_exclude:
                 ex_list = self.config.metadata_exclude.split(",")
                 for ex in ex_list:
-                    metadata_dict.pop(ex, None)
+                    elem["metadata"].pop(ex, None)
             elif self.config.metadata_include:
                 in_list = self.config.metadata_include.split(",")
                 for k in elem["metadata"]:
                     if k not in in_list:
-                        metadata_dict.pop(k, None)
-            elem["metadata"] = str(metadata_dict)
+                        elem["metadata"].pop(k, None)
 
             elem.pop("coordinates")  # type: ignore[attr-defined]
             self.isd_elems_no_filename.append(elem)

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -1,7 +1,7 @@
 """Defines Abstract Base Classes (ABC's) core to batch processing documents
 through Unstructured."""
 
-import json
+import ast
 from abc import ABC, abstractmethod
 
 from unstructured.ingest.logger import logger
@@ -99,7 +99,8 @@ class BaseIngestDoc(ABC):
         self.isd_elems_no_filename = []
         for elem in isd_elems:
             # type: ignore
-            metadata_dict = json.loads(elem["metadata"])
+            metadata_dict = ast.literal_eval(elem["metadata"])
+
             if self.config.metadata_exclude:
                 ex_list = self.config.metadata_exclude.split(",")
                 for ex in ex_list:

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -2,6 +2,7 @@
 through Unstructured."""
 
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from unstructured.ingest.logger import logger
 from unstructured.partition.auto import partition
@@ -47,8 +48,8 @@ class BaseConnectorConfig(ABC):
     # where to write structured data outputs
     output_dir: str
     re_download: bool = False
-    metadata_include: str = ""
-    metadata_exclude: str = ""
+    metadata_include: Optional[str] = None
+    metadata_exclude: Optional[str] = None
 
 
 class BaseIngestDoc(ABC):
@@ -98,11 +99,11 @@ class BaseIngestDoc(ABC):
         self.isd_elems_no_filename = []
         for elem in isd_elems:
             # type: ignore
-            if self.config.metadata_exclude:
+            if self.config.metadata_exclude is not None:
                 ex_list = self.config.metadata_exclude.split(",")
                 for ex in ex_list:
                     elem["metadata"].pop(ex, None)  # type: ignore[attr-defined]
-            elif self.config.metadata_include:
+            elif self.config.metadata_include is not None:
                 in_list = self.config.metadata_include.split(",")
                 for k in elem["metadata"]:
                     if k not in in_list:

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -105,8 +105,6 @@ class BaseIngestDoc(ABC):
                 for k in elem["metadata"]:
                     if k not in in_list:
                         elem["metadata"].pop(k, None)
-            else:
-                elem["metadata"].pop("filename", None)  # type: ignore[attr-defined]
             
             elem.pop("coordinates")  # type: ignore[attr-defined]
             self.isd_elems_no_filename.append(elem)

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -99,7 +99,15 @@ class BaseIngestDoc(ABC):
         self.isd_elems_no_filename = []
         for elem in isd_elems:
             # type: ignore
-            if self.config.metadata_exclude is not None:
+            if (
+                self.config.metadata_exclude is not None
+                and self.config.metadata_include is not None
+            ):
+                raise ValueError(
+                    "Arguments `--metadata-include` and `--metadata-exclude` are "
+                    "mutually exclusive with each other.",
+                )
+            elif self.config.metadata_exclude is not None:
                 ex_list = self.config.metadata_exclude.split(",")
                 for ex in ex_list:
                     elem["metadata"].pop(ex, None)  # type: ignore[attr-defined]

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -110,7 +110,7 @@ class BaseIngestDoc(ABC):
                     if k not in in_list:
                         metadata_dict.pop(k, None)
             elem["metadata"] = str(metadata_dict)
-            
+
             elem.pop("coordinates")  # type: ignore[attr-defined]
             self.isd_elems_no_filename.append(elem)
 

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -8,7 +8,8 @@ from contextlib import suppress
 from pathlib import Path
 from urllib.parse import urlparse
 
-from click import Option, UsageError, command, option
+import click
+from click import Option, UsageError
 
 from unstructured.ingest.connector.azure import (
     AzureBlobStorageConnector,

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from pathlib import Path
 from urllib.parse import urlparse
 
-import click
+from click import Option, UsageError
 
 from unstructured.ingest.connector.azure import (
     AzureBlobStorageConnector,

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from pathlib import Path
 from urllib.parse import urlparse
 
-from click import command, option, Option, UsageError
+from click import Option, UsageError, command, option
 
 from unstructured.ingest.connector.azure import (
     AzureBlobStorageConnector,

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -136,15 +136,19 @@ class MainProcess:
 @click.option(
     "--metadata-include",
     cls=MutuallyExclusiveOption,
-    default="",
-    help="If set, include the specified metadata fields if they exist and drop all other fields.",
+    default=None,
+    help="If set, include the specified metadata fields if they exist and drop all other fields. "
+    "Usage: provide a single string with comma separated values. "
+    "Example: --metadata-include filename,page_number ",
     mutually_exclusive=["--metadata-exclude"],
 )
 @click.option(
     "--metadata-exclude",
     cls=MutuallyExclusiveOption,
-    default="",
-    help="If set, drop the specified metadata fields if they exist.",
+    default=None,
+    help="If set, drop the specified metadata fields if they exist. "
+    "Usage: provide a single string with comma separated values. "
+    "Example: --metadata-exclude filename,page_number ",
     mutually_exclusive=["--metadata-include"],
 )
 @click.option(

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from pathlib import Path
 from urllib.parse import urlparse
 
-from click import Option, UsageError
+from click import command, option, Option, UsageError
 
 from unstructured.ingest.connector.azure import (
     AzureBlobStorageConnector,

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -339,7 +339,7 @@ def main(
     metadata_include,
     metadata_exclude,
 ):
-    if metadata_exclude and metadata_include:
+    if metadata_exclude is not None and metadata_include is not None:
         logger.error(
             "Arguments `--metadata-include` and `--metadata-exclude` are "
             "mutually exclusive with each other.",

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -136,14 +136,14 @@ class MainProcess:
 @click.option(
     "--metadata-include",
     cls=MutuallyExclusiveOption,
-    default=None,
+    default="",
     help="If set, include the specified metadata fields if they exist and drop all other fields.",
     mutually_exclusive=["--metadata-exclude"],
 )
 @click.option(
     "--metadata-exclude",
     cls=MutuallyExclusiveOption,
-    default=None,
+    default="",
     help="If set, drop the specified metadata fields if they exist.",
     mutually_exclusive=["--metadata-include"],
 )
@@ -366,6 +366,8 @@ def main(
     reprocess,
     num_processes,
     verbose,
+    metadata_include,
+    metadata_exclude,
 ):
     if not preserve_downloads and download_dir:
         logger.warning(
@@ -435,6 +437,8 @@ def main(
                     output_dir=structured_output_dir,
                     re_download=re_download,
                     preserve_downloads=preserve_downloads,
+                    metadata_exclude=metadata_exclude,
+                    metadata_include=metadata_include,
                 ),
             )
         elif protocol in ("abfs", "az"):
@@ -455,6 +459,8 @@ def main(
                     output_dir=structured_output_dir,
                     re_download=re_download,
                     preserve_downloads=preserve_downloads,
+                    metadata_exclude=metadata_exclude,
+                    metadata_include=metadata_include,
                 ),
             )
         else:
@@ -471,6 +477,8 @@ def main(
                     output_dir=structured_output_dir,
                     re_download=re_download,
                     preserve_downloads=preserve_downloads,
+                    metadata_exclude=metadata_exclude,
+                    metadata_include=metadata_include,
                 ),
             )
     elif github_url:
@@ -485,6 +493,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
+                metadata_exclude=metadata_exclude,
+                metadata_include=metadata_include,
             ),
         )
     elif gitlab_url:
@@ -499,6 +509,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
+                metadata_exclude=metadata_exclude,
+                metadata_include=metadata_include,
             ),
         )
     elif subreddit_name:
@@ -515,6 +527,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
+                metadata_exclude=metadata_exclude,
+                metadata_include=metadata_include,
             ),
         )
     elif wikipedia_page_title:
@@ -527,6 +541,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
+                metadata_exclude=metadata_exclude,
+                metadata_include=metadata_include,
             ),
         )
     elif drive_id:
@@ -541,6 +557,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
+                metadata_exclude=metadata_exclude,
+                metadata_include=metadata_include,
             ),
         )
     elif biomed_path or biomed_api_id or biomed_api_from or biomed_api_until:
@@ -555,6 +573,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
+                metadata_exclude=metadata_exclude,
+                metadata_include=metadata_include,
             ),
         )
     # Check for other connector-specific options here and define the doc_connector object

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import click
-from click import Option, UsageError
 
 from unstructured.ingest.connector.azure import (
     AzureBlobStorageConnector,
@@ -34,35 +33,6 @@ from unstructured.ingest.logger import ingest_log_streaming_init, logger
 
 with suppress(RuntimeError):
     mp.set_start_method("spawn")
-
-
-class MutuallyExclusiveOption(Option):
-    def __init__(self, *args, **kwargs):
-        self.mutually_exclusive = set(kwargs.pop("mutually_exclusive", []))
-        help = kwargs.get("help", "")
-        if self.mutually_exclusive:
-            mutex_str = ", ".join(self.mutually_exclusive)
-            kwargs["help"] = help + (
-                " NOTE: This argument is mutually exclusive with "
-                " arguments: [" + mutex_str + "]."
-            )
-        super(MutuallyExclusiveOption, self).__init__(*args, **kwargs)
-
-    def handle_parse_result(self, ctx, opts, args):
-        if self.mutually_exclusive.intersection(opts) and self.name in opts:
-            raise UsageError(
-                "Illegal usage: `{}` is mutually exclusive with "
-                "arguments `{}`.".format(
-                    self.name,
-                    ", ".join(self.mutually_exclusive),
-                ),
-            )
-
-        return super(MutuallyExclusiveOption, self).handle_parse_result(
-            ctx,
-            opts,
-            args,
-        )
 
 
 class MainProcess:
@@ -135,21 +105,17 @@ class MainProcess:
 @click.command()
 @click.option(
     "--metadata-include",
-    cls=MutuallyExclusiveOption,
     default=None,
     help="If set, include the specified metadata fields if they exist and drop all other fields. "
     "Usage: provide a single string with comma separated values. "
     "Example: --metadata-include filename,page_number ",
-    mutually_exclusive=["--metadata-exclude"],
 )
 @click.option(
     "--metadata-exclude",
-    cls=MutuallyExclusiveOption,
     default=None,
     help="If set, drop the specified metadata fields if they exist. "
     "Usage: provide a single string with comma separated values. "
     "Example: --metadata-exclude filename,page_number ",
-    mutually_exclusive=["--metadata-include"],
 )
 @click.option(
     "--remote-url",
@@ -373,6 +339,12 @@ def main(
     metadata_include,
     metadata_exclude,
 ):
+    if metadata_exclude and metadata_include:
+        logger.error(
+            "Arguments `--metadata-include` and `--metadata-exclude` are "
+            "mutually exclusive with each other.",
+        )
+        sys.exit(1)
     if not preserve_downloads and download_dir:
         logger.warning(
             "Not preserving downloaded files but --download_dir is specified",

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -53,14 +53,14 @@ class MutuallyExclusiveOption(Option):
                 "Illegal usage: `{}` is mutually exclusive with "
                 "arguments `{}`.".format(
                     self.name,
-                    ', '.join(self.mutually_exclusive)
-                )
+                    ', '.join(self.mutually_exclusive),
+                ),
             )
 
         return super(MutuallyExclusiveOption, self).handle_parse_result(
             ctx,
             opts,
-            args
+            args,
         )
 
 
@@ -137,14 +137,14 @@ class MainProcess:
     cls=MutuallyExclusiveOption,
     default=None,
     help="If set, include the specified metadata fields if they exist and drop all other fields.",
-    mutually_exclusive=["--metadata-exclude"]
+    mutually_exclusive=["--metadata-exclude"],
 )
 @click.option(
     "--metadata-exclude",
     cls=MutuallyExclusiveOption,
     default=None,
     help="If set, drop the specified metadata fields if they exist.",
-    mutually_exclusive=["--metadata-include"]
+    mutually_exclusive=["--metadata-include"],
 )
 @click.option(
     "--remote-url",

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -437,8 +437,8 @@ def main(
                     output_dir=structured_output_dir,
                     re_download=re_download,
                     preserve_downloads=preserve_downloads,
-                    metadata_exclude=metadata_exclude,
                     metadata_include=metadata_include,
+                    metadata_exclude=metadata_exclude,
                 ),
             )
         elif protocol in ("abfs", "az"):
@@ -459,8 +459,8 @@ def main(
                     output_dir=structured_output_dir,
                     re_download=re_download,
                     preserve_downloads=preserve_downloads,
-                    metadata_exclude=metadata_exclude,
                     metadata_include=metadata_include,
+                    metadata_exclude=metadata_exclude,
                 ),
             )
         else:
@@ -477,8 +477,8 @@ def main(
                     output_dir=structured_output_dir,
                     re_download=re_download,
                     preserve_downloads=preserve_downloads,
-                    metadata_exclude=metadata_exclude,
                     metadata_include=metadata_include,
+                    metadata_exclude=metadata_exclude,
                 ),
             )
     elif github_url:
@@ -493,8 +493,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
-                metadata_exclude=metadata_exclude,
                 metadata_include=metadata_include,
+                metadata_exclude=metadata_exclude,
             ),
         )
     elif gitlab_url:
@@ -509,8 +509,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
-                metadata_exclude=metadata_exclude,
                 metadata_include=metadata_include,
+                metadata_exclude=metadata_exclude,
             ),
         )
     elif subreddit_name:
@@ -527,8 +527,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
-                metadata_exclude=metadata_exclude,
                 metadata_include=metadata_include,
+                metadata_exclude=metadata_exclude,
             ),
         )
     elif wikipedia_page_title:
@@ -541,8 +541,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
-                metadata_exclude=metadata_exclude,
                 metadata_include=metadata_include,
+                metadata_exclude=metadata_exclude,
             ),
         )
     elif drive_id:
@@ -557,8 +557,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
-                metadata_exclude=metadata_exclude,
                 metadata_include=metadata_include,
+                metadata_exclude=metadata_exclude,
             ),
         )
     elif biomed_path or biomed_api_id or biomed_api_from or biomed_api_until:
@@ -573,8 +573,8 @@ def main(
                 preserve_downloads=preserve_downloads,
                 output_dir=structured_output_dir,
                 re_download=re_download,
-                metadata_exclude=metadata_exclude,
                 metadata_include=metadata_include,
+                metadata_exclude=metadata_exclude,
             ),
         )
     # Check for other connector-specific options here and define the doc_connector object

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -37,13 +37,13 @@ with suppress(RuntimeError):
 
 class MutuallyExclusiveOption(Option):
     def __init__(self, *args, **kwargs):
-        self.mutually_exclusive = set(kwargs.pop('mutually_exclusive', []))
-        help = kwargs.get('help', '')
+        self.mutually_exclusive = set(kwargs.pop("mutually_exclusive", []))
+        help = kwargs.get("help", "")
         if self.mutually_exclusive:
-            mutex_str = ', '.join(self.mutually_exclusive)
-            kwargs['help'] = help + (
-                ' NOTE: This argument is mutually exclusive with '
-                ' arguments: [' + mutex_str + '].'
+            mutex_str = ", ".join(self.mutually_exclusive)
+            kwargs["help"] = help + (
+                " NOTE: This argument is mutually exclusive with "
+                " arguments: [" + mutex_str + "]."
             )
         super(MutuallyExclusiveOption, self).__init__(*args, **kwargs)
 
@@ -53,7 +53,7 @@ class MutuallyExclusiveOption(Option):
                 "Illegal usage: `{}` is mutually exclusive with "
                 "arguments `{}`.".format(
                     self.name,
-                    ', '.join(self.mutually_exclusive),
+                    ", ".join(self.mutually_exclusive),
                 ),
             )
 


### PR DESCRIPTION
Currently, the default behavior of [unstructured-ingest](https://github.com/Unstructured-IO/unstructured/blob/main/unstructured/ingest/main.py) is to [drop the metadata field](https://github.com/Unstructured-IO/unstructured/blob/70420b5/unstructured/ingest/interfaces.py#L97) “filename” from the json output.

However, it would be better if the user could specify what metadata fields to drop (if they exist) or what fields to include (drop all other fields).