### PR TITLE
!fix: return a list of elements in `stage_for_transformers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 * Partitioning functions that accept a `text` kwarg no longer raise an error if an empty
   string is passed (and empty list of elements is returned instead).
 * `partition_json` no longer fails if the input is an empty list.
+
+### BREAKING CHANGES
+
 * `stage_for_transformers` now returns a list of elements, making it consistent with other
   staging bricks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-## 0.5.8-dev4
+## 0.5.8-dev5
 
 ### Enhancements
 
 * Update `elements_to_json` to return string when filename is not specified
 * `elements_from_json` may take a string instead of a filename with the `text` kwarg
 * `detect_filetype` now does a final fallback to file extension.
+* Empty tags are now skipped during the depth check for HTML processing.
 
 ### Features
 
@@ -18,6 +19,8 @@
 * Partitioning functions that accept a `text` kwarg no longer raise an error if an empty
   string is passed (and empty list of elements is returned instead).
 * `partition_json` no longer fails if the input is an empty list.
+* `stage_for_transformers` now returns a list of elements, making it consistent with other
+  staging bricks
 
 ## 0.5.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Partitioning functions that accept a `text` kwarg no longer raise an error if an empty
   string is passed (and empty list of elements is returned instead).
 * `partition_json` no longer fails if the input is an empty list.
+* Fixed bug in `chunk_by_attention_window` that caused the last word in segments to be cut-off
+  in some cases.
 
 ### BREAKING CHANGES
 

--- a/test_unstructured/staging/test_huggingface.py
+++ b/test_unstructured/staging/test_huggingface.py
@@ -1,6 +1,6 @@
 import pytest
 
-from unstructured.documents.elements import Text
+from unstructured.documents.elements import Text, Title
 from unstructured.staging import huggingface
 
 
@@ -12,14 +12,23 @@ class MockTokenizer:
 
 
 def test_stage_for_transformers():
-    elements = [Text(text="hello " * 20), Text(text="there " * 20)]
+    title_element = (Title(text="Here is a wonderful story"),)
+    elements = [title_element, Text(text="hello " * 20 + "there " * 20)]
+
     tokenizer = MockTokenizer()
 
-    chunks = huggingface.stage_for_transformers(elements, tokenizer, buffer=10)
+    chunk_elements = huggingface.stage_for_transformers(elements, tokenizer, buffer=10)
 
-    hello_chunk = ("hello " * 10).strip()
-    there_chunk = ("there " * 10).strip()
-    assert chunks == [hello_chunk, hello_chunk, "\n\n" + there_chunk, there_chunk]
+    hello_chunk = Text(("hello " * 10).strip())
+    there_chunk = Text(("there " * 10).strip())
+
+    assert chunk_elements == [
+        title_element,
+        hello_chunk,
+        hello_chunk,
+        there_chunk,
+        there_chunk,
+    ]
 
 
 def test_chunk_by_attention_window():

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.8-dev4"  # pragma: no cover
+__version__ = "0.5.8-dev5"  # pragma: no cover

--- a/unstructured/staging/huggingface.py
+++ b/unstructured/staging/huggingface.py
@@ -81,8 +81,8 @@ def chunk_by_attention_window(
                 f"error is: \n\n{segment}",
             )
 
-        if chunk_size + num_tokens > max_chunk_size or i == (num_splits - 1):
-            chunks.append(chunk_text)
+        if chunk_size + num_tokens > max_chunk_size:
+            chunks.append(chunk_text + chunk_separator.strip())
             chunk_text = ""
             chunk_size = 0
 
@@ -91,5 +91,8 @@ def chunk_by_attention_window(
             chunk_text += chunk_separator
         chunk_text += segment
         chunk_size += num_tokens
+
+        if i == (num_splits - 1) and len(chunk_text) > 0:
+            chunks.append(chunk_text)
 
     return chunks


### PR DESCRIPTION
### Summary

Updates the `stage_for_transformers` function to return a list of elements, like the other staging bricks. Users can continue to use `chunk_by_attention_window` if they need to operate directly on strings. Having `stage_for_transformers` enables you to run operations like getting a pandas dataframe with pre-chunked segments by running `convert_to_dataframe(stage_for_transformers(elements, tokenizer))`.

Also fixed a bug that was causing the last word of the last segment to get cut off in `chunk_by_attention_window`.

### Testing

```python
from unstructured.documents.elements import NarrativeText, Title
from unstructured.staging.huggingface import stage_for_transformers
from transformers import AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained("google/flan-t5-base")
# Copy paste text from this url: https://lite.cnn.com/2023/03/30/us/mlb-pitch-clock-batters-dg
text = <text>
elements = [Title("A baseball article"), NarrativeText(text=text)]
# You should see a title and several narrative text elements
stage_for_transformers(elements, tokenizer)
``` 