### PR TITLE
feat: parameter to turn off SSL verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.5.14-dev0
+
+### Enhancements
+
+* Adds an `ssl_verify` kwarg to `partition` and `partition_html` to enable turning off
+  SSL verification for HTTP requests. SSL verification is on by default.
+
+### Features
+
+### Fixes
+
+
 ## 0.5.13
 
 ### Enhancements

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -119,7 +119,9 @@ faster processing and `"hi_res"` for more accurate processing.
 The ``partition`` function also accepts a ``url`` kwarg for remotely hosted documents. If you want
 to force ``partition`` to treat the document as a particular MIME type, use the ``content_type``
 kwarg in conjunction with ``url``. Otherwise, ``partition`` will use the information from
-the ``Content-Type`` header in the HTTP response.
+the ``Content-Type`` header in the HTTP response. The ``ssl_verify`` kwarg controls whether
+or not SSL verification is enabled for the HTTP request. By default it is on. Use ``ssl_verify=False``
+to disable SSL verification in the request.
 
 
 .. code:: python
@@ -246,7 +248,10 @@ The following three invocations of partition_html() are essentially equivalent:
 
 
 
-The following illustrates fetching a url and partitioning the response content:
+The following illustrates fetching a url and partitioning the response content.
+The ``ssl_verify`` kwarg controls whether
+or not SSL verification is enabled for the HTTP request. By default it is on. Use ``ssl_verify=False``
+to disable SSL verification in the request.
 
 .. code:: python
 
@@ -258,6 +263,10 @@ The following illustrates fetching a url and partitioning the response content:
 
   elements = partition_html(url="https://python.org/",
                             headers={"User-Agent": "YourScriptName/1.0 ..."})
+
+  # and turn off SSL verification
+
+  elements = partition_html(url="https://python.org/", ssl_verify=False)
 
 
 

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -107,7 +107,7 @@ def test_partition_from_url_uses_headers(mocker):
     partition_html(url=test_url, headers=test_headers)
 
     # Check if requests.get was called with the correct arguments
-    mock_get.assert_called_once_with(test_url, headers=test_headers)
+    mock_get.assert_called_once_with(test_url, headers=test_headers, verify=True)
 
 
 def test_partition_html_raises_with_none_specified():

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.13"  # pragma: no cover
+__version__ = "0.5.14-dev0"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -33,6 +33,7 @@ def partition(
     encoding: str = "utf-8",
     paragraph_grouper: Optional[Callable[[str], str]] = None,
     headers: Dict[str, str] = {},
+    ssl_verify: bool = True,
 ):
     """Partitions a document into its constituent elements. Will use libmagic to determine
     the file's type and route it to the appropriate partitioning function. Applies the default
@@ -62,6 +63,9 @@ def partition(
         The encoding method used to decode the text input. If None, utf-8 will be used.
     headers
         The headers to be used in conjunction with the HTTP request if URL is set.
+    ssl_verify
+        If the URL parameter is set, determines whether or not partition uses SSL verification
+        in the HTTP request.
     """
     exactly_one(file=file, filename=filename, url=url)
 
@@ -70,6 +74,7 @@ def partition(
             url=url,
             content_type=content_type,
             headers=headers,
+            ssl_verify=ssl_verify,
         )
     else:
         if headers != {}:
@@ -171,8 +176,9 @@ def file_and_type_from_url(
     url: str,
     content_type: Optional[str] = None,
     headers: Dict[str, str] = {},
+    ssl_verify: bool = True,
 ) -> Tuple[io.BytesIO, Optional[FileType]]:
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, verify=ssl_verify)
     file = io.BytesIO(response.content)
 
     content_type = content_type or response.headers.get("Content-Type")

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -22,6 +22,7 @@ def partition_html(
     include_page_breaks: bool = False,
     include_metadata: bool = True,
     headers: Dict[str, str] = {},
+    ssl_verify: bool = True,
     parser: VALID_PARSERS = None,
 ) -> List[Element]:
     """Partitions an HTML document into its constituent elements.
@@ -43,6 +44,11 @@ def partition_html(
     include_metadata
         Optionally allows for excluding metadata from the output. Primarily intended
         for when partition_html is called in other partition bricks (like partition_email)
+    headers
+        The headers to be used in conjunction with the HTTP request if URL is set.
+    ssl_verify
+        If the URL parameter is set, determines whether or not partition uses SSL verification
+        in the HTTP request.
     parser
         The parser to use for parsing the HTML document. If None, default parser will be used.
     """
@@ -72,7 +78,7 @@ def partition_html(
         document = HTMLDocument.from_string(_text, parser=parser)
 
     elif url is not None:
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, verify=ssl_verify)
         if not response.ok:
             raise ValueError(f"URL return an error: {response.status_code}")
 


### PR DESCRIPTION
#### Summary

Closes #383. Adds an `ssl_verify` kwarg to `partition` and `partition_html` that enables users to turn off SSL verification for HTTP requests.

### Testing

```python
from unstructured.partition.auto import partition
from unstructured.partition.html import partition_html

url = 'https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXV/Chapter93A/Section1'

headers = {
    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0  Safari/537.36'
}

# This should give an error
elements = partition_html(url=url, headers=headers)

# These should work
elements = partition_html(url=url, ssl_verify=False, headers=headers)
elements = partition(url=url, ssl_verify=False, headers=headers)
```