### PR TITLE
feat: add sender and receive info to element metadata for emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.10-dev0
+
+### Enhancements
+
+* Add sender, recipient, date, and subject to element metadata for emails
+
+### Features
+
+### Fixes
+
 ## 0.5.9
 
 ### Enhancements

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -175,8 +175,8 @@ def test_partition_email_has_metadata():
         date="2022-12-16T17:04:16-05:00",
         page_number=None,
         url=None,
-        sent_from="Matthew Robinson <mrobinson@unstructured.io>",
-        sent_to="Matthew Robinson <mrobinson@unstructured.io>",
+        sent_from=["Matthew Robinson <mrobinson@unstructured.io>"],
+        sent_to=["Matthew Robinson <mrobinson@unstructured.io>"],
         subject="Test Email",
     )
 

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -5,7 +5,13 @@ import pathlib
 
 import pytest
 
-from unstructured.documents.elements import Image, ListItem, NarrativeText, Title
+from unstructured.documents.elements import (
+    ElementMetadata,
+    Image,
+    ListItem,
+    NarrativeText,
+    Title,
+)
 from unstructured.documents.email_elements import (
     MetaData,
     ReceivedInfo,
@@ -158,6 +164,21 @@ def test_partition_email_header():
     elements = partition_email_header(msg)
     assert len(elements) > 0
     assert elements == RECEIVED_HEADER_OUTPUT
+
+
+def test_partition_email_has_metadata():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email-header.eml")
+    elements = partition_email(filename=filename)
+    assert len(elements) > 0
+    assert elements[0].metadata == ElementMetadata(
+        filename=filename,
+        date="2022-12-16T17:04:16-05:00",
+        page_number=None,
+        url=None,
+        sent_from="Matthew Robinson <mrobinson@unstructured.io>",
+        sent_to="Matthew Robinson <mrobinson@unstructured.io>",
+        subject="Test Email",
+    )
 
 
 def test_extract_email_text_matches_html():

--- a/test_unstructured/partition/test_msg.py
+++ b/test_unstructured/partition/test_msg.py
@@ -4,7 +4,12 @@ import pathlib
 import msg_parser
 import pytest
 
-from unstructured.documents.elements import ListItem, NarrativeText, Title
+from unstructured.documents.elements import (
+    ElementMetadata,
+    ListItem,
+    NarrativeText,
+    Title,
+)
 from unstructured.partition.msg import partition_msg
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
@@ -22,6 +27,15 @@ def test_partition_msg_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.msg")
     elements = partition_msg(filename=filename)
     assert elements == EXPECTED_MSG_OUTPUT
+    assert elements[0].metadata == ElementMetadata(
+        filename=filename,
+        date="2022-12-16T17:04:16-05:00",
+        page_number=None,
+        url=None,
+        sent_from=["Matthew Robinson <mrobinson@unstructured.io>"],
+        sent_to=["Matthew Robinson (None)"],
+        subject="Test Email",
+    )
 
 
 class MockMsOxMessage:

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.9"  # pragma: no cover
+__version__ = "0.5.10-dev0"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -14,8 +14,18 @@ class NoID(ABC):
 @dataclass
 class ElementMetadata:
     filename: Optional[str] = None
+    date: Optional[str] = None
+
+    # Page numbers currenlty supported for PDF, HTML and PPT documents
     page_number: Optional[int] = None
+
+    # Webpage specific metadata fields
     url: Optional[str] = None
+
+    # E-mail specific metadata fields
+    sent_from: Optional[str] = None
+    sent_to: Optional[str] = None
+    subject: Optional[str] = None
 
     def __post_init__(self):
         if isinstance(self.filename, pathlib.Path):

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -23,8 +23,8 @@ class ElementMetadata:
     url: Optional[str] = None
 
     # E-mail specific metadata fields
-    sent_from: Optional[str] = None
-    sent_to: Optional[str] = None
+    sent_from: Optional[List[str]] = None
+    sent_to: Optional[List[str]] = None
     subject: Optional[str] = None
 
     def __post_init__(self):

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -89,7 +89,7 @@ def partition_email_header(msg: Message) -> List[Element]:
 
 
 def build_email_metadata(msg: Message) -> ElementMetadata:
-    """Creates and ElementMetadata object from the header information in the email."""
+    """Creates an ElementMetadata object from the header information in the email."""
     header_dict = dict(msg.raw_items())
     email_date = header_dict.get("Date")
     if email_date is not None:
@@ -104,8 +104,8 @@ def build_email_metadata(msg: Message) -> ElementMetadata:
         sent_to = [recipient.strip() for recipient in sent_to.split(",")]
 
     return ElementMetadata(
-        sent_to=sent_from,
-        sent_from=sent_to,
+        sent_to=sent_to,
+        sent_from=sent_from,
         subject=header_dict.get("Subject"),
         date=email_date,
     )

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -95,9 +95,17 @@ def build_email_metadata(msg: Message) -> ElementMetadata:
     if email_date is not None:
         email_date = convert_to_iso_8601(email_date)
 
+    sent_from = header_dict.get("To")
+    if sent_from is not None:
+        sent_from = [sender.strip() for sender in sent_from.split(",")]
+
+    sent_to = header_dict.get("To")
+    if sent_to is not None:
+        sent_to = [recipient.strip() for recipient in sent_to.split(",")]
+
     return ElementMetadata(
-        sent_to=header_dict.get("To"),
-        sent_from=header_dict.get("From"),
+        sent_to=sent_from,
+        sent_from=sent_to,
         subject=header_dict.get("Subject"),
         date=email_date,
     )

--- a/unstructured/partition/msg.py
+++ b/unstructured/partition/msg.py
@@ -3,8 +3,9 @@ from typing import IO, List, Optional
 
 import msg_parser
 
-from unstructured.documents.elements import Element
+from unstructured.documents.elements import Element, ElementMetadata
 from unstructured.partition.common import exactly_one
+from unstructured.partition.email import convert_to_iso_8601
 from unstructured.partition.html import partition_html
 from unstructured.partition.text import partition_text
 
@@ -38,4 +39,31 @@ def partition_msg(
     else:
         elements = partition_text(text=text)
 
+    metadata = build_msg_metadata(msg_obj)
+    metadata.filename = filename
+    for element in elements:
+        element.metadata = metadata
+
     return elements
+
+
+def build_msg_metadata(msg_obj: msg_parser.MsOxMessage) -> ElementMetadata:
+    """Creates an ElementMetadata object from the header information in the emai."""
+    email_date = getattr(msg_obj, "sent_date", None)
+    if email_date is not None:
+        email_date = convert_to_iso_8601(email_date)
+
+    sent_from = getattr(msg_obj, "sender", None)
+    if sent_from is not None:
+        sent_from = [str(sender) for sender in sent_from]
+
+    sent_to = getattr(msg_obj, "recipients", None)
+    if sent_to is not None:
+        sent_to = [str(recipient) for recipient in sent_to]
+
+    return ElementMetadata(
+        sent_to=sent_to,
+        sent_from=sent_from,
+        subject=getattr(msg_obj, "subject", None),
+        date=email_date,
+    )


### PR DESCRIPTION
### Summary

Adds `sent_from`, `sent_to`, `subject`, and `date` to the element metadata for emails

### Testing

The following code should now show the above metadata fields populated:

```python
from unstructured.partition.email import partition_email

elements = partition_email(filename="example-docs/fake-email.eml")
elements[0].metadata
```

```python
from unstructured.partition.msg import partition_msg

elements = partition_msg(filename="example-docs/fake-email.msg")
elements[0].metadata
```