### PR TITLE
Build using base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,80 +1,8 @@
 # syntax=docker/dockerfile:experimental
 
-FROM centos:centos7.9.2009
+FROM quay.io/unstructured-io/base-images:centos7.9
 
 ARG PIP_VERSION
-
-# Install dependency packages
-RUN yum -y update && \
-  yum -y install poppler-utils xz-devel wget tar curl make which mailcap && \
-  yum install -y epel-release && \
-  yum install -y pandoc && \
-  yum -y install libreoffice && \
-  yum clean all
-
-# Install gcc & g++ ≥ 8 for Tesseract and Detectron2
-RUN yum -y install centos-release-scl && \
-  yum -y install devtoolset-9-gcc* && \
-  yum clean all
-
-SHELL [ "/usr/bin/scl", "enable", "devtoolset-9"]
-
-# Install Tessaract
-RUN set -ex && \
-    $sudo yum install -y opencv opencv-devel opencv-python perl-core clang libpng-devel libtiff-devel libwebp-devel libjpeg-turbo-devel git-core libtool pkgconfig xz && \
-    wget https://github.com/DanBloomberg/leptonica/releases/download/1.75.1/leptonica-1.75.1.tar.gz && \
-    tar -xzvf leptonica-1.75.1.tar.gz && \
-    cd leptonica-1.75.1 || exit && \
-    ./configure && make && $sudo make install && \
-    cd .. && \
-    wget http://mirror.squ.edu.om/gnu/autoconf-archive/autoconf-archive-2017.09.28.tar.xz && \
-    tar -xvf autoconf-archive-2017.09.28.tar.xz && \
-    cd autoconf-archive-2017.09.28 || exit && \
-    ./configure && make && $sudo make install && \
-    $sudo cp m4/* /usr/share/aclocal && \
-    cd .. && \
-    git clone --depth 1  https://github.com/tesseract-ocr/tesseract.git tesseract-ocr && \
-    cd tesseract-ocr || exit && \
-    export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig && \
-    scl enable devtoolset-9 -- sh -c './autogen.sh && ./configure && make && make install' && \
-    cd .. && \
-    git clone https://github.com/tesseract-ocr/tessdata.git  && \
-    $sudo cp tessdata/*.traineddata /usr/local/share/tessdata && \
-    $sudo rm -rf /tesseract-ocr /tessdata /autoconf-archive-2017.09.28* /leptonica-1.75.1* && \
-    $sudo yum -y remove opencv opencv-devel opencv-python perl-core clang libpng-devel libtiff-devel libwebp-devel libjpeg-turbo-devel git-core libtool && \
-    $sudo rm -rf /var/cache/yum/* && \
-    $sudo rm -rf /tmp/* && \
-    yum clean all
-
-# SSL dependency gets baked into Python binary so do this first
-RUN yum -y update && \
-  yum install -y perl-core pcre-devel && \
-  wget https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz && \
-  tar -xzvf openssl-1.1.1k.tar.gz && \
-  cd openssl-1.1.1k && \
-  ./config shared --prefix=/usr/local/ssl --openssldir=/usr/local/ssl && \
-  make && \
-  make install && cd .. && \
-  ldconfig && \
-  rm -rf openssl-1.1.1k && rm openssl-1.1.1k.tar.gz && \
-  $sudo yum -y remove perl-core pcre-devel && \
-  yum clean all
-
-ENV PATH="/usr/local/ssl/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/ssl/lib:$LD_LIBRARY_PATH"
-ENV SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
-
-# Install Python
-RUN yum -y install bzip2-devel libffi-devel make git sqlite-devel && \
-  curl -O https://www.python.org/ftp/python/3.8.15/Python-3.8.15.tgz && tar -xzf Python-3.8.15.tgz && \
-  cd Python-3.8.15/ && \
-  ./configure --enable-optimizations --with-openssl=/usr/local/ssl && \
-  make altinstall && \
-  cd .. && rm -rf Python-3.8.15* && \
-  ln -s /usr/local/bin/python3.8 /usr/local/bin/python3 && \
-  $sudo yum -y remove bzip2-devel libffi-devel make sqlite-devel && \
-  $sudo rm -rf /var/cache/yum/* && \
-  yum clean all
 
 # Set up environment
 ENV HOME /home/


### PR DESCRIPTION
This should speed up the builds a lot by using a docker image that has all the required system libraries and packages compiled/installed.

You can find the Dockerfile for the base image at https://github.com/Unstructured-IO/base-images or pull them from quay at quay.io/unstructured-io/base-images:centos7.9

The base image has been built for both linux/arm64 and linux/amd64 using docker buildx