### PR TITLE
Chore(ingest): Add `--partition-strategy` parameter in  CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.6.7-dev0
+
+### Enhancements
+
+* Added a `--partition-strategy` parameter to unstructured-ingest so that users can specify
+  partition strategy in CLI. For example, `--partition-strategy fast`.
+
+### Features
+
+### Fixes
+
 ## 0.6.6
 
 ### Enhancements

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -38,7 +38,7 @@ odt_not_supported = "odt" not in pypandoc.get_pandoc_formats()[0]
 
 def test_auto_partition_email_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.eml")
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert len(elements) > 0
     assert elements == EXPECTED_EMAIL_OUTPUT
     assert elements[0].metadata.filename == os.path.basename(filename)
@@ -47,7 +47,7 @@ def test_auto_partition_email_from_filename():
 def test_auto_partition_email_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.eml")
     with open(filename) as f:
-        elements = partition(file=f)
+        elements = partition(file=f, strategy="hi_res")
     assert len(elements) > 0
     assert elements == EXPECTED_EMAIL_OUTPUT
 
@@ -55,7 +55,7 @@ def test_auto_partition_email_from_file():
 def test_auto_partition_email_from_file_rb():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.eml")
     with open(filename, "rb") as f:
-        elements = partition(file=f)
+        elements = partition(file=f, strategy="hi_res")
     assert len(elements) > 0
     assert elements == EXPECTED_EMAIL_OUTPUT
 
