### PR TITLE
fix: updates markdown code to process markdown with embedded html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
-## 0.5.13-dev0
+## 0.5.13-dev4
 
 ### Enhancements
 
 ### Features
 
 ### Fixes
+
 * unstructured-documents encode xml string if document_tree is `None` in `_read_xml`.
+* Update to `_read_xml` so that Markdown files with embedded HTML process correctly.
 
 ## 0.5.12
 

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -374,3 +374,15 @@ def test_auto_partition_from_url():
     elements = partition(url=url, content_type="text/plain")
     assert elements[0] == Title("Apache License")
     assert elements[0].metadata.url == url
+
+
+def test_partition_md_works_with_embedded_html():
+    url = "https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/README.md"
+    elements = partition(url=url, content_type="text/markdown")
+    elements[0].text
+    unstructured_found = False
+    for element in elements:
+        if "unstructured" in elements[0].text:
+            unstructured_found = True
+            break
+    assert unstructured_found is True

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -387,6 +387,7 @@ def test_partition_md_works_with_embedded_html():
             break
     assert unstructured_found is True
 
+
 def test_auto_partition_warns_if_header_set_and_not_url(caplog):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.eml")
     partition(filename=filename, headers={"Accept": "application/pdf"})

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.13-dev0"  # pragma: no cover
+__version__ = "0.5.13-dev4"  # pragma: no cover

--- a/unstructured/documents/xml.py
+++ b/unstructured/documents/xml.py
@@ -54,6 +54,12 @@ class XMLDocument(Document):
 
     def _read_xml(self, content):
         """Reads in an XML file and converts it to an lxml element tree object."""
+        # NOTE(robinson) - without the carriage return at the beginning, you get
+        # output that looks like the following when you run partition_pdf
+        #   'h   3       a   l   i   g   n   =   "   c   e   n   t   e   r   "   >'
+        # The correct output is returned once you add the initial return.
+        if content and not content.startswith("\n"):
+            content = "\n" + content
         if self.document_tree is None:
             try:
                 document_tree = etree.fromstring(content, self.parser)

--- a/unstructured/documents/xml.py
+++ b/unstructured/documents/xml.py
@@ -58,7 +58,8 @@ class XMLDocument(Document):
         # output that looks like the following when you run partition_pdf
         #   'h   3       a   l   i   g   n   =   "   c   e   n   t   e   r   "   >'
         # The correct output is returned once you add the initial return.
-        if content and not content.startswith("\n"):
+        is_html_parser = isinstance(self.parser, etree.HTMLParser)
+        if content and not content.startswith("\n") and is_html_parser:
             content = "\n" + content
         if self.document_tree is None:
             try:


### PR DESCRIPTION
### Summary

Closes #475. Updates the HTML code to support processing markdown files with embedded HTML. Adding a carriage return to the beginning of the HTML document appears to fix the issue.

### Testing

The following should show the content of the markdown file instead of `'h   3       a   l   i   g   n   =   "   c   e   n   t   e   r   "   >'`.

```python
from unstructured.partition.auto import partition

url = "https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/README.md"
elements = partition(url=url, content_type="text/markdown")
elements[0].text
```