### PR TITLE
fix: make `pytesseract` a function level import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.6.7-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* Makes `pytesseract` a function level import in `partition_pdf` so you can use the `"fast"`
+  or `"hi_res"` strategies if `pytesseract` is not installed. Also adds the
+  `required_dependencies` decorator for the `"hi_res"` and `"ocr_only"` strategies.
+
 ## 0.6.6
 
 ### Enhancements

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -384,7 +384,7 @@ Examples:
 
 
 The ``strategy`` kwarg controls the method that will be used to process the PDF.
-The available strategies for PDFs are `"auto"`, `"hi_res"`, `"ocr_only"`, and `"fast"`.
+The available strategies for PDFs are ``"auto"``, ``"hi_res"``, ``"ocr_only"``, and ``"fast"``.
 
 The ``"auto"`` strategy will choose the partitioning strategy based on document characteristics and the function kwargs.
 If ``infer_table_structure`` is passed, the strategy will be ``"hi_res"`` because that is the only strategy that

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.6"  # pragma: no cover
+__version__ = "0.6.7-dev0"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -4,7 +4,6 @@ from tempfile import SpooledTemporaryFile
 from typing import BinaryIO, List, Optional, Union, cast
 
 import pdf2image
-import pytesseract
 from pdfminer.high_level import extract_pages
 from pdfminer.utils import open_filename
 from PIL import Image
@@ -176,6 +175,7 @@ def partition_pdf_or_image(
     )
 
 
+@requires_dependencies("unstructured_inference")
 def _partition_pdf_or_image_local(
     filename: str = "",
     file: Optional[Union[bytes, BinaryIO]] = None,
@@ -301,6 +301,7 @@ def _process_pdfminer_pages(
     return elements
 
 
+@requires_dependencies("pytesseract")
 def _partition_pdf_or_image_with_ocr(
     filename: str = "",
     file: Optional[Union[bytes, BinaryIO, SpooledTemporaryFile]] = None,
@@ -310,6 +311,8 @@ def _partition_pdf_or_image_with_ocr(
 ):
     """Partitions and image or PDF using Tesseract OCR. For PDFs, each page is converted
     to an image prior to processing."""
+    import pytesseract
+
     if is_image:
         if file is not None:
             image = Image.open(file)


### PR DESCRIPTION
### Summary

Closes #562. Makes `pytesseract` a function level import so you can use strategies that don't require `pytesseract` without `pytesseract` being installed. Also added the `required_dependencies` decorator for the `"hi_res"` and `"ocr_only"` strategies.

This PR also includes a small docs formatting fix.

### Testing

If you uninstall `pytesseract`, the following should work:

```python
from unstructured.partition.pdf import partition_pdf

filename = "example-docs/layout-parser-paper-fast.pdf"
elements = partition_pdf(filename=filename, strategy="fast")
```