### PR TITLE
fix: `partition_via_api` reflects actual filetype in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.7.3-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* `partition_via_api` reflects that actual filetype for the file processed in the API.
+
 ## 0.7.2
 
 ### Enhancements

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -38,6 +38,9 @@ class MockResponse:
     }
 ]"""
 
+    def json(self):
+        return json.loads(self.text)
+
 
 def test_partition_via_api_from_filename(monkeypatch):
     monkeypatch.setattr(
@@ -138,6 +141,19 @@ class MockMultipleResponse:
         }
     ]
 ]"""
+
+
+def test_partition_multiple_via_api_with_single_filename(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: MockResponse(status_code=200),
+    )
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
+
+    elements = partition_multiple_via_api(filenames=[filename], api_key="FAKEROO")
+    assert elements[0][0] == NarrativeText("This is a test email to use for unit tests.")
+    assert elements[0][0].metadata.filetype == "message/rfc822"
 
 
 def test_partition_multiple_via_api_from_filenames(monkeypatch):

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -32,7 +32,8 @@ class MockResponse:
                 "Matthew Robinson <mrobinson@unstructured.io>"
             ],
             "subject": "Test Email",
-            "filename": "fake-email.eml"
+            "filename": "fake-email.eml",
+            "filetype": "message/rfc822"
         }
     }
 ]"""
@@ -47,6 +48,7 @@ def test_partition_via_api_from_filename(monkeypatch):
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-email.eml")
     elements = partition_via_api(filename=filename, api_key="FAKEROO")
     assert elements[0] == NarrativeText("This is a test email to use for unit tests.")
+    assert elements[0].metadata.filetype == "message/rfc822"
 
 
 def test_partition_via_api_from_file(monkeypatch):
@@ -60,6 +62,7 @@ def test_partition_via_api_from_file(monkeypatch):
     with open(filename, "rb") as f:
         elements = partition_via_api(file=f, file_filename=filename, api_key="FAKEROO")
     assert elements[0] == NarrativeText("This is a test email to use for unit tests.")
+    assert elements[0].metadata.filetype == "message/rfc822"
 
 
 def test_partition_via_api_from_file_raises_without_filename(monkeypatch):
@@ -110,7 +113,8 @@ class MockMultipleResponse:
                     "Matthew Robinson <mrobinson@unstructured.io>"
                 ],
                 "subject": "Test Email",
-                "filename": "fake-email.eml"
+                "filename": "fake-email.eml",
+                "filetype": "message/rfc822"
             }
         }
     ],
@@ -128,7 +132,8 @@ class MockMultipleResponse:
                     "Matthew Robinson <mrobinson@unstructured.io>"
                 ],
                 "subject": "Test Email",
-                "filename": "fake-email.eml"
+                "filename": "fake-email.eml",
+                "filetype": "message/rfc822"
             }
         }
     ]
@@ -150,6 +155,7 @@ def test_partition_multiple_via_api_from_filenames(monkeypatch):
     elements = partition_multiple_via_api(filenames=filenames, api_key="FAKEROO")
     assert len(elements) == 2
     assert elements[0][0] == NarrativeText("This is a test email to use for unit tests.")
+    assert elements[0][0].metadata.filetype == "message/rfc822"
 
 
 def test_partition_multiple_via_api_from_files(monkeypatch):
@@ -173,6 +179,7 @@ def test_partition_multiple_via_api_from_files(monkeypatch):
         )
     assert len(elements) == 2
     assert elements[0][0] == NarrativeText("This is a test email to use for unit tests.")
+    assert elements[0][0].metadata.filetype == "message/rfc822"
 
 
 def test_partition_multiple_via_api_raises_with_bad_response(monkeypatch):

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.2"  # pragma: no cover
+__version__ = "0.7.3-dev0"  # pragma: no cover

--- a/unstructured/partition/api.py
+++ b/unstructured/partition/api.py
@@ -10,7 +10,7 @@ import requests
 
 from unstructured.documents.elements import Element
 from unstructured.partition.common import exactly_one
-from unstructured.partition.json import partition_json
+from unstructured.staging.base import elements_from_json
 
 
 def partition_via_api(
@@ -82,7 +82,7 @@ def partition_via_api(
         response = requests.post(api_url, headers=headers, data=data, files=files)  # type: ignore
 
     if response.status_code == 200:
-        return partition_json(text=response.text)
+        return elements_from_json(text=response.text)
     else:
         raise ValueError(
             f"Receive unexpected status code {response.status_code} from the API.",
@@ -173,7 +173,7 @@ def partition_multiple_via_api(
     if response.status_code == 200:
         documents = []
         for document in response.json():
-            documents.append(partition_json(text=json.dumps(document)))
+            documents.append(elements_from_json(text=json.dumps(document)))
         return documents
     else:
         raise ValueError(


### PR DESCRIPTION
### Summary

Closes #692. Updates `partition_via_api` so that the filetype in the output metadata matches the result return by the API.

### Testing

```python
 from unstructured.partition.api import partition_via_api, partition_multiple_via_api

filename = "example-docs/layout-parser-paper-fast.pdf"

elements = partition_via_api(filename=filename, strategy="fast")
elements[0].metadata.filetype # Should be application/pdf

elements = partition_multiple_via_api(filenames=[filename], strategy="fast")
elements[0][0].metadata.filetype # Should be application/pdf
```