### PR TITLE
Docs: add Integrations section

### DIFF
--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -119,7 +119,7 @@ faster processing and `"hi_res"` for
 ------------------
 
 The ``partition_docx`` partitioning brick pre-processes Microsoft Word documents
-saved in the ``.docx`` format. This staging brick uses a combination of the styling
+saved in the ``.docx`` format. This partition brick uses a combination of the styling
 information in the document and the structure of the text to determine the type
 of a text element. The ``partition_docx`` can take a filename or file-like object
 as input, as shown in the two examples below.
@@ -148,7 +148,7 @@ Examples:
 ------------------
 
 The ``partition_doc`` partitioning brick pre-processes Microsoft Word documents
-saved in the ``.doc`` format. This staging brick uses a combination of the styling
+saved in the ``.doc`` format. This partition brick uses a combination of the styling
 information in the document and the structure of the text to determine the type
 of a text element. The ``partition_doc`` can take a filename or file-like object
 as input.
@@ -169,7 +169,7 @@ Examples:
 ---------------------
 
 The ``partition_pptx`` partitioning brick pre-processes Microsoft PowerPoint documents
-saved in the ``.pptx`` format. This staging brick uses a combination of the styling
+saved in the ``.pptx`` format. This partition brick uses a combination of the styling
 information in the document and the structure of the text to determine the type
 of a text element. The ``partition_pptx`` can take a filename or file-like object
 as input, as shown in the two examples below.
@@ -190,7 +190,7 @@ Examples:
 ---------------------
 
 The ``partition_ppt`` partitioning brick pre-processes Microsoft PowerPoint documents
-saved in the ``.ppt`` format. This staging brick uses a combination of the styling
+saved in the ``.ppt`` format. This partition brick uses a combination of the styling
 information in the document and the structure of the text to determine the type
 of a text element. The ``partition_ppt`` can take a filename or file-like object.
 ``partition_ppt`` uses ``libreoffice`` to convert the file to ``.pptx`` and then

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,8 @@ Library Documentation
 :doc:`examples`
   Examples of other types of workflows within the ``unstructured`` package.
 
+:doc:`integrations`
+  We make it easy for you to connect your output with other popular ML services.
 
 .. Hidden TOCs
 
@@ -32,3 +34,4 @@ Library Documentation
    getting_started
    bricks
    examples
+   integrations

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -1,36 +1,76 @@
 Integrations
 ======
-Integrate your model development pipeline with your favorite machine learning frameworks and libraries, and prepare your data for ingestion into downstream systems. For instance, you can check our example notebook to format and upload the risk section from an SEC filing to LabelStudio for a sentiment analysis labeling task `here <https://unstructured-io.github.io/unstructured/examples.html#sentiment-analysis-labeling-in-labelstudio>`_ . Integrations are result of our `staging bricks <https://unstructured-io.github.io/unstructured/bricks.html#staging>`_, design to get a list of document elements as input and return an appropriately formatted dictionary as output.
+Integrate your model development pipeline with your favorite machine learning frameworks and libraries, 
+and prepare your data for ingestion into downstream systems. For instance, you can check our example notebook 
+to format and upload the risk section from an SEC filing to LabelStudio for a sentiment analysis labeling 
+task `here <https://unstructured-io.github.io/unstructured/examples.html#sentiment-analysis-labeling-in-labelstudio>`_ . 
+Integrations are result of our `staging bricks <https://unstructured-io.github.io/unstructured/bricks.html#staging>`_, 
+design to get a list of document ``unstructured`` ``Element`` objects as input and return a formatted dictionaries as output.
 
 
 ``Integration with Arguila``
 --------------
-Description and snippet.
+You can convert a list of ``Text`` elements to an `Argilla <https://www.argilla.io/>`_ Dataset by specifying the type of 
+dataset to be generated using the ``argilla_task`` parameter. Valid values are "text_classification", "token_classification", and "text2text".
+Just follow the link for our staging brick `stage_for_arguila <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-argilla>`_ 
+to see how to do it.
+
 
 ``Integration with Datasaur``
 --------------
-Description and snippet.
+You can format a list of ``Text`` elements as input to token based tasks in `Datasaur <https://datasaur.ai/>`_ and obtain a list of dictionaries indexed by  the keys ``'text'`` with the content of the element, and ``'entities'`` with an empty list. Customise your entities and check how to use this integration in the documentation for our staging brick `stage_for_datasaur <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-datasaur>`_.
+
 
 ``Integration with Hugging Face``
 --------------
