### PR TITLE
fix: ingest-test-fixtures-update script to pass env vars

### DIFF
--- a/docker/ubuntu-22/Dockerfile
+++ b/docker/ubuntu-22/Dockerfile
@@ -20,4 +20,6 @@ RUN source ~/.bashrc && pyenv virtualenv 3.8.15 unstructured && \
     make install-ingest-azure && \
     make install-ingest-github && \
     make install-ingest-gitlab && \
-    make install-ingest-wikipedia
+    make install-ingest-wikipedia && \ 
+    make install-ingest-discord && \
+    make install install-ingest-slack

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -38,10 +38,12 @@ if [ "$AGE_DAYS" -gt 6 ]; then
     echo "You may want to 'docker rmi $IMAGE_NAME' and rerun this script if it is not current."
 fi
 
-docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured -v \
-   "$SCRIPT_DIR"/../test_unstructured_ingest:/root/test_unstructured_ingest \
-   -w /root "$IMAGE_NAME" \
-   bash -c "export OVERWRITE_FIXTURES=true && source ~/.bashrc && pyenv activate unstructured && tesseract --version &&
+docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured \
+    -v "$SCRIPT_DIR"/../test_unstructured_ingest:/root/test_unstructured_ingest \
+    -e DISCORD_TOKEN="$DISCORD_TOKEN" \
+    -e SLACK_TOKEN="$SLACK_TOKEN" \
+    -w /root "$IMAGE_NAME" \
+    bash -c "export OVERWRITE_FIXTURES=true && source ~/.bashrc && pyenv activate unstructured && tesseract --version &&
                ./test_unstructured_ingest/test-ingest-azure.sh &&
                ./test_unstructured_ingest/test-ingest-discord.sh &&
                ./test_unstructured_ingest/test-ingest-github.sh &&

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -42,6 +42,7 @@ docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured \
     -v "$SCRIPT_DIR"/../test_unstructured_ingest:/root/test_unstructured_ingest \
     -e DISCORD_TOKEN="$DISCORD_TOKEN" \
     -e SLACK_TOKEN="$SLACK_TOKEN" \
+    -e GH_READ_ONLY_ACCESS_TOKEN="$GH_READ_ONLY_ACCESS_TOKEN" \
     -w /root "$IMAGE_NAME" \
     bash -c "export OVERWRITE_FIXTURES=true && source ~/.bashrc && pyenv activate unstructured && tesseract --version &&
                ./test_unstructured_ingest/test-ingest-azure.sh &&

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -40,9 +40,9 @@ fi
 
 docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured \
     -v "$SCRIPT_DIR"/../test_unstructured_ingest:/root/test_unstructured_ingest \
-    -e DISCORD_TOKEN="${DISCORD_TOKEN:-''}" \
-    -e SLACK_TOKEN="${SLACK_TOKEN:-''}" \
-    -e GH_READ_ONLY_ACCESS_TOKEN="${GH_READ_ONLY_ACCESS_TOKEN:-''}" \
+    ${DISCORD_TOKEN:+-e DISCORD_TOKEN="$DISCORD_TOKEN"} \
+    ${SLACK_TOKEN:+-e SLACK_TOKEN="$SLACK_TOKEN"} \
+    ${GH_READ_ONLY_ACCESS_TOKEN:+-e GH_READ_ONLY_ACCESS_TOKEN="$GH_READ_ONLY_ACCESS_TOKEN"} \
     -w /root "$IMAGE_NAME" \
     bash -c "export OVERWRITE_FIXTURES=true && source ~/.bashrc && pyenv activate unstructured && tesseract --version &&
                ./test_unstructured_ingest/test-ingest-azure.sh &&

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -50,4 +50,4 @@ docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured \
                ./test_unstructured_ingest/test-ingest-biomed-api.sh &&
                ./test_unstructured_ingest/test-ingest-biomed-path.sh &&
                ./test_unstructured_ingest/test-ingest-s3.sh &&
-               ./test_unstructured_ingest/test-ingest-slack.sh
+               ./test_unstructured_ingest/test-ingest-slack.sh"

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -50,5 +50,4 @@ docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured \
                ./test_unstructured_ingest/test-ingest-biomed-api.sh &&
                ./test_unstructured_ingest/test-ingest-biomed-path.sh &&
                ./test_unstructured_ingest/test-ingest-s3.sh &&
-               ./test_unstructured_ingest/test-ingest-slack.sh &&
-               ./test_unstructured_ingest/test-ingest-slack.sh"
+               ./test_unstructured_ingest/test-ingest-slack.sh

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -40,9 +40,9 @@ fi
 
 docker run --rm -v "$SCRIPT_DIR"/../unstructured:/root/unstructured \
     -v "$SCRIPT_DIR"/../test_unstructured_ingest:/root/test_unstructured_ingest \
-    -e DISCORD_TOKEN="$DISCORD_TOKEN" \
-    -e SLACK_TOKEN="$SLACK_TOKEN" \
-    -e GH_READ_ONLY_ACCESS_TOKEN="$GH_READ_ONLY_ACCESS_TOKEN" \
+    -e DISCORD_TOKEN="${DISCORD_TOKEN:-''}" \
+    -e SLACK_TOKEN="${SLACK_TOKEN:-''}" \
+    -e GH_READ_ONLY_ACCESS_TOKEN="${GH_READ_ONLY_ACCESS_TOKEN:-''}" \
     -w /root "$IMAGE_NAME" \
     bash -c "export OVERWRITE_FIXTURES=true && source ~/.bashrc && pyenv activate unstructured && tesseract --version &&
                ./test_unstructured_ingest/test-ingest-azure.sh &&


### PR DESCRIPTION
Passes Docker, Slack, and Github tokens (`DISCORD_TOKEN`, `SLACK_TOKEN`, and `GH_READ_ONLY_ACCESS_TOKEN)` from the local environment to the docker container built and run in `ingest-test-fixtures-update.sh`, this way the script can run end to end without needing to run commands against the built image (to insert env vars and re-run) after the script has run.

bonus: removes duplicate run of slack test
bonus: fixes install of required discord and slack libraries in Dockerfile

## Testing
Export `DISCORD_TOKEN`, `SLACK_TOKEN`, and `GH_READ_ONLY_ACCESS_TOKEN`. Run `./scripts/ingest-test-fixtures-update.sh` on x86 arch.  It should build a container, run end to end, not skip tests, and update the fixtures.