### PR TITLE
fix: Enable MIME type detection if libmagic is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.7.4-dev0
+
+### Enhancements
+
+* Enable MIME type detection if libmagic is not available
+
+### Features
+
+### Fixes
+
 ## 0.7.3
 
 ### Enhancements

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -55,7 +55,7 @@ sphinx==6.2.1
     #   sphinxcontrib-jquery
 sphinx-basic-ng==1.0.0b1
     # via furo
-sphinx-rtd-theme==1.2.1
+sphinx-rtd-theme==1.2.2
     # via -r requirements/build.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
@@ -71,7 +71,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
 zipp==3.15.0
     # via importlib-metadata

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,7 @@
 -c "constraints.in"
 argilla
 chardet
+filetype
 lxml
 msg_parser
 nltk

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 anyio==3.7.0
     # via httpcore
-argilla==1.8.0
+argilla==1.9.0
     # via -r requirements/base.in
 backoff==2.2.1
     # via argilla
@@ -38,6 +38,8 @@ et-xmlfile==1.1.0
     # via openpyxl
 exceptiongroup==1.1.1
     # via anyio
+filetype==1.2.0
+    # via -r requirements/base.in
 h11==0.14.0
     # via httpcore
 httpcore==0.16.3
@@ -88,7 +90,7 @@ pillow==9.5.0
     #   python-pptx
 pycparser==2.21
     # via cffi
-pydantic==1.10.8
+pydantic==1.10.9
     # via argilla
 pygments==2.15.1
     # via rich

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -12,7 +12,7 @@ beautifulsoup4==4.12.2
     # via furo
 certifi==2023.5.7
     # via
-    #   -r build.in
+    #   -r requirements/build.in
     #   requests
 charset-normalizer==3.1.0
     # via requests
@@ -21,10 +21,12 @@ docutils==0.18.1
     #   sphinx
     #   sphinx-rtd-theme
 furo==2023.5.20
-    # via -r build.in
+    # via -r requirements/build.in
 idna==3.4
     # via requests
 imagesize==1.4.1
+    # via sphinx
+importlib-metadata==6.6.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
@@ -36,6 +38,8 @@ pygments==2.15.1
     # via
     #   furo
     #   sphinx
+pytz==2023.3
+    # via babel
 requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
@@ -44,7 +48,7 @@ soupsieve==2.4.1
     # via beautifulsoup4
 sphinx==6.2.1
     # via
-    #   -r build.in
+    #   -r requirements/build.in
     #   furo
     #   sphinx-basic-ng
     #   sphinx-rtd-theme
@@ -52,7 +56,7 @@ sphinx==6.2.1
 sphinx-basic-ng==1.0.0b1
     # via furo
 sphinx-rtd-theme==1.2.2
-    # via -r build.in
+    # via -r requirements/build.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -67,5 +71,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
+zipp==3.15.0
+    # via importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,10 +8,6 @@ anyio==3.7.0
     # via
     #   -c requirements/base.txt
     #   jupyter-server
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 argon2-cffi==21.3.0
     # via
     #   jupyter-server
@@ -369,7 +365,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.5.2
+websocket-client==1.5.3
     # via jupyter-server
 wheel==0.40.0
     # via

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -17,12 +17,15 @@ click==8.1.3
     # via
     #   -c requirements/base.txt
     #   sacremoses
+cmake==3.26.4
+    # via triton
 filelock==3.12.0
     # via
     #   huggingface-hub
     #   torch
     #   transformers
-fsspec==2023.5.0
+    #   triton
+fsspec==2023.6.0
     # via huggingface-hub
 huggingface-hub==0.15.1
     # via transformers
@@ -38,6 +41,8 @@ joblib==1.2.0
     #   sacremoses
 langdetect==1.0.9
     # via -r requirements/huggingface.in
+lit==16.0.5.post0
+    # via triton
 markupsafe==2.1.3
     # via jinja2
 mpmath==1.3.0
