### PR TITLE
fix: allow `replace_mime_encodings` to accept and `encoding` kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.5.12-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* Allow encoding to be passed into `replace_mime_encodings`.
+
+
 ## 0.5.11
 
 ### Enhancements

--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -81,7 +81,7 @@ def test_replace_mime_encodings(text, expected):
 
 
 def test_replace_mime_encodings_works_with_different_encodings():
-    text = '5 w=E2=80-99s=E2=80-92'
+    text = "5 w=E2=80-99s=E2=80-92"
     assert core.replace_mime_encodings(text=text, encoding="latin-1") == "5 wâ\x80-99sâ\x80-92"
 
 

--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -80,6 +80,11 @@ def test_replace_mime_encodings(text, expected):
     assert core.replace_mime_encodings(text=text) == expected
 
 
+def test_replace_mime_encodings_works_with_different_encodings():
+    text = '5 w=E2=80-99s=E2=80-92'
+    assert core.replace_mime_encodings(text=text, encoding="latin-1") == "5 wâ\x80-99sâ\x80-92"
+
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.11"  # pragma: no cover
+__version__ = "0.5.12-dev0"  # pragma: no cover

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -140,7 +140,7 @@ def clean_trailing_punctuation(text: str) -> str:
 
 
 def replace_mime_encodings(text: str, encoding: str = "utf-8") -> str:
-    """Replaces MIME encodings with their UTF-8 equivalent characters.
+    """Replaces MIME encodings with their equivalent characters in the specified encoding.
 
     Example
     -------

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -139,14 +139,14 @@ def clean_trailing_punctuation(text: str) -> str:
     return text.strip().rstrip(".,:;")
 
 
-def replace_mime_encodings(text: str) -> str:
+def replace_mime_encodings(text: str, encoding: str = "utf-8") -> str:
     """Replaces MIME encodings with their UTF-8 equivalent characters.
 
     Example
     -------
     5 w=E2=80-99s -> 5 w’s
     """
-    return quopri.decodestring(text.encode()).decode("utf-8")
+    return quopri.decodestring(text.encode()).decode(encoding)
 
 
 def clean_prefix(text: str, pattern: str, ignore_case: bool = False, strip: bool = True) -> str:

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -3,6 +3,7 @@ import email
 import re
 import sys
 from email.message import Message
+from functools import partial
 from typing import IO, Dict, List, Optional, Tuple, Union
 
 from unstructured.partition.common import exactly_one
@@ -247,7 +248,8 @@ def partition_email(
         elements = partition_html(text=content, include_metadata=False)
         for element in elements:
             if isinstance(element, Text):
-                element.apply(replace_mime_encodings)
+                _replace_mime_encodings = partial(replace_mime_encodings, encoding=encoding)
+                element.apply(_replace_mime_encodings)
     elif content_source == "text/plain":
         list_content = split_by_paragraph(content)
         elements = partition_text(text=content)


### PR DESCRIPTION
### Summary

Closes #444. Updates `replace_mime_encodings` to accept an `encoding` kwarg. Also passes in the `encoding` kwarg from `partition_email`.

### Testing

The following work now. With utf-8 encoding, this failed with a `UniDecodeError`.

```python
from unstructured.cleaners.core import replace_mime_encodings

text = '5 w=E2=80-92s'
replace_mime_encodings(text, encoding="latin-1")
```