### PR TITLE
ci: fix amd build issue

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,6 +31,8 @@ jobs:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     steps:
     - uses: docker/setup-buildx-action@v1
+      with:
+        driver: docker
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Login to Quay.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
-
+    branches:
+      - main
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured
@@ -65,41 +66,41 @@ jobs:
         # write to the build repository to cache for the publish-images job
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  # publish-images:
-  #   runs-on: ubuntu-latest
-  #   needs: [set-short-sha, build-images]
-  #   env:
-  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-  #   steps:
-  #   - uses: docker/setup-buildx-action@v1
-  #   - name: Checkout code
-  #     uses: actions/checkout@v3
-  #   - name: Login to Quay.io
-  #     uses: docker/login-action@v1
-  #     with:
-  #       registry: quay.io
-  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-  #   - name: Pull AMD image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-  #   - name: Pull ARM image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-  #   - name: Push latest build tags for AMD and ARM
-  #     run: |
-  #       # these are used to construct the final manifest but also cache-from in subsequent runs
-  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
-  #   - name: Push multiarch manifest
-  #     run: |
-  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker manifest push $DOCKER_REPOSITORY:latest
-  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
+  publish-images:
+   runs-on: ubuntu-latest
+   needs: [set-short-sha, build-images]
+   env:
+     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+   steps:
+   - uses: docker/setup-buildx-action@v1
+   - name: Checkout code
+     uses: actions/checkout@v3
+   - name: Login to Quay.io
+     uses: docker/login-action@v1
+     with:
+       registry: quay.io
+       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+   - name: Pull AMD image
+     run: |
+       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+   - name: Pull ARM image
+     run: |
+       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+   - name: Push latest build tags for AMD and ARM
+     run: |
+       # these are used to construct the final manifest but also cache-from in subsequent runs
+       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+       docker push $DOCKER_BUILD_REPOSITORY:amd64
+       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+       docker push $DOCKER_BUILD_REPOSITORY:arm64
+   - name: Push multiarch manifest
+     run: |
+       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
+       docker manifest push $DOCKER_REPOSITORY:latest
+       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
+       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+       docker manifest push $DOCKER_REPOSITORY:$VERSION
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,9 +30,14 @@ jobs:
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     steps:
-    - uses: docker/setup-buildx-action@v1
+    - name: Set up Buildx driver (AMD)
+      if: matrix.docker-platform == 'linux/amd64'
+      uses: docker/setup-buildx-action@v1
       with:
         driver: docker
+    - name: Set up Buildx driver (ARM)
+      if: matrix.docker-platform == 'linux/arm64'
+      uses: docker/setup-buildx-action@v1
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Login to Quay.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,41 +68,41 @@ jobs:
         # write to the build repository to cache for the publish-images job
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  publish-images:
-    runs-on: ubuntu-latest
-    needs: [set-short-sha, build-images]
-    env:
-      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-    steps:
-    - uses: docker/setup-buildx-action@v1
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Login to Quay.io
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-    - name: Pull AMD image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-    - name: Pull ARM image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-    - name: Push latest build tags for AMD and ARM
-      run: |
-        # these are used to construct the final manifest but also cache-from in subsequent runs
-        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-        docker push $DOCKER_BUILD_REPOSITORY:amd64
-        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-        docker push $DOCKER_BUILD_REPOSITORY:arm64
-    - name: Push multiarch manifest
-      run: |
-        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
-        docker manifest push $DOCKER_REPOSITORY:latest
-        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$VERSION
+  # publish-images:
+  #   runs-on: ubuntu-latest
+  #   needs: [set-short-sha, build-images]
+  #   env:
+  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+  #   steps:
+  #   - uses: docker/setup-buildx-action@v1
+  #   - name: Checkout code
+  #     uses: actions/checkout@v3
+  #   - name: Login to Quay.io
+  #     uses: docker/login-action@v1
+  #     with:
+  #       registry: quay.io
+  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+  #   - name: Pull AMD image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+  #   - name: Pull ARM image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+  #   - name: Push latest build tags for AMD and ARM
+  #     run: |
+  #       # these are used to construct the final manifest but also cache-from in subsequent runs
+  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
+  #   - name: Push multiarch manifest
+  #     run: |
+  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker manifest push $DOCKER_REPOSITORY:latest
+  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
+    branches:
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -66,41 +68,41 @@ jobs:
         # write to the build repository to cache for the publish-images job
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  # publish-images:
-  #   runs-on: ubuntu-latest
-  #   needs: [set-short-sha, build-images]
-  #   env:
-  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-  #   steps:
-  #   - uses: docker/setup-buildx-action@v1
-  #   - name: Checkout code
-  #     uses: actions/checkout@v3
-  #   - name: Login to Quay.io
-  #     uses: docker/login-action@v1
-  #     with:
-  #       registry: quay.io
-  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-  #   - name: Pull AMD image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-  #   - name: Pull ARM image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-  #   - name: Push latest build tags for AMD and ARM
-  #     run: |
-  #       # these are used to construct the final manifest but also cache-from in subsequent runs
-  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
-  #   - name: Push multiarch manifest
-  #     run: |
-  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker manifest push $DOCKER_REPOSITORY:latest
-  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
+  publish-images:
+    runs-on: ubuntu-latest
+    needs: [set-short-sha, build-images]
+    env:
+      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+    steps:
+    - uses: docker/setup-buildx-action@v1
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+    - name: Pull AMD image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+    - name: Pull ARM image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+    - name: Push latest build tags for AMD and ARM
+      run: |
+        # these are used to construct the final manifest but also cache-from in subsequent runs
+        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+        docker push $DOCKER_BUILD_REPOSITORY:amd64
+        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+        docker push $DOCKER_BUILD_REPOSITORY:arm64
+    - name: Push multiarch manifest
+      run: |
+        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
+        docker manifest push $DOCKER_REPOSITORY:latest
+        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$VERSION
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,40 +67,40 @@ jobs:
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
   publish-images:
