### PR TITLE
build: add mimetypes DB to docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
-## 0.5.12-dev0
+## 0.5.12-dev1
 
 ### Enhancements
+
+* Add OS mimetypes DB to docker image, mainly for unstructured-api compat.
 
 ### Features
 
 ### Fixes
 
 * Allow encoding to be passed into `replace_mime_encodings`.
-
 
 ## 0.5.11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG PIP_VERSION
 
 # Install dependency packages
 RUN yum -y update && \
-  yum -y install poppler-utils xz-devel wget tar curl make which && \
+  yum -y install poppler-utils xz-devel wget tar curl make which mailcap && \
   yum install -y epel-release && \
   yum install -y pandoc && \
   yum -y install libreoffice && \

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.12-dev0"  # pragma: no cover
+__version__ = "0.5.12-dev1"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -120,6 +120,7 @@ class FileType(Enum):
 STR_TO_FILETYPE = {
     "application/pdf": FileType.PDF,
     "application/msword": FileType.DOC,
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": FileType.DOCX,
     "image/jpeg": FileType.JPG,
     "image/png": FileType.PNG,
     "text/markdown": FileType.MD,


### PR DESCRIPTION
The `mailcap` centos7 package provides the file `/etc/mime.types`, which is used by the `mimetypes` python package. That said, the `unstructured` code base does not make much use of this but the upstream `unstructured-api` does.

Bonus: `docx` mimetype added in lookup table.