### PR TITLE
test: revive ingest unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
         source .venv/bin/activate
         mkdir "$NLTK_DATA"
         make install-ci
-    - name: Test (unit)
+    - name: Test Ingest (unit)
       run: |
         source .venv/bin/activate
         PYTHONPATH=. pytest test_unstructured_ingest/unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,11 @@ jobs:
         source .venv/bin/activate
         mkdir "$NLTK_DATA"
         make install-ci
-    - name: Test
+    - name: Test (unit)
+      run: |
+        source .venv/bin/activate
+        PYTHONPATH=. pytest test_unstructured_ingest/unit
+    - name: Test (end-to-end)
       env:
         GH_READ_ONLY_ACCESS_TOKEN: ${{ secrets.GH_READ_ONLY_ACCESS_TOKEN }}
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/test_unstructured_ingest/unit/test_interfaces.py
+++ b/test_unstructured_ingest/unit/test_interfaces.py
@@ -51,12 +51,12 @@ class TestIngestDoc(BaseIngestDoc):
 @pytest.fixture()
 def partition_test_results():
     # Reusable partition test results, calculated only once
-    yield partition(filename=str(TEST_FILE_PATH))
+    return partition(filename=str(TEST_FILE_PATH))
 
 @pytest.fixture()
 def partition_file_test_results(partition_test_results):
     # Reusable partition_file test results, calculated only once
