### PR TITLE
feat: add --flatten-metadata to unstructured-ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.7-dev0
+
+### Enhancements
+
+### Features
+
+* Add `--flatten-metadata` parameter to `unstructured-ingest`
+
+### Fixes
+
 ## 0.5.6
 
 * Fix problem with PDF partition (duplicated test)

--- a/test_unstructured_ingest/test_interfaces.py
+++ b/test_unstructured_ingest/test_interfaces.py
@@ -26,8 +26,7 @@ def test_process_file_metadata_include_filename(filename: str):
     isd_elems = ingest_doc.process_file()
 
     for elem in isd_elems:
-        for k in elem["metadata"]:
-            assert k == "filename"
+        assert set(elem["metadata"].keys()) == {"filename"}
 
 
 @pytest.mark.parametrize("filename", test_files)
@@ -42,8 +41,7 @@ def test_process_file_metadata_include_filename_pagenum(filename: str):
     isd_elems = ingest_doc.process_file()
 
     for elem in isd_elems:
-        for k in elem["metadata"]:
-            assert k in ["filename", "page_number"]
+        assert set(elem["metadata"].keys()) == {"filename", "page_number"}
 
 
 @pytest.mark.parametrize("filename", test_files)
@@ -58,8 +56,7 @@ def test_process_file_metadata_exclude_filename(filename: str):
     isd_elems = ingest_doc.process_file()
 
     for elem in isd_elems:
-        for k in elem["metadata"]:
-            assert k != "filename"
+        assert "filename" not in elem["metadata"].keys()
 
 
 @pytest.mark.parametrize("filename", test_files)
@@ -74,8 +71,8 @@ def test_process_file_metadata_exclude_filename_pagenum(filename: str):
     isd_elems = ingest_doc.process_file()
 
     for elem in isd_elems:
-        for k in elem["metadata"]:
-            assert k not in ["filename", "page_number"]
+        assert "filename" not in elem["metadata"].keys()
+        assert "page_number" not in elem["metadata"].keys()
 
 
 @pytest.mark.parametrize("filename", test_files)
@@ -87,7 +84,9 @@ def test_process_file_fields_include_default(filename: str):
         ),
     )
     isd_elems = ingest_doc.process_file()
-    assert set("element_id", "text", "type", "metadata") == set(elem.keys())
+
+    for elem in isd_elems:
+        assert {"element_id", "text", "type", "metadata"} == set(elem.keys())
 
 
 @pytest.mark.parametrize("filename", test_files)
@@ -100,5 +99,38 @@ def test_process_file_fields_include_elementid(filename: str):
         ),
     )
     isd_elems = ingest_doc.process_file()
-    assert set("element_id") == set(elem.keys())
 
+    for elem in isd_elems:
+        assert {"element_id"} == set(elem.keys())
+
+
+@pytest.mark.parametrize("filename", test_files)
+def test_process_file_flatten_metadata_filename(filename: str):
+    ingest_doc = GitIngestDoc(
+        path=filename,
+        config=SimpleGitConfig(
+          download_dir=EXAMPLE_DOCS_DIRECTORY,
+          metadata_include="filename",
+          flatten_metadata=True,
+        ),
+    )
+    isd_elems = ingest_doc.process_file()
+    
+    for elem in isd_elems:
+        assert {"element_id", "text", "type", "filename"} == set(elem.keys())
+
+
+@pytest.mark.parametrize("filename", test_files)
+def test_process_file_flatten_metadata_filename_pagenum(filename: str):
+    ingest_doc = GitIngestDoc(
+        path=filename,
+        config=SimpleGitConfig(
+          download_dir=EXAMPLE_DOCS_DIRECTORY,
+          metadata_include="filename,page_number",
+          flatten_metadata=True,
+        ),
+    )
+    isd_elems = ingest_doc.process_file()
+    
+    for elem in isd_elems:
+        assert {"element_id", "text", "type", "filename", "page_number"} == set(elem.keys())

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,2 +1,1 @@
 __version__ = "0.5.7-dev2"  # pragma: no cover
-

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,5 +1,2 @@
-<<<<<<< HEAD
-__version__ = "0.5.7-dev0"  # pragma: no cover
-=======
-__version__ = "0.5.7-dev1"  # pragma: no cover
->>>>>>> 66a0369fb62a4d9648c172c8a1e174ef9f83f295
+__version__ = "0.5.7-dev2"  # pragma: no cover
+

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.6"  # pragma: no cover
+__version__ = "0.5.7-dev0"  # pragma: no cover