-   runs-on: ubuntu-latest
-   needs: [set-short-sha, build-images]
-   env:
-     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-   steps:
-   - uses: docker/setup-buildx-action@v1
-   - name: Checkout code
-     uses: actions/checkout@v3
-   - name: Login to Quay.io
-     uses: docker/login-action@v1
-     with:
-       registry: quay.io
-       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-   - name: Pull AMD image
-     run: |
-       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-   - name: Pull ARM image
-     run: |
-       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-   - name: Push latest build tags for AMD and ARM
-     run: |
-       # these are used to construct the final manifest but also cache-from in subsequent runs
-       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-       docker push $DOCKER_BUILD_REPOSITORY:amd64
-       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-       docker push $DOCKER_BUILD_REPOSITORY:arm64
-   - name: Push multiarch manifest
-     run: |
-       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
-       docker manifest push $DOCKER_REPOSITORY:latest
-       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
-       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-       docker manifest push $DOCKER_REPOSITORY:$VERSION
+    runs-on: ubuntu-latest
+    needs: [set-short-sha, build-images]
+    env:
+      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+    steps:
+    - uses: docker/setup-buildx-action@v1
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+    - name: Pull AMD image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+    - name: Pull ARM image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+    - name: Push latest build tags for AMD and ARM
+      run: |
+        # these are used to construct the final manifest but also cache-from in subsequent runs
+        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+        docker push $DOCKER_BUILD_REPOSITORY:amd64
+        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+        docker push $DOCKER_BUILD_REPOSITORY:arm64
+    - name: Push multiarch manifest
+      run: |
+        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
+        docker manifest push $DOCKER_REPOSITORY:latest
+        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$VERSION
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,7 @@ name: Build And Push Docker Image
 
 on:
   push:
-    branches:
-      - main
+
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured
@@ -29,8 +28,9 @@ jobs:
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     steps:
-
     - uses: docker/setup-buildx-action@v1
+      with:
+        driver: "docker"
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Login to Quay.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Build And Push Docker Image
 
 on:
   push:
-    branches:
-      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -30,14 +28,8 @@ jobs:
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     steps:
-    - name: Set up Buildx driver (AMD)
-      if: matrix.docker-platform == 'linux/amd64'
-      uses: docker/setup-buildx-action@v1
-      with:
-        driver: docker
-    - name: Set up Buildx driver (ARM)
-      if: matrix.docker-platform == 'linux/arm64'
-      uses: docker/setup-buildx-action@v1
+
+    - uses: docker/setup-buildx-action@v1
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Login to Quay.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,41 +66,41 @@ jobs:
         # write to the build repository to cache for the publish-images job
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  publish-images:
-    runs-on: ubuntu-latest
-    needs: [set-short-sha, build-images]
-    env:
-      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-    steps:
-    - uses: docker/setup-buildx-action@v1
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Login to Quay.io
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-    - name: Pull AMD image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-    - name: Pull ARM image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-    - name: Push latest build tags for AMD and ARM
-      run: |
-        # these are used to construct the final manifest but also cache-from in subsequent runs
-        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-        docker push $DOCKER_BUILD_REPOSITORY:amd64
-        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-        docker push $DOCKER_BUILD_REPOSITORY:arm64
-    - name: Push multiarch manifest
-      run: |
-        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
-        docker manifest push $DOCKER_REPOSITORY:latest
-        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$VERSION
+  # publish-images:
+  #   runs-on: ubuntu-latest
+  #   needs: [set-short-sha, build-images]
+  #   env:
+  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+  #   steps:
+  #   - uses: docker/setup-buildx-action@v1
+  #   - name: Checkout code
+  #     uses: actions/checkout@v3
+  #   - name: Login to Quay.io
+  #     uses: docker/login-action@v1
+  #     with:
+  #       registry: quay.io
+  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+  #   - name: Pull AMD image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+  #   - name: Pull ARM image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+  #   - name: Push latest build tags for AMD and ARM
+  #     run: |
+  #       # these are used to construct the final manifest but also cache-from in subsequent runs
+  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
+  #   - name: Push multiarch manifest
+  #     run: |
+  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker manifest push $DOCKER_REPOSITORY:latest
+  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
 


### PR DESCRIPTION
AMD images were building but failing to load in CI (meaning there weren't able to test and publish). This seems to be an issue with buildx. The solution is to use the "docker" driver. 

[Here is a reference ](https://github.com/Unstructured-IO/unstructured/actions/runs/5366686113/jobs/9736247833)to test commit with build+test steps enabled on push.