### PR TITLE
fix: fix text_type.py exceeds_cap_ratio() returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * unstructured-documents encode xml string if document_tree is `None` in `_read_xml`.
 * Update to `_read_xml` so that Markdown files with embedded HTML process correctly.
 * Fallback to "fast" strategy only emits a warning if the user specifies the "hi_res" strategy.
+* unstructured-partition-text_type exceeds_cap_ratio fix returns and how capitalization ratios are calculated
 
 ## 0.5.12
 

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -212,6 +212,7 @@ def test_contains_english_word(text, expected, monkeypatch):
         ("Intellectual Property in the United States", True),
         ("Intellectual property helps incentivize innovation.", False),
         ("THIS IS ALL CAPS. BUT IT IS TWO SENTENCES.", False),
+        ("LOOK AT THIS IT IS CAPS BUT NOT A TITLE.", False),
         ("This Has All Caps. It's Weird But Two Sentences", False),
         ("The Business Report is expected within 6 hours of closing", False),
         ("", True),

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -212,10 +212,9 @@ def test_contains_english_word(text, expected, monkeypatch):
         ("Intellectual Property in the United States", True),
         ("Intellectual property helps incentivize innovation.", False),
         ("THIS IS ALL CAPS. BUT IT IS TWO SENTENCES.", False),
-        ("LOOK AT THIS IT IS CAPS BUT NOT A TITLE.", False),
         ("This Has All Caps. It's Weird But Two Sentences", False),
         ("The Business Report is expected within 6 hours of closing", False),
-        ("", False),
+        ("", True),
     ],
 )
 def test_contains_exceeds_cap_ratio(text, expected, monkeypatch):

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -265,15 +265,17 @@ def exceeds_cap_ratio(text: str, threshold: float = 0.5) -> bool:
     # NOTE(robinson) - Currently limiting this to only sections of text with one sentence.
     # The assumption is that sections with multiple sentences are not titles.
     if sentence_count(text, 3) > 1:
-        logger.debug(f"Text does not contain multiple sentences:\n\n{text}")
+        # logger.debug(f"Text contains multiple sentences:\n\n{text}")
         return False
 
     if text.isupper():
-        return False
+        # IF text.isupper() is True, it should be Title, not narrative text.
+        return True
 
     tokens = word_tokenize(text)
     if len(tokens) == 0:
-        return False
+        # If word_tokenize(text) is empty, return must be True to avoid being misclassified as Narrative Text.
+        return True
     capitalized = sum([word.istitle() or word.isupper() for word in tokens])
     ratio = capitalized / len(tokens)
     return ratio > threshold

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -266,22 +266,23 @@ def exceeds_cap_ratio(text: str, threshold: float = 0.5) -> bool:
     # The assumption is that sections with multiple sentences are not titles.
     if sentence_count(text, 3) > 1:
         return False
-    
+
     if text.isupper():
         return True
-    
-    # NOTE(jay-ylee) - The word_tokenize function also recognizes and separates special characters 
+
+    # NOTE(jay-ylee) - The word_tokenize function also recognizes and separates special characters
     # into one word, causing problems with ratio measurement.
     # Therefore, only words consisting of alphabets are used to measure the ratio.
     # ex. world_tokenize("ITEM 1. Financial Statements (Unaudited)")
     #     = ['ITEM', '1', '.', 'Financial', 'Statements', '(', 'Unaudited', ')'],
     # however, "ITEM 1. Financial Statements (Unaudited)" is Title, not NarrativeText
     tokens = [tk for tk in word_tokenize(text) if tk.isalpha()]
-    
-    # NOTE(jay-ylee) - If word_tokenize(text) is empty, return must be True to avoid being misclassified as Narrative Text.
+
+    # NOTE(jay-ylee) - If word_tokenize(text) is empty, return must be True to
+    # avoid being misclassified as Narrative Text.
     if len(tokens) == 0:
         return True
-    
+
     capitalized = sum([word.istitle() or word.isupper() for word in tokens])
     ratio = capitalized / len(tokens)
     return ratio > threshold

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -268,7 +268,7 @@ def exceeds_cap_ratio(text: str, threshold: float = 0.5) -> bool:
         return False
 
     if text.isupper():
-        return True
+        return False
 
     # NOTE(jay-ylee) - The word_tokenize function also recognizes and separates special characters
     # into one word, causing problems with ratio measurement.

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -267,15 +267,22 @@ def exceeds_cap_ratio(text: str, threshold: float = 0.5) -> bool:
     if sentence_count(text, 3) > 1:
         # logger.debug(f"Text contains multiple sentences:\n\n{text}")
         return False
-
+    
     if text.isupper():
-        # IF text.isupper() is True, it should be Title, not narrative text.
         return True
-
-    tokens = word_tokenize(text)
+    
+    # NOTE(jay-ylee) - The word_tokenize function also recognizes and separates special characters 
+    # into one word, causing problems with ratio measurement.
+    # Therefore, only words consisting of alphabets are used to measure the ratio.
+    # ex. world_tokenize("ITEM 1. Financial Statements (Unaudited)")
+    #     = ['ITEM', '1', '.', 'Financial', 'Statements', '(', 'Unaudited', ')'],
+    # however, "ITEM 1. Financial Statements (Unaudited)" is Title, not NarrativeText
+    tokens = [tk for tk in word_tokenize(text) if tk.isalpha()]
+    
+    # NOTE(jay-ylee) - If word_tokenize(text) is empty, return must be True to avoid being misclassified as Narrative Text.
     if len(tokens) == 0:
-        # If word_tokenize(text) is empty, return must be True to avoid being misclassified as Narrative Text.
         return True
+    
     capitalized = sum([word.istitle() or word.isupper() for word in tokens])
     ratio = capitalized / len(tokens)
     return ratio > threshold

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -265,7 +265,6 @@ def exceeds_cap_ratio(text: str, threshold: float = 0.5) -> bool:
     # NOTE(robinson) - Currently limiting this to only sections of text with one sentence.
     # The assumption is that sections with multiple sentences are not titles.
     if sentence_count(text, 3) > 1:
-        # logger.debug(f"Text contains multiple sentences:\n\n{text}")
         return False
     
     if text.isupper():


### PR DESCRIPTION
There are cases when function is_possible_narrative_text receives an incorrect return from function exceeds_cap_ratio and does an incorrect classification, so some of the return values of exceeds_cap_ratio are corrected