### PR TITLE
chore: bump version for `0.6.7` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.7-dev8
+## 0.6.7
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.7-dev8"  # pragma: no cover
+__version__ = "0.6.7"  # pragma: no cover


### PR DESCRIPTION
### Summary

Bumps the `unstructured` version for the `0.6.7` release.