@@ -48,6 +53,31 @@ numpy==1.23.5
     # via
     #   -c requirements/base.txt
     #   transformers
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   nvidia-cusolver-cu11
+    #   torch
+nvidia-cuda-cupti-cu11==11.7.101
+    # via torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
+nvidia-cufft-cu11==10.9.0.58
+    # via torch
+nvidia-curand-cu11==10.2.10.91
+    # via torch
+nvidia-cusolver-cu11==11.4.0.1
+    # via torch
+nvidia-cusparse-cu11==11.7.4.91
+    # via torch
+nvidia-nccl-cu11==2.14.3
+    # via torch
+nvidia-nvtx-cu11==11.7.91
+    # via torch
 packaging==23.1
     # via
     #   -c requirements/base.txt
@@ -69,6 +99,8 @@ requests==2.31.0
     #   transformers
 sacremoses==0.0.53
     # via -r requirements/huggingface.in
+safetensors==0.3.1
+    # via transformers
 sentencepiece==0.1.99
     # via -r requirements/huggingface.in
 six==1.16.0
@@ -81,15 +113,19 @@ sympy==1.12
 tokenizers==0.13.3
     # via transformers
 torch==2.0.1
-    # via -r requirements/huggingface.in
+    # via
+    #   -r requirements/huggingface.in
+    #   triton
 tqdm==4.65.0
     # via
     #   -c requirements/base.txt
     #   huggingface-hub
     #   sacremoses
     #   transformers
-transformers==4.29.2
+transformers==4.30.1
     # via -r requirements/huggingface.in
+triton==2.0.0
+    # via torch
 typing-extensions==4.6.3
     # via
     #   -c requirements/base.txt
@@ -100,3 +136,15 @@ urllib3==1.26.16
     #   -c requirements/base.txt
     #   -c requirements/constraints.in
     #   requests
+wheel==0.40.0
+    # via
+    #   -c requirements/constraints.in
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-cupti-cu11
+    #   nvidia-cuda-runtime-cu11
+    #   nvidia-curand-cu11
+    #   nvidia-cusparse-cu11
+    #   nvidia-nvtx-cu11
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/ingest-azure.txt
+++ b/requirements/ingest-azure.txt
@@ -51,7 +51,7 @@ frozenlist==1.3.3
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.5.0
+fsspec==2023.6.0
     # via
     #   -r requirements/ingest-azure.in
     #   adlfs

--- a/requirements/ingest-gitlab.txt
+++ b/requirements/ingest-gitlab.txt
@@ -17,7 +17,7 @@ idna==3.4
     # via
     #   -c requirements/base.txt
     #   requests
-python-gitlab==3.14.0
+python-gitlab==3.15.0
     # via -r requirements/ingest-gitlab.in
 requests==2.31.0
     # via

--- a/requirements/ingest-reddit.txt
+++ b/requirements/ingest-reddit.txt
@@ -33,5 +33,5 @@ urllib3==1.26.16
     #   -c requirements/base.txt
     #   -c requirements/constraints.in
     #   requests
-websocket-client==1.5.2
+websocket-client==1.5.3
     # via praw

--- a/requirements/ingest-s3.txt
+++ b/requirements/ingest-s3.txt
@@ -28,7 +28,7 @@ frozenlist==1.3.3
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.5.0
+fsspec==2023.6.0
     # via
     #   -r requirements/ingest-s3.in
     #   s3fs
@@ -46,7 +46,7 @@ python-dateutil==2.8.2
     # via
     #   -c requirements/base.txt
     #   botocore
-s3fs==2023.5.0
+s3fs==2023.6.0
     # via -r requirements/ingest-s3.in
 six==1.16.0
     # via

--- a/requirements/local-inference.txt
+++ b/requirements/local-inference.txt
@@ -20,6 +20,8 @@ charset-normalizer==3.1.0
     #   -c requirements/base.txt
     #   pdfminer-six
     #   requests
+cmake==3.26.4
+    # via triton
 coloredlogs==15.0.1
     # via onnxruntime
 contourpy==1.0.7
