### PR TITLE
Adding content_type and file_filename to autopartition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 0.5.7-dev3
+## 0.5.7-dev4
 
 ### Enhancements
 
 * Refactored codebase using `exactly_one`
 * Adds ability to pass headers when passing a url in partition_html()
+* Added optional `content_type` and `file_filename` parameters to `partition()` to bypass file detection
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.7-dev4
+## 0.5.7
 
 ### Enhancements
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -30,6 +30,7 @@ In cases where ``libmagic`` is not available, filetype detection will fall back 
 As shown in the examples below, the ``partition`` function accepts both filenames and file-like objects as input.
 ``partition`` also has some optional kwargs.
 For example, if you set ``include_page_breaks=True``, the output will include ``PageBreak`` elements if the filetype supports it.
+Additionally you can bypass the filetype detection logic with the optional  ``content_type`` argument.
 You can find a full listing of optional kwargs in the documentation below.
 
 .. code:: python
@@ -38,7 +39,7 @@ You can find a full listing of optional kwargs in the documentation below.
 
 
   filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper-fast.pdf")
-  elements = partition(filename=filename)
+  elements = partition(filename=filename, content_type="application/pdf")
   print("\n\n".join([str(el) for el in elements][:10]))
 
 
@@ -57,7 +58,7 @@ The ``unstructured`` library also includes partitioning bricks targeted at speci
 The ``partition`` brick uses these document-specific partitioning bricks under the hood.
 There are a few reasons you may want to use a document-specific partitioning brick instead of ``partition``:
 
-* If you already know the document type, filetype detection is unnecessary. Using the document-specific brick directly will make your program run faster.
+* If you already know the document type, filetype detection is unnecessary. Using the document-specific brick directly, or passing in the ``content_type`` will make your program run faster.
 * Fewer dependencies. You don't need to install ``libmagic`` for filetype detection if you're only using document-specific bricks.
 * Additional features. The API for partition is the least common denominator for all document types. Certain document-specific brick include extra features that you may want to take advantage of. For example, ``partition_html`` allows you to pass in a URL so you don't have to store the ``.html`` file locally. See the documentation below learn about the options available in each partitioning brick.
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -30,7 +30,7 @@ In cases where ``libmagic`` is not available, filetype detection will fall back 
 As shown in the examples below, the ``partition`` function accepts both filenames and file-like objects as input.
 ``partition`` also has some optional kwargs.
 For example, if you set ``include_page_breaks=True``, the output will include ``PageBreak`` elements if the filetype supports it.
-Additionally you can bypass the filetype detection logic with the optional  ``content_type`` argument.
+Additionally you can bypass the filetype detection logic with the optional  ``content_type`` argument which may be specified with either the ``filename`` or file-like object, ``file``.
 You can find a full listing of optional kwargs in the documentation below.
 
 .. code:: python

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -110,7 +110,11 @@ def test_auto_partition_docx_with_file(mock_docx_document, expected_docx_element
     [(False, None), (False, "application/msword"), (True, "application/msword"), (True, None)],
 )
 def test_auto_partition_doc_with_filename(
-    mock_docx_document, expected_docx_elements, tmpdir, pass_file_filename, content_type
+    mock_docx_document,
+    expected_docx_elements,
+    tmpdir,
+    pass_file_filename,
+    content_type,
 ):
     docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
