### PR TITLE
feat: add `partition_multiple_via_api` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.6.3-dev0
+
+### Enhancements
+
+
+### Features
+
+* Added `partition_multiple_via_api` for partitioning multiple documents in a single REST
+  API call.
+
+### Fixes
+
+
 ## 0.6.2
 
 ### Enhancements

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -166,7 +166,15 @@ Examples:
 ------------------------------
 
 ``partition_multiple_via_api`` is similar to ``partition_via_api``, but allows you to partition
-multiple documents in a single REST API call. The result has the type ``List[List[Element]]``.
+multiple documents in a single REST API call. The result has the type ``List[List[Element]]``,
+for example:
+
+.. code:: python
+
+  [
+    [NarrativeText("Narrative!"), Title("Title!")],
+    [NarrativeText("Narrative!"), Title("Title!")]
+  ]
 
 Examples:
 
@@ -180,6 +188,7 @@ Examples:
 
 
 .. code:: python
+
   from contextlib import ExitStack
 
   from unstructured.partition.api import partition_multiple_via_api

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -162,6 +162,36 @@ Examples:
     elements = partition_via_api(file=f, file_filename=filename, api_key="MY_API_KEY")
 
 
+``partition_multiple_via_api``
+------------------------------
+
+``partition_multiple_via_api`` is similar to ``partition_via_api``, but allows you to partition
+multiple documents in a single REST API call. The result has the type ``List[List[Element]]``.
+
+Examples:
+
+.. code:: python
+
+  from unstructured.partition.api import partition_multiple_via_api
+
+  filenames = ["example-docs/fake-email.eml", "example-docs/fake.docx"]
+
+  documents = partition_multiple_via_api(filenames=filenames)
+
+
+.. code:: python
+  from contextlib import ExitStack
+
+  from unstructured.partition.api import partition_multiple_via_api
+
+  filenames = ["example-docs/fake-email.eml", "example-docs/fake.docx"]
+  files = [open(filename, "rb") for filename in filenames]
+
+  with ExitStack() as stack:
+      files = [open(filename, "rb") for filename in filenames]
+      documents = partition_multiple_via_api(files=files, file_filenames=filenames)
+
+
 ``partition_docx``
 ------------------
 

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -188,7 +188,7 @@ Examples:
   files = [open(filename, "rb") for filename in filenames]
 
   with ExitStack() as stack:
-      files = [open(filename, "rb") for filename in filenames]
+      files = [stack.enter_context(open(filename, "rb")) for filename in filenames]
       documents = partition_multiple_via_api(files=files, file_filenames=filenames)
 
 

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -1,3 +1,5 @@
+import contextlib
+import json
 import os
 import pathlib
 
@@ -5,7 +7,7 @@ import pytest
 import requests
 
 from unstructured.documents.elements import NarrativeText
-from unstructured.partition.api import partition_via_api
+from unstructured.partition.api import partition_multiple_via_api, partition_via_api
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 
@@ -70,3 +72,108 @@ def test_partition_via_api_raises_with_bad_response(monkeypatch):
 
     with pytest.raises(ValueError):
         partition_via_api(filename=filename, api_key="FAKEROO")
+
+
+class MockMultipleResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+    def json(self):
+        return json.loads(self.text)
+
+    @property
+    def text(self):
+        return """[
+    [
+        {
+            "element_id": "f49fbd614ddf5b72e06f59e554e6ae2b",
+            "text": "This is a test email to use for unit tests.",
+            "type": "NarrativeText",
+            "metadata": {
+                "date": "2022-12-16T17:04:16-05:00",
+                "sent_from": [
+                    "Matthew Robinson <mrobinson@unstructured.io>"
+                ],
+                "sent_to": [
+                    "Matthew Robinson <mrobinson@unstructured.io>"
+                ],
+                "subject": "Test Email",
+                "filename": "fake-email.eml"
+            }
+        }
+    ],
+    [
+        {
+            "element_id": "f49fbd614ddf5b72e06f59e554e6ae2b",
+            "text": "This is a test email to use for unit tests.",
+            "type": "NarrativeText",
+            "metadata": {
+                "date": "2022-12-16T17:04:16-05:00",
+                "sent_from": [
+                    "Matthew Robinson <mrobinson@unstructured.io>"
+                ],
+                "sent_to": [
+                    "Matthew Robinson <mrobinson@unstructured.io>"
+                ],
+                "subject": "Test Email",
+                "filename": "fake-email.eml"
+            }
+        }
+    ]
+]"""
+
+
+def test_partition_multiple_via_api_from_filenames(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockMultipleResponse(status_code=200),
+    )
+
+    filenames = [
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml"),
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake.docx"),
+    ]
+
+    elements = partition_multiple_via_api(filenames=filenames, api_key="FAKEROO")
+    assert len(elements) == 2
+    assert elements[0][0] == NarrativeText("This is a test email to use for unit tests.")
+
+
+def test_partition_multiple_via_api_from_files(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockMultipleResponse(status_code=200),
+    )
+
+    filenames = [
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml"),
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake.docx"),
+    ]
+
+    with contextlib.ExitStack() as stack:
+        files = [stack.enter_context(open(filename, "rb")) for filename in filenames]
+        elements = partition_multiple_via_api(
+            files=files,
+            file_filenames=filenames,
+            api_key="FAKEROO",
+        )
+    assert len(elements) == 2
+    assert elements[0][0] == NarrativeText("This is a test email to use for unit tests.")
+
+
+def test_partition_multiple_via_api_raises_with_bad_response(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockMultipleResponse(status_code=500),
+    )
+
+    filenames = [
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml"),
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake.docx"),
+    ]
+
+    with pytest.raises(ValueError):
+        partition_multiple_via_api(filenames=filenames, api_key="FAKEROO")

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -177,3 +177,67 @@ def test_partition_multiple_via_api_raises_with_bad_response(monkeypatch):
 
     with pytest.raises(ValueError):
         partition_multiple_via_api(filenames=filenames, api_key="FAKEROO")