@@ -37,11 +39,12 @@ filelock==3.12.0
     #   huggingface-hub
     #   torch
     #   transformers
+    #   triton
 flatbuffers==23.5.26
     # via onnxruntime
 fonttools==4.39.4
     # via matplotlib
-fsspec==2023.5.0
+fsspec==2023.6.0
     # via huggingface-hub
 huggingface-hub==0.15.1
     # via
@@ -64,6 +67,8 @@ kiwisolver==1.4.4
     # via matplotlib
 layoutparser[layoutmodels,tesseract]==0.3.4
     # via unstructured-inference
+lit==16.0.5.post0
+    # via triton
 markupsafe==2.1.3
     # via jinja2
 matplotlib==3.7.1
@@ -85,6 +90,31 @@ numpy==1.23.5
     #   scipy
     #   torchvision
     #   transformers
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   nvidia-cusolver-cu11
+    #   torch
+nvidia-cuda-cupti-cu11==11.7.101
+    # via torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
+nvidia-cufft-cu11==10.9.0.58
+    # via torch
+nvidia-curand-cu11==10.2.10.91
+    # via torch
+nvidia-cusolver-cu11==11.4.0.1
+    # via torch
+nvidia-cusparse-cu11==11.7.4.91
+    # via torch
+nvidia-nccl-cu11==2.14.3
+    # via torch
+nvidia-nvtx-cu11==11.7.91
+    # via torch
 omegaconf==2.3.0
     # via effdet
 onnxruntime==1.15.0
@@ -167,7 +197,9 @@ requests==2.31.0
     #   torchvision
     #   transformers
 safetensors==0.3.1
-    # via timm
+    # via
+    #   timm
+    #   transformers
 scipy==1.10.1
     # via layoutparser
 six==1.16.0
@@ -188,6 +220,7 @@ torch==2.0.1
     #   layoutparser
     #   timm
     #   torchvision
+    #   triton
 torchvision==0.15.2
     # via
     #   effdet
@@ -199,8 +232,10 @@ tqdm==4.65.0
     #   huggingface-hub
     #   iopath
     #   transformers
-transformers==4.29.2
+transformers==4.30.1
     # via unstructured-inference
+triton==2.0.0
+    # via torch
 typing-extensions==4.6.3
     # via
     #   -c requirements/base.txt
@@ -216,7 +251,19 @@ urllib3==1.26.16
     #   requests
 wand==0.6.11
     # via pdfplumber
+wheel==0.40.0
+    # via
+    #   -c requirements/constraints.in
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-cupti-cu11
+    #   nvidia-cuda-runtime-cu11
+    #   nvidia-curand-cu11
+    #   nvidia-cusparse-cu11
+    #   nvidia-nvtx-cu11
 zipp==3.15.0
     # via
     #   -c requirements/base.txt
     #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,43 +7,47 @@
 appdirs==1.4.4
     # via label-studio-tools
 black==23.3.0
-    # via -r test.in
+    # via -r requirements/test.in
 certifi==2023.5.7
     # via
-    #   -c base.txt
-    #   -c constraints.in
+    #   -c requirements/base.txt
+    #   -c requirements/constraints.in
     #   requests
 charset-normalizer==3.1.0
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   requests
 click==8.1.3
     # via
-    #   -c base.txt
-    #   -r test.in
+    #   -c requirements/base.txt
+    #   -r requirements/test.in
     #   black
 coverage[toml]==7.2.7
     # via
-    #   -r test.in
+    #   -r requirements/test.in
     #   pytest-cov
+exceptiongroup==1.1.1
+    # via
+    #   -c requirements/base.txt
+    #   pytest
 flake8==6.0.0
-    # via -r test.in
+    # via -r requirements/test.in
 freezegun==1.2.2
-    # via -r test.in
+    # via -r requirements/test.in
 idna==3.4
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   requests
     #   yarl
 iniconfig==2.0.0
     # via pytest
 label-studio-sdk==0.0.28
