### PR TITLE
fix: check for xml attribute when identifying pagebreaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.7-dev1
+## 0.7.7
 
 ### Enhancements
 
@@ -9,6 +9,8 @@
 ### Features
 
 ### Fixes
+
+* Check for the `xml` attribute on `element` before looking for pagebreaks in `partition_docx`.
 
 ## 0.7.6
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.7-dev1"  # pragma: no cover
+__version__ = "0.7.7"  # pragma: no cover

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -220,9 +220,10 @@ def _element_contains_pagebreak(element) -> bool:
         ["w:br", 'type="page"'],  # "Hard" page break inserted by user
         ["lastRenderedPageBreak"],  # "Soft" page break inserted by renderer
     ]
-    for indicators in page_break_indicators:
-        if all(indicator in element.xml for indicator in indicators):
-            return True
+    if hasattr(element, "xml"):
+        for indicators in page_break_indicators:
+            if all(indicator in element.xml for indicator in indicators):
+                return True
     return False
 
 


### PR DESCRIPTION
### Summary

Closes #775. First checks for the `xml` attribute on the document elements before checking for pagebreaks.