### PR TITLE
fix: pdf2image library is core requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
-## 0.7.5-dev2
+## 0.7.5
 
 ### Enhancements
 
 * Adds functionality to sort elements in `partition_pdf` for `fast` strategy
 * Adds ingest tests with `--fast` strategy on PDF documents
 * Adds --api-key to unstructured-ingest
-
 
 ### Features
 
@@ -14,6 +13,7 @@
 ### Fixes
 
 * Adds handling for emails that do not have a datetime to extract.
+* Adds pdf2image package as core requirement of unstructured (with no extras)
 
 ## 0.7.4
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,6 +7,7 @@ msg_parser
 nltk
 openpyxl
 pandas
+pdf2image
 pdfminer.six
 pillow
 pypandoc

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -82,11 +82,14 @@ pandas==1.5.3
     # via
     #   -r requirements/base.in
     #   argilla
+pdf2image==1.16.3
+    # via -r requirements/base.in
 pdfminer-six==20221105
     # via -r requirements/base.in
 pillow==9.5.0
     # via
     #   -r requirements/base.in
+    #   pdf2image
     #   python-pptx
 pycparser==2.21
     # via cffi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,10 @@ anyio==3.7.0
     # via
     #   -c requirements/base.txt
     #   jupyter-server
+appnope==0.1.3
+    # via
+    #   ipykernel
+    #   ipython
 argon2-cffi==21.3.0
     # via
     #   jupyter-server

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,10 +8,6 @@ anyio==3.7.0
     # via
     #   -c requirements/base.txt
     #   jupyter-server
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 argon2-cffi==21.3.0
     # via
     #   jupyter-server
@@ -63,7 +59,7 @@ executing==1.2.0
     # via stack-data
 fastjsonschema==2.17.1
     # via nbformat
-filelock==3.12.1
+filelock==3.12.2
     # via virtualenv
 fqdn==1.5.1
     # via jsonschema
@@ -82,7 +78,7 @@ importlib-metadata==6.6.0
     #   nbconvert
 importlib-resources==5.12.0
     # via jsonschema
-ipykernel==6.23.1
+ipykernel==6.23.2
     # via
     #   ipywidgets
     #   jupyter
@@ -171,7 +167,7 @@ nbclassic==1.0.0
     # via notebook
 nbclient==0.8.0
     # via nbconvert
-nbconvert==7.4.0
+nbconvert==7.5.0
     # via
     #   jupyter
     #   jupyter-server
@@ -224,7 +220,7 @@ platformdirs==3.5.3
     #   -c requirements/test.txt
     #   jupyter-core
     #   virtualenv
-pre-commit==3.3.2
+pre-commit==3.3.3
     # via -r requirements/dev.in
 prometheus-client==0.17.0
     # via

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -17,14 +17,11 @@ click==8.1.3
     # via
     #   -c requirements/base.txt
     #   sacremoses
-cmake==3.26.4
-    # via triton
 filelock==3.12.2
     # via
     #   huggingface-hub
     #   torch
     #   transformers
-    #   triton
 fsspec==2023.6.0
     # via huggingface-hub
 huggingface-hub==0.15.1
@@ -41,8 +38,6 @@ joblib==1.2.0
     #   sacremoses
 langdetect==1.0.9
     # via -r requirements/huggingface.in
-lit==16.0.5.post0
-    # via triton
 markupsafe==2.1.3
     # via jinja2
 mpmath==1.3.0
@@ -53,31 +48,6 @@ numpy==1.23.5
     # via
     #   -c requirements/base.txt
     #   transformers
