### PR TITLE
Fix: duplicated addition to elements list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.5.5-dev1
+## 0.5.6
+
+* Fix problem with PDF partition (duplicated test)
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.5-dev1"  # pragma: no cover
+__version__ = "0.5.6"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -254,7 +254,6 @@ def _process_pdfminer_pages(
             for element in _elements:
                 element.metadata = metadata
                 elements.append(element)
-            elements.extend(partition_text(text=text))
 
         if include_page_breaks:
             elements.append(PageBreak())


### PR DESCRIPTION
This PR addresses the issue https://github.com/Unstructured-IO/unstructured/issues/374 with the suggested fix.

In order to test is possible to use

```
from unstructured.partition import pdf
results = pdf.partition_pdf("example-docs/layout-parser-paper-fast.pdf")
all_text =[r1.text for r1 in r]
print(all_text)
```
And the result should be the complete text from the file without any missing or duplicated text block.