-    yield convert_to_dict(partition_test_results)
+    return convert_to_dict(partition_test_results)
 
 def test_process_file_fields_include_default(mocker, partition_test_results):
     """Validate when metadata_include and metadata_exclude are not set, all fields:

--- a/test_unstructured_ingest/unit/test_interfaces.py
+++ b/test_unstructured_ingest/unit/test_interfaces.py
@@ -1,153 +1,139 @@
-from dataclasses import dataclass
 import os
 import pathlib
+from dataclasses import dataclass
 
 import pytest
 
-from unstructured.ingest.interfaces import BaseConnector, BaseConnectorConfig, BaseIngestDoc, StandardConnectorConfig
+from unstructured.ingest.connector.local import LocalIngestDoc, SimpleLocalConfig
+from unstructured.ingest.interfaces import (
+    BaseConnector,
+    BaseConnectorConfig,
+    BaseIngestDoc,
+    StandardConnectorConfig,
+)
+from unstructured.partition.auto import partition
+from unstructured.staging.base import convert_to_dict
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
-EXAMPLE_DOCS_DIRECTORY = os.path.join(DIRECTORY, "..", "example-docs")
-
-test_files = [
-    "layout-parser-paper-fast.jpg",
-    "layout-parser-paper-fast.pdf",
-]
+EXAMPLE_DOCS_DIRECTORY = os.path.join(DIRECTORY, "../..", "example-docs")
+TEST_DOWNLOAD_DIR="/tmp"
+TEST_OUTPUT_DIR="/tmp"
+TEST_ID="test"
+TEST_FILE_PATH=os.path.join(EXAMPLE_DOCS_DIRECTORY, "book-war-and-peace-1p.txt")
 
 @dataclass
 class TestConfig(BaseConnectorConfig):
     id: str
     path: str
 
+TEST_CONFIG=TestConfig(id=TEST_ID, path=TEST_FILE_PATH)
+
 @dataclass
 class TestIngestDoc(BaseIngestDoc):
-    pass
-
-@dataclass
-class TestConnector(BaseConnector):
     config: TestConfig
-    pass
 
+    @property
+    def filename(self):
+        return "test"
+    
+    def cleanup_file(self):
+        pass
 
+    def get_file(self):
+        pass
 
+    def has_output(self):
+        return True
+    
+    def write_result(self, result):
+        pass
 
-@pytest.mark.parametrize("filename", test_files)
-def test_process_file_metadata_include_filename(filename: str):
-    ingest_doc = GitIngestDoc(
-        path=filename,
-        config=SimpleGitConfig(),
-        standard_config=StandardConnectorConfig(
-            download_dir=EXAMPLE_DOCS_DIRECTORY,
-            output_dir="",  # not used
-            metadata_include="filename",
-        )
+@pytest.fixture()
+def partition_test_results():
+    # Reusable partition test results, calculated only once
+    return partition(filename=str(TEST_FILE_PATH))
+
+@pytest.fixture()
+def partition_file_test_results(partition_test_results):
+    # Reusable partition_file test results, calculated only once
+    return convert_to_dict(partition_test_results)
+
+def test_process_file_fields_include_default(mocker, partition_test_results):
+    """Validate when metadata_include and metadata_exclude are not set, all fields:
+    ("element_id", "text", "type", "metadata") are included"""
+    mocker.patch(
+        "unstructured.ingest.interfaces.partition",
+        return_value=partition_test_results,
     )
-    isd_elems = ingest_doc.process_file(strategy="hi_res")
-
-    for elem in isd_elems:
-        assert set(elem["metadata"].keys()) == {"filename"}
-
-
-@pytest.mark.parametrize("filename", test_files)
-def test_process_file_metadata_include_filename_pagenum(filename: str):
-    ingest_doc = GitIngestDoc(
-        path=filename,
-        config=SimpleGitConfig(
-            download_dir=EXAMPLE_DOCS_DIRECTORY,
+    test_ingest_doc = TestIngestDoc(
+        config=TEST_CONFIG,
+        standard_config=StandardConnectorConfig(
+            download_dir=TEST_DOWNLOAD_DIR,
+            output_dir=TEST_OUTPUT_DIR,
             metadata_include="filename,page_number",
         ),
     )
-    isd_elems = ingest_doc.process_file(strategy="hi_res")
-
-    for elem in isd_elems:
-        assert set(elem["metadata"].keys()) == {"filename", "page_number"}
-
-
-@pytest.mark.parametrize("filename", test_files)
-def test_process_file_metadata_exclude_filename(filename: str):
-    ingest_doc = GitIngestDoc(
-        path=filename,
-        config=SimpleGitConfig(
-            download_dir=EXAMPLE_DOCS_DIRECTORY,
-            metadata_exclude="filename",
-        ),
-    )
-    isd_elems = ingest_doc.process_file(strategy="hi_res")
-
-    for elem in isd_elems:
-        assert "filename" not in elem["metadata"].keys()
-
-
-@pytest.mark.parametrize("filename", test_files)
-def test_process_file_metadata_exclude_filename_pagenum(filename: str):
-    ingest_doc = GitIngestDoc(
-        path=filename,
-        config=SimpleGitConfig(
-            download_dir=EXAMPLE_DOCS_DIRECTORY,
-            metadata_exclude="filename,page_number",
-        ),
-    )
-    isd_elems = ingest_doc.process_file(strategy="hi_res")
-
-    for elem in isd_elems:
-        assert "filename" not in elem["metadata"].keys()
-        assert "page_number" not in elem["metadata"].keys()
-
-
-@pytest.mark.parametrize("filename", test_files)
-def test_process_file_fields_include_default(filename: str):
-    ingest_doc = GitIngestDoc(
-        path=filename,
-        config=SimpleGitConfig(
-            download_dir=EXAMPLE_DOCS_DIRECTORY,
-        ),
-    )
-    isd_elems = ingest_doc.process_file(strategy="hi_res")
-
+    isd_elems = test_ingest_doc.process_file()
+    assert len(isd_elems)
     for elem in isd_elems:
         assert {"element_id", "text", "type", "metadata"} == set(elem.keys())
 
 
-@pytest.mark.parametrize("filename", test_files)
-def test_process_file_fields_include_elementid(filename: str):
-    ingest_doc = GitIngestDoc(
-        path=filename,
-        config=SimpleGitConfig(
-            download_dir=EXAMPLE_DOCS_DIRECTORY,
-            fields_include="element_id",
+def test_process_file_metadata_includes_filename_and_page_number(mocker, partition_test_results):
+    """Validate when metadata_include is set to "filename,page_number",
+    only filename is included in metadata"""
+    mocker.patch(
+        "unstructured.ingest.interfaces.partition",
+        return_value=partition_test_results,
+    )
+    test_ingest_doc = TestIngestDoc(
+        config=TEST_CONFIG,
+        standard_config=StandardConnectorConfig(
+            download_dir=TEST_DOWNLOAD_DIR,
+            output_dir=TEST_OUTPUT_DIR,
+            metadata_include="filename,page_number",
         ),
     )
-    isd_elems = ingest_doc.process_file(strategy="hi_res")
-
+    isd_elems = test_ingest_doc.process_file()
+    assert len(isd_elems)
     for elem in isd_elems:
-        assert {"element_id"} == set(elem.keys())
+        assert set(elem["metadata"].keys()) == {"filename", "page_number"}
 
-
-@pytest.mark.parametrize("filename", test_files)
-def test_process_file_flatten_metadata_filename(filename: str):
-    ingest_doc = GitIngestDoc(
-        path=filename,
-        config=SimpleGitConfig(
-            download_dir=EXAMPLE_DOCS_DIRECTORY,
-            metadata_include="filename",
-            flatten_metadata=True,
+def test_process_file_metadata_exclude_filename_pagenum(mocker, partition_test_results):
+    """Validate when metadata_exclude is set to "filename,page_number",
+    neither filename nor page_number are included in metadata"""
+    mocker.patch(
+        "unstructured.ingest.interfaces.partition",
+        return_value=partition_test_results,
+    )
+    test_ingest_doc = TestIngestDoc(
+        config=TEST_CONFIG,
+        standard_config=StandardConnectorConfig(
+            download_dir=TEST_DOWNLOAD_DIR,
+            output_dir=TEST_OUTPUT_DIR,
+            metadata_exclude="filename,page_number",
         ),
     )
-    isd_elems = ingest_doc.process_file(strategy="hi_res")
+    isd_elems = test_ingest_doc.process_file()
+    assert len(isd_elems)
     for elem in isd_elems:
-        assert {"element_id", "text", "type", "filename"} == set(elem.keys())
+        assert "filename" not in elem["metadata"].keys()
+        assert "page_number" not in elem["metadata"].keys()
 
-
-@pytest.mark.parametrize("filename", test_files)
-def test_process_file_flatten_metadata_filename_pagenum(filename: str):
-    ingest_doc = GitIngestDoc(
-        path=filename,
-        config=SimpleGitConfig(
-            download_dir=EXAMPLE_DOCS_DIRECTORY,
+def test_process_file_flatten_metadata(mocker, partition_test_results):
+    mocker.patch(
+        "unstructured.ingest.interfaces.partition",
+        return_value=partition_test_results,
+    )
+    test_ingest_doc = TestIngestDoc(
+        config=TEST_CONFIG,
+        standard_config=StandardConnectorConfig(
+            download_dir=TEST_DOWNLOAD_DIR,
+            output_dir=TEST_OUTPUT_DIR,
             metadata_include="filename,page_number",
             flatten_metadata=True,
         ),
     )
-    isd_elems = ingest_doc.process_file(strategy="hi_res")
+    isd_elems = test_ingest_doc.process_file()
     for elem in isd_elems:
         assert {"element_id", "text", "type", "filename", "page_number"} == set(elem.keys())

--- a/test_unstructured_ingest/unit/test_interfaces.py
+++ b/test_unstructured_ingest/unit/test_interfaces.py
@@ -1,9 +1,10 @@
+from dataclasses import dataclass
 import os
 import pathlib
 
 import pytest
 
-from unstructured.ingest.connector.git import GitIngestDoc, SimpleGitConfig
+from unstructured.ingest.interfaces import BaseConnector, BaseConnectorConfig, BaseIngestDoc, StandardConnectorConfig
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 EXAMPLE_DOCS_DIRECTORY = os.path.join(DIRECTORY, "..", "example-docs")
@@ -13,15 +14,33 @@ test_files = [
     "layout-parser-paper-fast.pdf",
 ]
 
+@dataclass
+class TestConfig(BaseConnectorConfig):
+    id: str
+    path: str
+
+@dataclass
+class TestIngestDoc(BaseIngestDoc):
+    pass
+
+@dataclass
+class TestConnector(BaseConnector):
+    config: TestConfig
+    pass
+
+
+
 
 @pytest.mark.parametrize("filename", test_files)
 def test_process_file_metadata_include_filename(filename: str):
     ingest_doc = GitIngestDoc(
         path=filename,
-        config=SimpleGitConfig(
+        config=SimpleGitConfig(),
+        standard_config=StandardConnectorConfig(
             download_dir=EXAMPLE_DOCS_DIRECTORY,
+            output_dir="",  # not used
             metadata_include="filename",
-        ),
+        )
     )
     isd_elems = ingest_doc.process_file(strategy="hi_res")
 

--- a/test_unstructured_ingest/unit/test_interfaces.py
+++ b/test_unstructured_ingest/unit/test_interfaces.py
@@ -51,12 +51,12 @@ class TestIngestDoc(BaseIngestDoc):
 @pytest.fixture()
 def partition_test_results():
     # Reusable partition test results, calculated only once
-    return partition(filename=str(TEST_FILE_PATH))
+    yield partition(filename=str(TEST_FILE_PATH))
 
 @pytest.fixture()
 def partition_file_test_results(partition_test_results):
     # Reusable partition_file test results, calculated only once
-    return convert_to_dict(partition_test_results)
+    yield convert_to_dict(partition_test_results)
 
 def test_process_file_fields_include_default(mocker, partition_test_results):
     """Validate when metadata_include and metadata_exclude are not set, all fields:


### PR DESCRIPTION
At some point [tests were created](https://github.com/Unstructured-IO/unstructured/blob/main/test_unstructured_ingest/test_interfaces.py) to explicitly validate the features of the ingest interface definitions. These do not currently pass and aren't being processed in CI. This PR updates/fixes the tests (now pass). It also refactors such that they behave as unit tests and don't rely on external services. It also adds them to the CI workflow.