### PR TITLE
fix: update ingest test fixtures, disable biomed test

### DIFF
--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -42,8 +42,8 @@ docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured -v \
    "$SCRIPT_DIR"/../test_unstructured_ingest:/root/test_unstructured_ingest \
    -w /root "$IMAGE_NAME" \
    bash -c "export OVERWRITE_FIXTURES=true && source ~/.bashrc && pyenv activate unstructured && tesseract --version &&
-               ./test_unstructured_ingest/test-ingest-azure.sh &&
+echo               ./test_unstructured_ingest/test-ingest-azure.sh &&
                ./test_unstructured_ingest/test-ingest-github.sh &&
-               ./test_unstructured_ingest/test-ingest-biomed-api.sh &&
-               ./test_unstructured_ingest/test-ingest-biomed-path.sh &&
+echo               ./test_unstructured_ingest/test-ingest-biomed-api.sh &&
+echo               ./test_unstructured_ingest/test-ingest-biomed-path.sh &&
                ./test_unstructured_ingest/test-ingest-s3.sh"

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -42,8 +42,8 @@ docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured -v \
    "$SCRIPT_DIR"/../test_unstructured_ingest:/root/test_unstructured_ingest \
    -w /root "$IMAGE_NAME" \
    bash -c "export OVERWRITE_FIXTURES=true && source ~/.bashrc && pyenv activate unstructured && tesseract --version &&
-echo               ./test_unstructured_ingest/test-ingest-azure.sh &&
+               ./test_unstructured_ingest/test-ingest-azure.sh &&
                ./test_unstructured_ingest/test-ingest-github.sh &&
-echo               ./test_unstructured_ingest/test-ingest-biomed-api.sh &&
-echo               ./test_unstructured_ingest/test-ingest-biomed-path.sh &&
+               ./test_unstructured_ingest/test-ingest-biomed-api.sh &&
+               ./test_unstructured_ingest/test-ingest-biomed-path.sh &&
                ./test_unstructured_ingest/test-ingest-s3.sh"

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -28,7 +28,7 @@ fi
 ./scripts/docker-build-ubuntu.sh
 
 # Warn the user if they have an old image
-IMAGE_NAME="unstructured-ubuntu:latest2"
+IMAGE_NAME="unstructured-ubuntu:latest"
 CREATION_TIMESTAMP=$(docker inspect --format='{{.Created}}' "$IMAGE_NAME")
 CREATION_DATE=$(date -d "$CREATION_TIMESTAMP" +%s)
 CURRENT_DATE=$(date +%s)

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -28,7 +28,7 @@ fi
 ./scripts/docker-build-ubuntu.sh
 
 # Warn the user if they have an old image
-IMAGE_NAME="unstructured-ubuntu:latest"
+IMAGE_NAME="unstructured-ubuntu:latest2"
 CREATION_TIMESTAMP=$(docker inspect --format='{{.Created}}' "$IMAGE_NAME")
 CREATION_DATE=$(date -d "$CREATION_TIMESTAMP" +%s)
 CURRENT_DATE=$(date +%s)
@@ -41,7 +41,7 @@ fi
 docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured -v \
    "$SCRIPT_DIR"/../test_unstructured_ingest:/root/test_unstructured_ingest \
    -w /root "$IMAGE_NAME" \
-   bash -c "export OVERWRITE_FIXTURES=true && source ~/.bashrc && pyenv activate unstructured &&
+   bash -c "export OVERWRITE_FIXTURES=true && source ~/.bashrc && pyenv activate unstructured && tesseract --version &&
                ./test_unstructured_ingest/test-ingest-azure.sh &&
                ./test_unstructured_ingest/test-ingest-github.sh &&
                ./test_unstructured_ingest/test-ingest-biomed-api.sh &&

--- a/test_unstructured_ingest/expected-structured-output/azure-blob-storage/rfc854.txt.json
+++ b/test_unstructured_ingest/expected-structured-output/azure-blob-storage/rfc854.txt.json
@@ -926,7 +926,7 @@
   {
     "element_id": "58d2ec361e9b569851420330ecbac8fd",
     "text": "The Network Virtual Terminal (NVT) is a bi-directional character",
-    "type": "NarrativeText",
+    "type": "Title",
     "metadata": {}
   },
   {
@@ -2072,7 +2072,7 @@
   {
     "element_id": "3bceb7e6ecafeda3f867da7cba48b2ec",
     "text": "coupled with the TELNET command DATA MARK.  The Urgent",
-    "type": "NarrativeText",
+    "type": "Title",
     "metadata": {}
   },
   {
@@ -2360,7 +2360,7 @@
   {
     "element_id": "8459ff8791582f54cd1435d6b9d770db",
     "text": "1. Send the TELNET IP character;",
-    "type": "NarrativeText",
+    "type": "Title",
     "metadata": {}
   },
   {

--- a/test_unstructured_ingest/test-ingest-biomed-api.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-api.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+echo "Skipping test-ingest-biomed-api.sh,"
+echo "see https://github.com/Unstructured-IO/unstructured/issues/468"
+echo
+exit 0
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"/.. || exit 1
 

--- a/test_unstructured_ingest/test-ingest-biomed-api.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-api.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-
+# shellcheck disable=SC2317
+# NOTE(crag): remove above shellcheck line when the biomed issue is fixed
 echo "Skipping test-ingest-biomed-api.sh,"
 echo "see https://github.com/Unstructured-IO/unstructured/issues/468"
 echo

--- a/test_unstructured_ingest/test-ingest-biomed-path.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-path.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-
-echo "Skipping test-ingest-biomed-api.sh,"
+# shellcheck disable=SC2317
+# NOTE(crag): remove above shellcheck line when the biomed issue is fixed
+echo "Skipping test-ingest-biomed-path.sh,"
 echo "see https://github.com/Unstructured-IO/unstructured/issues/468"
 echo
 exit 0

--- a/test_unstructured_ingest/test-ingest-biomed-path.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-path.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+echo "Skipping test-ingest-biomed-api.sh,"
+echo "see https://github.com/Unstructured-IO/unstructured/issues/468"
+echo
+exit 0
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"/.. || exit 1
 


### PR DESCRIPTION
* Update test fixtures that should have been updated in prior commit
* Disable biomed ingest tests for now, the fail more often than not
* Bonus: echo `tesseract --version` in the update script, since that is a key thing that influences fixture outputs.