### PR TITLE
fix(ingest): import connector-specific modules on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.12-dev2
+## 0.5.12-dev3
 
 ### Enhancements
 
@@ -11,6 +11,7 @@
 ### Fixes
 
 * Allow encoding to be passed into `replace_mime_encodings`.
+* unstructured-ingest connector-specific dependencies are imported on demand.
 
 ## 0.5.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * Allow encoding to be passed into `replace_mime_encodings`.
 * unstructured-ingest connector-specific dependencies are imported on demand.
+* unstructured-ingest --flatten-metadata supported for local connector.
+* unstructured-ingest fix runtime error when using --metadata-include.
 
 ## 0.5.11
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.12-dev2"  # pragma: no cover
+__version__ = "0.5.12-dev3"  # pragma: no cover

--- a/unstructured/ingest/connector/local.py
+++ b/unstructured/ingest/connector/local.py
@@ -28,6 +28,7 @@ class SimpleLocalConfig(BaseConnectorConfig):
     metadata_include: Optional[str] = None
     metadata_exclude: Optional[str] = None
     fields_include: str = "element_id,text,type,metadata"
+    flatten_metadata: bool = False
 
     def __post_init__(self):
         if os.path.isfile(self.input_path):

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -117,7 +117,7 @@ class BaseIngestDoc(ABC):
                     elem["metadata"].pop(ex, None)  # type: ignore[attr-defined]
             elif self.config.metadata_include is not None:
                 in_list = self.config.metadata_include.split(",")
-                for k in list(elem["metadata"].keys()):
+                for k in list(elem["metadata"].keys()):  # type: ignore[attr-defined]
                     if k not in in_list:
                         elem["metadata"].pop(k, None)  # type: ignore[attr-defined]
 

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -117,7 +117,7 @@ class BaseIngestDoc(ABC):
                     elem["metadata"].pop(ex, None)  # type: ignore[attr-defined]
             elif self.config.metadata_include is not None:
                 in_list = self.config.metadata_include.split(",")
-                for k in elem["metadata"]:
+                for k in list(elem["metadata"].keys()):
                     if k not in in_list:
                         elem["metadata"].pop(k, None)  # type: ignore[attr-defined]
 

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -10,21 +10,6 @@ from urllib.parse import urlparse
 
 import click
 
