### PR TITLE
fix: Fix metadata merging strategy

### DIFF
--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -93,14 +93,14 @@ def _add_element_metadata(
         )
         if isinstance(element, list):
             for _element in element:
-                _element.metadata = metadata.merge(_element.metadata)
+                _element.metadata = _element.metadata.merge(metadata)
             elements.extend(element)
         elif isinstance(element, PageBreak):
             page_number += 1
             if include_page_breaks:
                 elements.append(element)
         else:
-            element.metadata = metadata.merge(element.metadata)
+            element.metadata = element.metadata.merge(metadata)
             elements.append(element)
     return elements
 


### PR DESCRIPTION
Hi!
I noticed that the current implementation in `_add_element_metadata` (called from the `add_metadata_with_filetype` decorator, etc.) is overriding metadata instead of 'adding' it, which leads to a bug where all elements with `page_number=1` are returned when parsing PDFs with multiple pages...
