### PR TITLE
fix: workaround .json file detection with old libmagic installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.13-dev7
+## 0.5.13-dev8
 
 ### Enhancements
 
@@ -15,6 +15,7 @@
 * Update to `_read_xml` so that Markdown files with embedded HTML process correctly.
 * Fallback to "fast" strategy only emits a warning if the user specifies the "hi_res" strategy.
 * unstructured-partition-text_type exceeds_cap_ratio fix returns and how capitalization ratios are calculated
+* .json files resolved as "application/json" on centos7 (or other installs with older libmagic libs)
 
 ## 0.5.12
 

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ docker-start-bash:
 docker-test:
 	docker run --rm \
 	-v ${CURRENT_DIR}/test_unstructured:/home/test_unstructured \
+	-v ${CURRENT_DIR}/test_unstructured_ingest:/home/test_unstructured_ingest \
 	$(DOCKER_IMAGE) \
 	bash -c "pytest $(if $(TEST_NAME),-k $(TEST_NAME),) test_unstructured"
 

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pathlib
 import warnings
@@ -18,6 +19,7 @@ from unstructured.documents.elements import (
 from unstructured.partition import auto
 from unstructured.partition.auto import partition
 from unstructured.partition.common import convert_office_doc
+from unstructured.staging.base import elements_to_json
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 EXAMPLE_DOCS_DIRECTORY = os.path.join(DIRECTORY, "..", "..", "example-docs")
@@ -177,6 +179,48 @@ def test_auto_partition_html_from_file_rb():
     with open(filename, "rb") as f:
         elements = partition(file=f)
     assert len(elements) > 0
+
+
+def test_auto_partition_json_from_filename():
+    """Test auto-processing an unstructured json output file by filename."""
+    filename = os.path.join(
+        EXAMPLE_DOCS_DIRECTORY,
+        "..",
+        "test_unstructured_ingest",
+        "expected-structured-output",
+        "azure-blob-storage",
+        "spring-weather.html.json",
+    )
+    with open(filename) as json_f:
+        json_data = json.load(json_f)
+    json_elems = json.loads(elements_to_json(partition(filename=filename)))
+    for elem in json_elems:
+        # coordinates are always in the element data structures, even if None
+        elem.pop("coordinates")
+    assert json_data == json_elems
+
+
+@pytest.mark.xfail(
+    reason="parsed as text not json, https://github.com/Unstructured-IO/unstructured/issues/492",
+)
+def test_auto_partition_json_from_file():
+    """Test auto-processing an unstructured json output file by file handle."""
+    filename = os.path.join(
+        EXAMPLE_DOCS_DIRECTORY,
+        "..",
+        "test_unstructured_ingest",
+        "expected-structured-output",
+        "azure-blob-storage",
+        "spring-weather.html.json",
+    )
+    with open(filename) as json_f:
+        json_data = json.load(json_f)
+    with open(filename, encoding="utf-8") as partition_f:
+        json_elems = json.loads(elements_to_json(partition(file=partition_f)))
+    for elem in json_elems:
+        # coordinates are always in the element data structures, even if None
+        elem.pop("coordinates")
+    assert json_data == json_elems
 
 
 EXPECTED_TEXT_OUTPUT = [

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.13-dev7"  # pragma: no cover
+__version__ = "0.5.13-dev8"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -183,6 +183,11 @@ def detect_filetype(
         extension = extension.lower()
         if os.path.isfile(_filename) and LIBMAGIC_AVAILABLE:
             mime_type = magic.from_file(filename or file_filename, mime=True)  # type: ignore
+            # NOTE(crag): for older versions of the OS libmagic package, such as is currently
+            # installed on the Unstructured docker image, .json files resolve to "text/plain"
+            # rather than "application/json". this corrects for that case.
+            if mime_type == "text/plain" and extension == ".json":
+                return FileType.JSON
         else:
             return EXT_TO_FILETYPE.get(extension.lower(), FileType.UNK)
     elif file is not None:


### PR DESCRIPTION
Fixes issue where .json files were recognized as "text/plain" rather than "application/json on the Unstructured image (and other installs that may have an older libmagic).

Also adds missing json auto partition tests.

Including an xfail test for https://github.com/Unstructured-IO/unstructured/issues/492 .