### PR TITLE
enhancement: add `file_directory` to element metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.6.7-dev0
+## 0.6.7-dev1
 
 ### Enhancements
+
+* Add `file_directory` to metadata
 
 ### Features
 

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -42,6 +42,7 @@ def test_auto_partition_email_from_filename():
     assert len(elements) > 0
     assert elements == EXPECTED_EMAIL_OUTPUT
     assert elements[0].metadata.filename == os.path.basename(filename)
+    assert elements[0].metadata.file_directory == os.path.split(filename)[0]
 
 
 def test_auto_partition_email_from_file():
@@ -135,6 +136,7 @@ def test_auto_partition_doc_with_filename(
     )
     assert elements == expected_docx_elements
     assert elements[0].metadata.filename == "mock_document.doc"
+    assert elements[0].metadata.file_directory == tmpdir.dirname
 
 
 # NOTE(robinson) - the application/x-ole-storage mime type is not specific enough to
@@ -161,6 +163,7 @@ def test_auto_partition_html_from_filename(pass_file_filename, content_type):
     elements = partition(filename=filename, file_filename=file_filename, content_type=content_type)
     assert len(elements) > 0
     assert elements[0].metadata.filename == os.path.basename(filename)
+    assert elements[0].metadata.file_directory == os.path.split(filename)[0]
 
 
 @pytest.mark.parametrize(
@@ -240,6 +243,7 @@ def test_auto_partition_text_from_filename():
     assert len(elements) > 0
     assert elements == EXPECTED_TEXT_OUTPUT
     assert elements[0].metadata.filename == os.path.basename(filename)
+    assert elements[0].metadata.file_directory == os.path.split(filename)[0]
 
 
 def test_auto_partition_text_from_file():
@@ -267,6 +271,7 @@ def test_auto_partition_pdf_from_filename(pass_file_filename, content_type):
     assert elements[1].text.startswith("Zejiang Shen")
 
     assert elements[0].metadata.filename == os.path.basename(filename)
+    assert elements[0].metadata.file_directory == os.path.split(filename)[0]
 
 
 def test_auto_partition_pdf_uses_table_extraction():
@@ -370,6 +375,7 @@ def test_auto_partition_pptx_from_filename():
     elements = partition(filename=filename)
     assert elements == EXPECTED_PPTX_OUTPUT
     assert elements[0].metadata.filename == os.path.basename(filename)
+    assert elements[0].metadata.file_directory == os.path.split(filename)[0]
 
 
 @pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")
@@ -378,6 +384,7 @@ def test_auto_partition_ppt_from_filename():
     elements = partition(filename=filename)
     assert elements == EXPECTED_PPTX_OUTPUT
     assert elements[0].metadata.filename == os.path.basename(filename)
+    assert elements[0].metadata.file_directory == os.path.split(filename)[0]
 
 
 def test_auto_with_page_breaks():

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -64,6 +64,8 @@ def test_partition_doc_with_filename(mock_document, expected_elements, tmpdir):
 
     elements = partition_doc(filename=doc_filename)
     assert elements == expected_elements
+    assert elements[0].metadata.filename == "mock_document.doc"
+    assert elements[0].metadata.file_directory == tmpdir.dirname
 
 
 def test_partition_doc_matches_partition_docx(mock_document, expected_elements, tmpdir):

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -13,10 +13,13 @@ DIRECTORY = pathlib.Path(__file__).parent.resolve()
 
 
 def test_partition_html_from_filename():
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")
+    directory = os.path.join(DIRECTORY, "..", "..", "example-docs")
+    filename = os.path.join(directory, "example-10k.html")
     elements = partition_html(filename=filename)
     assert PageBreak() not in elements
     assert len(elements) > 0
+    assert elements[0].metadata.filename == "example-10k.html"
+    assert elements[0].metadata.file_directory == directory
 
 
 def test_partition_html_with_page_breaks():

--- a/test_unstructured/partition/test_msg.py
+++ b/test_unstructured/partition/test_msg.py
@@ -58,6 +58,8 @@ def test_partition_msg_from_filename_with_text_content(monkeypatch):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.msg")
     elements = partition_msg(filename=filename)
     assert str(elements[0]) == "Here is an email with plain text."
+    assert elements[0].metadata.filename == "fake-email.msg"
+    assert elements[0].metadata.file_directory == EXAMPLE_DOCS_DIRECTORY
 
 
 def test_partition_msg_raises_with_missing_file():

--- a/test_unstructured/partition/test_msg.py
+++ b/test_unstructured/partition/test_msg.py
@@ -37,7 +37,7 @@ def test_partition_msg_from_filename():
     elements = partition_msg(filename=filename)
     assert elements == EXPECTED_MSG_OUTPUT
     assert elements[0].metadata == ElementMetadata(
-        filename="fake-email.msg",
+        filename=filename,
         date="2022-12-16T17:04:16-05:00",
         page_number=1,
         url=None,

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -211,6 +211,8 @@ def test_partition_pdf_with_auto_strategy(filename="example-docs/layout-parser-p
     titles = [el for el in elements if el.category == "Title" and len(el.text.split(" ")) > 10]
     title = "LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis"
     assert titles[0].text == title
+    assert titles[0].metadata.filename == "layout-parser-paper-fast.pdf"
+    assert titles[0].metadata.file_directory == "example-docs"
 
 
 def test_partition_pdf_with_page_breaks(filename="example-docs/layout-parser-paper-fast.pdf"):

--- a/test_unstructured_ingest/expected-structured-output/slack-ingest-channel/C052BGT7718.json
+++ b/test_unstructured_ingest/expected-structured-output/slack-ingest-channel/C052BGT7718.json
@@ -5,6 +5,7 @@
     "type": "NarrativeText",
     "metadata": {
       "filename": "C052BGT7718.txt",
+      "file_directory": "slack-ingest-download",
       "filetype": "text/plain",
       "page_number": 1
     }

--- a/test_unstructured_ingest/test-ingest-azure.sh
+++ b/test_unstructured_ingest/test-ingest-azure.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR"/.. || exit 1
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
-    --metadata-exclude filename \
+    --metadata-exclude filename,file_directory \
     --remote-url abfs://container1/ \
     --azure-account-name azureunstructured1 \
     --structured-output-dir azure-ingest-output \

--- a/test_unstructured_ingest/test-ingest-biomed-api.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-api.sh
@@ -25,7 +25,7 @@ if [[ "$(find test_unstructured_ingest/expected-structured-output/biomed-ingest-
 fi
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
-   --metadata-exclude filename \
+   --metadata-exclude filename,file_directory \
    --biomed-api-from "2019-01-02" \
    --biomed-api-until "2019-01-02+00:03:10" \
    --structured-output-dir biomed-ingest-output-api  \

--- a/test_unstructured_ingest/test-ingest-biomed-path.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-path.sh
@@ -25,7 +25,7 @@ if [[ "$(find test_unstructured_ingest/expected-structured-output/biomed-ingest-
 fi
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
-    --metadata-exclude filename \
+    --metadata-exclude filename,file_directory \
     --biomed-path "oa_pdf/07/07/sbaa031.073.PMC7234218.pdf" \
     --structured-output-dir biomed-ingest-output-path \
     --num-processes 2 \
@@ -44,7 +44,7 @@ if [[ "$OVERWRITE_FIXTURES" != "false" ]]; then
 
     OWNER_GROUP=$(stat -c "%u:%g" test_unstructured_ingest/expected-structured-output/biomed-ingest-output-path)
     rsync -rv --chown="$OWNER_GROUP" biomed-ingest-output-path/ test_unstructured_ingest/expected-structured-output/biomed-ingest-output-path
-    
+
 elif ! diff -ru biomed-ingest-output-path test_unstructured_ingest/expected-structured-output/biomed-ingest-output-path ; then
     echo
     echo "There are differences from the previously checked-in structured outputs."

--- a/test_unstructured_ingest/test-ingest-github.sh
+++ b/test_unstructured_ingest/test-ingest-github.sh
@@ -25,7 +25,7 @@ fi
 
 #shellcheck disable=SC2086
 PYTHONPATH=. ./unstructured/ingest/main.py \
-    --metadata-exclude filename \
+    --metadata-exclude filename,file_directory \
     --github-url dcneiner/Downloadify \
     --git-file-glob '*.html,*.txt' \
     --structured-output-dir github-downloadify-output \

--- a/test_unstructured_ingest/test-ingest-gitlab.sh
+++ b/test_unstructured_ingest/test-ingest-gitlab.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"/.. || exit 1
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
-    --metadata-exclude filename \
+    --metadata-exclude filename,file_directory \
     --gitlab-url https://gitlab.com/gitlab-com/content-sites/docsy-gitlab \
     --git-file-glob '*.md,*.txt' \
     --structured-output-dir gitlab-ingest-output \

--- a/test_unstructured_ingest/test-ingest-local.sh
+++ b/test_unstructured_ingest/test-ingest-local.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR"/.. || exit 1
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
-    --metadata-exclude filename \
+    --metadata-exclude filename,file_directory \
     --local-input-path example-docs \
     --local-file-glob "*.html" \
     --structured-output-dir local-ingest-output \

--- a/test_unstructured_ingest/test-ingest-s3.sh
+++ b/test_unstructured_ingest/test-ingest-s3.sh
@@ -12,7 +12,7 @@ if [[ "$(find test_unstructured_ingest/expected-structured-output/s3-small-batch
 fi
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
-    --metadata-exclude filename \
+    --metadata-exclude filename,file_directory \
     --s3-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
     --s3-anonymous \
     --structured-output-dir s3-small-batch-output \

--- a/test_unstructured_ingest/test-ingest-wikipedia.sh
+++ b/test_unstructured_ingest/test-ingest-wikipedia.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"/.. || exit 1
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
-    --metadata-exclude filename \
+    --metadata-exclude filename,file_directory \
     --wikipedia-page-title "Open Source Software" \
     --structured-output-dir wikipedia-ingest-output \
     --num-processes 2 \

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.7-dev0"  # pragma: no cover
+__version__ = "0.6.7-dev1"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -16,6 +16,7 @@ class NoID(ABC):
 @dataclass
 class ElementMetadata:
     filename: Optional[str] = None
+    file_directory: Optional[str] = None
     date: Optional[str] = None
 
     # Page numbers currenlty supported for PDF, HTML and PPT documents
@@ -37,7 +38,9 @@ class ElementMetadata:
             self.filename = str(self.filename)
 
         if self.filename is not None:
-            self.filename = os.path.basename(self.filename)
+            file_directory, filename = os.path.split(self.filename)
+            self.file_directory = file_directory or None
+            self.filename = filename
 
     def to_dict(self):
         return {key: value for key, value in self.__dict__.items() if value is not None}


### PR DESCRIPTION
### Summary

Adds a `file_directory` attribute alongside `filename` in the element metadata.

### Testing

```python
from unstructured.partition.pdf import partition_pdf

elements = partition_pdf("../unstructured/example-docs/layout-parser-paper-fast.pdf")

# Should be layout-parser-paper-fast.pdf
print(elements[0].metadata.filename)

# Should be ../unstructured/example-docs
print(elements[0].metadata.file_directory)
```