### PR TITLE
feat: add page_name to metadata for Excel documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.7-dev5
+
+### Enhancements
+
+* Add `page_name` to metadata. Currently used for the sheet name in XLSX documents.
+
 ## 0.6.7-dev4
 
 ### Enhancements

--- a/test_unstructured/partition/test_xlsx.py
+++ b/test_unstructured/partition/test_xlsx.py
@@ -32,6 +32,8 @@ EXPECTED_TEXT = "Team Location Stanley Cups Blues STL 1 Flyers PHI 2 Maple Leafs
 
 EXPECTED_FILETYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
+EXCEPTED_PAGE_NAME = "Stanley Cups"
+
 
 def test_partition_xlsx_from_filename(filename="example-docs/stanley-cups.xlsx"):
     elements = partition_xlsx(filename=filename)
@@ -43,6 +45,7 @@ def test_partition_xlsx_from_filename(filename="example-docs/stanley-cups.xlsx")
     assert elements[0].metadata.text_as_html == EXPECTED_TABLE
     assert elements[0].metadata.page_number == 1
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
+    assert elements[0].metadata.page_name == EXCEPTED_PAGE_NAME
 
 
 def test_partition_xlsx_from_file(filename="example-docs/stanley-cups.xlsx"):
@@ -56,6 +59,7 @@ def test_partition_xlsx_from_file(filename="example-docs/stanley-cups.xlsx"):
     assert elements[0].metadata.text_as_html == EXPECTED_TABLE
     assert elements[0].metadata.page_number == 1
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
+    assert elements[0].metadata.page_name == EXCEPTED_PAGE_NAME
 
 
 def test_partition_xlsx_can_exclude_metadata(filename="example-docs/stanley-cups.xlsx"):
@@ -68,3 +72,5 @@ def test_partition_xlsx_can_exclude_metadata(filename="example-docs/stanley-cups
     assert elements[0].metadata.text_as_html is None
     assert elements[0].metadata.page_number is None
     assert elements[0].metadata.filetype is None
+    assert elements[0].metadata.page_name is None
+  

--- a/test_unstructured/partition/test_xlsx.py
+++ b/test_unstructured/partition/test_xlsx.py
@@ -73,4 +73,3 @@ def test_partition_xlsx_can_exclude_metadata(filename="example-docs/stanley-cups
     assert elements[0].metadata.page_number is None
     assert elements[0].metadata.filetype is None
     assert elements[0].metadata.page_name is None
-  

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.7-dev4"  # pragma: no cover
+__version__ = "0.6.7-dev5"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -25,6 +25,9 @@ class ElementMetadata:
     # Page numbers currenlty supported for PDF, HTML and PPT documents
     page_number: Optional[int] = None
 
+    # Page name. The sheet name in XLXS documents.
+    page_name: Optional[str] = None
+
     # Webpage specific metadata fields
     url: Optional[str] = None
 

--- a/unstructured/partition/xlsx.py
+++ b/unstructured/partition/xlsx.py
@@ -51,6 +51,7 @@ def partition_xlsx(
         if include_metadata:
             metadata = ElementMetadata(
                 text_as_html=html_text,
+                page_name=sheet_name,
                 page_number=page_number,
                 filename=metadata_filename,
             )


### PR DESCRIPTION
Added tracking for the sheet name of Excels documents as a `page_name` field in the `ElementMetadata` class.

#600 