### PR TITLE
Fix(ingest): Deprecate `--s3-url` in favor of `--remote-url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.6.7-dev7
+## 0.6.7-dev8
 
 ### Enhancements
 
+* Deprecate `--s3-url` in favor of `--remote-url` in CLI
 * Refactor out non-connector-specific config variables
 * Add `file_directory` to metadata
 * Add `page_name` to metadata. Currently used for the sheet name in XLSX documents.

--- a/Ingest.md
+++ b/Ingest.md
@@ -6,10 +6,10 @@ The unstructured library includes a CLI to batch ingest documents from (soon to 
 various) sources, storing structured outputs locally on the filesystem.
 
 For example, the following command processes all the documents in S3 in the
-`utic-dev-tech-fixtures` bucket with a prefix of `small-pdf-set/`. 
+`utic-dev-tech-fixtures` bucket with a prefix of `small-pdf-set/`.
 
     unstructured-ingest \
-       --s3-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
+       --remote-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
        --s3-anonymous \
        --structured-output-dir s3-small-batch-output \
        --num-processes 2
@@ -30,7 +30,7 @@ When testing from a local checkout rather than a pip-installed version of `unstr
 just execute `unstructured/ingest/main.py`, e.g.:
 
     PYTHONPATH=. ./unstructured/ingest/main.py \
-       --s3-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
+       --remote-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
        --s3-anonymous \
        --structured-output-dir s3-small-batch-output \
        --num-processes 2

--- a/examples/ingest/s3-small-batch/ingest.sh
+++ b/examples/ingest/s3-small-batch/ingest.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR"/../../.. || exit 1
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
-         --s3-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
+         --remote-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
          --s3-anonymous \
          --structured-output-dir s3-small-batch-output \
          --num-processes 2

--- a/test_unstructured_ingest/test-ingest-s3.sh
+++ b/test_unstructured_ingest/test-ingest-s3.sh
@@ -18,7 +18,6 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --structured-output-dir s3-small-batch-output \
     --preserve-downloads \
     --partition-strategy hi_res \
-    --download-dir s3-download \
     --reprocess
 
 OVERWRITE_FIXTURES=${OVERWRITE_FIXTURES:-false}

--- a/test_unstructured_ingest/test-ingest-s3.sh
+++ b/test_unstructured_ingest/test-ingest-s3.sh
@@ -13,11 +13,12 @@ fi
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
     --metadata-exclude filename,file_directory \
-    --s3-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
+    --remote-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
     --s3-anonymous \
     --structured-output-dir s3-small-batch-output \
     --preserve-downloads \
     --partition-strategy hi_res \
+    --download-dir s3-download \
     --reprocess
 
 OVERWRITE_FIXTURES=${OVERWRITE_FIXTURES:-false}

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.7-dev7"  # pragma: no cover
+__version__ = "0.6.7-dev8"  # pragma: no cover

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -173,12 +173,6 @@ class MainProcess:
     "a directory or a single file. Supported protocols are: `s3`, `s3a`, `abfs`, and `az`.",
 )
 @click.option(
-    "--s3-url",
-    default=None,
-    help="Prefix of s3 objects (files) to download. E.g. s3://bucket1/path/. This value may "
-    "also be a single file. To be deprecated in favor of --remote-url.",
-)
-@click.option(
     "--s3-anonymous",
     is_flag=True,
     default=False,
@@ -399,7 +393,6 @@ class MainProcess:
 @click.option("-v", "--verbose", is_flag=True, default=False)
 def main(
     remote_url,
-    s3_url,  # TODO: deprecate this in the next minor release
     s3_anonymous,
     azure_account_name,
     azure_account_key,
@@ -491,13 +484,6 @@ def main(
         cache_path = Path.home() / ".cache" / "unstructured" / "ingest"
         if not cache_path.exists():
             cache_path.mkdir(parents=True, exist_ok=True)
-        if s3_url:
-            warnings.warn(
-                "The `--s3-url` option will be deprecated in favor of `--remote-url`"
-                " in the next minor release.",
-                DeprecationWarning,
-            )
-            remote_url = s3_url
         if remote_url:
             hashed_dir_name = hashlib.sha256(remote_url.encode("utf-8"))
         elif github_url:
@@ -561,7 +547,7 @@ def main(
             doc_connector = S3Connector(  # type: ignore
                 standard_config=standard_config,
                 config=SimpleS3Config(
-                    path=s3_url,
+                    path=remote_url,
                     access_kwargs={"anon": s3_anonymous},
                 ),
             )


### PR DESCRIPTION
### Summary
Deprecate `--s3-url` so that a s3 url can be passed into `--remote-url`. This fixes the problem that `--s3-url` and `--download-dir` can't be used together.

### Test
```
PYTHONPATH=. ./unstructured/ingest/main.py \
    --metadata-exclude filename,file_directory \
    --remote-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
    --s3-anonymous \
    --structured-output-dir s3-small-batch-output \
    --preserve-downloads \
    --partition-strategy hi_res \
    --download-dir s3-download \
    --reprocess
```