### PR TITLE
Fixing test for unstructured-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.9
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* Convert file to str in helper `split_by_paragraph` for `partition_text`
+
 ## 0.5.8
 
 ### Enhancements

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -52,8 +52,8 @@ def test_partition_text_from_file():
 
 def test_partition_text_from_bytes_file():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
-    with open(filename) as f:
-        file_bytes = f.read().encode("utf-8")
+    with open(filename, "rb") as f:
+        file_bytes = f.read()
         elements = partition_text(file=file_bytes)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -50,6 +50,15 @@ def test_partition_text_from_file():
     assert elements == EXPECTED_OUTPUT
 
 
+def test_partition_text_from_bytes_file():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
+    with open(filename) as f:
+        file_bytes = f.read().encode("utf-8")
+        elements = partition_text(file=file_bytes)
+    assert len(elements) > 0
+    assert elements == EXPECTED_OUTPUT
+
+
 def test_partition_text_from_text():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
     with open(filename) as f:

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -53,8 +53,7 @@ def test_partition_text_from_file():
 def test_partition_text_from_bytes_file():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
     with open(filename, "rb") as f:
-        file_bytes = f.read()
-        elements = partition_text(file=file_bytes)
+        elements = partition_text(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.8"  # pragma: no cover
+__version__ = "0.5.9"  # pragma: no cover

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -52,17 +52,20 @@ def partition_text(
     if filename is not None:
         with open(filename, encoding=encoding) as f:
             try:
-                file_text = f.read()
+                file_text = str(f.read())
             except (UnicodeDecodeError, UnicodeError) as error:
                 raise error
 
     elif file is not None:
-        file_text = file.read()
+        try:
+            file_text = file.read()
+        except AttributeError:
+            file_text = file.decode(encoding)  # type: ignore
 
     elif text is not None:
         file_text = str(text)
 
-    file_content = split_by_paragraph(str(file_text))
+    file_content = split_by_paragraph(file_text)
 
     elements: List[Element] = []
     metadata = ElementMetadata(filename=filename)

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -62,7 +62,7 @@ def partition_text(
     elif text is not None:
         file_text = str(text)
 
-    file_content = split_by_paragraph(file_text)
+    file_content = split_by_paragraph(str(file_text))
 
     elements: List[Element] = []
     metadata = ElementMetadata(filename=filename)

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -52,7 +52,7 @@ def partition_text(
     if filename is not None:
         with open(filename, encoding=encoding) as f:
             try:
-                file_text = str(f.read())
+                file_text = f.read()
             except (UnicodeDecodeError, UnicodeError) as error:
                 raise error
 

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -57,10 +57,9 @@ def partition_text(
                 raise error
 
     elif file is not None:
-        try:
-            file_text = file.read()
-        except AttributeError:
-            file_text = file.decode(encoding)  # type: ignore
+        file_text = file.read()
+        if isinstance(file_text, bytes):
+            file_text = file_text.decode(encoding)
 
     elif text is not None:
         file_text = str(text)


### PR DESCRIPTION
Ran into an error in tests for unstructured-api (see below for output). Somewhere along the lines we were reading a txt file into bytes and then the `PARAGRAPH_PATTERN` (a string) was not able to be compared to the bytes file. The simplest solution to make the test happy was to convert the `file_text` to a string before passing to the function resulting in the error.

```
test_general/api/test_app.py:43: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.venv/lib/python3.8/site-packages/starlette/testclient.py:590: in post
    return super().post(
.venv/lib/python3.8/site-packages/httpx/_client.py:1136: in post
    return self.request(
.venv/lib/python3.8/site-packages/starlette/testclient.py:465: in request
    return super().request(
.venv/lib/python3.8/site-packages/httpx/_client.py:821: in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
.venv/lib/python3.8/site-packages/httpx/_client.py:908: in send
    response = self._send_handling_auth(
.venv/lib/python3.8/site-packages/httpx/_client.py:936: in _send_handling_auth
    response = self._send_handling_redirects(
.venv/lib/python3.8/site-packages/httpx/_client.py:973: in _send_handling_redirects
    response = self._send_single_request(request)
.venv/lib/python3.8/site-packages/httpx/_client.py:1009: in _send_single_request
    response = transport.handle_request(request)
.venv/lib/python3.8/site-packages/starlette/testclient.py:342: in handle_request
    raise exc
.venv/lib/python3.8/site-packages/starlette/testclient.py:339: in handle_request
    portal.call(self.app, scope, receive, send)
.venv/lib/python3.8/site-packages/anyio/from_thread.py:283: in call
    return cast(T_Retval, self.start_task_soon(func, *args).result())
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/concurrent/futures/_base.py:444: in result
    return self.__get_result()
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/concurrent/futures/_base.py:389: in __get_result
    raise self._exception
.venv/lib/python3.8/site-packages/anyio/from_thread.py:219: in _call_func
    retval = await retval
.venv/lib/python3.8/site-packages/fastapi/applications.py:276: in __call__
    await super().__call__(scope, receive, send)
.venv/lib/python3.8/site-packages/starlette/applications.py:122: in __call__
    await self.middleware_stack(scope, receive, send)
.venv/lib/python3.8/site-packages/starlette/middleware/errors.py:184: in __call__
    raise exc
.venv/lib/python3.8/site-packages/starlette/middleware/errors.py:162: in __call__
    await self.app(scope, receive, _send)
.venv/lib/python3.8/site-packages/starlette/middleware/exceptions.py:79: in __call__
    raise exc
.venv/lib/python3.8/site-packages/starlette/middleware/exceptions.py:68: in __call__
    await self.app(scope, receive, sender)
.venv/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py:21: in __call__
    raise e
.venv/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py:18: in __call__
    await self.app(scope, receive, send)
.venv/lib/python3.8/site-packages/starlette/routing.py:718: in __call__
    await route.handle(scope, receive, send)
.venv/lib/python3.8/site-packages/starlette/routing.py:276: in handle
    await self.app(scope, receive, send)
.venv/lib/python3.8/site-packages/starlette/routing.py:66: in app
    response = await func(request)
.venv/lib/python3.8/site-packages/fastapi/routing.py:237: in app
    raw_response = await run_endpoint_function(
.venv/lib/python3.8/site-packages/fastapi/routing.py:165: in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
.venv/lib/python3.8/site-packages/starlette/concurrency.py:41: in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
.venv/lib/python3.8/site-packages/anyio/to_thread.py:31: in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
.venv/lib/python3.8/site-packages/anyio/_backends/_asyncio.py:937: in run_sync_in_worker_thread
    return await future
.venv/lib/python3.8/site-packages/anyio/_backends/_asyncio.py:[867](https://github.com/Unstructured-IO/unstructured-api/actions/runs/4578656772/jobs/8085577882?pr=65#step:4:868): in run
    result = context.run(func, *args)
prepline_general/api/general.py:218: in pipeline_1
    response = pipeline_api(
prepline_general/api/general.py:62: in pipeline_api
    elements = partition(
.venv/lib/python3.8/site-packages/unstructured/partition/auto.py:95: in partition
    return partition_text(filename=filename, file=file, encoding=encoding)
.venv/lib/python3.8/site-packages/unstructured/partition/text.py:63: in partition_text
    file_content = split_by_paragraph(file_text)
.venv/lib/python3.8/site-packages/unstructured/partition/text.py:25: in split_by_paragraph
    return re.split(PARAGRAPH_PATTERN, content)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pattern = '\\s*\\n\\s*'
string = b'This is a test document to use for unit tests.\n\nImportant points:\n\n   - Hamburgers are delicious\n   - Dogs are the best\n   - I love fuzzy blankets'
maxsplit = 0, flags = 0

    def split(pattern, string, maxsplit=0, flags=0):
        """Split the source string by the occurrences of the pattern,
        returning a list containing the resulting substrings.  If
        capturing parentheses are used in pattern, then the text of all
        groups in the pattern are also returned as part of the resulting
        list.  If maxsplit is nonzero, at most maxsplit splits occur,
        and the remainder of the string is returned as the final element
        of the list."""
>       return _compile(pattern, flags).split(string, maxsplit)
E       TypeError: cannot use a string pattern on a bytes-like object

/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/re.py:231: TypeError
```