### PR TITLE
chore: rm old detectron2 install from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,6 @@ install-ingest-wikipedia:
 install-unstructured-inference:
 	python3 -m pip install -r requirements/local-inference.txt
 
-.PHONY: install-tensorboard
-install-tensorboard:
-	@if [ ${ARCH} = "arm64" ] || [ ${ARCH} = "aarch64" ]; then\
-		python3 -m pip install tensorboard>=2.12.2;\
-	fi
-
 ## install-local-inference: installs requirements for local inference
 .PHONY: install-local-inference
 install-local-inference: install install-unstructured-inference

--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,6 @@ install-tensorboard:
 		python3 -m pip install tensorboard>=2.12.2;\
 	fi
 
-.PHONY: install-detectron2
-install-detectron2: install-tensorboard
-	python3 -m pip install "detectron2@git+https://github.com/facebookresearch/detectron2.git@e2ce8dc#egg=detectron2"
-
 ## install-local-inference: installs requirements for local inference
 .PHONY: install-local-inference
 install-local-inference: install install-unstructured-inference


### PR DESCRIPTION
Since the move to onnxruntime'd version of detetron2 in https://github.com/Unstructured-IO/unstructured/pull/662 , these makefile targets are no longer serving a purpose.