### PR TITLE
chore: Add note about python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ about. Bricks in the library fall into three categories:
 ## :eight_pointed_black_star: Quick Start
 
 Use the following instructions to get up and running with `unstructured` and test your
-installation.
+installation. NOTE: We currently support python 3.8.15.
 
 - Install the Python SDK with `pip install "unstructured[local-inference]"`
 		- If you do not need to process PDFs or images, you can run `pip install unstructured`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ about. Bricks in the library fall into three categories:
 ## :eight_pointed_black_star: Quick Start
 
 Use the following instructions to get up and running with `unstructured` and test your
-installation. NOTE: We currently support python 3.8.15.
+installation. NOTE: We do not currently support python 3.11, please use an older version.
 
 - Install the Python SDK with `pip install "unstructured[local-inference]"`
 		- If you do not need to process PDFs or images, you can run `pip install unstructured`


### PR DESCRIPTION
People are using the quick start code in the README and are getting errors when using the latest versions of python. This adds a note about python higher up in the docs.