### PR TITLE
feat: `partition_via_api` helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.2-dev1
+## 0.6.2-dev2
 
 ### Enhancements
 
@@ -6,6 +6,8 @@
   to the hi res strategy when necessary.
 
 ### Features
+
+* Add `partition_via_api` for partitioning documents through the hosted API.
 
 ### Fixes
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -133,6 +133,35 @@ to disable SSL verification in the request.
   elements = partition(url=url, content_type="text/markdown")
 
 
+``partition_via_api``
+---------------------
+
+``partition_via_api`` allows users to partition documents using the hosted Unstructured API.
+The API partitions documents using the automatic ``partition`` function. Currently, the API
+supports all filetypes except for RTF and EPUBs. 
+To use another URL for the API use the ``api_url`` kwarg. This is helpful if you're hosting
+the API yourself or running it locally through a container. You can pass in your API key
+using the ``api_key`` kwarg. You can use the ``content_type`` kwarg to pass in the MIME
+type for the file. If you do not explicitly pass it, the MIME type will be inferred.
+
+See `here <https://api.unstructured.io/general/docs>`_ for the hosted API swagger documentation
+and `here <https://github.com/Unstructured-IO/unstructured-api#dizzy-instructions-for-using-the-docker-image>`_ for
+documentation on how to run the API as a container locally.
+
+Examples:
+
+.. code:: python
+
+  from unstructured.partition.api import partition_via_api
+
+  filename = "example-docs/fake-email.eml"
+
+  elements = partition_via_api(filename=filename, api_key="MY_API_KEY", content_type="message/rfc822")
+
+  with open(filename, "rb") as f:
+    elements = partition_via_api(file=f, file_filename=filename, api_key="MY_API_KEY")
+
+
 ``partition_docx``
 ------------------
 

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -1,0 +1,72 @@
+import os
+import pathlib
+
+import pytest
+import requests
+
+from unstructured.documents.elements import NarrativeText
+from unstructured.partition.api import partition_via_api
+
+DIRECTORY = pathlib.Path(__file__).parent.resolve()
+
+
+class MockResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+    @property
+    def text(self):
+        return """[
+    {
+        "element_id": "f49fbd614ddf5b72e06f59e554e6ae2b",
+        "text": "This is a test email to use for unit tests.",
+        "type": "NarrativeText",
+        "metadata": {
+            "date": "2022-12-16T17:04:16-05:00",
+            "sent_from": [
+                "Matthew Robinson <mrobinson@unstructured.io>"
+            ],
+            "sent_to": [
+                "Matthew Robinson <mrobinson@unstructured.io>"
+            ],
+            "subject": "Test Email",
+            "filename": "fake-email.eml"
+        }
+    }
+]"""
+
+
+def test_partition_via_api_from_filename(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockResponse(status_code=200),
+    )
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
+    elements = partition_via_api(filename=filename, api_key="FAKEROO")
+    assert elements[0] == NarrativeText("This is a test email to use for unit tests.")
+
+
+def test_partition_via_api_from_file(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockResponse(status_code=200),
+    )
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
+
+    with open(filename, "rb") as f:
+        elements = partition_via_api(file=f, file_filename=filename, api_key="FAKEROO")
+    assert elements[0] == NarrativeText("This is a test email to use for unit tests.")
+
+
+def test_partition_via_api_raises_with_bad_response(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockResponse(status_code=500),
+    )
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
+
+    with pytest.raises(ValueError):
+        partition_via_api(filename=filename, api_key="FAKEROO")

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.2-dev1"  # pragma: no cover
+__version__ = "0.6.2-dev2"  # pragma: no cover

--- a/unstructured/partition/api.py
+++ b/unstructured/partition/api.py
@@ -1,0 +1,83 @@
+from typing import (
+    IO,
+    List,
+    Optional,
+)
+
+import requests
+
+from unstructured.documents.elements import Element
+from unstructured.partition.common import exactly_one
+from unstructured.partition.json import partition_json
+
+
+def partition_via_api(
+    filename: Optional[str] = None,
+    content_type: Optional[str] = None,
+    file: Optional[IO] = None,
+    file_filename: Optional[str] = None,
+    strategy: str = "hi_res",
+    api_url: str = "https://api.unstructured.io/general/v0/general",
+    api_key: str = "",
+) -> List[Element]:
+    """Partitions a document using the Unstructured REST API. This is equivalent to
+    running the document through partition.
+
+    See https://api.unstructured.io/general/docs for the hosted API documentation or
+    https://github.com/Unstructured-IO/unstructured-api for instructions on how to run
+    the API locally as a container.
+
+    Parameters
+    ----------
+    filename
+        A string defining the target filename path.
+    content_type
+        A string defining the file content in MIME type
+    file
+        A file-like object using "rb" mode --> open(filename, "rb").
+    file_filename
+        When file is not None, the filename (string) to store in element metadata. E.g. "foo.txt"
+    strategy
+        The strategy to use for partitioning the PDF. Uses a layout detection model if set
+        to 'hi_res', otherwise partition_pdf simply extracts the text from the document
+        and processes it.
+    api_url
+        The URL for the Unstructured API. Defaults to the hosted Unstructured API.
+    api_key
+        The API key to pass to the Unstructured API.
+    """
+    exactly_one(filename=filename, file=file)
+
+    headers = {
+        "ACCEPT": "application/json",
+        "UNSTRUCTURED-API-KEY": api_key,
+    }
+
+    data = {
+        "strategy": strategy,
+    }
+
+    if filename is not None:
+        with open(filename, "rb") as f:
+            files = [
+                ("files", (filename, f, content_type)),
+            ]
+            response = requests.post(
+                api_url,
+                headers=headers,
+                data=data,
+                files=files,  # type: ignore
+            )
+    elif file is not None:
+        _filename = file_filename or ""
+        files = [
+            ("files", (_filename, file, content_type)),  # type: ignore
+        ]
+        response = requests.post(api_url, headers=headers, data=data, files=files)  # type: ignore
+
+    if response.status_code == 200:
+        return partition_json(text=response.text)
+    else:
+        raise ValueError(
+            f"Receive unexpected status code {response.status_code} from the API.",
+        )


### PR DESCRIPTION
### Summary

Adds a helper function for partitioning documents through the hosted REST API. Implemented in response to feedback from users who were interested in more convenient ways to use the hosted API. 

Notes, this function processes a single document and mimics the `partition` and `partition_{doc_type}` functions. The API also accepts multiple files. There will be a follow on PR that calls the API with multiple files.

### Testing

Note the API key here is obviously fake. API keys are not enforced yet but will be soon. For future humans, if the test code doesn't work, please sign up for an API key :-)

```python
from unstructured.partition.api import partition_via_api

filename = "example-docs/fake-email.eml"

elements = partition_via_api(filename=filename, api_key="MY_API_KEY", content_type="message/rfc822")

with open(filename, "rb") as f:
  elements = partition_via_api(file=f, file_filename=filename, api_key="MY_API_KEY")
```