### PR TITLE
Chore: Allow passing kwargs to request data field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+* Reslove `grpcio` import issue on `weaviate.schema.validate_schema` for python 3.9 and 3.10
 * Remove building `detectron2` from source in Dockerfile
 
 ## 0.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.7.4
+
+### Enhancements
+
+* Allow passing kwargs to request data field for `partition_via_api` and `partition_multiple_via_api`
+
+### Features
+
+### Fixes
+
+
 ## 0.7.3
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixes
 
+* Remove building `detectron2` from source in Dockerfile
+
 ## 0.7.3
 
 ### Enhancements

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN python3.8 -m pip install pip==${PIP_VERSION} && \
   pip install --no-cache -r requirements/ingest-slack.txt && \
   pip install --no-cache -r requirements/ingest-wikipedia.txt && \
   pip install --no-cache -r requirements/local-inference.txt && \
-  pip install --no-cache "detectron2@git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2" && \
   dnf -y groupremove "Development Tools" && \
   dnf clean all
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,10 @@ anyio==3.7.0
     # via
     #   -c requirements/base.txt
     #   jupyter-server
+appnope==0.1.3
+    # via
+    #   ipykernel
+    #   ipython
 argon2-cffi==21.3.0
     # via
     #   jupyter-server
@@ -59,7 +63,7 @@ executing==1.2.0
     # via stack-data
 fastjsonschema==2.17.1
     # via nbformat
-filelock==3.12.0
+filelock==3.12.1
     # via virtualenv
 fqdn==1.5.1
     # via jsonschema
@@ -215,7 +219,7 @@ pip-tools==6.13.0
     # via -r requirements/dev.in
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via
     #   -c requirements/test.txt
     #   jupyter-core

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -17,14 +17,11 @@ click==8.1.3
     # via
     #   -c requirements/base.txt
     #   sacremoses
-cmake==3.26.4
-    # via triton
-filelock==3.12.0
+filelock==3.12.1
     # via
     #   huggingface-hub
     #   torch
     #   transformers
-    #   triton
 fsspec==2023.6.0
     # via huggingface-hub
 huggingface-hub==0.15.1
@@ -41,8 +38,6 @@ joblib==1.2.0
     #   sacremoses
 langdetect==1.0.9
     # via -r requirements/huggingface.in
-lit==16.0.5.post0
-    # via triton
 markupsafe==2.1.3
     # via jinja2
 mpmath==1.3.0
@@ -53,31 +48,6 @@ numpy==1.23.5
     # via
     #   -c requirements/base.txt
     #   transformers
-nvidia-cublas-cu11==11.10.3.66
-    # via
-    #   nvidia-cudnn-cu11
-    #   nvidia-cusolver-cu11
-    #   torch
-nvidia-cuda-cupti-cu11==11.7.101
-    # via torch
-nvidia-cuda-nvrtc-cu11==11.7.99
-    # via torch
-nvidia-cuda-runtime-cu11==11.7.99
-    # via torch
-nvidia-cudnn-cu11==8.5.0.96
-    # via torch
-nvidia-cufft-cu11==10.9.0.58
-    # via torch
-nvidia-curand-cu11==10.2.10.91
-    # via torch
-nvidia-cusolver-cu11==11.4.0.1
-    # via torch
-nvidia-cusparse-cu11==11.7.4.91
-    # via torch
-nvidia-nccl-cu11==2.14.3
-    # via torch
-nvidia-nvtx-cu11==11.7.91
-    # via torch
 packaging==23.1
     # via
     #   -c requirements/base.txt
@@ -113,9 +83,7 @@ sympy==1.12
 tokenizers==0.13.3
     # via transformers
 torch==2.0.1
-    # via
-    #   -r requirements/huggingface.in
-    #   triton
+    # via -r requirements/huggingface.in
 tqdm==4.65.0
     # via
     #   -c requirements/base.txt
@@ -124,8 +92,6 @@ tqdm==4.65.0
     #   transformers
 transformers==4.30.1
     # via -r requirements/huggingface.in
-triton==2.0.0
-    # via torch
 typing-extensions==4.6.3
     # via
     #   -c requirements/base.txt
@@ -136,15 +102,3 @@ urllib3==1.26.16
     #   -c requirements/base.txt
     #   -c requirements/constraints.in
     #   requests
-wheel==0.40.0
-    # via
-    #   -c requirements/constraints.in
-    #   nvidia-cublas-cu11
-    #   nvidia-cuda-cupti-cu11
-    #   nvidia-cuda-runtime-cu11
-    #   nvidia-curand-cu11
-    #   nvidia-cusparse-cu11
-    #   nvidia-nvtx-cu11
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/local-inference.txt
+++ b/requirements/local-inference.txt
@@ -20,8 +20,6 @@ charset-normalizer==3.1.0
     #   -c requirements/base.txt
     #   pdfminer-six
     #   requests
