### PR TITLE
feat: change english_words to set for performance gain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.5.5-dev0
+## 0.5.5-dev1
 
 ### Enhancements
+
+* `contains_english_word()`, used heavily in text processing, is 10x faster.
 
 ### Features
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.5-dev0"  # pragma: no cover
+__version__ = "0.5.5-dev1"  # pragma: no cover

--- a/unstructured/nlp/english_words.py
+++ b/unstructured/nlp/english_words.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from typing import List
+from typing import List, Set
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 # NOTE(robinson) - the list of English words is based on the nlkt.corpus.words corpus
@@ -14,4 +14,4 @@ with open(ENGLISH_WORDS_FILE) as f:
 
 # NOTE(robinson) - add new words that we want to pass for the English check in here
 ADDITIONAL_ENGLISH_WORDS: List[str] = []
-ENGLISH_WORDS: List[str] = BASE_ENGLISH_WORDS + ADDITIONAL_ENGLISH_WORDS
+ENGLISH_WORDS: Set[str] = set(BASE_ENGLISH_WORDS + ADDITIONAL_ENGLISH_WORDS)


### PR DESCRIPTION
Before:
```
(sec) MacBook-Pro-2:unstructured cragwolfe$ time python -c "from unstructured.partition.text import partition_text; partition_text('./unstructured/nlp/english-words.txt')"

real    16m14.820s
user    15m51.560s
sys     0m9.885s
```
After:
```
(sec) MacBook-Pro-2:unstructured cragwolfe$ time python -c "from unstructured.partition.text import partition_text; partition_text('./unstructured/nlp/english-words.txt')"

real    1m41.702s
user    1m40.683s
sys     0m2.806s
```