-nvidia-cublas-cu11==11.10.3.66
-    # via
-    #   nvidia-cudnn-cu11
-    #   nvidia-cusolver-cu11
-    #   torch
-nvidia-cuda-cupti-cu11==11.7.101
-    # via torch
-nvidia-cuda-nvrtc-cu11==11.7.99
-    # via torch
-nvidia-cuda-runtime-cu11==11.7.99
-    # via torch
-nvidia-cudnn-cu11==8.5.0.96
-    # via torch
-nvidia-cufft-cu11==10.9.0.58
-    # via torch
-nvidia-curand-cu11==10.2.10.91
-    # via torch
-nvidia-cusolver-cu11==11.4.0.1
-    # via torch
-nvidia-cusparse-cu11==11.7.4.91
-    # via torch
-nvidia-nccl-cu11==2.14.3
-    # via torch
-nvidia-nvtx-cu11==11.7.91
-    # via torch
 packaging==23.1
     # via
     #   -c requirements/base.txt
@@ -113,9 +83,7 @@ sympy==1.12
 tokenizers==0.13.3
     # via transformers
 torch==2.0.1
-    # via
-    #   -r requirements/huggingface.in
-    #   triton
+    # via -r requirements/huggingface.in
 tqdm==4.65.0
     # via
     #   -c requirements/base.txt
@@ -124,8 +92,6 @@ tqdm==4.65.0
     #   transformers
 transformers==4.30.2
     # via -r requirements/huggingface.in
-triton==2.0.0
-    # via torch
 typing-extensions==4.6.3
     # via
     #   -c requirements/base.txt
@@ -136,15 +102,3 @@ urllib3==1.26.16
     #   -c requirements/base.txt
     #   -c requirements/constraints.in
     #   requests
-wheel==0.40.0
-    # via
-    #   -c requirements/constraints.in
-    #   nvidia-cublas-cu11
-    #   nvidia-cuda-cupti-cu11
-    #   nvidia-cuda-runtime-cu11
-    #   nvidia-curand-cu11
-    #   nvidia-cusparse-cu11
-    #   nvidia-nvtx-cu11
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -17,11 +17,14 @@ click==8.1.3
     # via
     #   -c requirements/base.txt
     #   sacremoses
-filelock==3.12.1
+cmake==3.26.4
+    # via triton
+filelock==3.12.2
     # via
     #   huggingface-hub
     #   torch
     #   transformers
+    #   triton
 fsspec==2023.6.0
     # via huggingface-hub
 huggingface-hub==0.15.1
@@ -38,6 +41,8 @@ joblib==1.2.0
     #   sacremoses
 langdetect==1.0.9
     # via -r requirements/huggingface.in
+lit==16.0.5.post0
+    # via triton
 markupsafe==2.1.3
     # via jinja2
 mpmath==1.3.0
@@ -48,6 +53,31 @@ numpy==1.23.5
     # via
     #   -c requirements/base.txt
     #   transformers
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   nvidia-cusolver-cu11
+    #   torch
+nvidia-cuda-cupti-cu11==11.7.101
+    # via torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
+nvidia-cufft-cu11==10.9.0.58
+    # via torch
+nvidia-curand-cu11==10.2.10.91
+    # via torch
+nvidia-cusolver-cu11==11.4.0.1
+    # via torch
+nvidia-cusparse-cu11==11.7.4.91
+    # via torch
+nvidia-nccl-cu11==2.14.3
+    # via torch
+nvidia-nvtx-cu11==11.7.91
+    # via torch
 packaging==23.1
     # via
     #   -c requirements/base.txt
@@ -83,15 +113,19 @@ sympy==1.12
 tokenizers==0.13.3
     # via transformers
 torch==2.0.1
-    # via -r requirements/huggingface.in
+    # via
+    #   -r requirements/huggingface.in
+    #   triton
 tqdm==4.65.0
     # via
     #   -c requirements/base.txt
     #   huggingface-hub
     #   sacremoses
     #   transformers
-transformers==4.30.1
+transformers==4.30.2
     # via -r requirements/huggingface.in
+triton==2.0.0
+    # via torch
 typing-extensions==4.6.3
     # via
     #   -c requirements/base.txt
@@ -102,3 +136,15 @@ urllib3==1.26.16
     #   -c requirements/base.txt
     #   -c requirements/constraints.in
     #   requests