@@ -98,7 +98,7 @@ def test_auto_partition_docx_with_filename(mock_docx_document, expected_docx_ele
     filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     mock_docx_document.save(filename)
 
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert elements == expected_docx_elements
     assert elements[0].metadata.filename == os.path.basename(filename)
 
@@ -108,7 +108,7 @@ def test_auto_partition_docx_with_file(mock_docx_document, expected_docx_element
     mock_docx_document.save(filename)
 
     with open(filename, "rb") as f:
-        elements = partition(file=f)
+        elements = partition(file=f, strategy="hi_res")
     assert elements == expected_docx_elements
 
 
@@ -132,6 +132,7 @@ def test_auto_partition_doc_with_filename(
         filename=doc_filename,
         file_filename=file_filename,
         content_type=content_type,
+        strategy="hi_res",
     )
     assert elements == expected_docx_elements
     assert elements[0].metadata.filename == "mock_document.doc"
@@ -147,7 +148,7 @@ def test_auto_partition_doc_with_file(mock_docx_document, expected_docx_elements
     convert_office_doc(docx_filename, tmpdir.dirname, "doc")
 
     with open(doc_filename, "rb") as f:
-        elements = partition(file=f)
+        elements = partition(file=f, strategy="hi_res")
     assert elements == expected_docx_elements
 
 
@@ -158,7 +159,12 @@ def test_auto_partition_doc_with_file(mock_docx_document, expected_docx_elements
 def test_auto_partition_html_from_filename(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "example-10k.html")
     file_filename = filename if pass_file_filename else None
-    elements = partition(filename=filename, file_filename=file_filename, content_type=content_type)
+    elements = partition(
+        filename=filename,
+        file_filename=file_filename,
+        content_type=content_type,
+        strategy="hi_res",
+    )
     assert len(elements) > 0
     assert elements[0].metadata.filename == os.path.basename(filename)
 
@@ -171,14 +177,19 @@ def test_auto_partition_html_from_file(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-html.html")
     file_filename = filename if pass_file_filename else None
     with open(filename) as f:
-        elements = partition(file=f, file_filename=file_filename, content_type=content_type)
+        elements = partition(
+            file=f,
+            file_filename=file_filename,
+            content_type=content_type,
+            strategy="hi_res",
+        )
     assert len(elements) > 0
 
 
 def test_auto_partition_html_from_file_rb():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-html.html")
     with open(filename, "rb") as f:
-        elements = partition(file=f)
+        elements = partition(file=f, strategy="hi_res")
     assert len(elements) > 0
 
 
@@ -194,7 +205,7 @@ def test_auto_partition_json_from_filename():
     )
     with open(filename) as json_f:
         json_data = json.load(json_f)
-    json_elems = json.loads(elements_to_json(partition(filename=filename)))
+    json_elems = json.loads(elements_to_json(partition(filename=filename, strategy="hi_res")))
     for elem in json_elems:
         # coordinates are always in the element data structures, even if None
         elem.pop("coordinates")
@@ -217,7 +228,7 @@ def test_auto_partition_json_from_file():
     with open(filename) as json_f:
         json_data = json.load(json_f)
     with open(filename, encoding="utf-8") as partition_f:
-        json_elems = json.loads(elements_to_json(partition(file=partition_f)))
+        json_elems = json.loads(elements_to_json(partition(file=partition_f, strategy="hi_res")))
     for elem in json_elems:
         # coordinates are always in the element data structures, even if None
         elem.pop("coordinates")
@@ -236,7 +247,7 @@ EXPECTED_TEXT_OUTPUT = [
 
 def test_auto_partition_text_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-text.txt")
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert len(elements) > 0
     assert elements == EXPECTED_TEXT_OUTPUT
     assert elements[0].metadata.filename == os.path.basename(filename)
@@ -245,7 +256,7 @@ def test_auto_partition_text_from_filename():
 def test_auto_partition_text_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-text.txt")
     with open(filename) as f:
-        elements = partition(file=f)
+        elements = partition(file=f, strategy="hi_res")
     assert len(elements) > 0
     assert elements == EXPECTED_TEXT_OUTPUT
 
@@ -258,7 +269,12 @@ def test_auto_partition_pdf_from_filename(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper-fast.pdf")
     file_filename = filename if pass_file_filename else None
 
-    elements = partition(filename=filename, file_filename=file_filename, content_type=content_type)
+    elements = partition(
+        filename=filename,
+        file_filename=file_filename,
+        content_type=content_type,
+        strategy="hi_res",
+    )
 
     assert isinstance(elements[0], Title)
     assert elements[0].text.startswith("LayoutParser")
@@ -274,7 +290,7 @@ def test_auto_partition_pdf_uses_table_extraction():
     with patch(
         "unstructured_inference.inference.layout.process_file_with_model",
     ) as mock_process_file_with_model:
-        partition(filename, pdf_infer_table_structure=True)
+        partition(filename, pdf_infer_table_structure=True, strategy="hi_res")
         assert mock_process_file_with_model.call_args[1]["extract_tables"]
 
 
@@ -306,7 +322,12 @@ def test_auto_partition_pdf_from_file(pass_file_filename, content_type):
     file_filename = filename if pass_file_filename else None
 
     with open(filename, "rb") as f:
-        elements = partition(file=f, file_filename=file_filename, content_type=content_type)
+        elements = partition(
+            file=f,
+            file_filename=file_filename,
+            content_type=content_type,
+            strategy="hi_res",
+        )
 
     assert isinstance(elements[0], Title)
     assert elements[0].text.startswith("LayoutParser")
@@ -323,7 +344,7 @@ def test_partition_pdf_doesnt_raise_warning():
     #      #additional-use-cases-of-warnings-in-tests
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        partition(filename=filename)
+        partition(filename=filename, strategy="hi_res")
 
 
 @pytest.mark.parametrize(
@@ -333,7 +354,12 @@ def test_partition_pdf_doesnt_raise_warning():
 def test_auto_partition_jpg(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper-fast.jpg")
     file_filename = filename if pass_file_filename else None
-    elements = partition(filename=filename, file_filename=file_filename, content_type=content_type)
+    elements = partition(
+        filename=filename,
+        file_filename=file_filename,
+        content_type=content_type,
+        strategy="hi_res",
+    )
     assert len(elements) > 0
 
 
@@ -345,14 +371,19 @@ def test_auto_partition_jpg_from_file(pass_file_filename, content_type):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper-fast.jpg")
     file_filename = filename if pass_file_filename else None
     with open(filename, "rb") as f:
-        elements = partition(file=f, file_filename=file_filename, content_type=content_type)
+        elements = partition(
+            file=f,
+            file_filename=file_filename,
+            content_type=content_type,
+            strategy="hi_res",
+        )
     assert len(elements) > 0
 
 
 def test_auto_partition_raises_with_bad_type(monkeypatch):
     monkeypatch.setattr(auto, "detect_filetype", lambda *args, **kwargs: None)
     with pytest.raises(ValueError):
-        partition(filename="made-up.fake")
+        partition(filename="made-up.fake", strategy="hi_res")
 
 
 EXPECTED_PPTX_OUTPUT = [
@@ -367,7 +398,7 @@ EXPECTED_PPTX_OUTPUT = [
 
 def test_auto_partition_pptx_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.pptx")
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert elements == EXPECTED_PPTX_OUTPUT
     assert elements[0].metadata.filename == os.path.basename(filename)
 
@@ -375,21 +406,21 @@ def test_auto_partition_pptx_from_filename():
 @pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")
 def test_auto_partition_ppt_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.ppt")
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert elements == EXPECTED_PPTX_OUTPUT
     assert elements[0].metadata.filename == os.path.basename(filename)
 
 
 def test_auto_with_page_breaks():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "layout-parser-paper-fast.pdf")
-    elements = partition(filename=filename, include_page_breaks=True)
+    elements = partition(filename=filename, include_page_breaks=True, strategy="hi_res")
     assert PageBreak() in elements
 
 
 @pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")
 def test_auto_partition_epub_from_filename():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "winter-sports.epub")
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert len(elements) > 0
     assert elements[0].text.startswith("The Project Gutenberg eBook of Winter Sports")
 
@@ -398,7 +429,7 @@ def test_auto_partition_epub_from_filename():
 def test_auto_partition_epub_from_file():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "winter-sports.epub")
     with open(filename, "rb") as f:
-        elements = partition(file=f)
+        elements = partition(file=f, strategy="hi_res")
     assert len(elements) > 0
     assert elements[0].text.startswith("The Project Gutenberg eBook of Winter Sports")
 
@@ -413,7 +444,7 @@ EXPECTED_MSG_OUTPUT = [
 
 def test_auto_partition_msg_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.msg")
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert elements == EXPECTED_MSG_OUTPUT
 
 
@@ -421,20 +452,20 @@ def test_auto_partition_msg_from_filename():
 @pytest.mark.skipif(rtf_not_supported, reason="RTF not supported in this version of pypandoc.")
 def test_auto_partition_rtf_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-doc.rtf")
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert elements[0] == Title("My First Heading")
 
 
 def test_auto_partition_from_url():
     url = "https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/LICENSE.md"
-    elements = partition(url=url, content_type="text/plain")
+    elements = partition(url=url, content_type="text/plain", strategy="hi_res")
     assert elements[0] == Title("Apache License")
     assert elements[0].metadata.url == url
 
 
 def test_partition_md_works_with_embedded_html():
     url = "https://raw.githubusercontent.com/Unstructured-IO/unstructured/main/README.md"
-    elements = partition(url=url, content_type="text/markdown")
+    elements = partition(url=url, content_type="text/markdown", strategy="hi_res")
     elements[0].text
     unstructured_found = False
     for element in elements:
@@ -446,13 +477,13 @@ def test_partition_md_works_with_embedded_html():
 
 def test_auto_partition_warns_if_header_set_and_not_url(caplog):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.eml")
-    partition(filename=filename, headers={"Accept": "application/pdf"})
+    partition(filename=filename, headers={"Accept": "application/pdf"}, strategy="hi_res")
     assert caplog.records[0].levelname == "WARNING"
 
 
 def test_auto_partition_works_with_unstructured_jsons():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "spring-weather.html.json")
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert elements[0].text == "News Around NOAA"
 
 
@@ -460,7 +491,7 @@ def test_auto_partition_works_with_unstructured_jsons_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "spring-weather.html.json")
 
     with open(filename, "rb") as f:
-        elements = partition(file=f)
+        elements = partition(file=f, strategy="hi_res")
     assert elements[0].text == "News Around NOAA"
 
 
@@ -468,7 +499,7 @@ def test_auto_partition_works_with_unstructured_jsons_from_file():
 @pytest.mark.skipif(odt_not_supported, reason="odt not supported in this version of pypandoc.")
 def test_auto_partition_odt_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.odt")
-    elements = partition(filename=filename)
+    elements = partition(filename=filename, strategy="hi_res")
     assert elements == [Title("Lorem ipsum dolor sit amet.")]
 
 
@@ -477,6 +508,6 @@ def test_auto_partition_odt_from_filename():
 def test_auto_partition_odt_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.odt")
     with open(filename, "rb") as f:
-        elements = partition(file=f)
+        elements = partition(file=f, strategy="hi_res")
 
     assert elements == [Title("Lorem ipsum dolor sit amet.")]

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.6"  # pragma: no cover
+__version__ = "0.6.7-dev0"  # pragma: no cover

--- a/unstructured/ingest/doc_processor/generalized.py
+++ b/unstructured/ingest/doc_processor/generalized.py
@@ -17,15 +17,15 @@ def initialize():
     MODEL_TYPES[None]["config_path"]
 
 
-def process_document(doc: "IngestDoc") -> Optional[List[Dict[str, Any]]]:
-    """Process any IngestDoc-like class of document with Unstructured's auto partition logic."""
+def process_document(doc: "IngestDoc", **kwargs) -> Optional[List[Dict[str, Any]]]:
+    """Process any IngestDoc-like class of document with choosen Unstructured's partition logic."""
     isd_elems_no_filename = None
     try:
         # does the work necessary to load file into filesystem
         # in the future, get_file_handle() could also be supported
         doc.get_file()
 
-        isd_elems_no_filename = doc.process_file()
+        isd_elems_no_filename = doc.process_file(**kwargs)
 
         # Note, this may be a no-op if the IngestDoc doesn't do anything to persist
         # the results. Instead, the MainProcess (caller) may work with the aggregate

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -97,10 +97,10 @@ class BaseIngestDoc(ABC):
         """Write the structured json result for this doc. result must be json serializable."""
         pass
 
-    def partition_file(self):
+    def partition_file(self, **kwargs):
         if not self.config.partition_by_api:
             logger.debug("Using local partition")
-            elements = partition(filename=str(self.filename))
+            elements = partition(filename=str(self.filename), **kwargs)
             return convert_to_dict(elements)
 
         else:
@@ -119,12 +119,12 @@ class BaseIngestDoc(ABC):
 
             return response.json()
 
-    def process_file(self):
+    def process_file(self, **kwargs):
         if self.config.download_only:
             return
         logger.info(f"Processing {self.filename}")
 
-        isd_elems = self.partition_file()
+        isd_elems = self.partition_file(**kwargs)
 
         self.isd_elems_no_filename = []
         for elem in isd_elems:

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 import sys
 import warnings
 from contextlib import suppress
+from functools import partial
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -141,6 +142,11 @@ class MainProcess:
     default="https://api.unstructured.io/general/v0/general",
     help="If partitioning via api, use the following host. "
     "Default: https://api.unstructured.io/general/v0/general",
+)
+@click.option(
+    "--partition-strategy",
+    default="auto",
+    help="The method that will be used to process the documents. " "Default: auto",
 )
 @click.option(
     "--local-input-path",
@@ -420,6 +426,7 @@ def main(
     max_docs,
     partition_by_api,
     partition_endpoint,
+    partition_strategy,
     local_input_path,
     local_recursive,
     local_file_glob,
@@ -793,9 +800,14 @@ def main(
         logger.error("No connector-specific option was specified!")
         sys.exit(1)
 
+    process_document_with_partition_strategy = partial(
+        process_document,
+        partition_strategy=partition_strategy,
+    )
+
     MainProcess(
         doc_connector=doc_connector,
-        doc_processor_fn=process_document,
+        doc_processor_fn=process_document_with_partition_strategy,
         num_processes=num_processes,
         reprocess=reprocess,
         verbose=verbose,

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -800,9 +800,10 @@ def main(
         logger.error("No connector-specific option was specified!")
         sys.exit(1)
 
+    # NOTE(yuming): passing kwargs function `partition` in `unstructured.partition.auto`
     process_document_with_partition_strategy = partial(
         process_document,
-        partition_strategy=partition_strategy,
+        strategy=partition_strategy,
     )
 
     MainProcess(

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -30,7 +30,7 @@ def partition(
     file_filename: Optional[str] = None,
     url: Optional[str] = None,
     include_page_breaks: bool = False,
-    strategy: str = "hi_res",
+    strategy: str = "auto",
     encoding: str = "utf-8",
     paragraph_grouper: Optional[Callable[[str], str]] = None,
     headers: Dict[str, str] = {},


### PR DESCRIPTION
### Summary
Passes value of `--partition-strategy` from CLI to `partition` in `unstructured.partition.auto` so that user can specify it with `--partition-strategy fast` or `--partition-strategy hi_res` (default is `auto`).

### Test
* Test the `hi_res` option:
```
PYTHONPATH=. ./unstructured/ingest/main.py        
--s3-url s3://utic-dev-tech-fixtures/small-pdf-set/        
--s3-anonymous        
--structured-output-dir s3-small-batch-output        
--num-processes 2        
--partition-strategy hi_res
```
* Reprocess it with `fast` option to see the speed difference:
```
PYTHONPATH=. ./unstructured/ingest/main.py        
--s3-url s3://utic-dev-tech-fixtures/small-pdf-set/        
--s3-anonymous        
--structured-output-dir s3-small-batch-output        
--num-processes 2        
--partition-strategy fast
 --reprocess
```