-Description and snippet.
+You can prepare ``Text`` elements for processing in Hugging Face `Transformers <https://huggingface.co/docs/transformers/index>`_ 
+pipelines by splitting the elements into chunks that fit into the model's attention window. You can customise the transformation by defining 
+the ``buffer`` and ``window_size``, the ``split_function`` and the ``chunk_separator``. if you need to operate on 
+text directly instead of ``unstructured`` ``Text`` objects, use the `chunk_by_attention_window <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-transformers>`_ helper function. Just follow 
+the link for our staging brick `stage_for_transformers <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-transformers>`_ 
+to see how to do it.
+
 
 ``Integration with Labelbox``
 --------------
-Description and snippet x2.
+You can format your outputs for use with `LabelBox <https://labelbox.com/>`_ which accepts cloud-hosted data and does not support importing text directly. With this integration you can stage the data files in the ``output_directory`` to be uploaded to a cloud storage service (such as S3 buckets) and get a config of type ``List[Dict[str, Any]]`` that can be written to a ``.json`` file and imported into LabelBox. Just follow the link for our staging brick 
+`stage_for_label_box <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-box>`_ to see how to generate the ``config.json`` file that can be used with ``LabelBox`` and uploading the staged data files to an S3 bucket.
+
 
 ``Integration with Label Studio``
 --------------
-Description and snippet.
+You can format your outputs for upload to `Label Studio <https://labelstud.io/>`_. After running ``stage_for_label_studio``, you can write the results 
+to a JSON folder that is ready to be included in a new Label Studio project. You can also include pre-annotations and predictions 
+as part of your upload. Follow the link for our staging brick `stage_for_labelstudio <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-studio>`_ to see how to do it, and `Label Studio docs <https://labelstud.io/tags/labels.html>`_ for a full list of options 
+for labels and annotations.
+
 
 ``Integration with LangChain``
 --------------
-Description and snippet.
+Our integration with `LangChain <https://github.com/hwchase17/langchain>`_ makes it incredibly easy to combine language models with your data, no matter what form it is in. The `Unstructured.io File Loader <https://langchain.readthedocs.io/en/latest/modules/document_loaders/examples/unstructured_file.html>`_ extracts the text from a variety of unstructured text files using our ``unstructured`` library. It is designed to be used as a way to load data into `LlamaIndex <https://github.com/jerryjliu/llama_index>`_ and/or subsequently used as a Tool in a LangChain Agent. See `here <https://github.com/emptycrown/llama-hub/tree/main>`_ for more `LlamaHub <https://llamahub.ai/>`_ examples. 
+
+To use ``Unstructured.io File Loader`` you will need to have LlamaIndex 🦙 (GPT Index) installed in your environment. Just ``pip install llama-index`` and then pass in a ``Path`` to a local file. Optionally, you may specify split_documents if you want each element generated by ``unstructured`` to be placed in a separate document. Here is a simple example on how to use it:
+
+.. code:: python
+  from pathlib import Path
+  from llama_index import download_loader
+
+
+  UnstructuredReader = download_loader("UnstructuredReader")
+
+  loader = UnstructuredReader()
+  documents = loader.load_data(file=Path('./10k_filing.html'))
+
 
 ``Integration with Pandas``
 --------------
-Description and snippet.
+You can convert a list of document Element objects to a Pandas dataframe with a ``text`` and ``type`` columns with 
+the text from the element and its type such as ``NarrativeText`` or ``Title``. Just follow the link for our staging brick 
+`convert_to_dataframe <https://unstructured-io.github.io/unstructured/bricks.html#convert-to-dataframe>`_ to see how to use it.
+
 
 ``Integration with Prodigy``
 --------------
-Description and snippet.
+You can format your outputs in a JSON or CSV format for use with `Prodigy <https://prodi.gy/docs/api-loaders>`_. After running ``stage_for_prodigy`` | 
+``stage_csv_for_prodigy``, you can write the results to a ``.json`` | ``.jsonl`` or a ``.csv`` file. that is ready to be used with Prodigy. Just follow the link for our staging bricks `stage_for_prodigy <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-prodigy>`_ and 
+`stage_csv_for_prodigy <https://unstructured-io.github.io/unstructured/bricks.html#stage-csv-for-prodigy>`_ to see how to do this.

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -1,11 +1,9 @@
 Integrations
 ======
 Integrate your model development pipeline with your favorite machine learning frameworks and libraries, 