-from unstructured.ingest.connector.azure import (
-    AzureBlobStorageConnector,
-    SimpleAzureBlobStorageConfig,
-)
-from unstructured.ingest.connector.biomed import BiomedConnector, SimpleBiomedConfig
-from unstructured.ingest.connector.fsspec import FsspecConnector, SimpleFsspecConfig
-from unstructured.ingest.connector.github import GitHubConnector, SimpleGitHubConfig
-from unstructured.ingest.connector.gitlab import GitLabConnector, SimpleGitLabConfig
-from unstructured.ingest.connector.google_drive import (
-    GoogleDriveConnector,
-    SimpleGoogleDriveConfig,
-)
-from unstructured.ingest.connector.local import LocalConnector, SimpleLocalConfig
-from unstructured.ingest.connector.reddit import RedditConnector, SimpleRedditConfig
-from unstructured.ingest.connector.s3 import S3Connector, SimpleS3Config
 from unstructured.ingest.connector.wikipedia import (
     SimpleWikipediaConfig,
     WikipediaConnector,
@@ -480,6 +465,7 @@ def main(
     if remote_url:
         protocol = urlparse(remote_url).scheme
         if protocol in ("s3", "s3a"):
+            from unstructured.ingest.connector.s3 import S3Connector, SimpleS3Config
             doc_connector = S3Connector(  # type: ignore
                 config=SimpleS3Config(
                     path=s3_url,
@@ -496,6 +482,10 @@ def main(
                 ),
             )
         elif protocol in ("abfs", "az"):
+            from unstructured.ingest.connector.azure import (
+                AzureBlobStorageConnector,
+                SimpleAzureBlobStorageConfig,
+            )
             if azure_account_name:
                 access_kwargs = {
                     "account_name": azure_account_name,
@@ -527,6 +517,7 @@ def main(
                 " and `az`.",
                 UserWarning,
             )
+            from unstructured.ingest.connector.fsspec import FsspecConnector, SimpleFsspecConfig
             doc_connector = FsspecConnector(  # type: ignore
                 config=SimpleFsspecConfig(
                     path=remote_url,
@@ -542,6 +533,7 @@ def main(
                 ),
             )
     elif github_url:
+        from unstructured.ingest.connector.github import GitHubConnector, SimpleGitHubConfig
         doc_connector = GitHubConnector(  # type: ignore
             config=SimpleGitHubConfig(
                 url=github_url,
@@ -561,6 +553,7 @@ def main(
             ),
         )
     elif gitlab_url:
+        from unstructured.ingest.connector.gitlab import GitLabConnector, SimpleGitLabConfig
         doc_connector = GitLabConnector(  # type: ignore
             config=SimpleGitLabConfig(
                 url=gitlab_url,
@@ -580,6 +573,7 @@ def main(
             ),
         )
     elif subreddit_name:
+        from unstructured.ingest.connector.reddit import RedditConnector, SimpleRedditConfig
         doc_connector = RedditConnector(  # type: ignore
             config=SimpleRedditConfig(
                 subreddit_name=subreddit_name,
@@ -618,6 +612,10 @@ def main(
             ),
         )
     elif drive_id:
+        from unstructured.ingest.connector.google_drive import (
+            GoogleDriveConnector,
+            SimpleGoogleDriveConfig,
+        )
         doc_connector = GoogleDriveConnector(  # type: ignore
             config=SimpleGoogleDriveConfig(
                 drive_id=drive_id,
@@ -637,6 +635,7 @@ def main(
             ),
         )
     elif biomed_path or biomed_api_id or biomed_api_from or biomed_api_until:
+        from unstructured.ingest.connector.biomed import BiomedConnector, SimpleBiomedConfig
         doc_connector = BiomedConnector(  # type: ignore
             config=SimpleBiomedConfig(
                 path=biomed_path,
@@ -656,6 +655,7 @@ def main(
             ),
         )
     elif local_input_path:
+        from unstructured.ingest.connector.local import LocalConnector, SimpleLocalConfig
         doc_connector = LocalConnector(  # type: ignore
             config=SimpleLocalConfig(
                 input_path=local_input_path,

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -693,6 +693,7 @@ def main(
                 metadata_include=metadata_include,
                 metadata_exclude=metadata_exclude,
                 fields_include=fields_include,
+                flatten_metadata=flatten_metadata,
             ),
         )
     # Check for other connector-specific options here and define the doc_connector object

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -466,6 +466,7 @@ def main(
         protocol = urlparse(remote_url).scheme
         if protocol in ("s3", "s3a"):
             from unstructured.ingest.connector.s3 import S3Connector, SimpleS3Config
+
             doc_connector = S3Connector(  # type: ignore
                 config=SimpleS3Config(
                     path=s3_url,
@@ -486,6 +487,7 @@ def main(
                 AzureBlobStorageConnector,
                 SimpleAzureBlobStorageConfig,
             )
+
             if azure_account_name:
                 access_kwargs = {
                     "account_name": azure_account_name,
@@ -517,7 +519,11 @@ def main(
                 " and `az`.",
                 UserWarning,
             )
-            from unstructured.ingest.connector.fsspec import FsspecConnector, SimpleFsspecConfig
+            from unstructured.ingest.connector.fsspec import (
+                FsspecConnector,
+                SimpleFsspecConfig,
+            )
+
             doc_connector = FsspecConnector(  # type: ignore
                 config=SimpleFsspecConfig(
                     path=remote_url,
@@ -533,7 +539,11 @@ def main(
                 ),
             )
     elif github_url:
-        from unstructured.ingest.connector.github import GitHubConnector, SimpleGitHubConfig
+        from unstructured.ingest.connector.github import (
+            GitHubConnector,
+            SimpleGitHubConfig,
+        )
+
         doc_connector = GitHubConnector(  # type: ignore
             config=SimpleGitHubConfig(
                 url=github_url,
@@ -553,7 +563,11 @@ def main(
             ),
         )
     elif gitlab_url:
-        from unstructured.ingest.connector.gitlab import GitLabConnector, SimpleGitLabConfig
+        from unstructured.ingest.connector.gitlab import (
+            GitLabConnector,
+            SimpleGitLabConfig,
+        )
+
         doc_connector = GitLabConnector(  # type: ignore
             config=SimpleGitLabConfig(
                 url=gitlab_url,
@@ -573,7 +587,11 @@ def main(
             ),
         )
     elif subreddit_name:
-        from unstructured.ingest.connector.reddit import RedditConnector, SimpleRedditConfig
+        from unstructured.ingest.connector.reddit import (
+            RedditConnector,
+            SimpleRedditConfig,
+        )
+
         doc_connector = RedditConnector(  # type: ignore
             config=SimpleRedditConfig(
                 subreddit_name=subreddit_name,
@@ -616,6 +634,7 @@ def main(
             GoogleDriveConnector,
             SimpleGoogleDriveConfig,
         )
+
         doc_connector = GoogleDriveConnector(  # type: ignore
             config=SimpleGoogleDriveConfig(
                 drive_id=drive_id,
@@ -635,7 +654,11 @@ def main(
             ),
         )
     elif biomed_path or biomed_api_id or biomed_api_from or biomed_api_until:
-        from unstructured.ingest.connector.biomed import BiomedConnector, SimpleBiomedConfig
+        from unstructured.ingest.connector.biomed import (
+            BiomedConnector,
+            SimpleBiomedConfig,
+        )
+
         doc_connector = BiomedConnector(  # type: ignore
             config=SimpleBiomedConfig(
                 path=biomed_path,
@@ -655,7 +678,11 @@ def main(
             ),
         )
     elif local_input_path:
-        from unstructured.ingest.connector.local import LocalConnector, SimpleLocalConfig
+        from unstructured.ingest.connector.local import (
+            LocalConnector,
+            SimpleLocalConfig,
+        )
+
         doc_connector = LocalConnector(  # type: ignore
             config=SimpleLocalConfig(
                 input_path=local_input_path,


### PR DESCRIPTION
As most connectors have additional dependencies that may not be installed locally, only import those connectors' modules when they are being used.