### PR TITLE
feat: add `partition_rtf` for rich text files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.12-dev3
+## 0.5.12-dev4
 
 ### Enhancements
 
@@ -7,6 +7,8 @@
 * Adds the ability for `partition_text` to group together broken paragraphs.
 
 ### Features
+
+* Added `partition_rtf` for processing rich text files.
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ you can also uninstall the hooks with `pre-commit uninstall`.
 You can run this [Colab notebook](https://colab.research.google.com/drive/1U8VCjY2-x8c6y5TYMbSFtQGlQVFHCVIW) to run the examples below.
 
 The following examples show how to get started with the `unstructured` library.
-You can parse **TXT**, **HTML**, **PDF**, **EML**, **MSG**, **EPUB**, **DOC**, **DOCX**, **PPT**, **PPTX**, **JPG**,
+You can parse **TXT**, **HTML**, **PDF**, **EML**, **MSG**, **RTF**, **EPUB**, **DOC**, **DOCX**, **PPT**, **PPTX**, **JPG**,
 and **PNG** documents with one line of code!
 <br></br>
 See our [documentation page](https://unstructured-io.github.io/unstructured) for a full description

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -1091,9 +1091,7 @@ Examples:
 
     By the weekend, a second cold front will drop down from Canada and bring a reinforcing shot of chilly air across the eastern half of the country."""
 
-    chunks = stage_for_transformers([NarrativeText(text=text)], tokenizer)
-
-    results = [nlp(chunk) for chunk in chunks]
+    elements = stage_for_transformers([NarrativeText(text=text)], tokenizer)
 
 
 The following optional keyword arguments can be specified in

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -610,7 +610,10 @@ Examples:
 
 .. code:: python
 
+  import re
   from unstructured.cleaners.core import group_broken_paragraphs
+
+  para_split_re = re.compile(r"(\s*\n\s*){3}")
 
   text = """The big brown fox
 
@@ -621,7 +624,7 @@ Examples:
 
   fox met a bear."""
 
-  group_broken_paragraphs(text, line_split="\n\n", paragraph_split="\n\n\n")
+  group_broken_paragraphs(text, paragraph_split=para_split_re)
 
 
 ``replace_unicode_quotes``

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -83,7 +83,7 @@ If you call the ``partition`` function, ``unstructured`` will attempt to detect 
 file type and route it to the appropriate partitioning brick. All partitioning bricks
 called within ``partition`` are called using the default kwargs. Use the document-type
 specific bricks if you need to apply non-default settings.
-``partition`` currently supports ``.docx``, ``.doc``, ``.pptx``, ``.ppt``, ``.eml``, ``.msg``, ``.epub``, ``.html``, ``.pdf``,
+``partition`` currently supports ``.docx``, ``.doc``, ``.pptx``, ``.ppt``, ``.eml``, ``.msg``, ``.rtf``, ``.epub``, ``.html``, ``.pdf``,
 ``.png``, ``.jpg``, and ``.txt`` files.
 If you set the ``include_page_breaks`` kwarg to ``True``, the output will include page breaks. This is only supported for ``.pptx``, ``.html``, ``.pdf``,
 ``.png``, and ``.jpg``.
@@ -355,6 +355,24 @@ Examples:
   from unstructured.partition.epub import partition_epub
 
   elements = partition_epub(filename="example-docs/winter-sports.epub")
+
+
+``partition_rtf``
+---------------------
+
+The ``partition_rtf`` function processes rich text files. The function
+first converts the document to HTML using ``pandocs`` and then calls ``partition_html``.
+You'll need `pandocs <https://pandoc.org/installing.html>`_ installed on your system
+to use ``partition_rtf``.
+
+
+Examples:
+
+.. code:: python
+
+  from unstructured.partition.rtf import partition_rtf
+
+  elements = partition_rtf(filename="example-docs/fake-doc.rtf")
 
 
 ``partition_md``

--- a/example-docs/fake-doc.rtf
+++ b/example-docs/fake-doc.rtf
@@ -1,0 +1,2 @@
+{\pard \ql \f0 \sa180 \li0 \fi0 \outlinelevel0 \b \fs36 My First Heading\par}
+{\pard \ql \f0 \sa180 \li0 \fi0 My first paragraph.\par}

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -52,6 +52,7 @@ def test_detect_filetype_from_filename(file, expected):
         ("unsupported/fake-excel.xlsx", FileType.XLSX),
         ("fake-power-point.pptx", FileType.PPTX),
         ("winter-sports.epub", FileType.EPUB),
+        ("fake-doc.rtf", FileType.RTF),
     ],
 )
 def test_detect_filetype_from_filename_with_extension(monkeypatch, file, expected):
@@ -105,6 +106,13 @@ def test_detect_xml_application_xml(monkeypatch):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.xml")
     filetype = detect_filetype(filename=filename)
     assert filetype == FileType.XML
+
+
+def test_detect_xml_application_rtf(monkeypatch):
+    monkeypatch.setattr(magic, "from_file", lambda *args, **kwargs: "application/rtf")
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.rtf")
+    filetype = detect_filetype(filename=filename)
+    assert filetype == FileType.RTF
 
 
 def test_detect_xml_text_xml(monkeypatch):

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -4,6 +4,7 @@ import warnings
 from unittest.mock import patch
 
 import docx
+import pypandoc
 import pytest
 
 from unstructured.documents.elements import (
@@ -29,6 +30,7 @@ EXPECTED_EMAIL_OUTPUT = [
 ]
 
 is_in_docker = os.path.exists("/.dockerenv")
+rtf_not_supported = "rtf" not in pypandoc.get_pandoc_formats()[0]
 
 
 def test_auto_partition_email_from_filename():
@@ -360,6 +362,7 @@ def test_auto_partition_msg_from_filename():
 
 
 @pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")
+@pytest.mark.skipif(rtf_not_supported, reason="RTF not supported in this version of pypandoc.")
 def test_auto_partition_rtf_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-doc.rtf")
     elements = partition(filename=filename)

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -357,3 +357,9 @@ def test_auto_partition_msg_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.msg")
     elements = partition(filename=filename)
     assert elements == EXPECTED_MSG_OUTPUT
+
+
+def test_auto_partition_rtf_from_filename():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-doc.rtf")
+    elements = partition(filename=filename)
+    assert elements[0] == Title("My First Heading")

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -359,6 +359,7 @@ def test_auto_partition_msg_from_filename():
     assert elements == EXPECTED_MSG_OUTPUT
 
 
+@pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")
 def test_auto_partition_rtf_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-doc.rtf")
     elements = partition(filename=filename)

--- a/test_unstructured/partition/test_rtf.py
+++ b/test_unstructured/partition/test_rtf.py
@@ -1,0 +1,28 @@
+import os
+import pathlib
+
+import pytest
+
+from unstructured.documents.elements import Title
+from unstructured.partition.rtf import partition_rtf
+
+DIRECTORY = pathlib.Path(__file__).parent.resolve()
+
+is_in_docker = os.path.exists("/.dockerenv")
+
+
+@pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")
+def test_partition_rtf_from_filename():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-doc.rtf")
+    elements = partition_rtf(filename=filename)
+    assert len(elements) > 0
+    assert elements[0] == Title("My First Heading")
+
+
+@pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")
+def test_partition_rtf_from_file():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-doc.rtf")
+    with open(filename, "rb") as f:
+        elements = partition_rtf(file=f)
+    assert len(elements) > 0
+    assert elements[0] == Title("My First Heading")

--- a/test_unstructured/partition/test_rtf.py
+++ b/test_unstructured/partition/test_rtf.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 
+import pypandoc
 import pytest
 
 from unstructured.documents.elements import Title
@@ -8,10 +9,12 @@ from unstructured.partition.rtf import partition_rtf
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 
+rtf_not_supported = "rtf" not in pypandoc.get_pandoc_formats()[0]
 is_in_docker = os.path.exists("/.dockerenv")
 
 
 @pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")
+@pytest.mark.skipif(rtf_not_supported, reason="RTF not supported in this version of pypandoc.")
 def test_partition_rtf_from_filename():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-doc.rtf")
     elements = partition_rtf(filename=filename)
@@ -20,6 +23,7 @@ def test_partition_rtf_from_filename():
 
 
 @pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")
+@pytest.mark.skipif(rtf_not_supported, reason="RTF not supported in this version of pypandoc.")
 def test_partition_rtf_from_file():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-doc.rtf")
     with open(filename, "rb") as f:

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.12-dev3"  # pragma: no cover
+__version__ = "0.5.12-dev4"  # pragma: no cover

--- a/unstructured/file_utils/file_conversion.py
+++ b/unstructured/file_utils/file_conversion.py
@@ -22,11 +22,12 @@ def convert_file_to_text(filename: str, source_format: str, target_format: str) 
     return text
 
 
-def convert_epub_to_html(
+def convert_file_to_html_text(
+    source_format: str,
     filename: Optional[str] = None,
     file: Optional[IO] = None,
 ) -> str:
-    """Converts an EPUB document to HTML raw text. Enables an EPUB doucment to be
+    """Converts a document to HTML raw text. Enables a the doucment to be
     processed using the partition_html function."""
     exactly_one(filename=filename, file=file)
 
@@ -36,13 +37,13 @@ def convert_epub_to_html(
         tmp.close()
         html_text = convert_file_to_text(
             filename=tmp.name,
-            source_format="epub",
+            source_format=source_format,
             target_format="html",
         )
     elif filename is not None:
         html_text = convert_file_to_text(
             filename=filename,
-            source_format="epub",
+            source_format=source_format,
             target_format="html",
         )
 

--- a/unstructured/file_utils/file_conversion.py
+++ b/unstructured/file_utils/file_conversion.py
@@ -27,7 +27,7 @@ def convert_file_to_html_text(
     filename: Optional[str] = None,
     file: Optional[IO] = None,
 ) -> str:
-    """Converts a document to HTML raw text. Enables a the doucment to be
+    """Converts a document to HTML raw text. Enables the doucment to be
     processed using the partition_html function."""
     exactly_one(filename=filename, file=file)
 

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -229,11 +229,19 @@ def detect_filetype(
     elif mime_type in EPUB_MIME_TYPES:
         return FileType.EPUB
 
+    # NOTE(robinson) - examples are application/rtf or text/rtf.
+    # magic often returns text/plain for RTF files
+    elif mime_type.endswith("rtf"):
+        return FileType.RTF
+
     elif mime_type in TXT_MIME_TYPES:
         if extension and extension == ".eml":
             return FileType.EML
-        if extension and extension == ".md":
+        elif extension and extension == ".md":
             return FileType.MD
+        elif extension and extension == ".rtf":
+            return FileType.RTF
+
         if file and not extension and _check_eml_from_buffer(file=file) is True:
             return FileType.EML
         return FileType.TXT

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -13,6 +13,7 @@ from unstructured.partition.msg import partition_msg
 from unstructured.partition.pdf import partition_pdf
 from unstructured.partition.ppt import partition_ppt
 from unstructured.partition.pptx import partition_pptx
+from unstructured.partition.rtf import partition_rtf
 from unstructured.partition.text import partition_text
 
 
@@ -102,6 +103,8 @@ def partition(
             encoding=encoding,
             paragraph_grouper=paragraph_grouper,
         )
+    elif filetype == FileType.RTF:
+        return partition_rtf(filename=filename, file=file, include_page_breaks=include_page_breaks)
     elif filetype == FileType.PPT:
         return partition_ppt(filename=filename, file=file, include_page_breaks=include_page_breaks)
     elif filetype == FileType.PPTX:

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -5,6 +5,7 @@ import requests
 from unstructured.documents.elements import Element
 from unstructured.documents.html import HTMLDocument
 from unstructured.documents.xml import VALID_PARSERS
+from unstructured.file_utils.file_conversion import convert_file_to_html_text
 from unstructured.partition.common import (
     add_element_metadata,
     document_to_element_list,
@@ -91,3 +92,34 @@ def partition_html(
         )
     else:
         return layout_elements
+
+
+def convert_and_partition_html(
+    source_format: str,
+    filename: Optional[str] = None,
+    file: Optional[IO] = None,
+    include_page_breaks: bool = False,
+) -> List[Element]:
+    """Converts a document to HTML and then partitions it using partition_html. Works with
+    any file format support by pandoc.
+
+    Parameters
+    ----------
+    source_format
+        The format of the source document, i.e. rst
+    filename
+        A string defining the target filename path.
+    file
+        A file-like object using "rb" mode --> open(filename, "rb").
+
+    include_page_breaks
+        If True, the output will include page breaks if the filetype supports it
+    """
+    html_text = convert_file_to_html_text(source_format=source_format, filename=filename, file=file)
+    # NOTE(robinson) - pypandoc returns a text string with unicode encoding
+    # ref: https://github.com/JessicaTegner/pypandoc#usage
+    return partition_html(
+        text=html_text,
+        include_page_breaks=include_page_breaks,
+        encoding="unicode",
+    )

--- a/unstructured/partition/rtf.py
+++ b/unstructured/partition/rtf.py
@@ -4,12 +4,12 @@ from unstructured.documents.elements import Element
 from unstructured.partition.html import convert_and_partition_html
 
 
-def partition_epub(
+def partition_rtf(
     filename: Optional[str] = None,
     file: Optional[IO] = None,
     include_page_breaks: bool = False,
 ) -> List[Element]:
-    """Partitions an EPUB document. The document is first converted to HTML and then
+    """Partitions an RTF document. The document is first converted to HTML and then
     partitoned using partiton_html.
 
     Parameters
@@ -22,7 +22,7 @@ def partition_epub(
         If True, the output will include page breaks if the filetype supports it
     """
     return convert_and_partition_html(
-        source_format="epub",
+        source_format="rtf",
         filename=filename,
         file=file,
         include_page_breaks=include_page_breaks,

--- a/unstructured/partition/rtf.py
+++ b/unstructured/partition/rtf.py
@@ -10,7 +10,7 @@ def partition_rtf(
     include_page_breaks: bool = False,
 ) -> List[Element]:
     """Partitions an RTF document. The document is first converted to HTML and then
-    partitoned using partiton_html.
+    partitioned using partiton_html.
 
     Parameters
     ----------


### PR DESCRIPTION
### Summary

Closes #410. Adds `partition_rtf` for processing rich text files. Also refactors `partition_epub` to use a common function for converting docs to HTML with `pandoc` and partitioning with `partition_html`.

Updates a few outdated docs.

### Testing

First make sure the new RTF code works.

```python
  from unstructured.partition.rtf import partition_rtf

  elements = partition_rtf(filename="example-docs/fake-doc.rtf")
```

Next, make sure EPUBs still work

```python
  from unstructured.partition.epub import partition_epub

  elements = partition_epub(filename="example-docs/winter-sports.epub")
```