@@ -118,7 +122,9 @@ def test_auto_partition_doc_with_filename(
     convert_office_doc(docx_filename, tmpdir.dirname, "doc")
     file_filename = doc_filename if pass_file_filename else None
     elements = partition(
-        filename=doc_filename, file_filename=file_filename, content_type=content_type
+        filename=doc_filename,
+        file_filename=file_filename,
+        content_type=content_type,
     )
     assert elements == expected_docx_elements
     assert elements[0].metadata.filename == doc_filename

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -105,13 +105,21 @@ def test_auto_partition_docx_with_file(mock_docx_document, expected_docx_element
     assert elements == expected_docx_elements
 
 
-def test_auto_partition_doc_with_filename(mock_docx_document, expected_docx_elements, tmpdir):
+@pytest.mark.parametrize(
+    ("pass_file_filename", "content_type"),
+    [(False, None), (False, "application/msword"), (True, "application/msword"), (True, None)],
+)
+def test_auto_partition_doc_with_filename(
+    mock_docx_document, expected_docx_elements, tmpdir, pass_file_filename, content_type
+):
     docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
     mock_docx_document.save(docx_filename)
     convert_office_doc(docx_filename, tmpdir.dirname, "doc")
-
-    elements = partition(filename=doc_filename)
+    file_filename = doc_filename if pass_file_filename else None
+    elements = partition(
+        filename=doc_filename, file_filename=file_filename, content_type=content_type
+    )
     assert elements == expected_docx_elements
     assert elements[0].metadata.filename == doc_filename
 
@@ -130,17 +138,27 @@ def test_auto_partition_doc_with_file(mock_docx_document, expected_docx_elements
     assert elements == expected_docx_elements
 
 
-def test_auto_partition_html_from_filename():
+@pytest.mark.parametrize(
+    ("pass_file_filename", "content_type"),
+    [(False, None), (False, "text/html"), (True, "text/html"), (True, None)],
+)
+def test_auto_partition_html_from_filename(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "example-10k.html")
-    elements = partition(filename=filename)
+    file_filename = filename if pass_file_filename else None
+    elements = partition(filename=filename, file_filename=file_filename, content_type=content_type)
     assert len(elements) > 0
     assert elements[0].metadata.filename == filename
 
 
-def test_auto_partition_html_from_file():
+@pytest.mark.parametrize(
+    ("pass_file_filename", "content_type"),
+    [(False, None), (False, "text/html"), (True, "text/html"), (True, None)],
+)
+def test_auto_partition_html_from_file(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-html.html")
+    file_filename = filename if pass_file_filename else None
     with open(filename) as f:
-        elements = partition(file=f)
+        elements = partition(file=f, file_filename=file_filename, content_type=content_type)
     assert len(elements) > 0
 
 
@@ -177,9 +195,15 @@ def test_auto_partition_text_from_file():
     assert elements == EXPECTED_TEXT_OUTPUT
 
 
-def test_auto_partition_pdf_from_filename():
+@pytest.mark.parametrize(
+    ("pass_file_filename", "content_type"),
+    [(False, None), (False, "application/pdf"), (True, "application/pdf"), (True, None)],
+)
+def test_auto_partition_pdf_from_filename(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper-fast.pdf")
-    elements = partition(filename=filename)
+    file_filename = filename if pass_file_filename else None
+
+    elements = partition(filename=filename, file_filename=file_filename, content_type=content_type)
 
     assert isinstance(elements[0], Title)
     assert elements[0].text.startswith("LayoutParser")
@@ -207,10 +231,16 @@ def test_auto_partition_pdf_with_fast_strategy():
     )
 
 
-def test_auto_partition_pdf_from_file():
+@pytest.mark.parametrize(
+    ("pass_file_filename", "content_type"),
+    [(False, None), (False, "application/pdf"), (True, "application/pdf"), (True, None)],
+)
+def test_auto_partition_pdf_from_file(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper-fast.pdf")
+    file_filename = filename if pass_file_filename else None
+
     with open(filename, "rb") as f:
-        elements = partition(file=f)
+        elements = partition(file=f, file_filename=file_filename, content_type=content_type)
 
     assert isinstance(elements[0], Title)
     assert elements[0].text.startswith("LayoutParser")
@@ -230,16 +260,26 @@ def test_partition_pdf_doesnt_raise_warning():
         partition(filename=filename)
 
 
-def test_auto_partition_jpg():
+@pytest.mark.parametrize(
+    ("pass_file_filename", "content_type"),
+    [(False, None), (False, "image/jpeg"), (True, "image/jpeg"), (True, None)],
+)
+def test_auto_partition_jpg(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "example.jpg")
-    elements = partition(filename=filename)
+    file_filename = filename if pass_file_filename else None
+    elements = partition(filename=filename, file_filename=file_filename, content_type=content_type)
     assert len(elements) > 0
 
 
-def test_auto_partition_jpg_from_file():
+@pytest.mark.parametrize(
+    ("pass_file_filename", "content_type"),
+    [(False, None), (False, "image/jpeg"), (True, "image/jpeg"), (True, None)],
+)
+def test_auto_partition_jpg_from_file(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "example.jpg")
+    file_filename = filename if pass_file_filename else None
     with open(filename, "rb") as f:
-        elements = partition(file=f)
+        elements = partition(file=f, file_filename=file_filename, content_type=content_type)
     assert len(elements) > 0
 
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.7-dev4"  # pragma: no cover
+__version__ = "0.5.7"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.7-dev3"  # pragma: no cover
+__version__ = "0.5.7-dev4"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -170,10 +170,7 @@ def detect_filetype(
             return filetype
 
     if filename or file_filename:
-        if filename:
-            _, extension = os.path.splitext(filename)  # type: ignore
-        else:
-            _, extension = os.path.splitext(file_filename)  # type: ignore
+        _, extension = os.path.splitext(filename or file_filename or "")
         extension = extension.lower()
         if LIBMAGIC_AVAILABLE:
             if filename:

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -173,10 +173,7 @@ def detect_filetype(
         _, extension = os.path.splitext(filename or file_filename or "")
         extension = extension.lower()
         if LIBMAGIC_AVAILABLE:
-            if filename:
-                mime_type = magic.from_file(filename, mime=True)
-            else:
-                mime_type = magic.from_file(file_filename, mime=True)  # type: ignore
+                mime_type = magic.from_file(filename or file_filename, mime=True)  # type: ignore
         else:
             # might not need this
             return EXT_TO_FILETYPE.get(extension.lower(), FileType.UNK)

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -164,21 +164,22 @@ def detect_filetype(
     to use for a given file. A return value of None indicates a non-supported file type."""
     exactly_one(filename=filename, file=file)
 
-    filetype = STR_TO_FILETYPE.get(content_type)
-    if filetype:
-        return filetype
+    if content_type:
+        filetype = STR_TO_FILETYPE.get(content_type)
+        if filetype:
+            return filetype
 
     if filename or file_filename:
-        if not filename:
-            _, extension = os.path.splitext(file_filename)
+        if filename:
+            _, extension = os.path.splitext(filename)  # type: ignore
         else:
-            _, extension = os.path.splitext(filename)
+            _, extension = os.path.splitext(file_filename)  # type: ignore
         extension = extension.lower()
         if LIBMAGIC_AVAILABLE:
-            if not filename:
-                mime_type = magic.from_file(file_filename, mime=True)
-            else:
+            if filename:
                 mime_type = magic.from_file(filename, mime=True)
+            else:
+                mime_type = magic.from_file(file_filename, mime=True)  # type: ignore
         else:
             # might not need this
             return EXT_TO_FILETYPE.get(extension.lower(), FileType.UNK)

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -128,7 +128,6 @@ STR_TO_FILETYPE = {
     "application/vnd.openxmlformats-officedocument.presentationml.presentation": FileType.PPTX,
     "application/vnd.ms-powerpoint": FileType.PPT,
     "application/xml": FileType.XML,
-    "application/zip": FileType.ZIP,
 }
 
 
@@ -180,6 +179,7 @@ def detect_filetype(
         if LIBMAGIC_AVAILABLE:
             mime_type = magic.from_file(filename, mime=True)
         else:
+            # might not need this
             return EXT_TO_FILETYPE.get(extension.lower(), FileType.UNK)
     elif file is not None:
         extension = None

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -111,6 +111,27 @@ class FileType(Enum):
         return self.name < other.name
 
 
+STR_TO_FILETYPE = {
+    "application/pdf": FileType.PDF,
+    "application/json": FileType.JSON,
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": FileType.DOCX,
+    "application/msword": FileType.DOC,
+    "image/jpeg": FileType.JPG,
+    "image/png": FileType.PNG,
+    "text/markdown": FileType.MD,
+    "text/x-markdown": FileType.MD,
+    "application/epub": FileType.EPUB,
+    "application/epub+zip": FileType.EPUB,
+    "text/html": FileType.HTML,
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": FileType.XLSX,
+    "application/vnd.ms-excel": FileType.XLS,
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": FileType.PPTX,
+    "application/vnd.ms-powerpoint": FileType.PPT,
+    "application/xml": FileType.XML,
+    "application/zip": FileType.ZIP,
+}
+
+
 EXT_TO_FILETYPE = {
     ".pdf": FileType.PDF,
     ".docx": FileType.DOCX,
@@ -138,14 +159,23 @@ EXT_TO_FILETYPE = {
 
 def detect_filetype(
     filename: Optional[str] = None,
+    content_type: Optional[str] = None,
     file: Optional[IO] = None,
+    file_filename: Optional[str] = None,
 ) -> Optional[FileType]:
     """Use libmagic to determine a file's type. Helps determine which partition brick
     to use for a given file. A return value of None indicates a non-supported file type."""
     exactly_one(filename=filename, file=file)
 
-    if filename:
-        _, extension = os.path.splitext(filename)
+    filetype = STR_TO_FILETYPE.get(content_type)
+    if filetype:
+        return filetype
+
+    if filename or file_filename:
+        if not filename:
+            _, extension = os.path.splitext(file_filename)
+        else:
+            _, extension = os.path.splitext(filename)
         extension = extension.lower()
         if LIBMAGIC_AVAILABLE:
             mime_type = magic.from_file(filename, mime=True)
@@ -164,6 +194,8 @@ def detect_filetype(
                 "Filetype detection on file-like objects requires libmagic. "
                 "Please install libmagic and try again.",
             )
+    else:
+        raise ValueError("No filename, file, nor file_filename were specified.")
 
     if mime_type == "application/pdf":
         return FileType.PDF

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -113,8 +113,6 @@ class FileType(Enum):
 
 STR_TO_FILETYPE = {
     "application/pdf": FileType.PDF,
-    "application/json": FileType.JSON,
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": FileType.DOCX,
     "application/msword": FileType.DOC,
     "image/jpeg": FileType.JPG,
     "image/png": FileType.PNG,
@@ -177,7 +175,10 @@ def detect_filetype(
             _, extension = os.path.splitext(filename)
         extension = extension.lower()
         if LIBMAGIC_AVAILABLE:
-            mime_type = magic.from_file(filename, mime=True)
+            if not filename:
+                mime_type = magic.from_file(file_filename, mime=True)
+            else:
+                mime_type = magic.from_file(filename, mime=True)
         else:
             # might not need this
             return EXT_TO_FILETYPE.get(extension.lower(), FileType.UNK)

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -173,7 +173,7 @@ def detect_filetype(
         _, extension = os.path.splitext(filename or file_filename or "")
         extension = extension.lower()
         if LIBMAGIC_AVAILABLE:
-                mime_type = magic.from_file(filename or file_filename, mime=True)  # type: ignore
+            mime_type = magic.from_file(filename or file_filename, mime=True)  # type: ignore
         else:
             # might not need this
             return EXT_TO_FILETYPE.get(extension.lower(), FileType.UNK)

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -48,7 +48,9 @@ def partition(
     encoding
         The encoding method used to decode the text input. If None, utf-8 will be used.
     """
-    filetype = detect_filetype(filename=filename, file=file, file_filename=file_filename, content_type=content_type)
+    filetype = detect_filetype(
+        filename=filename, file=file, file_filename=file_filename, content_type=content_type
+    )
 
     if file is not None:
         file.seek(0)

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -17,7 +17,9 @@ from unstructured.partition.text import partition_text
 
 def partition(
     filename: Optional[str] = None,
+    content_type: Optional[str] = None,
     file: Optional[IO] = None,
+    file_filename: Optional[str] = None,
     include_page_breaks: bool = False,
     strategy: str = "hi_res",
     encoding: str = "utf-8",
@@ -31,8 +33,12 @@ def partition(
     ----------
      filename
         A string defining the target filename path.
+    content_type
+        A string defining the file content in MIME type
     file
         A file-like object using "rb" mode --> open(filename, "rb").
+    file_filename
+        A string defining the file.
     include_page_breaks
         If True, the output will include page breaks if the filetype supports it
     strategy
@@ -42,7 +48,7 @@ def partition(
     encoding
         The encoding method used to decode the text input. If None, utf-8 will be used.
     """
-    filetype = detect_filetype(filename=filename, file=file)
+    filetype = detect_filetype(filename=filename, file=file, file_filename=file_filename, content_type=content_type)
 
     if file is not None:
         file.seek(0)

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -38,7 +38,7 @@ def partition(
     file
         A file-like object using "rb" mode --> open(filename, "rb").
     file_filename
-        A string defining the file.
+        When file is not None, the filename (string) to store in element metadata. E.g. "foo.txt"
     include_page_breaks
         If True, the output will include page breaks if the filetype supports it
     strategy

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -49,7 +49,10 @@ def partition(
         The encoding method used to decode the text input. If None, utf-8 will be used.
     """
     filetype = detect_filetype(
-        filename=filename, file=file, file_filename=file_filename, content_type=content_type
+        filename=filename,
+        file=file,
+        file_filename=file_filename,
+        content_type=content_type,
     )
 
     if file is not None:


### PR DESCRIPTION
Adding content_type and file_filename to auto_partition function. By accepting content_type as a string, we can bypass filetype detection in a lot of cases. 