-    # via -r test.in
+    # via -r requirements/test.in
 label-studio-tools==0.0.2
     # via label-studio-sdk
 lxml==4.9.2
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   label-studio-sdk
     #   label-studio-tools
 mccabe==0.7.0
@@ -51,14 +55,14 @@ mccabe==0.7.0
 multidict==6.0.4
     # via yarl
 mypy==1.3.0
-    # via -r test.in
+    # via -r requirements/test.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
 packaging==23.1
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   black
     #   pytest
 pathspec==0.11.1
@@ -69,9 +73,9 @@ pluggy==1.0.0
     # via pytest
 pycodestyle==2.10.0
     # via flake8
-pydantic==1.10.8
+pydantic==1.10.9
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   label-studio-sdk
 pyflakes==3.0.1
     # via flake8
@@ -80,49 +84,57 @@ pytest==7.3.1
     #   pytest-cov
     #   pytest-mock
 pytest-cov==4.1.0
-    # via -r test.in
+    # via -r requirements/test.in
 pytest-mock==3.10.0
-    # via -r test.in
+    # via -r requirements/test.in
 python-dateutil==2.8.2
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   freezegun
 pyyaml==6.0
     # via vcrpy
 requests==2.31.0
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   label-studio-sdk
 ruff==0.0.272
-    # via -r test.in
+    # via -r requirements/test.in
 six==1.16.0
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   python-dateutil
     #   vcrpy
+tomli==2.0.1
+    # via
+    #   black
+    #   coverage
+    #   mypy
+    #   pytest
 types-markdown==3.4.2.9
-    # via -r test.in
+    # via -r requirements/test.in
 types-requests==2.31.0.1
-    # via -r test.in
+    # via -r requirements/test.in
 types-tabulate==0.9.0.2
-    # via -r test.in
+    # via -r requirements/test.in
 types-urllib3==1.26.25.13
     # via types-requests
 typing-extensions==4.6.3
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
+    #   black
     #   mypy
     #   pydantic
 urllib3==1.26.16
     # via
-    #   -c base.txt
-    #   -c constraints.in
+    #   -c requirements/base.txt
+    #   -c requirements/constraints.in
     #   requests
+    #   vcrpy
 vcrpy==4.3.1
-    # via -r test.in
+    # via -r requirements/test.in
 wrapt==1.14.1
     # via
-    #   -c base.txt
+    #   -c requirements/base.txt
     #   vcrpy
 yarl==1.9.2
     # via vcrpy

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -114,11 +114,12 @@ def test_detect_filetype_from_file(file, expected):
         assert detect_filetype(file=f) in expected
 
 
-def test_detect_filetype_from_file_raises_without_libmagic(monkeypatch):
+def test_detect_filetype_from_file_warning_without_libmagic(monkeypatch, caplog):
     monkeypatch.setattr(filetype, "LIBMAGIC_AVAILABLE", False)
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-text.txt")
-    with open(filename, "rb") as f, pytest.raises(ImportError):
+    with open(filename, "rb") as f:
         detect_filetype(file=f)
