### PR TITLE
Sync version-sync.sh across repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,8 @@ check-scripts:
 .PHONY: check-version
 check-version:
     # Fail if syncing version would produce changes
-	scripts/version-sync.sh -c -f "unstructured/__version__.py" semver
+	scripts/version-sync.sh -c \
+		-f "unstructured/__version__.py" semver
 
 ## tidy:                    run black
 .PHONY: tidy
@@ -179,7 +180,8 @@ tidy:
 ## version-sync:            update __version__.py with most recent version from CHANGELOG.md
 .PHONY: version-sync
 version-sync:
-	scripts/version-sync.sh -f "unstructured/__version__.py" semver
+	scripts/version-sync.sh \
+		-f "unstructured/__version__.py" semver
 
 .PHONY: check-coverage
 check-coverage:

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -62,12 +62,12 @@ while getopts ":hcs:f:" opt; do
 done
 
 # Parse REPLACEMENT_FORMATS
-RE_SEMVER_FULL='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?'
+RE_SEMVER_FULL="(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?"
 RE_RELEASE="(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
 RE_API_RELEASE="v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
 # Pull out semver appearing earliest in SOURCE_FILE.
 LAST_VERSION=$(grep -o -m 1 -E "${RE_SEMVER_FULL}" "$SOURCE_FILE")
-LAST_RELEASE=$(grep -o -m 1 -E "${RE_RELEASE}($|[^-+])$" "$SOURCE_FILE" | grep -o -m 1 -E "${RE_RELEASE}")
+LAST_RELEASE=$(grep -o -m 1 -E "${RE_RELEASE}($|[^-+])" "$SOURCE_FILE" | grep -o -m 1 -E "${RE_RELEASE}")
 LAST_API_RELEASE="v$(grep -o -m 1 -E "${RE_RELEASE}($|[^-+])$" "$SOURCE_FILE" | grep -o -m 1 -E "${RE_RELEASE}")"
 declare -a RE_SEMVERS=()
 declare -a UPDATED_VERSIONS=()
@@ -126,7 +126,7 @@ for i in "${!FILES_TO_CHECK[@]}"; do
         if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
             echo "sed version must be >= ${REQUIRED_VERSION}" && exit 1
         fi
-        sed -r "s/$RE_SEMVER/$UPDATED_VERSION/" "$FILE_TO_CHANGE" > "$TMPFILE"
+        sed -E -r "s/$RE_SEMVER/$UPDATED_VERSION/" "$FILE_TO_CHANGE" > "$TMPFILE"
         if [ $CHECK == 1 ];
         then
             DIFF=$(diff "$FILE_TO_CHANGE"  "$TMPFILE" )


### PR DESCRIPTION
There are currently a few versions of the `version-sync.sh` script floating around in various repos. This issue provides for updating them all to the same script.