### PR TITLE
fix:  Filetype detection if a CSV has a text/plain MIME type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.3-dev1
+## 0.7.3-dev2
 
 ### Enhancements
 
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+* Filetype detection if a CSV has a `text/plain` MIME type
 * `convert_office_doc` no longers prints file conversion info messages to stdout.
 * `partition_via_api` reflects the actual filetype for the file processed in the API.
 
@@ -22,7 +23,6 @@
 
 ### Fixes
 
-* Filetype detection if a CSV has a text/plain MIME type
 * Update the `read_txt_file` utility function to keep using `spooled_to_bytes_io_if_needed` for xml
 * Add functionality to the `read_txt_file` utility function to handle file-like object from URL
 * Remove the unused parameter `encoding` from `partition_pdf`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixes
 
+* Filetype detection if a CSV has a text/plain MIME type
 * Update the `read_txt_file` utility function to keep using `spooled_to_bytes_io_if_needed` for xml
 * Add functionality to the `read_txt_file` utility function to handle file-like object from URL
 * Remove the unused parameter `encoding` from `partition_pdf`

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -9,6 +9,7 @@ from unstructured.file_utils import filetype
 from unstructured.file_utils.filetype import (
     FileType,
     _is_code_mime_type,
+    _is_text_file_a_csv,
     _is_text_file_a_json,
     detect_filetype,
 )
@@ -368,7 +369,9 @@ def test_filetype_order():
 @pytest.mark.parametrize(
     ("content", "expected"),
     [
-        (b"d\xe2\x80", False),
+        (b"d\xe2\x80", False),  # Invalid JSON
+        (b'{"key": "value"}', True),  # Valid JSON
+        (b"", False),  # Empty content
     ],
 )
 def test_is_text_file_a_json(content, expected):
@@ -376,3 +379,19 @@ def test_is_text_file_a_json(content, expected):
 
     with BytesIO(content) as f:
         assert _is_text_file_a_json(file=f) == expected
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (b"d\xe2\x80", False),  # Invalid CSV
+        (b'{"key": "value"}', False),  # Invalid CSV
+        (b"column1,column2,column3\nvalue1,value2,value3\n", True),  # Valid CSV
+        (b"", False),  # Empty content
+    ],
+)
+def test_is_text_file_a_csv(content, expected):
+    from io import BytesIO
+
+    with BytesIO(content) as f:
+        assert _is_text_file_a_csv(file=f) == expected

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -370,7 +370,7 @@ def test_filetype_order():
     ("content", "expected"),
     [
         (b"d\xe2\x80", False),  # Invalid JSON
-        (b'{"key": "value"}', True),  # Valid JSON
+        (b'[{"key": "value"}]', True),  # Valid JSON
         (b"", False),  # Empty content
     ],
 )
@@ -385,7 +385,7 @@ def test_is_text_file_a_json(content, expected):
     ("content", "expected"),
     [
         (b"d\xe2\x80", False),  # Invalid CSV
-        (b'{"key": "value"}', False),  # Invalid CSV
+        (b'[{"key": "value"}]', False),  # Invalid CSV
         (b"column1,column2,column3\nvalue1,value2,value3\n", True),  # Valid CSV
         (b"", False),  # Empty content
     ],

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -502,7 +502,6 @@ def test_auto_partition_works_with_unstructured_jsons():
 
 def test_auto_partition_works_with_unstructured_jsons_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "spring-weather.html.json")
-
     with open(filename, "rb") as f:
         elements = partition(file=f, strategy="hi_res")
     assert elements[0].text == "News Around NOAA"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.3-dev1"  # pragma: no cover
+__version__ = "0.7.3-dev2"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -260,6 +260,9 @@ def detect_filetype(
         if _is_text_file_a_json(file=file, filename=filename):
             return FileType.JSON
 
+        if _is_text_file_a_csv(file=file, filename=filename):
+            return FileType.CSV
+
         if file and not extension and _check_eml_from_buffer(file=file) is True:
             return FileType.EML
 

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -105,3 +105,4 @@ ENDS_IN_PUNCT_RE = re.compile(ENDS_IN_PUNCT_PATTERN)
 # NOTE(robinson) - Used to detect if text is in the expected "list of dicts"
 # format for document elements
 LIST_OF_DICTS_PATTERN = r"\A\s*\[\s*{?"
+JSON_PATTERN = r"^(?:\{.*\}|\[.*\])$"


### PR DESCRIPTION
## Summary

Creates filetype detection if a CSV has a text/plain MIME type. 
Closes #621.
Also adds some parameters for `test_is_text_file_a_json`, removes unnecessary empty lines, and improves regex pattern for JSON matching.

## Testing
```
from unstructured.file_utils.filetype import _is_text_file_a_csv
from io import BytesIO

# [invalid, invalid, valid]
files = [b"d\xe2\x80", b'[{"key": "value"}]', b"column1,column2,column3\nvalue1,value2,value3\n"]

for file in files:
    with BytesIO(file) as f:
        print(_is_text_file_a_csv(file=f))
```