-cmake==3.26.4
-    # via triton
 coloredlogs==15.0.1
     # via onnxruntime
 contourpy==1.0.7
@@ -34,15 +32,14 @@ cycler==0.11.0
     # via matplotlib
 effdet==0.4.1
     # via layoutparser
-filelock==3.12.0
+filelock==3.12.1
     # via
     #   huggingface-hub
     #   torch
     #   transformers
-    #   triton
 flatbuffers==23.5.26
     # via onnxruntime
-fonttools==4.39.4
+fonttools==4.40.0
     # via matplotlib
 fsspec==2023.6.0
     # via huggingface-hub
@@ -67,8 +64,6 @@ kiwisolver==1.4.4
     # via matplotlib
 layoutparser[layoutmodels,tesseract]==0.3.4
     # via unstructured-inference
-lit==16.0.5.post0
-    # via triton
 markupsafe==2.1.3
     # via jinja2
 matplotlib==3.7.1
@@ -90,31 +85,6 @@ numpy==1.23.5
     #   scipy
     #   torchvision
     #   transformers
-nvidia-cublas-cu11==11.10.3.66
-    # via
-    #   nvidia-cudnn-cu11
-    #   nvidia-cusolver-cu11
-    #   torch
-nvidia-cuda-cupti-cu11==11.7.101
-    # via torch
-nvidia-cuda-nvrtc-cu11==11.7.99
-    # via torch
-nvidia-cuda-runtime-cu11==11.7.99
-    # via torch
-nvidia-cudnn-cu11==8.5.0.96
-    # via torch
-nvidia-cufft-cu11==10.9.0.58
-    # via torch
-nvidia-curand-cu11==10.2.10.91
-    # via torch
-nvidia-cusolver-cu11==11.4.0.1
-    # via torch
-nvidia-cusparse-cu11==11.7.4.91
-    # via torch
-nvidia-nccl-cu11==2.14.3
-    # via torch
-nvidia-nvtx-cu11==11.7.91
-    # via torch
 omegaconf==2.3.0
     # via effdet
 onnxruntime==1.15.0
@@ -220,7 +190,6 @@ torch==2.0.1
     #   layoutparser
     #   timm
     #   torchvision
-    #   triton
 torchvision==0.15.2
     # via
     #   effdet
@@ -234,8 +203,6 @@ tqdm==4.65.0
     #   transformers
 transformers==4.30.1
     # via unstructured-inference
-triton==2.0.0
-    # via torch
 typing-extensions==4.6.3
     # via
     #   -c requirements/base.txt
@@ -251,19 +218,7 @@ urllib3==1.26.16
     #   requests
 wand==0.6.11
     # via pdfplumber
-wheel==0.40.0
-    # via
-    #   -c requirements/constraints.in
-    #   nvidia-cublas-cu11
-    #   nvidia-cuda-cupti-cu11
-    #   nvidia-cuda-runtime-cu11
-    #   nvidia-curand-cu11
-    #   nvidia-cusparse-cu11
-    #   nvidia-nvtx-cu11
 zipp==3.15.0
     # via
     #   -c requirements/base.txt
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -17,3 +17,4 @@ types-Markdown
 types-requests
 types-tabulate
 vcrpy
+grpcio

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -67,7 +67,7 @@ packaging==23.1
     #   pytest
 pathspec==0.11.1
     # via black
-platformdirs==3.5.1
+platformdirs==3.5.3
     # via black
 pluggy==1.0.0
     # via pytest
@@ -79,7 +79,7 @@ pydantic==1.10.9
     #   label-studio-sdk
 pyflakes==3.0.1
     # via flake8
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   pytest-cov
     #   pytest-mock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -34,6 +34,8 @@ flake8==6.0.0
     # via -r requirements/test.in
 freezegun==1.2.2
     # via -r requirements/test.in
+grpcio==1.54.2
+    # via -r requirements/test.in
 idna==3.4
     # via
     #   -c requirements/base.txt

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -92,6 +92,19 @@ def test_partition_via_api_raises_with_bad_response(monkeypatch):
         partition_via_api(filename=filename, api_key="FAKEROO")
 
 
