### PR TITLE
Fixes issue where detectron2 would not install on OSX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN yum -y install openssl-devel bzip2-devel libffi-devel make git sqlite-devel 
   $sudo rm -rf /var/cache/yum/* && \
   yum clean all
 
-# Set up environment 
+# Set up environment
 ENV HOME /home/
 WORKDIR ${HOME}
 RUN mkdir ${HOME}/.ssh && chmod go-rwx ${HOME}/.ssh \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PACKAGE_NAME := unstructured
 PIP_VERSION := 22.2.1
 CURRENT_DIR := $(shell pwd)
+OS := $(shell uname)
 
 
 .PHONY: help
@@ -87,8 +88,14 @@ install-ingest-wikipedia:
 install-unstructured-inference:
 	python3 -m pip install -r requirements/local-inference.txt
 
+.PHONY: install-tensorboard
+install-tensorboard:
+	@if [ ${OS} = "Darwin" ]; then\
+		python3 -m pip install tensorboard;\
+	fi
+
 .PHONY: install-detectron2
-install-detectron2:
+install-detectron2: install-tensorboard
 	python3 -m pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2"
 
 ## install-local-inference: installs requirements for local inference

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ install-unstructured-inference:
 .PHONY: install-tensorboard
 install-tensorboard:
 	@if [ ${ARCH} = "arm64" ] || [ ${ARCH} = "aarch64" ]; then\
-		python3 -m pip install tensorboard;\
+		python3 -m pip install tensorboard>=2.12.2;\
 	fi
 
 .PHONY: install-detectron2

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PACKAGE_NAME := unstructured
 PIP_VERSION := 22.2.1
 CURRENT_DIR := $(shell pwd)
-OS := $(shell uname)
+ARCH := $(shell uname -m)
 
 
 .PHONY: help
@@ -90,7 +90,7 @@ install-unstructured-inference:
 
 .PHONY: install-tensorboard
 install-tensorboard:
-	@if [ ${OS} = "Darwin" ]; then\
+	@if [ ${ARCH} = "arm64" ] || [ ${ARCH} = "aarch64" ]; then\
 		python3 -m pip install tensorboard;\
 	fi
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ installation. NOTE: We do not currently support python 3.11, please use an older
     - `libreoffice` (MS Office docs)
 - If you are parsing PDFs, run the following to install the `detectron2` model, which
   `unstructured` uses for layout detection:
-    - `pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2"`
+    - make install-detectron2
 
 At this point, you should be able to run the following code:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ installation. NOTE: We do not currently support python 3.11, please use an older
     - `libreoffice` (MS Office docs)
 - If you are parsing PDFs, run the following to install the `detectron2` model, which
   `unstructured` uses for layout detection:
-    - make install-detectron2
+    - `pip install tensorboard>=2.12.2`
+    - `pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2"`
 
 At this point, you should be able to run the following code:
 


### PR DESCRIPTION
Tested on Apple silicon based MacBook Pro.  This installs tensorboard which is required on OSX and arm based cpu’s for detectron2.