### PR TITLE
ci: workflow to create JIRA issue on GH issue create

### DIFF
--- a/.github/workflows/create_issue.yml
+++ b/.github/workflows/create_issue.yml
@@ -24,7 +24,8 @@ jobs:
         issuetype: Task
         summary: ${{ github.event.issue.title }}
         description: ${{ github.event.issue.body }}
-        fields: '{}'
+        fields: '{ "labels": ["github-issue"] }'
+
 
     - name: Log created issue
       run: echo "Issue ${{ steps.create.outputs.issue }} was created"

--- a/.github/workflows/create_issue.yml
+++ b/.github/workflows/create_issue.yml
@@ -1,0 +1,30 @@
+name: create_jira_issue
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    name: Create JIRA Issue
+    steps:
+    - name: Login
+      uses: atlassian/gajira-login@v3
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+    - name: Create
+      uses: atlassian/gajira-create@v3
+      with:
+        project: CORE
+        issuetype: Task
+        summary: ${{ github.event.issue.title }}
+        description: ${{ github.event.issue.body }}
+        fields: '{}'
+
+    - name: Log created issue
+      run: echo "Issue ${{ steps.create.outputs.issue }} was created"


### PR DESCRIPTION
Created a github workflow to create a new issue in JIRA when a github issue is created, mirroring the summary and description.

Pretty simplistic for now with a hardcoded project, and no support for any ongoing sync events.