### PR TITLE
build(deps): add `pdfminer.six` to dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,12 +16,18 @@ certifi==2022.12.7
     #   httpx
     #   requests
     #   unstructured (setup.py)
+cffi==1.15.1
+    # via cryptography
 charset-normalizer==3.1.0
-    # via requests
+    # via
+    #   pdfminer-six
+    #   requests
 click==8.1.3
     # via nltk
 commonmark==0.9.1
     # via rich
+cryptography==40.0.2
+    # via pdfminer-six
 deprecated==1.2.13
     # via argilla
 et-xmlfile==1.1.0
@@ -68,10 +74,14 @@ pandas==1.5.3
     # via
     #   argilla
     #   unstructured (setup.py)
+pdfminer-six==20221105
+    # via unstructured (setup.py)
 pillow==9.5.0
     # via
     #   python-pptx
     #   unstructured (setup.py)
+pycparser==2.21
+    # via cffi
 pydantic==1.10.7
     # via argilla
 pygments==2.15.1
@@ -88,9 +98,9 @@ python-pptx==0.6.21
     # via unstructured (setup.py)
 pytz==2023.3
     # via pandas
-regex==2023.3.23
+regex==2023.5.2
     # via nltk
-requests==2.28.2
+requests==2.29.0
     # via unstructured (setup.py)
 rfc3986[idna2008]==1.5.0
     # via httpx

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "nltk",
         "openpyxl",
         "pandas",
+        "pdfminer.six",
         "pillow",
         "pypandoc",
         "python-docx",


### PR DESCRIPTION
### Summary

Closes #523 . Adds `pdfminer-six` explicitly to the list of `unstructured` dependencies since it is used when the `"fast"` strategy is called for `partition_pdf`. 