### PR TITLE
ci: add cache version to ingest-test-fixtures-update-pr workflow

### DIFF
--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -3,6 +3,9 @@ name: Ingest Test Fixtures Update PR
 on:
   push:
   workflow_dispatch:
+  
+env:
+  GHA_CACHE_KEY_VERSION: "v1"
 
 jobs:
   setup:


### PR DESCRIPTION
Without a version specified this added one more cache, set to v1 so this re-uses the same one in the CI workflow