+def test_partition_via_api_valid_request_data_kwargs():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.pdf")
+
+    elements = partition_via_api(filename=filename, api_key="FAKEROO", strategy="fast")
+    assert isinstance(elements, list)
+
+
+def test_partition_via_api_invalid_request_data_kwargs():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.pdf")
+    with pytest.raises(ValueError):
+        partition_via_api(filename=filename, api_key="FAKEROO", strategy="not_a_strategy")
+
+
 class MockMultipleResponse:
     def __init__(self, status_code):
         self.status_code = status_code
@@ -276,3 +289,27 @@ def test_partition_multiple_via_api_from_files_raises_without_filenames(monkeypa
                 files=files,
                 api_key="FAKEROO",
             )
+
+
+def test_partition_multiple_via_api_valid_request_data_kwargs():
+    filenames = [
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.pdf"),
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.jpg"),
+    ]
+
+    elements = partition_multiple_via_api(filenames=filenames, api_key="FAKEROO", strategy="fast")
+    assert isinstance(elements, list)
+
+
+def test_partition_multiple_via_api_invalid_request_data_kwargs():
+    filenames = [
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.pdf"),
+        os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.jpg"),
+    ]
+
+    with pytest.raises(ValueError):
+        partition_multiple_via_api(
+            filenames=filenames,
+            api_key="FAKEROO",
+            strategy="not_a_strategy",
+        )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.3"  # pragma: no cover
+__version__ = "0.7.4"  # pragma: no cover

--- a/unstructured/partition/api.py
+++ b/unstructured/partition/api.py
@@ -19,7 +19,7 @@ def partition_via_api(
     file_filename: Optional[str] = None,
     api_url: str = "https://api.unstructured.io/general/v0/general",
     api_key: str = "",
-    **request_data_kwargs,
+    **request_kwargs,
 ) -> List[Element]:
     """Partitions a document using the Unstructured REST API. This is equivalent to
     running the document through partition.
@@ -42,7 +42,7 @@ def partition_via_api(
         The URL for the Unstructured API. Defaults to the hosted Unstructured API.
     api_key
         The API key to pass to the Unstructured API.
-    request_data_kwargs
+    request_kwargs
         Additional parameters to pass to the data field of the request to the Unstructured API.
         For example the `strategy` parameter.
     """
@@ -54,8 +54,8 @@ def partition_via_api(
     }
 
     # set default values for kwargs
-    strategy = request_data_kwargs.pop("strategy", "hi_res")
-    request_data_kwargs["strategy"] = strategy
+    strategy = request_kwargs.pop("strategy", "hi_res")
+    request_kwargs["strategy"] = strategy
 
     if filename is not None:
         with open(filename, "rb") as f:
