### PR TITLE
Fix: support `hml` filetype in partition as a variation of html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.7-dev2
+## 0.6.7-dev3
 
 ### Enhancements
 
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+* Supports `hml` filetype for partition as a variation of html filetype.
 * Makes `pytesseract` a function level import in `partition_pdf` so you can use the `"fast"`
   or `"hi_res"` strategies if `pytesseract` is not installed. Also adds the
   `required_dependencies` decorator for the `"hi_res"` and `"ocr_only"` strategies.

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.7-dev2"  # pragma: no cover
+__version__ = "0.6.7-dev3"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -166,6 +166,7 @@ EXT_TO_FILETYPE = {
     ".text": FileType.TXT,
     ".eml": FileType.EML,
     ".xml": FileType.XML,
+    ".htm": FileType.HTML,
     ".html": FileType.HTML,
     ".md": FileType.MD,
     ".xlsx": FileType.XLSX,
@@ -266,7 +267,7 @@ def detect_filetype(
         return FileType.RTF
 
     elif mime_type.endswith("xml"):
-        if extension and extension == ".html":
+        if extension and (extension == ".html" or extension == ".htm"):
             return FileType.HTML
         else:
             return FileType.XML


### PR DESCRIPTION
### Summary
Addresses https://github.com/Unstructured-IO/unstructured/issues/584 and adds `hml` as a filetype

### Test
```
from unstructured.partition.auto import partition

file_path = "example-docs/example.htm"
partition(filename=file_path)
```