### PR TITLE
enhancement: include coords in fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.6.9-dev0
+## 0.6.9-dev1
 
 ### Enhancements
+
+* fast strategy for pdf now keeps element bounding box data
 
 ### Features
 

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -404,7 +404,15 @@ def test_partition_pdf_fast_groups_text_in_text_box():
     filename = os.path.join("example-docs", "chevron-page.pdf")
     elements = pdf.partition_pdf(filename=filename, strategy="fast")
 
-    assert elements[0] == Title("eastern mediterranean")
+    assert elements[0] == Title(
+        "eastern mediterranean",
+        coordinates=(
+            (193.1741, 71.94000000000005),
+            (193.1741, 91.94000000000005),
+            (418.6881, 91.94000000000005),
+            (418.6881, 71.94000000000005),
+        ),
+    )
 
     assert isinstance(elements[1], NarrativeText)
     assert str(elements[1]).startswith("We")
@@ -412,4 +420,10 @@ def test_partition_pdf_fast_groups_text_in_text_box():
 
     assert elements[3] == Title(
         "kilograms CO₂e/boe carbon intensity from our Eastern Mediterranean operations in 2022",
+        coordinates=(
+            (69.4871, 222.4357),
+            (69.4871, 272.1607),
+            (197.8209, 272.1607),
+            (197.8209, 222.4357),
+        ),
     )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.9-dev0"  # pragma: no cover
+__version__ = "0.6.9-dev1"  # pragma: no cover

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -90,17 +90,22 @@ def partition_text(
     for ctext in file_content:
         ctext = ctext.strip()
 
-        if ctext == "":
-            continue
-        if is_bulleted_text(ctext):
-            elements.append(ListItem(text=clean_bullets(ctext), metadata=metadata))
-        elif is_us_city_state_zip(ctext):
-            elements.append(Address(text=ctext, metadata=metadata))
-        elif is_possible_narrative_text(ctext):
-            elements.append(NarrativeText(text=ctext, metadata=metadata))
-        elif is_possible_title(ctext):
-            elements.append(Title(text=ctext, metadata=metadata))
-        else:
-            elements.append(Text(text=ctext, metadata=metadata))
+        if ctext:
+            element = element_from_text(ctext)
+            element.metadata = metadata
+            elements.append(element)
 
     return elements
+
+
+def element_from_text(text: str) -> Element:
+    if is_bulleted_text(text):
+        return ListItem(text=clean_bullets(text))
+    elif is_us_city_state_zip(text):
+        return Address(text=text)
+    elif is_possible_narrative_text(text):
+        return NarrativeText(text=text)
+    elif is_possible_title(text):
+        return Title(text=text)
+    else:
+        return Text(text=text)


### PR DESCRIPTION
After telling a user that the element bounding box coordinates were available when using the `fast` strategy, I realized that's actually not true. This PR is to make the bounding box coordinates available.

- Refactored `partition_text` to make the workflow of categorizing an element purely from the text available without running the entirety of `partition_text`. 
- Transformed the coordinates from pdf space into pixel space to be consistent with `hi_res`. We will probably want to revisit the coordinate system soon.
- Updated a test

#### Testing:
```python
from unstructured.partition.pdf import partition_pdf
elements = partition_pdf("example-docs/layout-parser-paper-fast.pdf", strategy="fast")
for el in elements:
    print(el.coordinates)

```
Coordinates should not be `None`.

You can also run the following notebook from the unstructured base folder in the unstructured environment.

[fast-coords.ipynb.zip](https://github.com/Unstructured-IO/unstructured/files/11523184/fast-coords.ipynb.zip)