-and prepare your data for ingestion into downstream systems. For instance, you can check our example notebook 
-to format and upload the risk section from an SEC filing to LabelStudio for a sentiment analysis labeling 
-task `here <https://unstructured-io.github.io/unstructured/examples.html#sentiment-analysis-labeling-in-labelstudio>`_ . 
-Integrations are result of our `staging bricks <https://unstructured-io.github.io/unstructured/bricks.html#staging>`_, 
-design to get a list of document ``unstructured`` ``Element`` objects as input and return a formatted dictionaries as output.
+and prepare your data for ingestion into downstream systems. Most of out integrations are in the form of 
+some of our `staging bricks <https://unstructured-io.github.io/unstructured/bricks.html#staging>`_, 
+design to get a list of document ``unstructured`` ``Element`` objects as input and return formatted dictionaries as output.
 
 
 ``Integration with Arguila``
@@ -41,7 +39,9 @@ You can format your outputs for use with `LabelBox <https://labelbox.com/>`_ whi
 --------------
 You can format your outputs for upload to `Label Studio <https://labelstud.io/>`_. After running ``stage_for_label_studio``, you can write the results 
 to a JSON folder that is ready to be included in a new Label Studio project. You can also include pre-annotations and predictions 
-as part of your upload. Follow the link for our staging brick `stage_for_labelstudio <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-studio>`_ to see how to do it, and `Label Studio docs <https://labelstud.io/tags/labels.html>`_ for a full list of options 
+as part of your upload.
+
+Check our example notebook to format and upload the risk section from an SEC filing to Label Studio for a sentiment analysis labeling task `here <https://unstructured-io.github.io/unstructured/examples.html#sentiment-analysis-labeling-in-labelstudio>`_ .Follow the link for our staging brick `stage_for_labelstudio <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-studio>`_ to see how to do it, and `Label Studio docs <https://labelstud.io/tags/labels.html>`_ for a full list of options 
 for labels and annotations.
 
 

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -1,0 +1,36 @@
+Integrations
+======
+Integrate your model development pipeline with your favorite machine learning frameworks and libraries, and prepare your data for ingestion into downstream systems. For instance, you can check our example notebook to format and upload the risk section from an SEC filing to LabelStudio for a sentiment analysis labeling task `here <https://unstructured-io.github.io/unstructured/examples.html#sentiment-analysis-labeling-in-labelstudio>`_ . Integrations are result of our `staging bricks <https://unstructured-io.github.io/unstructured/bricks.html#staging>`_, design to get a list of document elements as input and return an appropriately formatted dictionary as output.
+
+
+``Integration with Arguila``
+--------------
+Description and snippet.
+
+``Integration with Datasaur``
+--------------
+Description and snippet.
+
+``Integration with Hugging Face``
+--------------
+Description and snippet.
+
+``Integration with Labelbox``
+--------------
+Description and snippet x2.
+
+``Integration with Label Studio``
+--------------
+Description and snippet.
+
+``Integration with LangChain``
+--------------
+Description and snippet.
+
+``Integration with Pandas``
+--------------
+Description and snippet.
+
+``Integration with Prodigy``
+--------------
+Description and snippet.

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -8,41 +8,34 @@ which take a list of ``Element`` objects as input and return formatted dictionar
 
 ``Integration with Argilla``
 --------------
-You can convert a list of ``Text`` elements to an `Argilla <https://www.argilla.io/>`_ ``Dataset`` by specifying the type of 
-dataset to be generated using the ``argilla_task`` parameter. Valid values are ``"text_classification"``, ``"token_classification"``, and ``"text2text"``.
-Just follow the link for our staging brick `stage_for_argilla <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-argilla>`_ 
-to see how to do it.
+You can convert a list of ``Text`` elements to an `Argilla <https://www.argilla.io/>`_ ``Dataset`` using the `stage_for_argilla <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-argilla>`_ staging brick. Specify the type of dataset to be generated using the ``argilla_task`` parameter. Valid values are ``"text_classification"``, ``"token_classification"``, and ``"text2text"``. Follow the link for more details on usage.
 
 
 ``Integration with Datasaur``
 --------------