+wheel==0.40.0
+    # via
+    #   -c requirements/constraints.in
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-cupti-cu11
+    #   nvidia-cuda-runtime-cu11
+    #   nvidia-curand-cu11
+    #   nvidia-cusparse-cu11
+    #   nvidia-nvtx-cu11
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/ingest-azure.txt
+++ b/requirements/ingest-azure.txt
@@ -14,7 +14,7 @@ async-timeout==4.0.2
     # via aiohttp
 attrs==23.1.0
     # via aiohttp
-azure-core==1.27.0
+azure-core==1.27.1
     # via
     #   adlfs
     #   azure-identity

--- a/requirements/ingest-discord.txt
+++ b/requirements/ingest-discord.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.1.0
     # via
     #   -c requirements/base.txt
     #   aiohttp
-discord-py==2.2.3
+discord-py==2.3.0
     # via -r requirements/ingest-discord.in
 frozenlist==1.3.3
     # via

--- a/requirements/ingest-google-drive.txt
+++ b/requirements/ingest-google-drive.txt
@@ -17,16 +17,16 @@ charset-normalizer==3.1.0
     #   requests
 google-api-core==2.11.0
     # via google-api-python-client
-google-api-python-client==2.88.0
+google-api-python-client==2.89.0
     # via -r requirements/ingest-google-drive.in
-google-auth==2.19.1
+google-auth==2.20.0
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
 google-auth-httplib2==0.1.0
     # via google-api-python-client
-googleapis-common-protos==1.59.0
+googleapis-common-protos==1.59.1
     # via google-api-core
 httplib2==0.22.0
     # via

--- a/requirements/local-inference.txt
+++ b/requirements/local-inference.txt
@@ -20,8 +20,6 @@ charset-normalizer==3.1.0
     #   -c requirements/base.txt
     #   pdfminer-six
     #   requests
-cmake==3.26.4
-    # via triton
 coloredlogs==15.0.1
     # via onnxruntime
 contourpy==1.1.0
@@ -39,7 +37,6 @@ filelock==3.12.2
     #   huggingface-hub
     #   torch
     #   transformers
-    #   triton
 flatbuffers==23.5.26
     # via onnxruntime
 fonttools==4.40.0
@@ -67,8 +64,6 @@ kiwisolver==1.4.4
     # via matplotlib
 layoutparser[layoutmodels,tesseract]==0.3.4
     # via unstructured-inference
-lit==16.0.5.post0
-    # via triton
 markupsafe==2.1.3
     # via jinja2
 matplotlib==3.7.1
@@ -90,31 +85,6 @@ numpy==1.23.5
     #   scipy
     #   torchvision
     #   transformers
-nvidia-cublas-cu11==11.10.3.66
-    # via
-    #   nvidia-cudnn-cu11
-    #   nvidia-cusolver-cu11
-    #   torch
-nvidia-cuda-cupti-cu11==11.7.101
-    # via torch
-nvidia-cuda-nvrtc-cu11==11.7.99
-    # via torch
-nvidia-cuda-runtime-cu11==11.7.99
-    # via torch
-nvidia-cudnn-cu11==8.5.0.96
-    # via torch
-nvidia-cufft-cu11==10.9.0.58
-    # via torch
-nvidia-curand-cu11==10.2.10.91
-    # via torch
-nvidia-cusolver-cu11==11.4.0.1
-    # via torch
-nvidia-cusparse-cu11==11.7.4.91
-    # via torch
-nvidia-nccl-cu11==2.14.3
-    # via torch
-nvidia-nvtx-cu11==11.7.91
-    # via torch
 omegaconf==2.3.0
     # via effdet
 onnxruntime==1.15.0
@@ -222,7 +192,6 @@ torch==2.0.1
     #   layoutparser
     #   timm
     #   torchvision
-    #   triton
 torchvision==0.15.2
     # via
     #   effdet
@@ -236,8 +205,6 @@ tqdm==4.65.0
     #   transformers
 transformers==4.30.2
     # via unstructured-inference
-triton==2.0.0
-    # via torch
 typing-extensions==4.6.3
     # via
     #   -c requirements/base.txt
