### PR TITLE
docs: update slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <div>
   <p align="center">
   <a
-  href="https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-1nlh1ot5d-dfY7zCRlhFboZrIWLA4Qgw">
+  href="https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-1x7cgo0pg-PTptXWylzPQF9xZolzCnwQ">
     <img src="https://img.shields.io/badge/JOIN US ON SLACK-4A154B?style=for-the-badge&logo=slack&logoColor=white" />
   </a>
   <a href="https://www.linkedin.com/company/unstructuredio/">

--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -143,7 +143,7 @@
         </div>
         <article role="main">
           <div class="social social--main" style="margin-top: 1em; display: flex; justify-content: right; gap: 8px">
-  					<a href="https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-1nlh1ot5d-dfY7zCRlhFboZrIWLA4Qgw"
+            <a href="https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-1x7cgo0pg-PTptXWylzPQF9xZolzCnwQ"
               class="button--primary" target="_blank">Join <span aria-label="slack"
                 class="slack-icon"></span></span></a>
             <div class="github-stars github-stars--top-page"></div>

--- a/docs/source/_templates/sidebar/brand.html
+++ b/docs/source/_templates/sidebar/brand.html
@@ -30,7 +30,8 @@ Hope your day's going well. :)
   {% endblock brand_content %}
 </a>
 <div class="social social--sidebar" style="margin-top: 1em; display: flex; justify-content: right; gap: 8px">
-  <a href="https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-1nlh1ot5d-dfY7zCRlhFboZrIWLA4Qgw"
+  <a
+    href="https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-1x7cgo0pg-PTptXWylzPQF9xZolzCnwQ">
     class="button--primary" target="_blank">Join <span aria-label="slack" class="slack-icon"></span></span></a>
     <div class="github-stars github-stars--sidebar"></div>
 </div>


### PR DESCRIPTION
### Summary

Updating the Slack link due to reports that we had a few people experiencing difficult signing up for the community Slack. This Slack link is set to never expire.