### PR TITLE
fix: change url to html_url

### DIFF
--- a/.github/workflows/create_issue.yml
+++ b/.github/workflows/create_issue.yml
@@ -24,7 +24,7 @@ jobs:
         project: CORE
         issuetype: Task
         summary: ${{ github.event.issue.title }}
-        description: "Created from Github issue: ${{ github.event.issue.url }} \\ \\${{ github.event.issue.body }}"
+        description: "Created from Github issue: ${{ github.event.issue.html_url }} \\ \\${{ github.event.issue.body }}"
         fields: '{ "labels": ["github-issue"] }'
 
     - name: Log created issue


### PR DESCRIPTION
I realized that `github.event.issue.url` gives a url to the domain `api.github.com`. `html_url` (which doesn't seem to be documented in the `issues` interface) gives the url we want.