### PR TITLE
Chore: Add a trace logger for NLP output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Enhancements
 
 * Added an additional trace logger for NLP debugging.
-* PLACEHOLDER - delete this line when there is an actual changelog item to report for 0.6.5
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-* Added an additional trace logger for debugging `partition_text_type`.
+* Added an additional trace logger for NLP debugging.
 * PLACEHOLDER - delete this line when there is an actual changelog item to report for 0.6.5
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.6.5-dev0
+## 0.6.5-dev1
 
 ### Enhancements
 
+* Added an additional trace logger for debugging `partition_text_type`.
 * PLACEHOLDER - delete this line when there is an actual changelog item to report for 0.6.5
 
 ### Features

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.5-dev0"  # pragma: no cover
+__version__ = "0.6.5-dev1"  # pragma: no cover

--- a/unstructured/logger.py
+++ b/unstructured/logger.py
@@ -1,3 +1,18 @@
 import logging
 
 logger = logging.getLogger("unstructured")
+trace_logger = logging.getLogger("unstructured.trace")
+
+# Create a custom logging level
+DETAIL = 15
+logging.addLevelName(DETAIL, "DETAIL")
+
+
+# Create a custom log method for the "DETAIL" level
+def detail(self, message, *args, **kws):
+    if self.isEnabledFor(DETAIL):
+        self._log(DETAIL, message, args, **kws)
+
+
+# Add the custom log method to the logging. Logger class
+logging.Logger.detail = detail

--- a/unstructured/logger.py
+++ b/unstructured/logger.py
@@ -14,5 +14,5 @@ def detail(self, message, *args, **kws):
         self._log(DETAIL, message, args, **kws)
 
 
-# Add the custom log method to the logging. Logger class
-logging.Logger.detail = detail
+# Add the custom log method to the logging.Logger class
+logging.Logger.detail = detail  # type: ignore

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -10,7 +10,7 @@ else:
     from typing import Final
 
 from unstructured.cleaners.core import remove_punctuation