@@ -253,19 +220,7 @@ urllib3==1.26.16
     #   requests
 wand==0.6.11
     # via pdfplumber
-wheel==0.40.0
-    # via
-    #   -c requirements/constraints.in
-    #   nvidia-cublas-cu11
-    #   nvidia-cuda-cupti-cu11
-    #   nvidia-cuda-runtime-cu11
-    #   nvidia-curand-cu11
-    #   nvidia-cusparse-cu11
-    #   nvidia-nvtx-cu11
 zipp==3.15.0
     # via
     #   -c requirements/base.txt
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/local-inference.txt
+++ b/requirements/local-inference.txt
@@ -20,9 +20,11 @@ charset-normalizer==3.1.0
     #   -c requirements/base.txt
     #   pdfminer-six
     #   requests
+cmake==3.26.4
+    # via triton
 coloredlogs==15.0.1
     # via onnxruntime
-contourpy==1.0.7
+contourpy==1.1.0
     # via matplotlib
 cryptography==41.0.1
     # via
@@ -32,11 +34,12 @@ cycler==0.11.0
     # via matplotlib
 effdet==0.4.1
     # via layoutparser
-filelock==3.12.1
+filelock==3.12.2
     # via
     #   huggingface-hub
     #   torch
     #   transformers
+    #   triton
 flatbuffers==23.5.26
     # via onnxruntime
 fonttools==4.40.0
@@ -64,6 +67,8 @@ kiwisolver==1.4.4
     # via matplotlib
 layoutparser[layoutmodels,tesseract]==0.3.4
     # via unstructured-inference
+lit==16.0.5.post0
+    # via triton
 markupsafe==2.1.3
     # via jinja2
 matplotlib==3.7.1
@@ -85,6 +90,31 @@ numpy==1.23.5
     #   scipy
     #   torchvision
     #   transformers
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   nvidia-cusolver-cu11
+    #   torch
+nvidia-cuda-cupti-cu11==11.7.101
+    # via torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
+nvidia-cufft-cu11==10.9.0.58
+    # via torch
+nvidia-curand-cu11==10.2.10.91
+    # via torch
+nvidia-cusolver-cu11==11.4.0.1
+    # via torch
+nvidia-cusparse-cu11==11.7.4.91
+    # via torch
+nvidia-nccl-cu11==2.14.3
+    # via torch
+nvidia-nvtx-cu11==11.7.91
+    # via torch
 omegaconf==2.3.0
     # via effdet
 onnxruntime==1.15.0
@@ -106,7 +136,9 @@ pandas==1.5.3
     #   -c requirements/base.txt
     #   layoutparser
 pdf2image==1.16.3
-    # via layoutparser
+    # via
+    #   -c requirements/base.txt
+    #   layoutparser
 pdfminer-six==20221105
     # via
     #   -c requirements/base.txt
@@ -190,6 +222,7 @@ torch==2.0.1
     #   layoutparser
     #   timm
     #   torchvision
+    #   triton
 torchvision==0.15.2
     # via
     #   effdet
@@ -201,8 +234,10 @@ tqdm==4.65.0
     #   huggingface-hub
     #   iopath
     #   transformers
-transformers==4.30.1
+transformers==4.30.2
     # via unstructured-inference
+triton==2.0.0
+    # via torch
 typing-extensions==4.6.3
     # via
     #   -c requirements/base.txt
@@ -218,7 +253,19 @@ urllib3==1.26.16
     #   requests
 wand==0.6.11
     # via pdfplumber
+wheel==0.40.0
+    # via
+    #   -c requirements/constraints.in
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-cupti-cu11
+    #   nvidia-cuda-runtime-cu11
+    #   nvidia-curand-cu11
+    #   nvidia-cusparse-cu11
+    #   nvidia-nvtx-cu11
 zipp==3.15.0
     # via
     #   -c requirements/base.txt
     #   importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.5-dev2"  # pragma: no cover
+__version__ = "0.7.5"  # pragma: no cover


### PR DESCRIPTION
Fixes an issue of a missing python dependency if one installs `unstructured` without any extras.