### PR TITLE
fix: encode xml string if document_tree is `None` in `_read_xml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.5.13-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+* unstructured-documents encode xml string if document_tree is `None` in `_read_xml`.
+
 ## 0.5.12
 
 ### Enhancements

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -646,4 +646,4 @@ def test_sample_doc_with_scripts():
 def test_sample_doc_with_emoji():
     raw_html = "<p>Hello again 😀</p>"
     doc = HTMLDocument.from_string(raw_html)
-    assert doc.elements[0].text.encode("latin-1").decode("utf-8") == "Hello again 😀"
+    assert doc.elements[0].text == "Hello again ð\x9f\x98\x80"

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -641,3 +641,9 @@ def test_sample_doc_with_scripts():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-with-scripts.html")
     doc = HTMLDocument.from_file(filename=filename)
     assert all(["function (" not in element.text for element in doc.elements])
+
+
+def test_sample_doc_with_emoji():
+    raw_html = "<p>Hello again 😀</p>"
+    doc = HTMLDocument.from_string(raw_html)
+    assert doc.elements[0].text.encode("latin-1").decode("utf-8") == "Hello again 😀"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.12"  # pragma: no cover
+__version__ = "0.5.13-dev0"  # pragma: no cover

--- a/unstructured/documents/xml.py
+++ b/unstructured/documents/xml.py
@@ -57,6 +57,8 @@ class XMLDocument(Document):
         if self.document_tree is None:
             try:
                 document_tree = etree.fromstring(content, self.parser)
+                if document_tree is None:
+                    raise ValueError("document_tree is None")
             # NOTE(robinson) - The following ValueError occurs with unicode strings. In that
             # case, we call back to encoding the string and passing in bytes.
             #     ValueError: Unicode strings with encoding declaration are not supported.


### PR DESCRIPTION
I had trouble reading a markdown document in langchain which contained an emoji. Currently in that case `etree.fromstring(content, self.parser)` returns None. So it doesn't raise the ValueError and doesn't try to encode to string. I'm raising the ValueError in that case to ensure we enter the except block and encode the string.