--- a/unstructured/ingest/connector/biomed.py
+++ b/unstructured/ingest/connector/biomed.py
@@ -50,6 +50,7 @@ class SimpleBiomedConfig(BaseConnectorConfig):
     preserve_downloads: bool = False
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
+    flatten_metadata: bool = False
 
     def _validate_date_args(self, date):
         date_formats = ["%Y-%m-%d", "%Y-%m-%d+%H:%M:%S"]

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -31,6 +31,7 @@ class SimpleFsspecConfig(BaseConnectorConfig):
     re_download: bool = False
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
+    flatten_metadata: bool = False
 
     # fsspec specific options
     access_kwargs: dict = field(default_factory=dict)

--- a/unstructured/ingest/connector/git.py
+++ b/unstructured/ingest/connector/git.py
@@ -28,6 +28,7 @@ class SimpleGitConfig(BaseConnectorConfig):
     re_download: bool = False
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
+    flatten_metadata: bool = False
 
     repo_path: str = field(init=False, repr=False)
 

--- a/unstructured/ingest/connector/google_drive.py
+++ b/unstructured/ingest/connector/google_drive.py
@@ -79,6 +79,7 @@ class SimpleGoogleDriveConfig(BaseConnectorConfig):
     preserve_downloads: bool = False
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
+    flatten_metadata: bool = False
 
     recursive: bool = False
 

--- a/unstructured/ingest/connector/reddit.py
+++ b/unstructured/ingest/connector/reddit.py
@@ -33,6 +33,7 @@ class SimpleRedditConfig(BaseConnectorConfig):
     re_download: bool = False
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
+    flatten_metadata: bool = False
 
     def __post_init__(self):
         if self.num_posts <= 0:

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -28,6 +28,7 @@ class SimpleWikipediaConfig(BaseConnectorConfig):
     re_download: bool = False
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
+    flatten_metadata: bool = False
 
 
 @dataclass

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -50,6 +50,7 @@ class BaseConnectorConfig(ABC):
     re_download: bool = False
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
+    flatten_metadata: bool = False
 
 
 class BaseIngestDoc(ABC):
@@ -118,6 +119,12 @@ class BaseIngestDoc(ABC):
                         elem["metadata"].pop(k, None)  # type: ignore[attr-defined]
 
             elem.pop("coordinates")  # type: ignore[attr-defined]
+
+            if self.config.flatten_metadata:
+                for k, v in elem["metadata"].items():  # type: ignore[attr-defined]
+                    elem[k] = v
+                elem.pop("metadata")  # type: ignore[attr-defined]
+
             self.isd_elems_no_filename.append(elem)
 
         return self.isd_elems_no_filename

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -50,11 +50,8 @@ class BaseConnectorConfig(ABC):
     re_download: bool = False
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
-<<<<<<< HEAD
-    flatten_metadata: bool = False
-=======
     fields_include: str = "element_id,text,type,metadata"
->>>>>>> 66a0369fb62a4d9648c172c8a1e174ef9f83f295
+    flatten_metadata: bool = False
 
 
 class BaseIngestDoc(ABC):

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -104,6 +104,13 @@ class MainProcess:
 
 @click.command()
 @click.option(
+    "--flatten-metadata",
+    is_flag=True,
+    default=False,
+    help="If set, flatten metadata by moving elements in the metadata field up a level "
+    "and removing the metadata field.",
+)
+@click.option(
     "--metadata-include",
     default=None,
     help="If set, include the specified metadata fields if they exist and drop all other fields. "
@@ -338,7 +345,13 @@ def main(
     verbose,
     metadata_include,
     metadata_exclude,
+    flatten_metadata,
 ):
+    if flatten_metadata and "metadata" not in fields_include:
+        logger.warning(
+            "`--flatten-metadata` is specified, but there is no metadata to flatten, "
+            "since `metadata` is not specified in `--fields-include`."
+        )
     if metadata_exclude is not None and metadata_include is not None:
         logger.error(
             "Arguments `--metadata-include` and `--metadata-exclude` are "
@@ -415,6 +428,7 @@ def main(
                     preserve_downloads=preserve_downloads,
                     metadata_include=metadata_include,
                     metadata_exclude=metadata_exclude,
+                    flatten_metadata=flatten_metadata,
                 ),
             )
         elif protocol in ("abfs", "az"):
@@ -437,6 +451,7 @@ def main(
                     preserve_downloads=preserve_downloads,
                     metadata_include=metadata_include,
                     metadata_exclude=metadata_exclude,
+                    flatten_metadata=flatten_metadata,
                 ),
             )
         else:
@@ -455,6 +470,7 @@ def main(
                     preserve_downloads=preserve_downloads,
                     metadata_include=metadata_include,
                     metadata_exclude=metadata_exclude,
+                    flatten_metadata=flatten_metadata,
                 ),
             )
     elif github_url:
@@ -471,6 +487,7 @@ def main(
                 re_download=re_download,
                 metadata_include=metadata_include,
                 metadata_exclude=metadata_exclude,
+                flatten_metadata=flatten_metadata,
             ),
         )
     elif gitlab_url:
@@ -487,6 +504,7 @@ def main(
                 re_download=re_download,
                 metadata_include=metadata_include,
                 metadata_exclude=metadata_exclude,
+                flatten_metadata=flatten_metadata,
             ),
         )
     elif subreddit_name:
@@ -505,6 +523,7 @@ def main(
                 re_download=re_download,
                 metadata_include=metadata_include,
                 metadata_exclude=metadata_exclude,
+                flatten_metadata=flatten_metadata,
             ),
         )
     elif wikipedia_page_title:
@@ -519,6 +538,7 @@ def main(
                 re_download=re_download,
                 metadata_include=metadata_include,
                 metadata_exclude=metadata_exclude,
+                flatten_metadata=flatten_metadata,
             ),
         )
     elif drive_id:
@@ -535,6 +555,7 @@ def main(
                 re_download=re_download,
                 metadata_include=metadata_include,
                 metadata_exclude=metadata_exclude,
+                flatten_metadata=flatten_metadata,
             ),
         )
     elif biomed_path or biomed_api_id or biomed_api_from or biomed_api_until:
@@ -551,6 +572,7 @@ def main(
                 re_download=re_download,
                 metadata_include=metadata_include,
                 metadata_exclude=metadata_exclude,
+                flatten_metadata=flatten_metadata,
             ),
         )
     # Check for other connector-specific options here and define the doc_connector object

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -350,7 +350,7 @@ def main(
     if flatten_metadata and "metadata" not in fields_include:
         logger.warning(
             "`--flatten-metadata` is specified, but there is no metadata to flatten, "
-            "since `metadata` is not specified in `--fields-include`."
+            "since `metadata` is not specified in `--fields-include`.",
         )
     if metadata_exclude is not None and metadata_include is not None:
         logger.error(

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -104,18 +104,17 @@ class MainProcess:
 
 @click.command()
 @click.option(
-<<<<<<< HEAD
     "--flatten-metadata",
     is_flag=True,
     default=False,
     help="If set, flatten metadata by moving elements in the metadata field up a level "
     "and removing the metadata field.",
-=======
+)
+@click.option(
     "--fields-include",
     default="element_id,text,type,metadata",
     help="If set, include the specified top-level fields in an element. "
     "Default is `element_id,text,type,metadata`.",
->>>>>>> 66a0369fb62a4d9648c172c8a1e174ef9f83f295
 )
 @click.option(
     "--metadata-include",

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -107,8 +107,9 @@ class MainProcess:
     "--flatten-metadata",
     is_flag=True,
     default=False,
-    help="If set, flatten metadata by moving elements in the metadata field up a level "
-    "and removing the metadata field.",
+    help="Results in flattened json elements. "
+    "Specifically, the metadata key values are brought to the top-level of the element, "
+    "and the `metadata` key itself is removed.",
 )
 @click.option(
     "--fields-include",


### PR DESCRIPTION
For some use cases, json output is often translated into a single row in a table, but having an extra level of indirection with a metadata nested dictionary makes inserting into such a table awkward.

Therefore, we want to add a `--flatten-metadata` parameter to https://github.com/Unstructured-IO/unstructured/blob/main/unstructured/ingest/main.py, which simply results in all elements in the metadata field moving up a level and removing the metadata field. I.e.:
```
{
    "element_id": "d551bbfc9477547e4dce6264d8196c7b",
    "text": "More info available at the Github Project Page",
    "type": "Title",
    "metadata": {
      "page_number": 1
    }
},
```
->
```
{
    "element_id": "d551bbfc9477547e4dce6264d8196c7b",
    "text": "More info available at the Github Project Page",
    "type": "Title",
    "page_number": 1
},
```