-You can format a list of ``Text`` elements as input to token based tasks in `Datasaur <https://datasaur.ai/>`_ and obtain a list of dictionaries indexed by the keys ``"text"`` with the content of the element, and ``"entities"`` with an empty list. Customise your entities and check how to use this integration in the documentation for our staging brick `stage_for_datasaur <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-datasaur>`_.
+You can format a list of ``Text`` elements as input to token based tasks in `Datasaur <https://datasaur.ai/>`_ using the `stage_for_datasaur <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-datasaur>`_ staging brick. You will obtain a list of dictionaries indexed by the keys ``"text"`` with the content of the element, and ``"entities"`` with an empty list. Follow the link to learn how to customise your entities and for more details on usage.
 
 
 ``Integration with Hugging Face``
 --------------
 You can prepare ``Text`` elements for processing in Hugging Face `Transformers <https://huggingface.co/docs/transformers/index>`_ 
-pipelines by splitting the elements into chunks that fit into the model's attention window. You can customise the transformation by defining 
+pipelines by splitting the elements into chunks that fit into the model's attention window using the `stage_for_transformers <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-transformers>`_ staging brick. You can customise the transformation by defining 
 the ``buffer`` and ``window_size``, the ``split_function`` and the ``chunk_separator``. if you need to operate on 
-text directly instead of ``unstructured`` ``Text`` objects, use the `chunk_by_attention_window <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-transformers>`_ helper function. Just follow 
-the link for our staging brick `stage_for_transformers <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-transformers>`_ 
-to see how to do it.
+text directly instead of ``unstructured`` ``Text`` objects, use the `chunk_by_attention_window <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-transformers>`_ helper function. Follow the links for more details on usage.
 
 
 ``Integration with Labelbox``
 --------------
-You can format your outputs for use with `LabelBox <https://labelbox.com/>`_ which accepts cloud-hosted data and does not support importing text directly. With this integration you can stage the data files in the ``output_directory`` to be uploaded to a cloud storage service (such as S3 buckets) and get a config of type ``List[Dict[str, Any]]`` that can be written to a ``.json`` file and imported into LabelBox. Just follow the link for our staging brick 
-`stage_for_label_box <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-box>`_ to see how to generate the ``config.json`` file that can be used with LabelBox and uploading the staged data files to an S3 bucket.
+You can format your outputs for use with `LabelBox <https://labelbox.com/>`_ using the `stage_for_label_box <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-box>`_ staging brick. LabelBox accepts cloud-hosted data and does not support importing text directly. With this integration you can stage the data files in the ``output_directory`` to be uploaded to a cloud storage service (such as S3 buckets) and get a config of type ``List[Dict[str, Any]]`` that can be written to a ``.json`` file and imported into LabelBox. Follow the link to see how to generate the ``config.json`` file that can be used with LabelBox, how to upload the staged data files to an S3 bucket, and for more details on usage.
 
 
 ``Integration with Label Studio``
 --------------
-You can format your outputs for upload to `Label Studio <https://labelstud.io/>`_. After running ``stage_for_label_studio``, you can write the results 
+You can format your outputs for upload to `Label Studio <https://labelstud.io/>`_ using the `stage_for_label_studio <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-studio>`_ staging brick. After running ``stage_for_label_studio``, you can write the results 
 to a JSON folder that is ready to be included in a new Label Studio project. You can also include pre-annotations and predictions 
 as part of your upload.
 
-Check our example notebook to format and upload the risk section from an SEC filing to Label Studio for a sentiment analysis labeling task `here <https://unstructured-io.github.io/unstructured/examples.html#sentiment-analysis-labeling-in-labelstudio>`_ . Follow the link for our staging brick `stage_for_label_studio <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-studio>`_ to see how to do it, and `Label Studio docs <https://labelstud.io/tags/labels.html>`_ for a full list of options 
-for labels and annotations.
+Check our example notebook to format and upload the risk section from an SEC filing to Label Studio for a sentiment analysis labeling task `here <https://unstructured-io.github.io/unstructured/examples.html#sentiment-analysis-labeling-in-labelstudio>`_ . Follow the link for more details on usage, and check `Label Studio docs <https://labelstud.io/tags/labels.html>`_ for a full list of options for labels and annotations.
 
 
 ``Integration with LangChain``
