### PR TITLE
ci: only build docs on tags

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -5,7 +5,8 @@ name: Sphinx build
 
 on:
   push:
-    branches: [ main ]
+    tags:
+      - '*'
 
 jobs:
   docs:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -5,6 +5,7 @@ name: Sphinx build
 
 on:
   push:
+    branches: [ docs-build ]
     tags:
       - '*'
 


### PR DESCRIPTION
### Summary

Updates the documentation job to only build on tags. Currently, it builds on every push to `main`, which can result in documentation for new features becoming public before the features themselves are available. Also builds on a `docs-build` branch if we need to do a docs only update between releases. `docs-build` is now a protected branch.