### PR TITLE
Bump version of unstructured-inference and unstructured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.8-dev1
+## 0.7.8
 
 ### Enhancements
 

--- a/requirements/local-inference.in
+++ b/requirements/local-inference.in
@@ -1,3 +1,3 @@
 -c constraints.in
 -c base.txt
-unstructured-inference==0.5.1
+unstructured-inference==0.5.2

--- a/requirements/local-inference.txt
+++ b/requirements/local-inference.txt
@@ -211,7 +211,7 @@ typing-extensions==4.6.3
     #   huggingface-hub
     #   iopath
     #   torch
-unstructured-inference==0.5.1
+unstructured-inference==0.5.2
     # via -r requirements/local-inference.in
 urllib3==1.26.16
     # via

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.8-dev1"  # pragma: no cover
+__version__ = "0.7.8"  # pragma: no cover


### PR DESCRIPTION
unstructured-inference recently have a paddle ocr fix pushed out. The version of unstructured-inference was bumped for unstructured to leverage that fix and the version of unstructured was updated to expose that as well. 