### PR TITLE
feat: add `url` kwarg to `partititon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.12-dev5
+## 0.5.12
 
 ### Enhancements
 
@@ -10,6 +10,7 @@
 
 * Add --partition-by-api parameter to unstructured-ingest
 * Added `partition_rtf` for processing rich text files.
+* `partition` now accepts a `url` kwarg in addition to `file` and `filename`.
 
 ### Fixes
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -116,6 +116,21 @@ faster processing and `"hi_res"` for
   elements = partition(filename="example-docs/layout-parser-paper-fast.pdf")
 
 
+The ``partition`` function also accepts a ``url`` kwarg for remotely hosted documents. If you want
+to force ``partition`` to treat the document as a particular MIME type, use the ``content_type``
+kwarg in conjunction with ``url``. Otherwise, ``partition`` will use the information from
+the ``Content-Type`` header in the HTTP response.
+
+
+.. code:: python
+
+  from unstructured.partition.auto import partition
+
+  url = "https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/LICENSE.md"
+  elements = partition(url=url)
+  elements = partition(url=url, content_type="text/markdown")
+
+
 ``partition_docx``
 ------------------
 

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -373,3 +373,4 @@ def test_auto_partition_from_url():
     url = "https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/LICENSE.md"
     elements = partition(url=url, content_type="text/plain")
     assert elements[0] == Title("Apache License")
+    assert elements[0].metadata.url == url

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -367,3 +367,9 @@ def test_auto_partition_rtf_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-doc.rtf")
     elements = partition(filename=filename)
     assert elements[0] == Title("My First Heading")
+
+
+def test_auto_partition_from_url():
+    url = "https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/LICENSE.md"
+    elements = partition(url=url, content_type="text/plain")
+    assert elements[0] == Title("Apache License")

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.12-dev5"  # pragma: no cover
+__version__ = "0.5.12"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -75,26 +75,34 @@ def partition(
         file.seek(0)
 
     if filetype == FileType.DOC:
-        return partition_doc(filename=filename, file=file)
-    if filetype == FileType.DOCX:
-        return partition_docx(filename=filename, file=file)
+        elements = partition_doc(filename=filename, file=file)
+    elif filetype == FileType.DOCX:
+        elements = partition_docx(filename=filename, file=file)
     elif filetype == FileType.EML:
-        return partition_email(filename=filename, file=file, encoding=encoding)
+        elements = partition_email(filename=filename, file=file, encoding=encoding)
     elif filetype == FileType.MSG:
-        return partition_msg(filename=filename, file=file)
+        elements = partition_msg(filename=filename, file=file)
     elif filetype == FileType.HTML:
-        return partition_html(
+        elements = partition_html(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
             encoding=encoding,
         )
     elif filetype == FileType.EPUB:
-        return partition_epub(filename=filename, file=file, include_page_breaks=include_page_breaks)
+        elements = partition_epub(
+            filename=filename,
+            file=file,
+            include_page_breaks=include_page_breaks,
+        )
     elif filetype == FileType.MD:
-        return partition_md(filename=filename, file=file, include_page_breaks=include_page_breaks)
+        elements = partition_md(
+            filename=filename,
+            file=file,
+            include_page_breaks=include_page_breaks,
+        )
     elif filetype == FileType.PDF:
-        return partition_pdf(
+        elements = partition_pdf(
             filename=filename,  # type: ignore
             file=file,  # type: ignore
             url=None,
@@ -103,30 +111,47 @@ def partition(
             strategy=strategy,
         )
     elif (filetype == FileType.PNG) or (filetype == FileType.JPG):
-        return partition_image(
+        elements = partition_image(
             filename=filename,  # type: ignore
             file=file,  # type: ignore
             url=None,
             include_page_breaks=include_page_breaks,
         )
     elif filetype == FileType.TXT:
-        return partition_text(
+        elements = partition_text(
             filename=filename,
             file=file,
             encoding=encoding,
             paragraph_grouper=paragraph_grouper,
         )
     elif filetype == FileType.RTF:
-        return partition_rtf(filename=filename, file=file, include_page_breaks=include_page_breaks)
+        elements = partition_rtf(
+            filename=filename,
+            file=file,
+            include_page_breaks=include_page_breaks,
+        )
     elif filetype == FileType.PPT:
-        return partition_ppt(filename=filename, file=file, include_page_breaks=include_page_breaks)
+        elements = partition_ppt(
+            filename=filename,
+            file=file,
+            include_page_breaks=include_page_breaks,
+        )
     elif filetype == FileType.PPTX:
-        return partition_pptx(filename=filename, file=file, include_page_breaks=include_page_breaks)
+        elements = partition_pptx(
+            filename=filename,
+            file=file,
+            include_page_breaks=include_page_breaks,
+        )
     elif filetype == FileType.JSON:
-        return partition_json(filename=filename, file=file)
+        elements = partition_json(filename=filename, file=file)
     else:
         msg = "Invalid file" if not filename else f"Invalid file {filename}"
         raise ValueError(f"{msg}. The {filetype} file type is not supported in partition.")
+
+    for element in elements:
+        element.metadata.url = url
+
+    return elements
 
 
 def file_and_type_from_url(


### PR DESCRIPTION
### Summary

Closes #464 and addresses user requests in [langchain#979](https://github.com/hwchase17/langchain/pull/979) Adds a `url` kwarg to `partition` to allow users to process remote documents directly. If the user passes in `content_type`, `partition` will process the document using `content_type` as the MIME type. Otherwise, it will use the `Content-Type` header to determine the MIME type.

### Testing

```python
  from unstructured.partition.auto import partition

  # A markdown file
  url = "https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/LICENSE.md"
  elements = partition(url=url, content_type="text/markdown")

  # An HTML file
  url = "https://www.understandingwar.org/backgrounder/russian-offensive-campaign-assessment-april-11-2023"
  elements = partition(url=url)

  # A PDF file
  url = "https://www.understandingwar.org/sites/default/files/Russian%20Offensive%20Campaign%20Assessment%2C%20April%2011%2C%202023.pdf"
  elements = partition(url=url, strategy="fast")
```