### PR TITLE
ci: update dockerfile to also add models and nltk

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - "main" 
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - main
+      - "*" 
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/test-unstructured

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
+  DOCKER_REPOSITORY: quay.io/unstructured-io/test-unstructured
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured
   PIP_VERSION: "22.2.1"
   PYTHON_VERSION: "3.8"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - "*" 
+      - "**" 
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/test-unstructured

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,10 +3,10 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - "**" 
+      - "main" 
 
 env:
-  DOCKER_REPOSITORY: quay.io/unstructured-io/test-unstructured
+  DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured
   PIP_VERSION: "22.2.1"
   PYTHON_VERSION: "3.8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,4 +78,8 @@ RUN python3.8 -m pip install pip==${PIP_VERSION} && \
 COPY example-docs example-docs
 COPY unstructured unstructured
 
+RUN python3.8 -c "import nltk; nltk.download('punkt')" && \
+  python3.8 -c "import nltk; nltk.download('averaged_perceptron_tagger')" && \
+  python3.8 -c "from unstructured.ingest.doc_processor.generalized import initialize; initialize()"
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
This doesn't significantly impact image size nor build time and resolves issues where the first run needs to download content.

```
remote/compressed (there's some rounding here):
original: 3.7 GB
+nltk: 3.8 GB
+nltk+models: 4.0 GB

local/decompressed:
original: 8.91GB
+nltk: 8.97GB
+nltk+models: 9.3GB
```

## Testing
I pushed a test build in this [commit](https://github.com/Unstructured-IO/unstructured/pull/418/commits/5dafc53f9b11cb384bafae798f765a5f7f8e1c42) and the output can be pulled from [here](https://github.com/Unstructured-IO/unstructured/actions/runs/4559588428).

Test by running:
```
docker pull quay.io/unstructured-io/test-unstructured:5dafc53
docker run -it quay.io/unstructured-io/test-unstructured:5dafc53
# in container
python3
>> from unstructured.partition.auto import partition
>> elements = partition("example-docs/layout-parser-paper.pdf")
>> elements[3]
```
Verify a valid value is found for `elements[3]` and that the neither nltk nor the models are downloaded.