### PR TITLE
fix(ci):  prevent gha caching conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  GHA_CACHE_KEY: unstructured-${{ runner.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('requirements/*.txt') }}
+  GHA_CACHE_KEY_SUFFIX: -v1-${{ hashFiles('requirements/*.txt') }}
 
 jobs:
   setup:
@@ -25,7 +25,7 @@ jobs:
         path: |
           .venv
           nltk_data
-        key: $GHA_CACHE_KEY
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -50,7 +50,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: $GHA_CACHE_KEY
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -78,7 +78,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: $GHA_CACHE_KEY
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -118,7 +118,7 @@ jobs:
         path: |
           .venv
           nltk_data
-        key: $GHA_CACHE_KEY
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
@@ -154,7 +154,7 @@ jobs:
         path: |
           .venv
           nltk_data
-        key: $GHA_CACHE_KEY
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
@@ -211,7 +211,7 @@ jobs:
           path: |
             .venv
             nltk_data
-          key: $GHA_CACHE_KEY
+          key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
     - uses: actions/cache/restore@v3
       id: virtualenv-cache
       with:
-        path: .venv
+        path: |
+          .venv
+          nltk_data
         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -77,7 +79,9 @@ jobs:
     - uses: actions/cache/restore@v3
       id: virtualenv-cache
       with:
-        path: .venv
+        path: |
+          .venv
+          nltk_data
         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
       run: |
         python${{ matrix.python-version}} -m venv .venv
         source .venv/bin/activate
+        mkdir "$NLTK_DATA"
         make install-ci
     - name: Test
       run: |
@@ -158,6 +159,7 @@ jobs:
       run: |
         python${{ matrix.python-version}} -m venv .venv
         source .venv/bin/activate
+        mkdir "$NLTK_DATA"
         make install-ci
     - name: Test
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  GHA_CACHE_KEY_SUFFIX: -v1-${{ hashFiles('requirements/*.txt') }}
+  GHA_CACHE_KEY_VERSION: "v1"
 
 jobs:
   setup:
@@ -25,7 +25,7 @@ jobs:
         path: |
           .venv
           nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -50,7 +50,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -78,7 +78,7 @@ jobs:
       id: virtualenv-cache
       with:
         path: .venv
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -118,7 +118,7 @@ jobs:
         path: |
           .venv
           nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
@@ -154,7 +154,7 @@ jobs:
         path: |
           .venv
           nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
@@ -211,7 +211,7 @@ jobs:
           path: |
             .venv
             nltk_data
-          key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_SUFFIX }}
+          key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
       run: |
         python${{ matrix.python-version }} -m venv .venv
         source .venv/bin/activate
-        mkdir "$NLTK_DATA"
         make install-ci
     - name: Lint
       run: |
@@ -124,7 +123,6 @@ jobs:
       run: |
         python${{ matrix.python-version}} -m venv .venv
         source .venv/bin/activate
-        mkdir "$NLTK_DATA"
         make install-ci
     - name: Test
       run: |
@@ -160,7 +158,6 @@ jobs:
       run: |
         python${{ matrix.python-version}} -m venv .venv
         source .venv/bin/activate
-        mkdir "$NLTK_DATA"
         make install-ci
     - name: Test
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,13 @@
 name: CI
 
 on:
-  # NOTE(robinson) - We are limiting when we run CI avoid exceeding our 2,000 min/month limit.
-  # We can switch to running on push if we make this repo public or are fine with
-  # paying for CI minutes.
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
 
+env:
+  GHA_CACHE_KEY: unstructured-${{ runner.os }}-${{ matrix.python-version }}-v1-${{ hashFiles('requirements/*.txt') }}
 
 jobs:
   setup:
@@ -26,7 +25,7 @@ jobs:
         path: |
           .venv
           nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
+        key: $GHA_CACHE_KEY
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -36,6 +35,7 @@ jobs:
       run: |
         python${{ matrix.python-version }} -m venv .venv
         source .venv/bin/activate
+        mkdir "$NLTK_DATA"
         make install-ci
 
   check-deps:
@@ -46,13 +46,11 @@ jobs:
     needs: setup
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/cache/restore@v3
       id: virtualenv-cache
       with:
         path: .venv
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
-    # NOTE(robinson) - This is a fallback in case the lint job does not find the cache.
-    # We can take this out when we implement the fix in CORE-99
+        key: $GHA_CACHE_KEY
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -76,13 +74,11 @@ jobs:
     needs: setup
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/cache/restore@v3
       id: virtualenv-cache
       with:
         path: .venv
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
-    # NOTE(robinson) - This is a fallback in case the lint job does not find the cache.
-    # We can take this out when we implement the fix in CORE-99
+        key: $GHA_CACHE_KEY
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -92,6 +88,7 @@ jobs:
       run: |
         python${{ matrix.python-version }} -m venv .venv
         source .venv/bin/activate
+        mkdir "$NLTK_DATA"
         make install-ci
     - name: Lint
       run: |
@@ -115,20 +112,19 @@ jobs:
     needs: [setup, lint]
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/cache/restore@v3
       id: virtualenv-cache
       with:
         path: |
           .venv
           nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
-    # NOTE(robinson) - This is a fallback in case the job does not find the cache.
-    # We can take this out when we implement the fix in CORE-99
+        key: $GHA_CACHE_KEY
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         python${{ matrix.python-version}} -m venv .venv
         source .venv/bin/activate
+        mkdir "$NLTK_DATA"
         make install-ci
     - name: Test
       run: |
@@ -152,20 +148,19 @@ jobs:
     needs: [setup, lint]
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/cache/restore@v3
       id: virtualenv-cache
       with:
         path: |
           .venv
           nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
-    # NOTE(robinson) - This is a fallback in case the lint job does not find the cache.
-    # We can take this out when we implement the fix in CORE-99
+        key: $GHA_CACHE_KEY
     - name: Setup virtual environment (no cache hit)
       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
       run: |
         python${{ matrix.python-version}} -m venv .venv
         source .venv/bin/activate
+        mkdir "$NLTK_DATA"
         make install-ci
     - name: Test
       env:
@@ -210,13 +205,13 @@ jobs:
     needs: [ setup, lint ]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         id: virtualenv-cache
         with:
           path: |
             .venv
             nltk_data
-          key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
+          key: $GHA_CACHE_KEY
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Jobs occasionally fall in to a competing state to set the cache where they don't all install the same things in the venv (which is cached), but they all use the same cache key. So if say `check-deps` wins, it will only install base-pip-packages [here](https://github.com/Unstructured-IO/unstructured/blob/main/.github/workflows/ci.yml#L65). Then any time anyone else fetches they'll get -that- version of the venv and not have the modules they necessarily need.

To resolve, this makes the setup job solely responsible for writing to the cache. All other jobs require setup to complete and then only pull the cache (not try to write to it). 

To make matters slightly more odd, afaict it seems the path argument for the gha cache module will impact whether or not a key matches. So when we were matching again `path: .venv` vs `path: .venv nldk_data` these were actually retrieving different caches. For now, just always specifying the same path every time regardless of the needs and this works reliably. Pulling the nldk_data is pretty quick so seems like a fine compromise for stability (and not managing multiple caches).

bonus: adds a version to the gha cache key so it's easier to invalidate/bump in the future. also only sets this in one place as an env var.
bonus: creates NLTK directory at specified location which should actually allow it to be downloaded and cached as expected
bonus: removes note on CI limits (not relevant)
