### PR TITLE
ci: update CI for deprecated set-output

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,10 +3,10 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - "**"
+      - "main"
 
 env:
-  DOCKER_REPOSITORY: quay.io/unstructured-io/test-unstructured
+  DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured
   PIP_VERSION: "22.2.1"
   PYTHON_VERSION: "3.8"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - main
+      - "*"
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/test-unstructured

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
+  DOCKER_REPOSITORY: quay.io/unstructured-io/test-unstructured
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured
   PIP_VERSION: "22.2.1"
   PYTHON_VERSION: "3.8"
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Set Short SHA
         id: set_short_sha
-        run: echo "::set-output name=short_sha::$(echo ${{ github.sha }} | cut -c1-7)"
+        run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
   build-amd:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - "*"
+      - "**"
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/test-unstructured

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - "main"
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured


### PR DESCRIPTION
The set-output command will [soon be deprecated ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)in GitHub Actions. This updates to use GITHUB_OUTPUT as recommended.