### PR TITLE
fix: docker smoke test on build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
         # only run a subset of tests on ARM, since they take a long time with emulation
         DOCKER_PLATFORM="linux/arm64" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:arm-$SHORT_SHA" make docker-test TEST_NAME=partition/test_text.py
-        IMAGE_NAME=$DOCKER_BUILD_REPOSITORY:arm-$SHORT_SHA make docker-smoke-test
+        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:arm-$SHORT_SHA make docker-smoke-test
     - name: Push ARM image
       run: |
         # write to the build repository to cache for the publish-images job

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,10 +3,10 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - main
+      - "**"
 
 env:
-  DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
+  DOCKER_REPOSITORY: quay.io/unstructured-io/test-unstructured
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured
   PIP_VERSION: "22.2.1"
   PYTHON_VERSION: "3.8"
@@ -47,7 +47,7 @@ jobs:
     - name: Test AMD image
       run: |
         DOCKER_PLATFORM="linux/amd64" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:amd-$SHORT_SHA" make docker-test 
-        IMAGE_NAME=$DOCKER_BUILD_REPOSITORY:amd-$SHORT_SHA make docker-smoke-test
+        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:amd-$SHORT_SHA make docker-smoke-test
     - name: Push AMD image
       run: |
         # write to the build repository to cache for the publish-images job

--- a/Makefile
+++ b/Makefile
@@ -205,4 +205,4 @@ docker-test:
 
 .PHONY: docker-smoke-test
 docker-smoke-test:
-	IMAGE_NAME=${DOCKER_IMAGE} ./scripts/docker-smoke-test.sh
+	DOCKER_IMAGE=${DOCKER_IMAGE} ./scripts/docker-smoke-test.sh

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -3,14 +3,14 @@
 set -euo pipefail
 DOCKER_REPOSITORY="${DOCKER_REPOSITORY:-quay.io/unstructured-io/unstructured}"
 PIP_VERSION="${PIP_VERSION:-22.2.1}"
-DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-unstructured:dev}"
+DOCKER_IMAGE="${DOCKER_IMAGE:-unstructured:dev}"
 
 DOCKER_BUILD_CMD=(docker buildx build --load -f Dockerfile \
   --build-arg PIP_VERSION="$PIP_VERSION" \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
   --progress plain \
   --cache-from "$DOCKER_REPOSITORY":latest \
-  -t "$DOCKER_IMAGE_NAME" .)
+  -t "$DOCKER_IMAGE" .)
 
 # only build for specific platform if DOCKER_BUILD_PLATFORM is set
 if [ -n "${DOCKER_BUILD_PLATFORM:-}" ]; then

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -7,7 +7,7 @@
 set -eux -o pipefail
 
 CONTAINER_NAME=unstructured-smoke-test
-IMAGE_NAME="${IMAGE_NAME:-unstructured:dev}"
+DOCKER_IMAGE="${DOCKER_IMAGE:-unstructured:dev}"
 
 # Change to the root of the repository
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -15,7 +15,7 @@ cd "$SCRIPT_DIR"/.. || exit 1
 
 start_container() {
     echo Starting container "$CONTAINER_NAME"
-    docker run -dt --rm --name "$CONTAINER_NAME" "$IMAGE_NAME"
+    docker run -dt --rm --name "$CONTAINER_NAME" "$DOCKER_IMAGE"
 }
 
 await_container() {

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -7,7 +7,7 @@
 set -eux -o pipefail
 
 CONTAINER_NAME=unstructured-smoke-test
-IMAGE_NAME="${IMAGE_NAME:-unstructured:latest}"
+IMAGE_NAME="${IMAGE_NAME:-unstructured:dev}"
 
 # Change to the root of the repository
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
The DOCKER_IMAGE variable  from the publish workflow gets overridden in the Makefile when calling docker-smoke-test.

* simplifies calls to universally use DOCKER_IMAGE since this is valid in all cases and easier to track