### PR TITLE
fix: raise `ValueError` in `partition_via_api` if filename not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.12-dev0
+## 0.6.12-dev1
 
 ### Enhancements
 
@@ -12,6 +12,8 @@
 * Adds functionality to try other common encodings for email (`.eml`) files if an error related to the encoding is raised and the user has not specified an encoding.
 * Allow passed encoding to be used in the `replace_mime_encodings`
 * Fixes page metadata for `partition_html` when `include_metadata=False`
+* A `ValueError` now raises if `file_filename` is not specified when you use `partition_via_api`
+  with a file-like object.
 
 ## 0.6.11
 

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -62,6 +62,18 @@ def test_partition_via_api_from_file(monkeypatch):
     assert elements[0] == NarrativeText("This is a test email to use for unit tests.")
 
 
+def test_partition_via_api_from_file_raises_without_filename(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockResponse(status_code=200),
+    )
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
+
+    with open(filename, "rb") as f, pytest.raises(ValueError):
+        partition_via_api(file=f, api_key="FAKEROO")
+
+
 def test_partition_via_api_raises_with_bad_response(monkeypatch):
     monkeypatch.setattr(
         requests,

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.12-dev0"  # pragma: no cover
+__version__ = "0.6.12-dev1"  # pragma: no cover

--- a/unstructured/partition/api.py
+++ b/unstructured/partition/api.py
@@ -71,9 +71,13 @@ def partition_via_api(
                 files=files,  # type: ignore
             )
     elif file is not None:
-        _filename = file_filename or ""
+        if file_filename is None:
+            raise ValueError(
+                "If file is specified in partition_via_api, "
+                "file_filename must be specified as well.",
+            )
         files = [
-            ("files", (_filename, file, content_type)),  # type: ignore
+            ("files", (file_filename, file, content_type)),  # type: ignore
         ]
         response = requests.post(api_url, headers=headers, data=data, files=files)  # type: ignore
 


### PR DESCRIPTION
### Summary

Closes #533. Raises a `ValueError` if you use `partition_via_api` with a file-like object but do not specify `file_filename`. Currently this fails with a `400`, making it unclear what the problem was. We can remove the `ValueError` if the API supports files without `file_filename` in the future.