+
+
+def test_partition_multiple_via_api_raises_with_content_types_size_mismatch(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockMultipleResponse(status_code=500),
+    )
+
+    filenames = [
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml"),
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake.docx"),
+    ]
+
+    with pytest.raises(ValueError):
+        partition_multiple_via_api(
+            filenames=filenames,
+            content_types=["text/plain"],
+            api_key="FAKEROO",
+        )
+
+
+def test_partition_multiple_via_api_from_files_raises_with_size_mismatch(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockMultipleResponse(status_code=200),
+    )
+
+    filenames = [
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml"),
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake.docx"),
+    ]
+
+    with contextlib.ExitStack() as stack:
+        files = [stack.enter_context(open(filename, "rb")) for filename in filenames]
+        with pytest.raises(ValueError):
+            partition_multiple_via_api(
+                files=files,
+                file_filenames=filenames,
+                content_types=["text/plain"],
+                api_key="FAKEROO",
+            )
+
+
+def test_partition_multiple_via_api_from_files_raises_without_filenames(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockMultipleResponse(status_code=200),
+    )
+
+    filenames = [
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml"),
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "fake.docx"),
+    ]
+
+    with contextlib.ExitStack() as stack:
+        files = [stack.enter_context(open(filename, "rb")) for filename in filenames]
+        with pytest.raises(ValueError):
+            partition_multiple_via_api(
+                files=files,
+                api_key="FAKEROO",
+            )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.2"  # pragma: no cover
+__version__ = "0.6.3-dev0"  # pragma: no cover

--- a/unstructured/partition/api.py
+++ b/unstructured/partition/api.py
@@ -84,7 +84,7 @@ def partition_via_api(
         )
 
 
-def partition_files_via_api(
+def partition_multiple_via_api(
     filenames: Optional[List[str]] = None,
     content_types: Optional[List[str]] = None,
     files: Optional[List[str]] = None,
@@ -93,8 +93,8 @@ def partition_files_via_api(
     api_url: str = "https://api.unstructured.io/general/v0/general",
     api_key: str = "",
 ) -> List[List[Element]]:
-    """Partitions a document using the Unstructured REST API. This is equivalent to
-    running the document through partition.
+    """Partitions multiple document using the Unstructured REST API by batching
+    the documents into a single HTTP request.
 
     See https://api.unstructured.io/general/docs for the hosted API documentation or
     https://github.com/Unstructured-IO/unstructured-api for instructions on how to run
@@ -102,10 +102,14 @@ def partition_files_via_api(
 
     Parameters
     ----------
-    filenames
-        A list string defining the target filename paths.
-    content_type
-        A list string defining the file content in MIME type in the filenames.
+    filename
+        A list of strings defining the target filename paths.
+    content_types
+        A list of strings defining the file contents in MIME types.
+    files
+        A list of file-like object using "rb" mode --> open(filename, "rb").
+    file_filename
+        When file is not None, the filename (string) to store in element metadata. E.g. "foo.txt"
     strategy
         The strategy to use for partitioning the PDF. Uses a layout detection model if set
         to 'hi_res', otherwise partition_pdf simply extracts the text from the document


### PR DESCRIPTION
### Summary

Adds a function for partitioning multiple files through the API. The new function batches multiple files into a single request.

### Testing

```python
  from unstructured.partition.api import partition_multiple_via_api

  filenames = ["example-docs/fake-email.eml", "example-docs/fake.docx"]

  documents = partition_multiple_via_api(filenames=filenames)
```


```python
  from contextlib import ExitStack

  from unstructured.partition.api import partition_multiple_via_api

  filenames = ["example-docs/fake-email.eml", "example-docs/fake.docx"]
  files = [open(filename, "rb") for filename in filenames]

  with ExitStack() as stack:
      files = [stack.enter_context(open(filename, "rb")) for filename in filenames]
      documents = partition_multiple_via_api(files=files, file_filenames=filenames)
```