+        assert "WARNING" in caplog.text
 
 
 def test_detect_xml_application_xml(monkeypatch):

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.3"  # pragma: no cover
+__version__ = "0.7.4-dev0"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -233,11 +233,11 @@ def detect_filetype(
         else:
             mime_type = ft.guess_mime(file.read(4096))
         if mime_type is None:
-            raise ImportError(
-                "libmagic is unavailable."
-                "Filetype detection on file-like objects requires libmagic."
-                "Please install libmagic and try again.",
+            logger.warning(
+                "libmagic is unavailable but assists in filetype detection on file-like objects."
+                "Please consider installing libmagic for better results.",
             )
+            return EXT_TO_FILETYPE.get(extension, FileType.UNK)
 
     else:
         raise ValueError("No filename, file, nor file_filename were specified.")

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -6,6 +6,8 @@ from enum import Enum
 from functools import wraps
 from typing import IO, Callable, List, Optional
 
+import filetype as ft
+
 from unstructured.documents.elements import Element, PageBreak
 from unstructured.file_utils.encoding import detect_file_encoding
 from unstructured.nlp.patterns import LIST_OF_DICTS_PATTERN
@@ -196,13 +198,17 @@ def detect_filetype(
     """Use libmagic to determine a file's type. Helps determine which partition brick
     to use for a given file. A return value of None indicates a non-supported file type.
     """
+    mime_type = None
     exactly_one(filename=filename, file=file)
 
+    # first check (content_type)
     if content_type:
         filetype = STR_TO_FILETYPE.get(content_type)
         if filetype:
             return filetype
 
+    # second check (filename/file_name/file)
+    # continue if successfully define mime_type
     if filename or file_filename:
         _filename = filename or file_filename or ""
         _, extension = os.path.splitext(_filename)
@@ -212,8 +218,10 @@ def detect_filetype(
                 _resolve_symlink(filename or file_filename),
                 mime=True,
             )  # type: ignore
-        else:
-            return EXT_TO_FILETYPE.get(extension.lower(), FileType.UNK)
+        elif os.path.isfile(_filename):
+            mime_type = ft.guess_mime(filename)
+        if mime_type==None:
+            return EXT_TO_FILETYPE.get(extension, FileType.UNK)
 
     elif file is not None:
         extension = None
@@ -223,16 +231,19 @@ def detect_filetype(
         if LIBMAGIC_AVAILABLE:
             mime_type = magic.from_buffer(file.read(4096), mime=True)
         else:
+            mime_type = ft.guess_mime(file.read(4096))
+        if mime_type == None:
             raise ImportError(
-                "libmagic is unavailable. "
-                "Filetype detection on file-like objects requires libmagic. "
+                "libmagic is unavailable."
+                "Filetype detection on file-like objects requires libmagic."
                 "Please install libmagic and try again.",
             )
+            
     else:
         raise ValueError("No filename, file, nor file_filename were specified.")
 
     """Mime type special cases."""
-
+    # third check (mime_type)
     # NOTE(crag): for older versions of the OS libmagic package, such as is currently
     # installed on the Unstructured docker image, .json files resolve to "text/plain"
     # rather than "application/json". this corrects for that case.

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -220,7 +220,7 @@ def detect_filetype(
             )  # type: ignore
         elif os.path.isfile(_filename):
             mime_type = ft.guess_mime(filename)
-        if mime_type == None:
+        if mime_type is None:
             return EXT_TO_FILETYPE.get(extension, FileType.UNK)
 
     elif file is not None:
@@ -232,7 +232,7 @@ def detect_filetype(
             mime_type = magic.from_buffer(file.read(4096), mime=True)
         else:
             mime_type = ft.guess_mime(file.read(4096))
-        if mime_type == None:
+        if mime_type is None:
             raise ImportError(
                 "libmagic is unavailable."
                 "Filetype detection on file-like objects requires libmagic."

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -220,7 +220,7 @@ def detect_filetype(
             )  # type: ignore
         elif os.path.isfile(_filename):
             mime_type = ft.guess_mime(filename)
-        if mime_type==None:
+        if mime_type == None:
             return EXT_TO_FILETYPE.get(extension, FileType.UNK)
 
     elif file is not None:
@@ -238,7 +238,7 @@ def detect_filetype(
                 "Filetype detection on file-like objects requires libmagic."
                 "Please install libmagic and try again.",
             )
-            
+
     else:
         raise ValueError("No filename, file, nor file_filename were specified.")
 


### PR DESCRIPTION
## Summary
Closes #682
Enables MIME type detection if libmagic is not available. 
Uses [filetype](https://github.com/h2non/filetype.py/tree/master) as a fallback if libmagic is not present.
Updates associated `ImportError` test to check for `warning`
Adds comments

## Testing
```
pytest test_unstructured/file_utils/test_filetype.py
```