@@ -65,7 +65,7 @@ def partition_via_api(
             response = requests.post(
                 api_url,
                 headers=headers,
-                data=request_data_kwargs,
+                data=request_kwargs,
                 files=files,  # type: ignore
             )
     elif file is not None:
@@ -80,7 +80,7 @@ def partition_via_api(
         response = requests.post(
             api_url,
             headers=headers,
-            data=request_data_kwargs,
+            data=request_kwargs,
             files=files,  # type: ignore
         )
 
@@ -99,7 +99,7 @@ def partition_multiple_via_api(
     file_filenames: Optional[List[str]] = None,
     api_url: str = "https://api.unstructured.io/general/v0/general",
     api_key: str = "",
-    **request_data_kwargs,
+    **request_kwargs,
 ) -> List[List[Element]]:
     """Partitions multiple document using the Unstructured REST API by batching
     the documents into a single HTTP request.
@@ -126,7 +126,7 @@ def partition_multiple_via_api(
         The URL for the Unstructured API. Defaults to the hosted Unstructured API.
     api_key
         The API key to pass to the Unstructured API.
-    request_data_kwargs
+    request_kwargs
         Additional parameters to pass to the data field of the request to the Unstructured API.
         For example the `strategy` parameter.
     """
@@ -136,8 +136,8 @@ def partition_multiple_via_api(
     }
 
     # set default values for kwargs
-    strategy = request_data_kwargs.pop("strategy", "hi_res")
-    request_data_kwargs["strategy"] = strategy
+    strategy = request_kwargs.pop("strategy", "hi_res")
+    request_kwargs["strategy"] = strategy
 
     if filenames is not None:
         if content_types and len(content_types) != len(filenames):
@@ -155,7 +155,7 @@ def partition_multiple_via_api(
             response = requests.post(
                 api_url,
                 headers=headers,
-                data=request_data_kwargs,
+                data=request_kwargs,
                 files=_files,  # type: ignore
             )
 
@@ -177,7 +177,7 @@ def partition_multiple_via_api(
         response = requests.post(
             api_url,
             headers=headers,
-            data=request_data_kwargs,
+            data=request_kwargs,
             files=_files,  # type: ignore
         )
 

--- a/unstructured/partition/api.py
+++ b/unstructured/partition/api.py
@@ -17,9 +17,9 @@ def partition_via_api(
     content_type: Optional[str] = None,
     file: Optional[IO] = None,
     file_filename: Optional[str] = None,
-    strategy: str = "hi_res",
     api_url: str = "https://api.unstructured.io/general/v0/general",
     api_key: str = "",
+    **request_data_kwargs,
 ) -> List[Element]:
     """Partitions a document using the Unstructured REST API. This is equivalent to
     running the document through partition.
@@ -38,14 +38,13 @@ def partition_via_api(
         A file-like object using "rb" mode --> open(filename, "rb").
     file_filename
         When file is not None, the filename (string) to store in element metadata. E.g. "foo.txt"
-    strategy
-        The strategy to use for partitioning the PDF. Uses a layout detection model if set
-        to 'hi_res', otherwise partition_pdf simply extracts the text from the document
-        and processes it.
     api_url
         The URL for the Unstructured API. Defaults to the hosted Unstructured API.
     api_key
         The API key to pass to the Unstructured API.
+    request_data_kwargs
+        Additional parameters to pass to the data field of the request to the Unstructured API.
+        For example the `strategy` parameter.
     """
     exactly_one(filename=filename, file=file)
 
@@ -54,9 +53,9 @@ def partition_via_api(
         "UNSTRUCTURED-API-KEY": api_key,
     }
 
-    data = {
-        "strategy": strategy,
-    }
+    # set default values for kwargs
+    strategy = request_data_kwargs.pop("strategy", "hi_res")
+    request_data_kwargs["strategy"] = strategy
 
     if filename is not None:
         with open(filename, "rb") as f:
@@ -66,7 +65,7 @@ def partition_via_api(
             response = requests.post(
                 api_url,
                 headers=headers,
-                data=data,
+                data=request_data_kwargs,
                 files=files,  # type: ignore
             )
     elif file is not None:
@@ -78,7 +77,12 @@ def partition_via_api(
         files = [
             ("files", (file_filename, file, content_type)),  # type: ignore
         ]
-        response = requests.post(api_url, headers=headers, data=data, files=files)  # type: ignore
+        response = requests.post(
+            api_url,
+            headers=headers,
+            data=request_data_kwargs,
+            files=files,  # type: ignore
+        )
 
     if response.status_code == 200:
         return elements_from_json(text=response.text)
@@ -93,9 +97,9 @@ def partition_multiple_via_api(
     content_types: Optional[List[str]] = None,
     files: Optional[List[str]] = None,
     file_filenames: Optional[List[str]] = None,
-    strategy: str = "hi_res",
     api_url: str = "https://api.unstructured.io/general/v0/general",
     api_key: str = "",
+    **request_data_kwargs,
 ) -> List[List[Element]]:
     """Partitions multiple document using the Unstructured REST API by batching
     the documents into a single HTTP request.
@@ -122,15 +126,18 @@ def partition_multiple_via_api(
         The URL for the Unstructured API. Defaults to the hosted Unstructured API.
     api_key
         The API key to pass to the Unstructured API.
+    request_data_kwargs
+        Additional parameters to pass to the data field of the request to the Unstructured API.
+        For example the `strategy` parameter.
     """
     headers = {
         "ACCEPT": "application/json",
         "UNSTRUCTURED-API-KEY": api_key,
     }
 
-    data = {
-        "strategy": strategy,
-    }
+    # set default values for kwargs
+    strategy = request_data_kwargs.pop("strategy", "hi_res")
+    request_data_kwargs["strategy"] = strategy
 
     if filenames is not None:
         if content_types and len(content_types) != len(filenames):
@@ -148,7 +155,7 @@ def partition_multiple_via_api(
             response = requests.post(
                 api_url,
                 headers=headers,
-                data=data,
+                data=request_data_kwargs,
                 files=_files,  # type: ignore
             )
 
@@ -167,7 +174,12 @@ def partition_multiple_via_api(
             filename = file_filenames[i]
             _files.append(("files", (filename, _file, content_type)))
 
-        response = requests.post(api_url, headers=headers, data=data, files=_files)  # type: ignore
+        response = requests.post(
+            api_url,
+            headers=headers,
+            data=request_data_kwargs,
+            files=_files,  # type: ignore
+        )
 
     if response.status_code == 200:
         documents = []


### PR DESCRIPTION
### Summary

Passing kwargs to the data field of request to Unstructrued API. This allows additional parameters to be passed in like `strategy`, `coordinates` or `ocr_languages`. Have to bump this version again for upstream `unstructured-api`.