### PR TITLE
fix(ci): don't skip docs deploy for tags

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -23,7 +23,6 @@ jobs:
         path: docs/build/html/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build/html


### PR DESCRIPTION
### Summary

Removing the conditional statement from the deploy step in the docs build CI job. Now we only run the docs on tag. Since the tag ref isn't main, this was causing our docs not to deploy.