### PR TITLE
fix: fix github issue formatting

### DIFF
--- a/.github/workflows/create_issue.yml
+++ b/.github/workflows/create_issue.yml
@@ -24,7 +24,10 @@ jobs:
         project: CORE
         issuetype: Task
         summary: ${{ github.event.issue.title }}
-        description: "Created from Github issue: ${{ github.event.issue.html_url }} \\ \\${{ github.event.issue.body }}"
+        description: |
+          Created from github issue: ${{ github.event.issue.html_url }}
+          ----
+          ${{ github.event.issue.body }}
         fields: '{ "labels": ["github-issue"] }'
 
     - name: Log created issue


### PR DESCRIPTION
Attempting to fix formatting of github issues transferred to Jira.

The old format was attempting to use double-slashes (`\\`) to specify line breaks. This worked in the [test repo](https://github.com/Unstructured-IO/jira-integration-test) but didn't look right when merged to this repo (see description in [CORE-910](https://unstructured-ai.atlassian.net/browse/CORE-910) for an example of how it looks).

Now attempting to use formatted text in the `yaml` with `|`. This worked in the test repo, but I guess that's no guarantee. See attached image for results from personal Jira project from [this issue](https://github.com/Unstructured-IO/jira-integration-test/issues/14).

<img width="735" alt="image" src="https://user-images.githubusercontent.com/64741807/231525382-c4796410-d5c8-41e6-9864-857e05faa8cf.png">

#### Testing:
It's been tested using the test repo linked to a personal Jira project. We won't be able to see the results in this repo until merging, so the best we can do is look over the code and see if it makes sense.

[CORE-910]: https://unstructured-ai.atlassian.net/browse/CORE-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


