### PR TITLE
ci: fix arm build issue with docker driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,246 +1,246 @@
-# name: CI
+name: CI
 
-# on:
-#   push:
-#     branches: [ main ]
-#   pull_request:
-#     branches: [ main ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
-# env:
-#   GHA_CACHE_KEY_VERSION: "v1"
+env:
+  GHA_CACHE_KEY_VERSION: "v1"
 
-# jobs:
-#   setup:
-#     strategy:
-#       matrix:
-#         python-version: ["3.8","3.9","3.10"]
-#     runs-on: ubuntu-latest
-#     env:
-#       NLTK_DATA: ${{ github.workspace }}/nltk_data
-#     steps:
-#     - uses: actions/checkout@v3
-#     - uses: actions/cache@v3
-#       id: virtualenv-cache
-#       with:
-#         path: |
-#           .venv
-#           nltk_data
-#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v4
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Setup virtual environment (no cache hit)
-#       run: |
-#         python${{ matrix.python-version }} -m venv .venv
-#         source .venv/bin/activate
-#         [ ! -d "$NLTK_DATA" ] && mkdir "$NLTK_DATA"
-#         make install-ci
+jobs:
+  setup:
+    strategy:
+      matrix:
+        python-version: ["3.8","3.9","3.10"]
+    runs-on: ubuntu-latest
+    env:
+      NLTK_DATA: ${{ github.workspace }}/nltk_data
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      id: virtualenv-cache
+      with:
+        path: |
+          .venv
+          nltk_data
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup virtual environment (no cache hit)
+      run: |
+        python${{ matrix.python-version }} -m venv .venv
+        source .venv/bin/activate
+        [ ! -d "$NLTK_DATA" ] && mkdir "$NLTK_DATA"
+        make install-ci
 
-#   check-deps:
-#     strategy:
-#       matrix:
-#         python-version: ["3.8","3.9","3.10"]
-#     runs-on: ubuntu-latest
-#     needs: setup
-#     steps:
-#     - uses: actions/checkout@v3
-#     - uses: actions/cache/restore@v3
-#       id: virtualenv-cache
-#       with:
-#         path: |
-#           .venv
-#           nltk_data
-#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v4
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Setup virtual environment (no cache hit)
-#       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-#       run: |
-#         python${{ matrix.python-version }} -m venv .venv
-#         source .venv/bin/activate
-#         make install-base-pip-packages
-#     - name: Check for dependency conflicts
-#       run: |
-#         source .venv/bin/activate
-#         make check-deps
+  check-deps:
+    strategy:
+      matrix:
+        python-version: ["3.8","3.9","3.10"]
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/cache/restore@v3
+      id: virtualenv-cache
+      with:
+        path: |
+          .venv
+          nltk_data
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup virtual environment (no cache hit)
+      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+      run: |
+        python${{ matrix.python-version }} -m venv .venv
+        source .venv/bin/activate
+        make install-base-pip-packages
+    - name: Check for dependency conflicts
+      run: |
+        source .venv/bin/activate
+        make check-deps
 
-#   lint:
-#     strategy:
-#       matrix:
-#         python-version: ["3.8","3.9","3.10"]
-#     runs-on: ubuntu-latest
-#     needs: setup
-#     steps:
-#     - uses: actions/checkout@v3
-#     - uses: actions/cache/restore@v3
-#       id: virtualenv-cache
-#       with:
-#         path: |
-#           .venv
-#           nltk_data
-#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v4
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Setup virtual environment (no cache hit)
-#       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-#       run: |
-#         python${{ matrix.python-version }} -m venv .venv
-#         source .venv/bin/activate
-#         make install-ci
-#     - name: Lint
-#       run: |
-#         source .venv/bin/activate
-#         make check
+  lint:
+    strategy:
+      matrix:
+        python-version: ["3.8","3.9","3.10"]
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/cache/restore@v3
+      id: virtualenv-cache
+      with:
+        path: |
+          .venv
+          nltk_data
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup virtual environment (no cache hit)
+      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+      run: |
+        python${{ matrix.python-version }} -m venv .venv
+        source .venv/bin/activate
+        make install-ci
+    - name: Lint
+      run: |
+        source .venv/bin/activate
+        make check
 
-#   shellcheck:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
-#       - name: ShellCheck
-#         uses: ludeeus/action-shellcheck@master
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@master
 
