### PR TITLE
feat: cleaning brick for normalizing bytes string output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 0.5.13-dev4
+## 0.5.13-dev5
 
 ### Enhancements
 
 * Allow headers to be passed into `partition` when `url` is used.
 
 ### Features
+
+* `bytes_string_to_string` cleaning brick for bytes string output.
 
 ### Fixes
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -801,6 +801,37 @@ Examples:
   # Returns "Look at me, I'm flying!"
   extract_text_after(text, r"SPEAKER \d{1}:")
 
+
+``bytes_string_to_string``
+---------------------------
+
+Converts an output string that looks like a byte string to a string using the specified encoding. This
+happens sometimes in ``partition_html`` when there is a character like an emoji that isn't expected
+by the HTML parser. In that case, the encoded bytes get processed.
+
+Examples:
+
+.. code:: python
+
+  from unstructured.cleaners.core import bytes_string_to_string
+
+  text = "Hello ð\x9f\x98\x80"
+  # The output should be "Hello 😀"
+  bytes_string_to_string(text, encoding="utf-8")
+
+
+.. code:: python
+
+  from unstructured.cleaners.core import bytes_string_to_string
+  from unstructured.partition.html import partition_html
+
+  text = """\n<html charset="utf-8"><p>Hello 😀</p></html>"""
+  elements = partition_html(text=text)
+  elements[0].apply(bytes_string_to_string)
+  # The output should be "Hello 😀"
+  elements[0].text
+
+
 ``extract_email_address``
 --------------------------
 

--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -240,3 +240,8 @@ def test_clean(text, extra_whitespace, dashes, bullets, lowercase, trailing_punc
         )
         == expected
     )
+
+
+def test_bytes_string_to_string():
+    text = "\xe6\xaf\x8f\xe6\x97\xa5\xe6\x96\xb0\xe9\x97\xbb"
+    assert core.bytes_string_to_string(text, "utf-8") == "每日新闻"

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -6,7 +6,6 @@ import pytest
 import requests
 from requests.models import Response
 
-from unstructured.cleaners.core import bytes_string_to_string
 from unstructured.documents.elements import PageBreak, Title
 from unstructured.partition.html import partition_html
 
@@ -156,13 +155,6 @@ def test_partition_html_processes_chinese_chracters():
     html_text = "<html><div><p>每日新闻</p></div></html>"
     elements = partition_html(text=html_text)
     assert elements[0].text == "每日新闻"
-
-
-def test_recovery_emoji_from_html_bytes_output():
-    html_text = """\n<html charset="utf-8"><p>Hello 😀</p></html>"""
-    elements = partition_html(text=html_text)
-    elements[0].apply(bytes_string_to_string)
-    assert elements[0] == Title("Hello 😀")
 
 
 def test_emoji_appears_with_emoji_utf8_code():

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -6,7 +6,8 @@ import pytest
 import requests
 from requests.models import Response
 
-from unstructured.documents.elements import PageBreak
+from unstructured.cleaners.core import bytes_string_to_string
+from unstructured.documents.elements import PageBreak, Title
 from unstructured.partition.html import partition_html
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
@@ -155,3 +156,16 @@ def test_partition_html_processes_chinese_chracters():
     html_text = "<html><div><p>每日新闻</p></div></html>"
     elements = partition_html(text=html_text)
     assert elements[0].text == "每日新闻"
+
+
+def test_recovery_emoji_from_html_bytes_output():
+    html_text = """\n<html charset="utf-8"><p>Hello 😀</p></html>"""
+    elements = partition_html(text=html_text)
+    elements[0].apply(bytes_string_to_string)
+    assert elements[0] == Title("Hello 😀")
+
+
+def test_emoji_appears_with_emoji_utf8_code():
+    html_text = """\n<html charset="utf-8"><p>Hello &#128512;</p></html>"""
+    elements = partition_html(text=html_text)
+    assert elements[0] == Title("Hello 😀")

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.13-dev4"  # pragma: no cover
+__version__ = "0.5.13-dev5"  # pragma: no cover

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -238,3 +238,10 @@ def clean(
     cleaned_text = clean_extra_whitespace(cleaned_text) if extra_whitespace else cleaned_text
     cleaned_text = clean_bullets(cleaned_text) if bullets else cleaned_text
     return cleaned_text.strip()
+
+
+def bytes_string_to_string(text: str, encoding: str = "utf-8"):
+    """Converts a string representation of a byte string to a regular string using the
+    specified encoding."""
+    text_bytes = bytes([ord(char) for char in text])
+    return text_bytes.decode(encoding)


### PR DESCRIPTION
### Summary

Closes #474, expanding on the fix from #477. Adds a cleaning brick for converting bytes string output to properly encoded strings. This type of output occurs when there's a character like an emoji in HTML or Markdown that the HTML parser does not understand. Note that this is not required if the HTML document uses [UTF-8 codes](https://www.w3schools.com/html/html_emojis.asp) for emojis.

### Testing

The following two snippets should result in outputs that contain the emoji.

```python
  from unstructured.cleaners.core import bytes_string_to_string
  from unstructured.partition.html import partition_html

  text = """\n<html charset="utf-8"><p>Hello 😀</p></html>"""
  elements = partition_html(text=text)
  elements[0].apply(bytes_string_to_string)
  # The output should be "Hello 😀"
  elements[0].text
```

```python
  from unstructured.partition.html import partition_html

  text = """\n<html charset="utf-8"><p>Hello &#128512;</p></html>"""
  elements = partition_html(text=text)
  # The output should be "Hello 😀"
  elements[0].text
```