-from unstructured.logger import logger
+from unstructured.logger import trace_logger
 from unstructured.nlp.english_words import ENGLISH_WORDS
 from unstructured.nlp.patterns import (
     ENDS_IN_PUNCT_RE,
@@ -57,11 +57,11 @@ def is_possible_narrative_text(
         language_checks = _language_checks.lower() == "true"
 
     if len(text) == 0:
-        logger.debug("Not narrative. Text is empty.")
+        trace_logger.detail("Not narrative. Text is empty.")
         return False
 
     if text.isnumeric():
-        logger.debug(f"Not narrative. Text is all numeric:\n\n{text}")
+        trace_logger.detail(f"Not narrative. Text is all numeric:\n\n{text}")
         return False
 
     language = os.environ.get("UNSTRUCTURED_LANGUAGE", language)
@@ -74,7 +74,7 @@ def is_possible_narrative_text(
         os.environ.get("UNSTRUCTURED_NARRATIVE_TEXT_CAP_THRESHOLD", cap_threshold),
     )
     if exceeds_cap_ratio(text, threshold=cap_threshold):
-        logger.debug(f"Not narrative. Text exceeds cap ratio {cap_threshold}:\n\n{text}")
+        trace_logger.detail(f"Not narrative. Text exceeds cap ratio {cap_threshold}:\n\n{text}")
         return False
 
     non_alpha_threshold = float(
@@ -84,7 +84,7 @@ def is_possible_narrative_text(
         return False
 
     if (sentence_count(text, 3) < 2) and (not contains_verb(text)) and language == "en":
-        logger.debug(f"Not narrative. Text does not contain a verb:\n\n{text}")
+        trace_logger.detail(f"Not narrative. Text does not contain a verb:\n\n{text}")
         return False
 
     return True
@@ -121,7 +121,7 @@ def is_possible_title(
         language_checks = _language_checks.lower() == "true"
 
     if len(text) == 0:
-        logger.debug("Not a title. Text is empty.")
+        trace_logger.detail("Not a title. Text is empty.")
         return False
 
     if text.isupper() and ENDS_IN_PUNCT_RE.search(text) is not None:
@@ -150,14 +150,16 @@ def is_possible_title(
         return False
 
     if text.isnumeric():
-        logger.debug(f"Not a title. Text is all numeric:\n\n{text}")
+        trace_logger.detail(f"Not a title. Text is all numeric:\n\n{text}")
         return False
 
     # NOTE(robinson) - The min length is to capture content such as "ITEM 1A. RISK FACTORS"
     # that sometimes get tokenized as separate sentences due to the period, but are still
     # valid titles
     if sentence_count(text, min_length=sentence_min_length) > 1:
-        logger.debug(f"Not a title. Text is longer than {sentence_min_length} sentences:\n\n{text}")
+        trace_logger.detail(
+            f"Not a title. Text is longer than {sentence_min_length} sentences:\n\n{text}",
+        )
         return False
 
     return True
@@ -223,7 +225,7 @@ def sentence_count(text: str, min_length: Optional[int] = None) -> int:
         sentence = remove_punctuation(sentence)
         words = [word for word in word_tokenize(sentence) if word != "."]
         if min_length and len(words) < min_length:
-            logger.debug(
+            trace_logger.detail(
                 f"Skipping sentence because does not exceed {min_length} word tokens\n"
                 f"{sentence}",
             )

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -57,11 +57,11 @@ def is_possible_narrative_text(
         language_checks = _language_checks.lower() == "true"
 
     if len(text) == 0:
-        trace_logger.detail("Not narrative. Text is empty.")
+        trace_logger.detail("Not narrative. Text is empty.")  # type: ignore
         return False
 
     if text.isnumeric():
-        trace_logger.detail(f"Not narrative. Text is all numeric:\n\n{text}")
+        trace_logger.detail(f"Not narrative. Text is all numeric:\n\n{text}")  # type: ignore
         return False
 
     language = os.environ.get("UNSTRUCTURED_LANGUAGE", language)
@@ -74,7 +74,7 @@ def is_possible_narrative_text(
         os.environ.get("UNSTRUCTURED_NARRATIVE_TEXT_CAP_THRESHOLD", cap_threshold),
     )
     if exceeds_cap_ratio(text, threshold=cap_threshold):
-        trace_logger.detail(f"Not narrative. Text exceeds cap ratio {cap_threshold}:\n\n{text}")
+        trace_logger.detail(f"Not narrative. Text exceeds cap ratio {cap_threshold}:\n\n{text}")  # type: ignore # noqa: E501
         return False
 
     non_alpha_threshold = float(
@@ -84,7 +84,7 @@ def is_possible_narrative_text(
         return False
 
     if (sentence_count(text, 3) < 2) and (not contains_verb(text)) and language == "en":
-        trace_logger.detail(f"Not narrative. Text does not contain a verb:\n\n{text}")
+        trace_logger.detail(f"Not narrative. Text does not contain a verb:\n\n{text}")  # type: ignore # noqa: E501
         return False
 
     return True
@@ -121,7 +121,7 @@ def is_possible_title(
         language_checks = _language_checks.lower() == "true"
 
     if len(text) == 0:
-        trace_logger.detail("Not a title. Text is empty.")
+        trace_logger.detail("Not a title. Text is empty.")  # type: ignore
         return False
 
     if text.isupper() and ENDS_IN_PUNCT_RE.search(text) is not None:
@@ -150,14 +150,14 @@ def is_possible_title(
         return False
 
     if text.isnumeric():
-        trace_logger.detail(f"Not a title. Text is all numeric:\n\n{text}")
+        trace_logger.detail(f"Not a title. Text is all numeric:\n\n{text}")  # type: ignore
         return False
 
     # NOTE(robinson) - The min length is to capture content such as "ITEM 1A. RISK FACTORS"
     # that sometimes get tokenized as separate sentences due to the period, but are still
     # valid titles
     if sentence_count(text, min_length=sentence_min_length) > 1:
-        trace_logger.detail(
+        trace_logger.detail(  # type: ignore
             f"Not a title. Text is longer than {sentence_min_length} sentences:\n\n{text}",
         )
         return False
@@ -225,7 +225,7 @@ def sentence_count(text: str, min_length: Optional[int] = None) -> int:
         sentence = remove_punctuation(sentence)
         words = [word for word in word_tokenize(sentence) if word != "."]
         if min_length and len(words) < min_length:
-            trace_logger.detail(
+            trace_logger.detail(  # type: ignore
                 f"Skipping sentence because does not exceed {min_length} word tokens\n"
                 f"{sentence}",
             )


### PR DESCRIPTION
### Summary
Addresses https://github.com/Unstructured-IO/unstructured/issues/331 and adds an additional trace logger to differentiate between `DEBUG` and `DETAIL` level output so that most NLP debug logs to the trace logger.

### Test
Python script:
```
import logging
logger = logging.getLogger("unstructured")
trace_logger = logging.getLogger("unstructured.trace")
handler = logging.StreamHandler()
handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
logger.addHandler(handler)
logger.setLevel(logging.DEBUG)
trace_logger.setLevel(logging.WARNING)

from unstructured.partition.auto import partition
elements = partition(filename="example-docs/fake-email.eml")
```
And the output will not contain any `DEBUG` or `DETAIL` level logs.