-#   test_unit:
-#     strategy:
-#       matrix:
-#         python-version: ["3.8","3.9","3.10"]
-#     runs-on: ubuntu-latest
-#     env:
-#       NLTK_DATA: ${{ github.workspace }}/nltk_data
-#     needs: [setup, lint]
-#     steps:
-#     - uses: actions/checkout@v3
-#     - uses: actions/cache/restore@v3
-#       id: virtualenv-cache
-#       with:
-#         path: |
-#           .venv
-#           nltk_data
-#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v4
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Setup virtual environment (no cache hit)
-#       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-#       run: |
-#         python${{ matrix.python-version}} -m venv .venv
-#         source .venv/bin/activate
-#         mkdir "$NLTK_DATA"
-#         make install-ci
-#     - name: Test
-#       run: |
-#         source .venv/bin/activate
-#         sudo apt-get update
-#         sudo apt-get install -y libmagic-dev poppler-utils libreoffice
-#         make install-pandoc
-#         sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
-#         sudo apt-get install -y tesseract-ocr tesseract-ocr-kor
-#         tesseract --version
-#         # NOTE(robinson) - Installing weaviate-client separately here because the requests
-#         # version conflicts with label_studio_sdk
-#         pip install weaviate-client
-#         make test
-#         make check-coverage
+  test_unit:
+    strategy:
+      matrix:
+        python-version: ["3.8","3.9","3.10"]
+    runs-on: ubuntu-latest
+    env:
+      NLTK_DATA: ${{ github.workspace }}/nltk_data
+    needs: [setup, lint]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/cache/restore@v3
+      id: virtualenv-cache
+      with:
+        path: |
+          .venv
+          nltk_data
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup virtual environment (no cache hit)
+      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+      run: |
+        python${{ matrix.python-version}} -m venv .venv
+        source .venv/bin/activate
+        mkdir "$NLTK_DATA"
+        make install-ci
+    - name: Test
+      run: |
+        source .venv/bin/activate
+        sudo apt-get update
+        sudo apt-get install -y libmagic-dev poppler-utils libreoffice
+        make install-pandoc
+        sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
+        sudo apt-get install -y tesseract-ocr tesseract-ocr-kor
+        tesseract --version
+        # NOTE(robinson) - Installing weaviate-client separately here because the requests
+        # version conflicts with label_studio_sdk
+        pip install weaviate-client
+        make test
+        make check-coverage
 
