### PR TITLE
fix: Fix typo in function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.13-dev6
+## 0.5.13-dev7
 
 ### Enhancements
 
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+* Fixed typo in call to `exactly_one` in `partition_json`
 * unstructured-documents encode xml string if document_tree is `None` in `_read_xml`.
 * Update to `_read_xml` so that Markdown files with embedded HTML process correctly.
 * Fallback to "fast" strategy only emits a warning if the user specifies the "hi_res" strategy.

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.13-dev6"  # pragma: no cover
+__version__ = "0.5.13-dev7"  # pragma: no cover

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -18,7 +18,7 @@ def partition_json(
     if text is not None and text.strip() == "" and not file and not filename:
         return []
 
-    exactly_one(filenmae=filename, file=file, text=text)
+    exactly_one(filename=filename, file=file, text=text)
 
     if filename is not None:
         with open(filename, encoding="utf8") as f:


### PR DESCRIPTION
Closes [487](https://github.com/Unstructured-IO/unstructured/issues/487). Fixed typo in call to `exactly_one` in `partition_json`.