@@ -65,12 +58,10 @@ To use ``Unstructured.io File Loader`` you will need to have LlamaIndex 🦙 (GP
 ``Integration with Pandas``
 --------------
 You can convert a list of ``Element`` objects to a Pandas dataframe with columns for 
-the text from each element and their types such as ``NarrativeText`` or ``Title``. Just follow the link for our staging brick 
-`convert_to_dataframe <https://unstructured-io.github.io/unstructured/bricks.html#convert-to-dataframe>`_ to see how to use it.
+the text from each element and their types such as ``NarrativeText`` or ``Title`` using the `convert_to_dataframe <https://unstructured-io.github.io/unstructured/bricks.html#convert-to-dataframe>`_ staging brick. Follow the link for more details on usage.
 
 
 ``Integration with Prodigy``
 --------------
-You can format your JSON or CSV outputs for use with `Prodigy <https://prodi.gy/docs/api-loaders>`_. After running ``stage_for_prodigy`` | 
-``stage_csv_for_prodigy``, you can write the results to a ``.json`` | ``.jsonl`` or a ``.csv`` file that is ready to be used with Prodigy. Just follow the links for our staging bricks `stage_for_prodigy <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-prodigy>`_ and 
-`stage_csv_for_prodigy <https://unstructured-io.github.io/unstructured/bricks.html#stage-csv-for-prodigy>`_ to see how to do this.
+You can format your JSON or CSV outputs for use with `Prodigy <https://prodi.gy/docs/api-loaders>`_ using the `stage_for_prodigy <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-prodigy>`_ and `stage_csv_for_prodigy <https://unstructured-io.github.io/unstructured/bricks.html#stage-csv-for-prodigy>`_ staging bricks. After running ``stage_for_prodigy`` | 
+``stage_csv_for_prodigy``, you can write the results to a ``.json`` | ``.jsonl`` or a ``.csv`` file that is ready to be used with Prodigy. Follow the links for more details on usage.

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -1,22 +1,22 @@
 Integrations
 ======
 Integrate your model development pipeline with your favorite machine learning frameworks and libraries, 
-and prepare your data for ingestion into downstream systems. Most of out integrations are in the form of 
-some of our `staging bricks <https://unstructured-io.github.io/unstructured/bricks.html#staging>`_, 
-design to get a list of document ``unstructured`` ``Element`` objects as input and return formatted dictionaries as output.
+and prepare your data for ingestion into downstream systems. Most of our integrations come in the form of 
+`staging bricks <https://unstructured-io.github.io/unstructured/bricks.html#staging>`_, 
+which take a list of ``Element`` objects as input and return formatted dictionaries as output.
 
 
-``Integration with Arguila``
+``Integration with Argilla``
 --------------
-You can convert a list of ``Text`` elements to an `Argilla <https://www.argilla.io/>`_ Dataset by specifying the type of 
-dataset to be generated using the ``argilla_task`` parameter. Valid values are "text_classification", "token_classification", and "text2text".
-Just follow the link for our staging brick `stage_for_arguila <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-argilla>`_ 
+You can convert a list of ``Text`` elements to an `Argilla <https://www.argilla.io/>`_ ``Dataset`` by specifying the type of 
+dataset to be generated using the ``argilla_task`` parameter. Valid values are ``"text_classification"``, ``"token_classification"``, and ``"text2text"``.
+Just follow the link for our staging brick `stage_for_argilla <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-argilla>`_ 
 to see how to do it.
 
 
 ``Integration with Datasaur``
 --------------
-You can format a list of ``Text`` elements as input to token based tasks in `Datasaur <https://datasaur.ai/>`_ and obtain a list of dictionaries indexed by  the keys ``'text'`` with the content of the element, and ``'entities'`` with an empty list. Customise your entities and check how to use this integration in the documentation for our staging brick `stage_for_datasaur <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-datasaur>`_.
+You can format a list of ``Text`` elements as input to token based tasks in `Datasaur <https://datasaur.ai/>`_ and obtain a list of dictionaries indexed by the keys ``"text"`` with the content of the element, and ``"entities"`` with an empty list. Customise your entities and check how to use this integration in the documentation for our staging brick `stage_for_datasaur <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-datasaur>`_.
 
 
 ``Integration with Hugging Face``
@@ -32,7 +32,7 @@ to see how to do it.
 ``Integration with Labelbox``
 --------------
 You can format your outputs for use with `LabelBox <https://labelbox.com/>`_ which accepts cloud-hosted data and does not support importing text directly. With this integration you can stage the data files in the ``output_directory`` to be uploaded to a cloud storage service (such as S3 buckets) and get a config of type ``List[Dict[str, Any]]`` that can be written to a ``.json`` file and imported into LabelBox. Just follow the link for our staging brick 
-`stage_for_label_box <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-box>`_ to see how to generate the ``config.json`` file that can be used with ``LabelBox`` and uploading the staged data files to an S3 bucket.
+`stage_for_label_box <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-box>`_ to see how to generate the ``config.json`` file that can be used with LabelBox and uploading the staged data files to an S3 bucket.
 
 
 ``Integration with Label Studio``
@@ -41,7 +41,7 @@ You can format your outputs for upload to `Label Studio <https://labelstud.io/>`
 to a JSON folder that is ready to be included in a new Label Studio project. You can also include pre-annotations and predictions 
 as part of your upload.
 
-Check our example notebook to format and upload the risk section from an SEC filing to Label Studio for a sentiment analysis labeling task `here <https://unstructured-io.github.io/unstructured/examples.html#sentiment-analysis-labeling-in-labelstudio>`_ .Follow the link for our staging brick `stage_for_labelstudio <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-studio>`_ to see how to do it, and `Label Studio docs <https://labelstud.io/tags/labels.html>`_ for a full list of options 
+Check our example notebook to format and upload the risk section from an SEC filing to Label Studio for a sentiment analysis labeling task `here <https://unstructured-io.github.io/unstructured/examples.html#sentiment-analysis-labeling-in-labelstudio>`_ . Follow the link for our staging brick `stage_for_label_studio <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-label-studio>`_ to see how to do it, and `Label Studio docs <https://labelstud.io/tags/labels.html>`_ for a full list of options 
 for labels and annotations.
 
 
@@ -64,13 +64,13 @@ To use ``Unstructured.io File Loader`` you will need to have LlamaIndex 🦙 (GP
 
 ``Integration with Pandas``
 --------------
-You can convert a list of document Element objects to a Pandas dataframe with a ``text`` and ``type`` columns with 
-the text from the element and its type such as ``NarrativeText`` or ``Title``. Just follow the link for our staging brick 
+You can convert a list of ``Element`` objects to a Pandas dataframe with columns for 
+the text from each element and their types such as ``NarrativeText`` or ``Title``. Just follow the link for our staging brick 
 `convert_to_dataframe <https://unstructured-io.github.io/unstructured/bricks.html#convert-to-dataframe>`_ to see how to use it.
 
 
 ``Integration with Prodigy``
 --------------
-You can format your outputs in a JSON or CSV format for use with `Prodigy <https://prodi.gy/docs/api-loaders>`_. After running ``stage_for_prodigy`` | 
-``stage_csv_for_prodigy``, you can write the results to a ``.json`` | ``.jsonl`` or a ``.csv`` file. that is ready to be used with Prodigy. Just follow the link for our staging bricks `stage_for_prodigy <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-prodigy>`_ and 
+You can format your JSON or CSV outputs for use with `Prodigy <https://prodi.gy/docs/api-loaders>`_. After running ``stage_for_prodigy`` | 
+``stage_csv_for_prodigy``, you can write the results to a ``.json`` | ``.jsonl`` or a ``.csv`` file that is ready to be used with Prodigy. Just follow the links for our staging bricks `stage_for_prodigy <https://unstructured-io.github.io/unstructured/bricks.html#stage-for-prodigy>`_ and 
 `stage_csv_for_prodigy <https://unstructured-io.github.io/unstructured/bricks.html#stage-csv-for-prodigy>`_ to see how to do this.


### PR DESCRIPTION
Created `integrations.rst` with intro and 8 integrations, and added that to the index. I only included code for LangChain integration (not visible in github preview though). The other integrations have a simple descriptions with capabilities, some parameters usage, and links to the "integration company"/github and to the code snippet in our staging bricks docu. Here is the list:
- Arguila
- Datasaur
- Hugging Face
- Labelbox
- Label Studio
- LangChain
- Pandas
- Prodigy