-#   test_ingest:
-#     strategy:
-#       matrix:
-#         python-version: ["3.8","3.9","3.10"]
-#     runs-on: ubuntu-latest
-#     env:
-#       NLTK_DATA: ${{ github.workspace }}/nltk_data
-#     needs: [setup, lint]
-#     steps:
-#     - uses: actions/checkout@v3
-#     - uses: actions/cache/restore@v3
-#       id: virtualenv-cache
-#       with:
-#         path: |
-#           .venv
-#           nltk_data
-#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v4
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Setup virtual environment (no cache hit)
-#       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-#       run: |
-#         python${{ matrix.python-version}} -m venv .venv
-#         source .venv/bin/activate
-#         mkdir "$NLTK_DATA"
-#         make install-ci
-#     - name: Test Ingest (unit)
-#       run: |
-#         source .venv/bin/activate
-#         PYTHONPATH=. pytest test_unstructured_ingest/unit
-#     - name: Test (end-to-end)
-#       env:
-#         GH_READ_ONLY_ACCESS_TOKEN: ${{ secrets.GH_READ_ONLY_ACCESS_TOKEN }}
-#         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-#         DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
-#         GCP_INGEST_SERVICE_KEY: ${{ secrets.GCP_INGEST_SERVICE_KEY }}
-#       run: |
-#         source .venv/bin/activate
-#         sudo apt-get update
-#         sudo apt-get install -y libmagic-dev poppler-utils libreoffice pandoc
-#         sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
-#         sudo apt-get install -y tesseract-ocr
-#         tesseract --version
-#         make install-ingest-s3
-#         make install-ingest-azure
-#         make install-ingest-discord
-#         make install-ingest-gcs
-#         make install-ingest-google-drive
-#         make install-ingest-github
-#         make install-ingest-gitlab
-#         make install-ingest-slack
-#         make install-ingest-wikipedia
-#         ./test_unstructured_ingest/test-ingest.sh
+  test_ingest:
+    strategy:
+      matrix:
+        python-version: ["3.8","3.9","3.10"]
+    runs-on: ubuntu-latest
+    env:
+      NLTK_DATA: ${{ github.workspace }}/nltk_data
+    needs: [setup, lint]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/cache/restore@v3
+      id: virtualenv-cache
+      with:
+        path: |
+          .venv
+          nltk_data
+        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup virtual environment (no cache hit)
+      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+      run: |
+        python${{ matrix.python-version}} -m venv .venv
+        source .venv/bin/activate
+        mkdir "$NLTK_DATA"
+        make install-ci
+    - name: Test Ingest (unit)
+      run: |
+        source .venv/bin/activate
+        PYTHONPATH=. pytest test_unstructured_ingest/unit
+    - name: Test (end-to-end)
+      env:
+        GH_READ_ONLY_ACCESS_TOKEN: ${{ secrets.GH_READ_ONLY_ACCESS_TOKEN }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+        GCP_INGEST_SERVICE_KEY: ${{ secrets.GCP_INGEST_SERVICE_KEY }}
+      run: |
+        source .venv/bin/activate
+        sudo apt-get update
+        sudo apt-get install -y libmagic-dev poppler-utils libreoffice pandoc
+        sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
+        sudo apt-get install -y tesseract-ocr
+        tesseract --version
+        make install-ingest-s3
+        make install-ingest-azure
+        make install-ingest-discord
+        make install-ingest-gcs
+        make install-ingest-google-drive
+        make install-ingest-github
+        make install-ingest-gitlab
+        make install-ingest-slack
+        make install-ingest-wikipedia
+        ./test_unstructured_ingest/test-ingest.sh
 
-#   changelog:
-#     runs-on: ubuntu-latest
-#     steps:
-#     - if: github.ref != 'refs/heads/main'
-#       uses: dorny/paths-filter@v2
-#       id: changes
-#       with:
-#         filters: |
-#           src:
-#             - 'unstructured/**'
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - if: github.ref != 'refs/heads/main'
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          src:
+            - 'unstructured/**'
 
-#     - if: steps.changes.outputs.src == 'true' && github.ref != 'refs/heads/main'
-#       uses: dangoslen/changelog-enforcer@v3
+    - if: steps.changes.outputs.src == 'true' && github.ref != 'refs/heads/main'
+      uses: dangoslen/changelog-enforcer@v3
 
-#   # TODO - figure out best practice for caching docker images
-#   # (Using the virtualenv to get pytest)
-#   test_dockerfile:
-#     runs-on: ubuntu-latest
-#     needs: [ setup, lint ]
-#     steps:
-#       - uses: actions/checkout@v3
-#       - uses: actions/cache/restore@v3
-#         id: virtualenv-cache
-#         with:
-#           path: |
-#             .venv
-#             nltk_data
-#           key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-#       - name: Set up Python ${{ matrix.python-version }}
-#         uses: actions/setup-python@v4
-#         with:
-#           python-version: ${{ matrix.python-version }}
-#       - name: Setup virtual environment (no cache hit)
-#         if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-#         run: |
-#           python${{ matrix.python-version }} -m venv .venv
-#       - name: Test Dockerfile
-#         run: |
-#           source .venv/bin/activate
-#           make docker-build
-#           make docker-test
+  # TODO - figure out best practice for caching docker images
+  # (Using the virtualenv to get pytest)
+  test_dockerfile:
+    runs-on: ubuntu-latest
+    needs: [ setup, lint ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache/restore@v3
+        id: virtualenv-cache
+        with:
+          path: |
+            .venv
+            nltk_data
+          key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup virtual environment (no cache hit)
+        if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+        run: |
+          python${{ matrix.python-version }} -m venv .venv
+      - name: Test Dockerfile
+        run: |
+          source .venv/bin/activate
+          make docker-build
+          make docker-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,246 +1,246 @@
-name: CI
+# name: CI
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+# on:
+#   push:
+#     branches: [ main ]
+#   pull_request:
+#     branches: [ main ]
 
-env:
-  GHA_CACHE_KEY_VERSION: "v1"
+# env:
+#   GHA_CACHE_KEY_VERSION: "v1"
 
-jobs:
-  setup:
-    strategy:
-      matrix:
-        python-version: ["3.8","3.9","3.10"]
-    runs-on: ubuntu-latest
-    env:
-      NLTK_DATA: ${{ github.workspace }}/nltk_data
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      id: virtualenv-cache
-      with:
-        path: |
-          .venv
-          nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Setup virtual environment (no cache hit)
-      run: |
-        python${{ matrix.python-version }} -m venv .venv
-        source .venv/bin/activate
-        [ ! -d "$NLTK_DATA" ] && mkdir "$NLTK_DATA"
-        make install-ci
+# jobs:
+#   setup:
+#     strategy:
+#       matrix:
+#         python-version: ["3.8","3.9","3.10"]
+#     runs-on: ubuntu-latest
+#     env:
+#       NLTK_DATA: ${{ github.workspace }}/nltk_data
+#     steps:
+#     - uses: actions/checkout@v3
+#     - uses: actions/cache@v3
+#       id: virtualenv-cache
+#       with:
+#         path: |
+#           .venv
+#           nltk_data
+#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+#     - name: Set up Python ${{ matrix.python-version }}
+#       uses: actions/setup-python@v4
+#       with:
+#         python-version: ${{ matrix.python-version }}
+#     - name: Setup virtual environment (no cache hit)
+#       run: |
+#         python${{ matrix.python-version }} -m venv .venv
+#         source .venv/bin/activate
+#         [ ! -d "$NLTK_DATA" ] && mkdir "$NLTK_DATA"
+#         make install-ci
 
-  check-deps:
-    strategy:
-      matrix:
-        python-version: ["3.8","3.9","3.10"]
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache/restore@v3
-      id: virtualenv-cache
-      with:
-        path: |
-          .venv
-          nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Setup virtual environment (no cache hit)
-      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-      run: |
-        python${{ matrix.python-version }} -m venv .venv
-        source .venv/bin/activate
-        make install-base-pip-packages
-    - name: Check for dependency conflicts
-      run: |
-        source .venv/bin/activate
-        make check-deps
+#   check-deps:
+#     strategy:
+#       matrix:
+#         python-version: ["3.8","3.9","3.10"]
+#     runs-on: ubuntu-latest
+#     needs: setup
+#     steps:
+#     - uses: actions/checkout@v3
+#     - uses: actions/cache/restore@v3
+#       id: virtualenv-cache
+#       with:
+#         path: |
+#           .venv
+#           nltk_data
+#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+#     - name: Set up Python ${{ matrix.python-version }}
+#       uses: actions/setup-python@v4
+#       with:
+#         python-version: ${{ matrix.python-version }}
+#     - name: Setup virtual environment (no cache hit)
+#       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+#       run: |
+#         python${{ matrix.python-version }} -m venv .venv
+#         source .venv/bin/activate
+#         make install-base-pip-packages
+#     - name: Check for dependency conflicts
+#       run: |
+#         source .venv/bin/activate
+#         make check-deps
 
-  lint:
-    strategy:
-      matrix:
-        python-version: ["3.8","3.9","3.10"]
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache/restore@v3
-      id: virtualenv-cache
-      with:
-        path: |
-          .venv
-          nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Setup virtual environment (no cache hit)
-      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-      run: |
-        python${{ matrix.python-version }} -m venv .venv
-        source .venv/bin/activate
-        make install-ci
-    - name: Lint
-      run: |
-        source .venv/bin/activate
-        make check
+#   lint:
+#     strategy:
+#       matrix:
+#         python-version: ["3.8","3.9","3.10"]
+#     runs-on: ubuntu-latest
+#     needs: setup
+#     steps:
+#     - uses: actions/checkout@v3
+#     - uses: actions/cache/restore@v3
+#       id: virtualenv-cache
+#       with:
+#         path: |
+#           .venv
+#           nltk_data
+#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+#     - name: Set up Python ${{ matrix.python-version }}
+#       uses: actions/setup-python@v4
+#       with:
+#         python-version: ${{ matrix.python-version }}
+#     - name: Setup virtual environment (no cache hit)
+#       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+#       run: |
+#         python${{ matrix.python-version }} -m venv .venv
+#         source .venv/bin/activate
+#         make install-ci
+#     - name: Lint
+#       run: |
+#         source .venv/bin/activate
+#         make check
 
-  shellcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: ShellCheck
-        uses: ludeeus/action-shellcheck@master
+#   shellcheck:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#       - name: ShellCheck
+#         uses: ludeeus/action-shellcheck@master
 
-  test_unit:
-    strategy:
-      matrix:
-        python-version: ["3.8","3.9","3.10"]
-    runs-on: ubuntu-latest
-    env:
-      NLTK_DATA: ${{ github.workspace }}/nltk_data
-    needs: [setup, lint]
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache/restore@v3
-      id: virtualenv-cache
-      with:
-        path: |
-          .venv
-          nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Setup virtual environment (no cache hit)
-      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-      run: |
-        python${{ matrix.python-version}} -m venv .venv
-        source .venv/bin/activate
-        mkdir "$NLTK_DATA"
-        make install-ci
-    - name: Test
-      run: |
-        source .venv/bin/activate
-        sudo apt-get update
-        sudo apt-get install -y libmagic-dev poppler-utils libreoffice
-        make install-pandoc
-        sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
-        sudo apt-get install -y tesseract-ocr tesseract-ocr-kor
-        tesseract --version
-        # NOTE(robinson) - Installing weaviate-client separately here because the requests
-        # version conflicts with label_studio_sdk
-        pip install weaviate-client
-        make test
-        make check-coverage
+#   test_unit:
+#     strategy:
+#       matrix:
+#         python-version: ["3.8","3.9","3.10"]
+#     runs-on: ubuntu-latest
+#     env:
+#       NLTK_DATA: ${{ github.workspace }}/nltk_data
+#     needs: [setup, lint]
+#     steps:
+#     - uses: actions/checkout@v3
+#     - uses: actions/cache/restore@v3
+#       id: virtualenv-cache
+#       with:
+#         path: |
+#           .venv
+#           nltk_data
+#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+#     - name: Set up Python ${{ matrix.python-version }}
+#       uses: actions/setup-python@v4
+#       with:
+#         python-version: ${{ matrix.python-version }}
+#     - name: Setup virtual environment (no cache hit)
+#       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+#       run: |
+#         python${{ matrix.python-version}} -m venv .venv
+#         source .venv/bin/activate
+#         mkdir "$NLTK_DATA"
+#         make install-ci
+#     - name: Test
+#       run: |
+#         source .venv/bin/activate
+#         sudo apt-get update
+#         sudo apt-get install -y libmagic-dev poppler-utils libreoffice
+#         make install-pandoc
+#         sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
+#         sudo apt-get install -y tesseract-ocr tesseract-ocr-kor
+#         tesseract --version
+#         # NOTE(robinson) - Installing weaviate-client separately here because the requests
+#         # version conflicts with label_studio_sdk
+#         pip install weaviate-client
+#         make test
+#         make check-coverage
 
-  test_ingest:
-    strategy:
-      matrix:
-        python-version: ["3.8","3.9","3.10"]
-    runs-on: ubuntu-latest
-    env:
-      NLTK_DATA: ${{ github.workspace }}/nltk_data
-    needs: [setup, lint]
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache/restore@v3
-      id: virtualenv-cache
-      with:
-        path: |
-          .venv
-          nltk_data
-        key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Setup virtual environment (no cache hit)
-      if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-      run: |
-        python${{ matrix.python-version}} -m venv .venv
-        source .venv/bin/activate
-        mkdir "$NLTK_DATA"
-        make install-ci
-    - name: Test Ingest (unit)
-      run: |
-        source .venv/bin/activate
-        PYTHONPATH=. pytest test_unstructured_ingest/unit
-    - name: Test (end-to-end)
-      env:
-        GH_READ_ONLY_ACCESS_TOKEN: ${{ secrets.GH_READ_ONLY_ACCESS_TOKEN }}
-        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
-        GCP_INGEST_SERVICE_KEY: ${{ secrets.GCP_INGEST_SERVICE_KEY }}
-      run: |
-        source .venv/bin/activate
-        sudo apt-get update
-        sudo apt-get install -y libmagic-dev poppler-utils libreoffice pandoc
-        sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
-        sudo apt-get install -y tesseract-ocr
-        tesseract --version
-        make install-ingest-s3
-        make install-ingest-azure
-        make install-ingest-discord
-        make install-ingest-gcs
-        make install-ingest-google-drive
-        make install-ingest-github
-        make install-ingest-gitlab
-        make install-ingest-slack
-        make install-ingest-wikipedia
-        ./test_unstructured_ingest/test-ingest.sh
+#   test_ingest:
+#     strategy:
+#       matrix:
+#         python-version: ["3.8","3.9","3.10"]
+#     runs-on: ubuntu-latest
+#     env:
+#       NLTK_DATA: ${{ github.workspace }}/nltk_data
+#     needs: [setup, lint]
+#     steps:
+#     - uses: actions/checkout@v3
+#     - uses: actions/cache/restore@v3
+#       id: virtualenv-cache
+#       with:
+#         path: |
+#           .venv
+#           nltk_data
+#         key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+#     - name: Set up Python ${{ matrix.python-version }}
+#       uses: actions/setup-python@v4
+#       with:
+#         python-version: ${{ matrix.python-version }}
+#     - name: Setup virtual environment (no cache hit)
+#       if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+#       run: |
+#         python${{ matrix.python-version}} -m venv .venv
+#         source .venv/bin/activate
+#         mkdir "$NLTK_DATA"
+#         make install-ci
+#     - name: Test Ingest (unit)
+#       run: |
+#         source .venv/bin/activate
+#         PYTHONPATH=. pytest test_unstructured_ingest/unit
+#     - name: Test (end-to-end)
+#       env:
+#         GH_READ_ONLY_ACCESS_TOKEN: ${{ secrets.GH_READ_ONLY_ACCESS_TOKEN }}
+#         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+#         DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+#         GCP_INGEST_SERVICE_KEY: ${{ secrets.GCP_INGEST_SERVICE_KEY }}
+#       run: |
+#         source .venv/bin/activate
+#         sudo apt-get update
+#         sudo apt-get install -y libmagic-dev poppler-utils libreoffice pandoc
+#         sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
+#         sudo apt-get install -y tesseract-ocr
+#         tesseract --version
+#         make install-ingest-s3
+#         make install-ingest-azure
+#         make install-ingest-discord
+#         make install-ingest-gcs
+#         make install-ingest-google-drive
+#         make install-ingest-github
+#         make install-ingest-gitlab
+#         make install-ingest-slack
+#         make install-ingest-wikipedia
+#         ./test_unstructured_ingest/test-ingest.sh
 
-  changelog:
-    runs-on: ubuntu-latest
-    steps:
-    - if: github.ref != 'refs/heads/main'
-      uses: dorny/paths-filter@v2
-      id: changes
-      with:
-        filters: |
-          src:
-            - 'unstructured/**'
+#   changelog:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - if: github.ref != 'refs/heads/main'
+#       uses: dorny/paths-filter@v2
+#       id: changes
+#       with:
+#         filters: |
+#           src:
+#             - 'unstructured/**'
 
-    - if: steps.changes.outputs.src == 'true' && github.ref != 'refs/heads/main'
-      uses: dangoslen/changelog-enforcer@v3
+#     - if: steps.changes.outputs.src == 'true' && github.ref != 'refs/heads/main'
+#       uses: dangoslen/changelog-enforcer@v3
 
-  # TODO - figure out best practice for caching docker images
-  # (Using the virtualenv to get pytest)
-  test_dockerfile:
-    runs-on: ubuntu-latest
-    needs: [ setup, lint ]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache/restore@v3
-        id: virtualenv-cache
-        with:
-          path: |
-            .venv
-            nltk_data
-          key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Setup virtual environment (no cache hit)
-        if: steps.virtualenv-cache.outputs.cache-hit != 'true'
-        run: |
-          python${{ matrix.python-version }} -m venv .venv
-      - name: Test Dockerfile
-        run: |
-          source .venv/bin/activate
-          make docker-build
-          make docker-test
+#   # TODO - figure out best practice for caching docker images
+#   # (Using the virtualenv to get pytest)
+#   test_dockerfile:
+#     runs-on: ubuntu-latest
+#     needs: [ setup, lint ]
+#     steps:
+#       - uses: actions/checkout@v3
+#       - uses: actions/cache/restore@v3
+#         id: virtualenv-cache
+#         with:
+#           path: |
+#             .venv
+#             nltk_data
+#           key: unstructured-${{ runner.os }}-${{ matrix.python-version }}-${{ env.GHA_CACHE_KEY_VERSION }}-${{ hashFiles('requirements/*.txt') }}
+#       - name: Set up Python ${{ matrix.python-version }}
+#         uses: actions/setup-python@v4
+#         with:
+#           python-version: ${{ matrix.python-version }}
+#       - name: Setup virtual environment (no cache hit)
+#         if: steps.virtualenv-cache.outputs.cache-hit != 'true'
+#         run: |
+#           python${{ matrix.python-version }} -m venv .venv
+#       - name: Test Dockerfile
+#         run: |
+#           source .venv/bin/activate
+#           make docker-build
+#           make docker-test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: docker/setup-buildx-action@v1
       with:
-        driver: "docker"
+        driver: "docker-container"
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Login to Quay.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Build And Push Docker Image
 
 on:
   push:
-    branches:
-      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -24,7 +22,7 @@ jobs:
   build-images:
     strategy:
       matrix:
-        docker-platform: ["linux/arm64", "linux/amd64"]
+        docker-platform: ["linux/arm64"]
     runs-on: ubuntu-latest
     needs: set-short-sha
     env:
@@ -50,59 +48,59 @@ jobs:
           --progress plain \
           --cache-from $DOCKER_BUILD_REPOSITORY:$ARCH \
           -t $DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA .
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-    - name: Test images
-      run: |
-        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-        if [ "$ARCH" = "amd64" ]; then
-        DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-          make docker-test
-        else
-          DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-            make docker-test TEST_NAME=partition/test_text.py
-        fi
-        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
-    - name: Push images
-      run: |
-        # write to the build repository to cache for the publish-images job
-        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-        docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  publish-images:
-    runs-on: ubuntu-latest
-    needs: [set-short-sha, build-images]
-    env:
-      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-    steps:
-    - uses: docker/setup-buildx-action@v1
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Login to Quay.io
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-    - name: Pull AMD image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-    - name: Pull ARM image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-    - name: Push latest build tags for AMD and ARM
-      run: |
-        # these are used to construct the final manifest but also cache-from in subsequent runs
-        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-        docker push $DOCKER_BUILD_REPOSITORY:amd64
-        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-        docker push $DOCKER_BUILD_REPOSITORY:arm64
-    - name: Push multiarch manifest
-      run: |
-        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
-        docker manifest push $DOCKER_REPOSITORY:latest
-        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$VERSION
+    # - name: Set up QEMU
+    #   uses: docker/setup-qemu-action@v2
+    # - name: Test images
+    #   run: |
+    #     ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+    #     if [ "$ARCH" = "amd64" ]; then
+    #     DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
+    #       make docker-test
+    #     else
+    #       DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
+    #         make docker-test TEST_NAME=partition/test_text.py
+    #     fi
+    #     DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
+    # - name: Push images
+    #   run: |
+    #     # write to the build repository to cache for the publish-images job
+    #     ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+    #     docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
+  # publish-images:
+  #   runs-on: ubuntu-latest
+  #   needs: [set-short-sha, build-images]
+  #   env:
+  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+  #   steps:
+  #   - uses: docker/setup-buildx-action@v1
+  #   - name: Checkout code
+  #     uses: actions/checkout@v3
+  #   - name: Login to Quay.io
+  #     uses: docker/login-action@v1
+  #     with:
+  #       registry: quay.io
+  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+  #   - name: Pull AMD image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+  #   - name: Pull ARM image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+  #   - name: Push latest build tags for AMD and ARM
+  #     run: |
+  #       # these are used to construct the final manifest but also cache-from in subsequent runs
+  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
+  #   - name: Push multiarch manifest
+  #     run: |
+  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker manifest push $DOCKER_REPOSITORY:latest
+  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,6 +31,9 @@ jobs:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     steps:
     - name: Set up Docker
+      # Use the `docker` driver for AMD builds because the `docker-container` driver may fail to locally load the built image.
+      # This could be due to the larger size of the AMD build and the `docker-container` driver needing to load the tarball.
+      # Use the `docker-container` for ARM builds because it may otherwise intermittently fail with: `exec /bin/sh: exec format error`
       uses: docker/setup-buildx-action@v1
       with:
         driver: ${{ matrix.docker-platform == 'linux/amd64' && 'docker' || 'docker-container' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Docker
       # Use the `docker` driver for AMD builds because the `docker-container` driver may fail to locally load the built image.
       # This could be due to the larger size of the AMD build and the `docker-container` driver needing to load the tarball.
-      # Use the `docker-container` for ARM builds because it may otherwise intermittently fail with: `exec /bin/sh: exec format error`
+      # Use the `docker-container` driver for ARM builds because it may otherwise intermittently fail with: `exec /bin/sh: exec format error`
       uses: docker/setup-buildx-action@v1
       with:
         driver: ${{ matrix.docker-platform == 'linux/amd64' && 'docker' || 'docker-container' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
+    branches:
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -67,41 +69,41 @@ jobs:
         # write to the build repository to cache for the publish-images job
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  # publish-images:
-  #   runs-on: ubuntu-latest
-  #   needs: [set-short-sha, build-images]
-  #   env:
-  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-  #   steps:
-  #   - uses: docker/setup-buildx-action@v1
-  #   - name: Checkout code
-  #     uses: actions/checkout@v3
-  #   - name: Login to Quay.io
-  #     uses: docker/login-action@v1
-  #     with:
-  #       registry: quay.io
-  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-  #   - name: Pull AMD image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-  #   - name: Pull ARM image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-  #   - name: Push latest build tags for AMD and ARM
-  #     run: |
-  #       # these are used to construct the final manifest but also cache-from in subsequent runs
-  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
-  #   - name: Push multiarch manifest
-  #     run: |
-  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker manifest push $DOCKER_REPOSITORY:latest
-  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
+  publish-images:
+    runs-on: ubuntu-latest
+    needs: [set-short-sha, build-images]
+    env:
+      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+    steps:
+    - uses: docker/setup-buildx-action@v1
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+    - name: Pull AMD image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+    - name: Pull ARM image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+    - name: Push latest build tags for AMD and ARM
+      run: |
+        # these are used to construct the final manifest but also cache-from in subsequent runs
+        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+        docker push $DOCKER_BUILD_REPOSITORY:amd64
+        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+        docker push $DOCKER_BUILD_REPOSITORY:arm64
+    - name: Push multiarch manifest
+      run: |
+        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
+        docker manifest push $DOCKER_REPOSITORY:latest
+        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$VERSION
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,15 +22,16 @@ jobs:
   build-images:
     strategy:
       matrix:
-        docker-platform: ["linux/arm64"]
+        docker-platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     needs: set-short-sha
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     steps:
-    - uses: docker/setup-buildx-action@v1
+    - name: Set up Docker
+      uses: docker/setup-buildx-action@v1
       with:
-        driver: "docker-container"
+        driver: ${{ matrix.docker-platform == 'linux/amd64' && 'docker' || 'docker-container' }}
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Login to Quay.io
@@ -48,24 +49,24 @@ jobs:
           --progress plain \
           --cache-from $DOCKER_BUILD_REPOSITORY:$ARCH \
           -t $DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA .
-    # - name: Set up QEMU
-    #   uses: docker/setup-qemu-action@v2
-    # - name: Test images
-    #   run: |
-    #     ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-    #     if [ "$ARCH" = "amd64" ]; then
-    #     DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-    #       make docker-test
-    #     else
-    #       DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-    #         make docker-test TEST_NAME=partition/test_text.py
-    #     fi
-    #     DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
-    # - name: Push images
-    #   run: |
-    #     # write to the build repository to cache for the publish-images job
-    #     ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-    #     docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Test images
+      run: |
+        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+        if [ "$ARCH" = "amd64" ]; then
+        DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
+          make docker-test
+        else
+          DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
+            make docker-test TEST_NAME=partition/test_text.py
+        fi
+        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
+    - name: Push images
+      run: |
+        # write to the build repository to cache for the publish-images job
+        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+        docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
   # publish-images:
   #   runs-on: ubuntu-latest
   #   needs: [set-short-sha, build-images]


### PR DESCRIPTION
[This PR](https://github.com/Unstructured-IO/unstructured/pull/804) introduced a change to use the "docker" driver instead of the "docker-container" driver that docker/setup-buildx-action@v1 defaults to. This intermittently hits an issue with arm builds where the build fails with `exec /bin/sh: exec format error`. Because the original issue only affected AMD builds, this PR reverts the change specifically for ARM builds by making the driver condition on the architecture specified.

[Here](https://github.com/Unstructured-IO/unstructured/actions/runs/5383408561/jobs/9770135678) is a run showing this conditional driver logic working and passing the image build steps for both architectures.

