### PR TITLE
feat: add metadata_filename parameter across all partition functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 0.7.13-dev0
+## 0.7.13-dev1
 
 ### Enhancements
 
 ### Features
+
+* Add metadata_filename parameter across all partition functions
 
 ### Fixes
 

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -12,6 +12,7 @@ def test_partition_csv_from_filename(filename="example-docs/stanley-cups.csv"):
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
     assert elements[0].metadata.text_as_html == EXPECTED_TABLE
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
+    assert elements[0].metadata.filename == "stanley-cups.csv"
 
 
 def test_partition_csv_from_file(filename="example-docs/stanley-cups.csv"):
@@ -22,6 +23,7 @@ def test_partition_csv_from_file(filename="example-docs/stanley-cups.csv"):
     assert isinstance(elements[0], Table)
     assert elements[0].metadata.text_as_html == EXPECTED_TABLE
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
+    assert elements[0].metadata.filename is None
 
 
 def test_partition_csv_can_exclude_metadata(filename="example-docs/stanley-cups.csv"):
@@ -31,3 +33,4 @@ def test_partition_csv_can_exclude_metadata(filename="example-docs/stanley-cups.
     assert isinstance(elements[0], Table)
     assert elements[0].metadata.text_as_html is None
     assert elements[0].metadata.filetype is None
+    assert elements[0].metadata.filename is None

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -15,7 +15,9 @@ def test_partition_csv_from_filename(filename="example-docs/stanley-cups.csv"):
     assert elements[0].metadata.filename == "stanley-cups.csv"
 
 
-def test_partition_csv_from_filename_with_metadata_filename(filename="example-docs/stanley-cups.csv"):
+def test_partition_csv_from_filename_with_metadata_filename(
+    filename="example-docs/stanley-cups.csv",
+):
     elements = partition_csv(filename=filename, metadata_filename="test")
 
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
@@ -31,7 +33,7 @@ def test_partition_csv_from_file(filename="example-docs/stanley-cups.csv"):
     assert elements[0].metadata.text_as_html == EXPECTED_TABLE
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     assert elements[0].metadata.filename is None
-    
+
 
 def test_partition_csv_from_file_with_metadata_filename(filename="example-docs/stanley-cups.csv"):
     with open(filename, "rb") as f:

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -15,6 +15,13 @@ def test_partition_csv_from_filename(filename="example-docs/stanley-cups.csv"):
     assert elements[0].metadata.filename == "stanley-cups.csv"
 
 
+def test_partition_csv_from_filename_with_metadata_filename(filename="example-docs/stanley-cups.csv"):
+    elements = partition_csv(filename=filename, metadata_filename="test")
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert elements[0].metadata.filename == "test"
+
+
 def test_partition_csv_from_file(filename="example-docs/stanley-cups.csv"):
     with open(filename, "rb") as f:
         elements = partition_csv(file=f)
@@ -24,6 +31,14 @@ def test_partition_csv_from_file(filename="example-docs/stanley-cups.csv"):
     assert elements[0].metadata.text_as_html == EXPECTED_TABLE
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     assert elements[0].metadata.filename is None
+    
+
+def test_partition_csv_from_file_with_metadata_filename(filename="example-docs/stanley-cups.csv"):
+    with open(filename, "rb") as f:
+        elements = partition_csv(file=f, metadata_filename="test")
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert elements[0].metadata.filename == "test"
 
 
 def test_partition_csv_can_exclude_metadata(filename="example-docs/stanley-cups.csv"):

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -110,9 +110,8 @@ def test_partition_doc_from_file(mock_document, expected_elements, tmpdir, capsy
     assert elements == expected_elements
     assert capsys.readouterr().out == ""
     assert capsys.readouterr().err == ""
-    # TODO(jennings) the filename is changed after parsing
-    # for element in elements:
-    #     assert element.metadata.filename is None
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_doc_from_file_with_metadata_filename(mock_document, tmpdir):

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -61,14 +61,27 @@ def test_partition_doc_with_filename(mock_document, expected_elements, tmpdir, c
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
     mock_document.save(docx_filename)
     convert_office_doc(docx_filename, tmpdir.dirname, "doc")
-
     elements = partition_doc(filename=doc_filename)
     assert elements == expected_elements
     assert elements[0].metadata.filename == "mock_document.doc"
     assert elements[0].metadata.file_directory == tmpdir.dirname
-
     assert capsys.readouterr().out == ""
     assert capsys.readouterr().err == ""
+
+
+def test_partition_doc_with_filename_and_metadata_filename(
+    mock_document,
+    expected_elements,
+    tmpdir,
+):
+    docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
+    doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
+    mock_document.save(docx_filename)
+    convert_office_doc(docx_filename, tmpdir.dirname, "doc")
+
+    elements = partition_doc(filename=doc_filename, metadata_filename="test")
+    assert elements == expected_elements
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 def test_partition_doc_matches_partition_docx(mock_document, expected_elements, tmpdir):
@@ -76,8 +89,7 @@ def test_partition_doc_matches_partition_docx(mock_document, expected_elements, 
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
     mock_document.save(docx_filename)
     convert_office_doc(docx_filename, tmpdir.dirname, "doc")
-
-    partition_doc(filename=doc_filename) == partition_docx(filename=docx_filename)
+    assert partition_doc(filename=doc_filename) == partition_docx(filename=docx_filename)
 
 
 def test_partition_raises_with_missing_doc(mock_document, expected_elements, tmpdir):
@@ -96,9 +108,11 @@ def test_partition_doc_with_file(mock_document, expected_elements, tmpdir, capsy
     with open(doc_filename, "rb") as f:
         elements = partition_doc(file=f)
     assert elements == expected_elements
-
     assert capsys.readouterr().out == ""
     assert capsys.readouterr().err == ""
+    # TODO(jennings) the filename is changed after parsing
+    # for element in elements:
+    #     assert element.metadata.filename == "mock_document.doc"
 
 
 def test_partition_doc_raises_with_both_specified(mock_document, tmpdir):

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -113,8 +113,8 @@ def test_partition_doc_from_file(mock_document, expected_elements, tmpdir, capsy
     # TODO(jennings) the filename is changed after parsing
     # for element in elements:
     #     assert element.metadata.filename is None
-        
-        
+
+
 def test_partition_doc_from_file_with_metadata_filename(mock_document, tmpdir):
     docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -56,7 +56,7 @@ def expected_elements():
     ]
 
 
-def test_partition_doc_with_filename(mock_document, expected_elements, tmpdir, capsys):
+def test_partition_doc_from_filename(mock_document, expected_elements, tmpdir, capsys):
     docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
     mock_document.save(docx_filename)
@@ -69,7 +69,7 @@ def test_partition_doc_with_filename(mock_document, expected_elements, tmpdir, c
     assert capsys.readouterr().err == ""
 
 
-def test_partition_doc_with_filename_and_metadata_filename(
+def test_partition_doc_from_filename_with_metadata_filename(
     mock_document,
     expected_elements,
     tmpdir,
@@ -99,7 +99,7 @@ def test_partition_raises_with_missing_doc(mock_document, expected_elements, tmp
         partition_doc(filename=doc_filename)
 
 
-def test_partition_doc_with_file(mock_document, expected_elements, tmpdir, capsys):
+def test_partition_doc_from_file(mock_document, expected_elements, tmpdir, capsys):
     docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
     mock_document.save(docx_filename)
@@ -112,7 +112,19 @@ def test_partition_doc_with_file(mock_document, expected_elements, tmpdir, capsy
     assert capsys.readouterr().err == ""
     # TODO(jennings) the filename is changed after parsing
     # for element in elements:
-    #     assert element.metadata.filename == "mock_document.doc"
+    #     assert element.metadata.filename is None
+        
+        
+def test_partition_doc_from_file_with_metadata_filename(mock_document, tmpdir):
+    docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
+    doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
+    mock_document.save(docx_filename)
+    convert_office_doc(docx_filename, tmpdir.dirname, "doc")
+
+    with open(doc_filename, "rb") as f:
+        elements = partition_doc(file=f, metadata_filename="test")
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_doc_raises_with_both_specified(mock_document, tmpdir):
@@ -130,7 +142,7 @@ def test_partition_doc_raises_with_neither():
         partition_doc()
 
 
-def test_partition_doc_with_file_exclude_metadata(mock_document, tmpdir):
+def test_partition_doc_from_file_exclude_metadata(mock_document, tmpdir):
     docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
     mock_document.save(docx_filename)
@@ -144,7 +156,7 @@ def test_partition_doc_with_file_exclude_metadata(mock_document, tmpdir):
     assert elements[0].metadata.filename is None
 
 
-def test_partition_doc_with_filename_exclude_metadata(mock_document, tmpdir):
+def test_partition_doc_from_filename_exclude_metadata(mock_document, tmpdir):
     docx_filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     doc_filename = os.path.join(tmpdir.dirname, "mock_document.doc")
     mock_document.save(docx_filename)

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -101,8 +101,8 @@ def test_partition_docx_from_file(mock_document, expected_elements, tmpdir):
     assert elements == expected_elements
     for element in elements:
         assert element.metadata.filename is None
-        
-        
+
+
 def test_partition_docx_from_file_with_metadata_filename(mock_document, expected_elements, tmpdir):
     filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     mock_document.save(filename)

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -57,7 +57,7 @@ def expected_elements():
     ]
 
 
-def test_partition_docx_with_filename(mock_document, expected_elements, tmpdir):
+def test_partition_docx_from_filename(mock_document, expected_elements, tmpdir):
     filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     mock_document.save(filename)
 
@@ -68,7 +68,7 @@ def test_partition_docx_with_filename(mock_document, expected_elements, tmpdir):
         assert element.metadata.filename == "mock_document.docx"
 
 
-def test_partition_docx_with_filename_metadata(mock_document, tmpdir):
+def test_partition_docx_from_filename_with_metadata_filename(mock_document, tmpdir):
     filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     mock_document.save(filename)
     elements = partition_docx(filename=filename, metadata_filename="test")
@@ -92,7 +92,7 @@ def test_partition_docx_with_spooled_file(mock_document, expected_elements, tmpd
             assert element.metadata.filename is None
 
 
-def test_partition_docx_with_file(mock_document, expected_elements, tmpdir):
+def test_partition_docx_from_file(mock_document, expected_elements, tmpdir):
     filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     mock_document.save(filename)
 
@@ -101,6 +101,17 @@ def test_partition_docx_with_file(mock_document, expected_elements, tmpdir):
     assert elements == expected_elements
     for element in elements:
         assert element.metadata.filename is None
+        
+        
+def test_partition_docx_from_file_with_metadata_filename(mock_document, expected_elements, tmpdir):
+    filename = os.path.join(tmpdir.dirname, "mock_document.docx")
+    mock_document.save(filename)
+
+    with open(filename, "rb") as f:
+        elements = partition_docx(file=f, metadata_filename="test")
+    assert elements == expected_elements
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_docx_raises_with_both_specified(mock_document, tmpdir):
@@ -160,14 +171,14 @@ def test_partition_docx_includes_page_breaks(filename="example-docs/handbook-1p.
         assert element.metadata.filename == "handbook-1p.docx"
 
 
-def test_partition_docx_with_filename_exclude_metadata(filename="example-docs/handbook-1p.docx"):
+def test_partition_docx_from_filename_exclude_metadata(filename="example-docs/handbook-1p.docx"):
     elements = partition_docx(filename=filename, include_metadata=False)
     assert elements[0].metadata.filetype is None
     assert elements[0].metadata.page_name is None
     assert elements[0].metadata.filename is None
 
 
-def test_partition_docx_with_file_exclude_metadata(mock_document, tmpdir):
+def test_partition_docx_from_file_exclude_metadata(mock_document, tmpdir):
     filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     mock_document.save(filename)
 

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -64,6 +64,15 @@ def test_partition_docx_with_filename(mock_document, expected_elements, tmpdir):
     elements = partition_docx(filename=filename)
     assert elements == expected_elements
     assert elements[0].metadata.page_number is None
+    for element in elements:
+        assert element.metadata.filename == "mock_document.docx"
+
+
+def test_partition_docx_with_filename_metadata(mock_document, tmpdir):
+    filename = os.path.join(tmpdir.dirname, "mock_document.docx")
+    mock_document.save(filename)
+    elements = partition_docx(filename=filename, metadata_filename="test")
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 def test_partition_docx_with_spooled_file(mock_document, expected_elements, tmpdir):
@@ -79,6 +88,8 @@ def test_partition_docx_with_spooled_file(mock_document, expected_elements, tmpd
         spooled_temp_file.seek(0)
         elements = partition_docx(file=spooled_temp_file)
         assert elements == expected_elements
+        for element in elements:
+            assert element.metadata.filename is None
 
 
 def test_partition_docx_with_file(mock_document, expected_elements, tmpdir):
@@ -88,6 +99,8 @@ def test_partition_docx_with_file(mock_document, expected_elements, tmpdir):
     with open(filename, "rb") as f:
         elements = partition_docx(file=f)
     assert elements == expected_elements
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_docx_raises_with_both_specified(mock_document, tmpdir):
@@ -125,6 +138,8 @@ def test_partition_docx_grabs_header_and_footer(filename="example-docs/handbook-
     elements = partition_docx(filename=filename)
     assert elements[0] == Header("US Trustee Handbook")
     assert elements[-1] == Footer("Copyright")
+    for element in elements:
+        assert element.metadata.filename == "handbook-1p.docx"
 
 
 def test_partition_docx_includes_pages_if_present(filename="example-docs/handbook-1p.docx"):
@@ -132,6 +147,8 @@ def test_partition_docx_includes_pages_if_present(filename="example-docs/handboo
     assert "PageBreak" not in [elem.category for elem in elements]
     assert elements[1].metadata.page_number == 1
     assert elements[-2].metadata.page_number == 2
+    for element in elements:
+        assert element.metadata.filename == "handbook-1p.docx"
 
 
 def test_partition_docx_includes_page_breaks(filename="example-docs/handbook-1p.docx"):
@@ -139,6 +156,8 @@ def test_partition_docx_includes_page_breaks(filename="example-docs/handbook-1p.
     assert "PageBreak" in [elem.category for elem in elements]
     assert elements[1].metadata.page_number == 1
     assert elements[-2].metadata.page_number == 2
+    for element in elements:
+        assert element.metadata.filename == "handbook-1p.docx"
 
 
 def test_partition_docx_with_filename_exclude_metadata(filename="example-docs/handbook-1p.docx"):

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -311,8 +311,6 @@ def test_extract_attachment_info():
     attachment_info = extract_attachment_info(msg)
     assert len(attachment_info) > 0
     assert attachment_info == ATTACH_EXPECTED_OUTPUT
-    # TODO(jennings) the filename is changed after parsing
-    # assert attachment_info[0].get("filename", None) == "fake-email-attachment.eml"
 
 
 def test_partition_email_raises_with_none_specified():

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -106,6 +106,15 @@ def test_partition_email_from_filename():
     elements = partition_email(filename=filename)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "fake-email.eml"
+
+
+def test_partition_email_from_filename_with_metadata_filename():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.eml")
+    elements = partition_email(filename=filename, metadata_filename="test")
+    assert len(elements) > 0
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 @pytest.mark.parametrize(
@@ -124,11 +133,13 @@ def test_partition_email_from_filename():
     ],
 )
 def test_partition_email_from_filename_default_encoding(filename, expected_output):
-    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, filename)
-    elements = partition_email(filename=filename)
+    filename_path = os.path.join(EXAMPLE_DOCS_DIRECTORY, filename)
+    elements = partition_email(filename=filename_path)
     assert len(elements) > 0
     if expected_output:
         assert elements == expected_output
+    for element in elements:
+        assert element.metadata.filename == filename
 
 
 def test_partition_email_from_file():
@@ -137,6 +148,8 @@ def test_partition_email_from_file():
         elements = partition_email(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 @pytest.mark.parametrize(
@@ -155,12 +168,14 @@ def test_partition_email_from_file():
     ],
 )
 def test_partition_email_from_file_default_encoding(filename, expected_output):
-    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, filename)
-    with open(filename) as f:
+    filename_path = os.path.join(EXAMPLE_DOCS_DIRECTORY, filename)
+    with open(filename_path) as f:
         elements = partition_email(file=f)
     assert len(elements) > 0
     if expected_output:
         assert elements == expected_output
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_email_from_file_rb():
@@ -169,6 +184,8 @@ def test_partition_email_from_file_rb():
         elements = partition_email(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 @pytest.mark.parametrize(
@@ -187,12 +204,14 @@ def test_partition_email_from_file_rb():
     ],
 )
 def test_partition_email_from_file_rb_default_encoding(filename, expected_output):
-    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, filename)
-    with open(filename, "rb") as f:
+    filename_path = os.path.join(EXAMPLE_DOCS_DIRECTORY, filename)
+    with open(filename_path, "rb") as f:
         elements = partition_email(file=f)
     assert len(elements) > 0
     if expected_output:
         assert elements == expected_output
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_email_from_text_file():
@@ -201,6 +220,8 @@ def test_partition_email_from_text_file():
         elements = partition_email(file=f, content_source="text/plain")
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_email_from_text_file_with_headers():
@@ -209,6 +230,8 @@ def test_partition_email_from_text_file_with_headers():
         elements = partition_email(file=f, content_source="text/plain", include_headers=True)
     assert len(elements) > 0
     assert elements == ALL_EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_email_from_text():
@@ -218,6 +241,8 @@ def test_partition_email_from_text():
     elements = partition_email(text=text)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_email_from_text_work_with_empty_string():
@@ -229,18 +254,22 @@ def test_partition_email_from_filename_with_embedded_image():
     elements = partition_email(filename=filename, content_source="text/plain")
     assert len(elements) > 0
     assert elements == IMAGE_EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "fake-email-image-embedded.eml"
 
 
-def test_partition_email_header():
+def test_partition_email_from_file_with_header():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email-header.eml")
     with open(filename) as f:
         msg = email.message_from_file(f)
     elements = partition_email_header(msg)
     assert len(elements) > 0
     assert elements == RECEIVED_HEADER_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
-def test_partition_email_has_metadata():
+def test_partition_email_from_filename_has_metadata():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email-header.eml")
     elements = partition_email(filename=filename)
     assert len(elements) > 0
@@ -257,21 +286,22 @@ def test_partition_email_has_metadata():
             filetype="message/rfc822",
         ).to_dict()
     )
-
     expected_dt = datetime.datetime.fromisoformat("2022-12-16T17:04:16-05:00")
     assert elements[0].metadata.get_date() == expected_dt
+    for element in elements:
+        assert element.metadata.filename == "fake-email-header.eml"
 
 
 def test_extract_email_text_matches_html():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email-attachment.eml")
     elements_from_text = partition_email(filename=filename, content_source="text/plain")
     elements_from_html = partition_email(filename=filename, content_source="text/html")
-
     assert len(elements_from_text) == len(elements_from_html)
     # NOTE(robinson) - checking each individually is necessary because the text/html returns
     # HTMLTitle, HTMLNarrativeText, etc
     for i, element in enumerate(elements_from_text):
         assert element == elements_from_text[i]
+        assert element.metadata.filename == "fake-email-attachment.eml"
 
 
 def test_extract_attachment_info():
@@ -281,6 +311,8 @@ def test_extract_attachment_info():
     attachment_info = extract_attachment_info(msg)
     assert len(attachment_info) > 0
     assert attachment_info == ATTACH_EXPECTED_OUTPUT
+    # TODO(jennings) the filename is changed after parsing
+    # assert attachment_info[0].get("filename", None) == "fake-email-attachment.eml"
 
 
 def test_partition_email_raises_with_none_specified():
@@ -292,7 +324,6 @@ def test_partition_email_raises_with_too_many_specified():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.eml")
     with open(filename) as f:
         text = f.read()
-
     with pytest.raises(ValueError):
         partition_email(filename=filename, text=text)
 
@@ -307,6 +338,8 @@ def test_partition_email_processes_fake_email_with_header():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email-header.eml")
     elements = partition_email(filename=filename)
     assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename == "fake-email-header.eml"
 
 
 @pytest.mark.parametrize(

--- a/test_unstructured/partition/test_epub.py
+++ b/test_unstructured/partition/test_epub.py
@@ -30,7 +30,16 @@ def test_partition_epub_from_file():
     assert elements[0].text.startswith("The Project Gutenberg eBook of Winter Sports")
     for element in elements:
         assert element.metadata.filename is None
-
+        
+        
+def test_partition_epub_from_file_with_metadata_filename():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "winter-sports.epub")
+    with open(filename, "rb") as f:
+        elements = partition_epub(file=f, metadata_filename="test")
+    assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename == "test"
+        
 
 def test_partition_epub_from_filename_exclude_metadata():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "winter-sports.epub")

--- a/test_unstructured/partition/test_epub.py
+++ b/test_unstructured/partition/test_epub.py
@@ -30,8 +30,8 @@ def test_partition_epub_from_file():
     assert elements[0].text.startswith("The Project Gutenberg eBook of Winter Sports")
     for element in elements:
         assert element.metadata.filename is None
-        
-        
+
+
 def test_partition_epub_from_file_with_metadata_filename():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "winter-sports.epub")
     with open(filename, "rb") as f:
@@ -39,7 +39,7 @@ def test_partition_epub_from_file_with_metadata_filename():
     assert len(elements) > 0
     for element in elements:
         assert element.metadata.filename == "test"
-        
+
 
 def test_partition_epub_from_filename_exclude_metadata():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "winter-sports.epub")

--- a/test_unstructured/partition/test_epub.py
+++ b/test_unstructured/partition/test_epub.py
@@ -11,6 +11,15 @@ def test_partition_epub_from_filename():
     elements = partition_epub(filename=filename)
     assert len(elements) > 0
     assert elements[0].text.startswith("The Project Gutenberg eBook of Winter Sports")
+    for element in elements:
+        assert element.metadata.filename == "winter-sports.epub"
+
+
+def test_partition_epub_from_filename_with_metadata_filename():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "winter-sports.epub")
+    elements = partition_epub(filename=filename, metadata_filename="test")
+    assert len(elements) > 0
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 def test_partition_epub_from_file():
@@ -19,6 +28,8 @@ def test_partition_epub_from_file():
         elements = partition_epub(file=f)
     assert len(elements) > 0
     assert elements[0].text.startswith("The Project Gutenberg eBook of Winter Sports")
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_epub_from_filename_exclude_metadata():

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -81,7 +81,7 @@ def test_partition_html_from_file():
     assert len(elements) > 0
     for element in elements:
         assert element.metadata.filename is None
-        
+
 
 def test_partition_html_from_file_with_metadata_filename():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -81,6 +81,15 @@ def test_partition_html_from_file():
     assert len(elements) > 0
     for element in elements:
         assert element.metadata.filename is None
+        
+
+def test_partition_html_from_file_with_metadata_filename():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")
+    with open(filename) as f:
+        elements = partition_html(file=f, metadata_filename="test")
+    assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 @pytest.mark.parametrize(
@@ -290,3 +299,13 @@ def test_partition_html_with_pre_tag():
     assert isinstance(elements[0], Title)
     assert elements[0].metadata.filetype == "text/html"
     assert elements[0].metadata.filename == "fake-html-pre.htm"
+
+
+def test_partition_html_from_filename_exclude_metadata():
+    directory = os.path.join(DIRECTORY, "..", "..", "example-docs")
+    filename = os.path.join(directory, "example-10k.html")
+    elements = partition_html(filename=filename, include_metadata=False)
+    assert len(elements) > 0
+    assert "PageBreak" not in [elem.category for elem in elements]
+    assert elements[0].metadata.filename is None
+    assert elements[0].metadata.file_directory is None

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -23,6 +23,14 @@ def test_partition_html_from_filename():
     assert elements[0].metadata.file_directory == directory
 
 
+def test_partition_html_from_filename_with_metadata_filename():
+    directory = os.path.join(DIRECTORY, "..", "..", "example-docs")
+    filename = os.path.join(directory, "example-10k.html")
+    elements = partition_html(filename=filename, metadata_filename="test")
+    assert len(elements) > 0
+    assert all(element.metadata.filename == "test" for element in elements)
+
+
 @pytest.mark.parametrize(
     ("filename", "encoding", "error"),
     [
@@ -42,9 +50,11 @@ def test_partition_html_from_filename_raises_encoding_error(filename, encoding, 
     ["example-10k-utf-16.html", "example-steelJIS-datasheet-utf-16.html"],
 )
 def test_partition_html_from_filename_default_encoding(filename):
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-    elements = partition_html(filename=filename)
+    filename_path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
+    elements = partition_html(filename=filename_path)
     assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename == filename
 
 
 def test_partition_html_from_filename_metadata_false():
@@ -60,6 +70,8 @@ def test_partition_html_with_page_breaks():
     elements = partition_html(filename=filename, include_page_breaks=True)
     assert "PageBreak" in [elem.category for elem in elements]
     assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename == "example-10k.html"
 
 
 def test_partition_html_from_file():
@@ -67,6 +79,8 @@ def test_partition_html_from_file():
     with open(filename) as f:
         elements = partition_html(file=f)
     assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 @pytest.mark.parametrize(
@@ -79,7 +93,7 @@ def test_partition_html_from_file():
 def test_partition_html_from_file_raises_encoding_error(filename, encoding, error):
     with pytest.raises(error):
         filename = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-        with open(filename) as f:
+        with open(filename) as f, pytest.raises(UnicodeEncodeError):
             partition_html(file=f, encoding=encoding)
 
 

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -85,7 +85,7 @@ def test_partition_json_from_file(filename: str):
     for i in range(len(elements)):
         assert elements[i] == test_elements[i]
         assert elements[i].metadata.filename == filename.split("/")[-1]
-        
+
 
 @pytest.mark.parametrize("filename", test_files)
 def test_partition_json_from_file_with_metadata_filename(filename: str):

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -85,6 +85,22 @@ def test_partition_json_from_file(filename: str):
     for i in range(len(elements)):
         assert elements[i] == test_elements[i]
         assert elements[i].metadata.filename == filename.split("/")[-1]
+        
+
+@pytest.mark.parametrize("filename", test_files)
+def test_partition_json_from_file_with_metadata_filename(filename: str):
+    path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
+    elements = partition(filename=path)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _filename = os.path.basename(filename)
+        test_path = os.path.join(tmpdir, _filename + ".json")
+        elements_to_json(elements, filename=test_path, indent=2)
+        with open(test_path) as f:
+            test_elements = partition_json(file=f, metadata_filename="test")
+
+    for i in range(len(test_elements)):
+        assert test_elements[i].metadata.filename == "test"
 
 
 @pytest.mark.parametrize("filename", test_files)

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -48,6 +48,23 @@ def test_partition_json_from_filename(filename: str):
         print(elements[i].coordinates)
         print(test_elements[i].coordinates)
         assert elements[i] == test_elements[i]
+        assert elements[i].metadata.filename == filename.split("/")[-1]
+
+
+@pytest.mark.parametrize("filename", test_files)
+def test_partition_json_from_filename_with_metadata_filename(filename: str):
+    path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
+    elements = partition(filename=path)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _filename = os.path.basename(filename)
+        test_path = os.path.join(tmpdir, _filename + ".json")
+        elements_to_json(elements, filename=test_path, indent=2)
+        test_elements = partition_json(filename=test_path, metadata_filename="test")
+
+    assert len(test_elements) > 0
+    assert len(str(test_elements[0])) > 0
+    assert all(element.metadata.filename == "test" for element in test_elements)
 
 
 @pytest.mark.parametrize("filename", test_files)
@@ -64,10 +81,10 @@ def test_partition_json_from_file(filename: str):
 
     assert len(elements) > 0
     assert len(str(elements[0])) > 0
-
     assert len(elements) == len(test_elements)
     for i in range(len(elements)):
         assert elements[i] == test_elements[i]
+        assert elements[i].metadata.filename == filename.split("/")[-1]
 
 
 @pytest.mark.parametrize("filename", test_files)
@@ -85,10 +102,10 @@ def test_partition_json_from_text(filename: str):
 
     assert len(elements) > 0
     assert len(str(elements[0])) > 0
-
     assert len(elements) == len(test_elements)
     for i in range(len(elements)):
         assert elements[i] == test_elements[i]
+        assert elements[i].metadata.filename == filename.split("/")[-1]
 
 
 def test_partition_json_raises_with_none_specified():

--- a/test_unstructured/partition/test_md.py
+++ b/test_unstructured/partition/test_md.py
@@ -17,6 +17,15 @@ def test_partition_md_from_filename():
     assert len(elements) > 0
     for element in elements:
         assert element.metadata.filename == "README.md"
+        
+        
+def test_partition_md_from_filename():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "README.md")
+    elements = partition_md(filename=filename, metadata_filename="test")
+    assert "PageBreak" not in [elem.category for elem in elements]
+    assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_md_from_file():

--- a/test_unstructured/partition/test_md.py
+++ b/test_unstructured/partition/test_md.py
@@ -15,6 +15,8 @@ def test_partition_md_from_filename():
     elements = partition_md(filename=filename)
     assert "PageBreak" not in [elem.category for elem in elements]
     assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename == "README.md"
 
 
 def test_partition_md_from_file():
@@ -22,6 +24,16 @@ def test_partition_md_from_file():
     with open(filename) as f:
         elements = partition_md(file=f)
     assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename is None
+
+
+def test_partition_md_from_file_with_metadata_filename():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "README.md")
+    with open(filename) as f:
+        elements = partition_md(file=f, metadata_filename="test")
+    assert len(elements) > 0
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 def test_partition_md_from_text():
@@ -30,6 +42,8 @@ def test_partition_md_from_text():
         text = f.read()
     elements = partition_md(text=text)
     assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 class MockResponse:
@@ -50,6 +64,8 @@ def test_partition_md_from_url():
         elements = partition_md(url="https://fake.url")
 
     assert len(elements) > 0
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_md_from_url_raises_with_bad_status_code():

--- a/test_unstructured/partition/test_md.py
+++ b/test_unstructured/partition/test_md.py
@@ -17,9 +17,9 @@ def test_partition_md_from_filename():
     assert len(elements) > 0
     for element in elements:
         assert element.metadata.filename == "README.md"
-        
-        
-def test_partition_md_from_filename():
+
+
+def test_partition_md_from_filename_with_metadata_filename():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "README.md")
     elements = partition_md(filename=filename, metadata_filename="test")
     assert "PageBreak" not in [elem.category for elem in elements]

--- a/test_unstructured/partition/test_msg.py
+++ b/test_unstructured/partition/test_msg.py
@@ -50,6 +50,14 @@ def test_partition_msg_from_filename():
             filetype="application/vnd.ms-outlook",
         ).to_dict()
     )
+    for element in elements:
+        assert element.metadata.filename == "fake-email.msg"
+
+
+def test_partition_msg_from_filename_with_metadata_filename():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.msg")
+    elements = partition_msg(filename=filename, metadata_filename="test")
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 class MockMsOxMessage:
@@ -77,6 +85,8 @@ def test_partition_msg_from_file():
     with open(filename, "rb") as f:
         elements = partition_msg(file=f)
     assert elements == EXPECTED_MSG_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_extract_attachment_info():
@@ -84,6 +94,8 @@ def test_extract_attachment_info():
     attachment_info = extract_msg_attachment_info(filename)
     assert len(attachment_info) > 0
     assert attachment_info == ATTACH_EXPECTED_OUTPUT
+    # # TODO(jennings) the filename is changed after parsing
+    # assert attachment_info[0].get("filename") == "fake-email-attachment.msg"
 
 
 def test_partition_msg_raises_with_both_specified():

--- a/test_unstructured/partition/test_msg.py
+++ b/test_unstructured/partition/test_msg.py
@@ -87,9 +87,9 @@ def test_partition_msg_from_file():
     assert elements == EXPECTED_MSG_OUTPUT
     for element in elements:
         assert element.metadata.filename is None
-        
-        
-def test_partition_msg_from_file():
+
+
+def test_partition_msg_from_file_with_metadata_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.msg")
     with open(filename, "rb") as f:
         elements = partition_msg(file=f, metadata_filename="test")

--- a/test_unstructured/partition/test_msg.py
+++ b/test_unstructured/partition/test_msg.py
@@ -103,8 +103,6 @@ def test_extract_attachment_info():
     attachment_info = extract_msg_attachment_info(filename)
     assert len(attachment_info) > 0
     assert attachment_info == ATTACH_EXPECTED_OUTPUT
-    # # TODO(jennings) the filename is changed after parsing
-    # assert attachment_info[0].get("filename") == "fake-email-attachment.msg"
 
 
 def test_partition_msg_raises_with_both_specified():

--- a/test_unstructured/partition/test_msg.py
+++ b/test_unstructured/partition/test_msg.py
@@ -87,6 +87,15 @@ def test_partition_msg_from_file():
     assert elements == EXPECTED_MSG_OUTPUT
     for element in elements:
         assert element.metadata.filename is None
+        
+        
+def test_partition_msg_from_file():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email.msg")
+    with open(filename, "rb") as f:
+        elements = partition_msg(file=f, metadata_filename="test")
+    assert elements == EXPECTED_MSG_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_extract_attachment_info():

--- a/test_unstructured/partition/test_odt.py
+++ b/test_unstructured/partition/test_odt.py
@@ -28,8 +28,8 @@ def test_partition_odt_from_file():
         elements = partition_odt(file=f)
 
     assert elements == [Title("Lorem ipsum dolor sit amet.")]
-    
-    
+
+
 def test_partition_odt_from_file_with_metadata_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.odt")
     with open(filename, "rb") as f:

--- a/test_unstructured/partition/test_odt.py
+++ b/test_unstructured/partition/test_odt.py
@@ -12,6 +12,14 @@ def test_partition_odt_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.odt")
     elements = partition_odt(filename=filename)
     assert elements == [Title("Lorem ipsum dolor sit amet.")]
+    for element in elements:
+        assert element.metadata.filename == "fake.odt"
+
+
+def test_partition_odt_from_filename_with_metadata_filename():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.odt")
+    elements = partition_odt(filename=filename, metadata_filename="test")
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 def test_partition_odt_from_file():

--- a/test_unstructured/partition/test_odt.py
+++ b/test_unstructured/partition/test_odt.py
@@ -28,6 +28,14 @@ def test_partition_odt_from_file():
         elements = partition_odt(file=f)
 
     assert elements == [Title("Lorem ipsum dolor sit amet.")]
+    
+    
+def test_partition_odt_from_file_with_metadata_filename():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake.odt")
+    with open(filename, "rb") as f:
+        elements = partition_odt(file=f, metadata_filename="test")
+
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 def test_partition_odt_from_filename_exclude_metadata():

--- a/test_unstructured/partition/test_org.py
+++ b/test_unstructured/partition/test_org.py
@@ -7,8 +7,8 @@ def test_partition_org_from_filename(filename="example-docs/README.org"):
 
     assert elements[0] == Title("Example Docs")
     assert elements[0].metadata.filetype == "text/org"
-    
-    
+
+
 def test_partition_org_from_filename_with_metadata_filename(filename="example-docs/README.org"):
     elements = partition_org(filename=filename, metadata_filename="test")
 
@@ -22,8 +22,8 @@ def test_partition_org_from_file(filename="example-docs/README.org"):
 
     assert elements[0] == Title("Example Docs")
     assert elements[0].metadata.filetype == "text/org"
-    
-    
+
+
 def test_partition_org_from_file_with_metadata_filename(filename="example-docs/README.org"):
     with open(filename, "rb") as f:
         elements = partition_org(file=f, metadata_filename="test")

--- a/test_unstructured/partition/test_org.py
+++ b/test_unstructured/partition/test_org.py
@@ -7,6 +7,13 @@ def test_partition_org_from_filename(filename="example-docs/README.org"):
 
     assert elements[0] == Title("Example Docs")
     assert elements[0].metadata.filetype == "text/org"
+    
+    
+def test_partition_org_from_filename_with_metadata_filename(filename="example-docs/README.org"):
+    elements = partition_org(filename=filename, metadata_filename="test")
+
+    assert elements[0] == Title("Example Docs")
+    assert elements[0].metadata.filename == "test"
 
 
 def test_partition_org_from_file(filename="example-docs/README.org"):
@@ -15,6 +22,14 @@ def test_partition_org_from_file(filename="example-docs/README.org"):
 
     assert elements[0] == Title("Example Docs")
     assert elements[0].metadata.filetype == "text/org"
+    
+    
+def test_partition_org_from_file_with_metadata_filename(filename="example-docs/README.org"):
+    with open(filename, "rb") as f:
+        elements = partition_org(file=f, metadata_filename="test")
+
+    assert elements[0] == Title("Example Docs")
+    assert elements[0].metadata.filename == "test"
 
 
 def test_partition_org_from_filename_exclude_metadata(filename="example-docs/README.org"):

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -406,11 +406,16 @@ def test_partition_pdf_fast_groups_text_in_text_box():
 def test_partition_pdf_with_metadata_filename(
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):
-    elements = pdf.partition_pdf(filename=filename, url=None, include_page_breaks=True, metadata_filename="test")
+    elements = pdf.partition_pdf(
+        filename=filename,
+        url=None,
+        include_page_breaks=True,
+        metadata_filename="test",
+    )
     for element in elements:
         assert element.metadata.filename == "test"
-        
-        
+
+
 def test_partition_pdf_with_fast_strategy_from_file_with_metadata_filename(
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -177,6 +177,8 @@ def test_partition_pdf_with_fast_strategy(
     assert len(elements) > 10
     # check that the pdf has multiple different page numbers
     assert {element.metadata.page_number for element in elements} == {1, 2}
+    for element in elements:
+        assert element.metadata.filename == "layout-parser-paper-fast.pdf"
 
 
 def test_partition_pdf_with_fast_groups_text(
@@ -189,10 +191,10 @@ def test_partition_pdf_with_fast_groups_text(
         if isinstance(element, NarrativeText):
             first_narrative_element = element
             break
-
     assert len(first_narrative_element.text) > 1000
     assert first_narrative_element.text.startswith("Abstract. Recent advances")
     assert first_narrative_element.text.endswith("https://layout-parser.github.io.")
+    assert first_narrative_element.metadata.filename == "layout-parser-paper-fast.pdf"
 
 
 def test_partition_pdf_with_fast_strategy_from_file(
@@ -217,6 +219,8 @@ def test_partition_pdf_with_fast_strategy_and_page_breaks(
     assert "PageBreak" in [elem.category for elem in elements]
 
     assert "unstructured_inference is not installed" not in caplog.text
+    for element in elements:
+        assert element.metadata.filename == "layout-parser-paper-fast.pdf"
 
 
 def test_partition_pdf_raises_with_bad_strategy(
@@ -384,11 +388,9 @@ def test_partition_pdf_fast_groups_text_in_text_box():
         ),
         coordinate_system=PixelSpace(width=612, height=792),
     )
-
     assert isinstance(elements[1], NarrativeText)
     assert str(elements[1]).startswith("We")
     assert str(elements[1]).endswith("Jordan and Egypt.")
-
     assert elements[3] == Title(
         "1st",
         coordinates=(

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -403,6 +403,23 @@ def test_partition_pdf_fast_groups_text_in_text_box():
     )
 
 
+def test_partition_pdf_with_metadata_filename(
+    filename="example-docs/layout-parser-paper-fast.pdf",
+):
+    elements = pdf.partition_pdf(filename=filename, url=None, include_page_breaks=True, metadata_filename="test")
+    for element in elements:
+        assert element.metadata.filename == "test"
+        
+        
+def test_partition_pdf_with_fast_strategy_from_file_with_metadata_filename(
+    filename="example-docs/layout-parser-paper-fast.pdf",
+):
+    with open(filename, "rb") as f:
+        elements = pdf.partition_pdf(file=f, url=None, strategy="fast", metadata_filename="test")
+    for element in elements:
+        assert element.metadata.filename == "test"
+
+
 def test_partition_pdf_with_auto_strategy_exclude_metadata(
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):

--- a/test_unstructured/partition/test_ppt.py
+++ b/test_unstructured/partition/test_ppt.py
@@ -47,8 +47,8 @@ def test_partition_ppt_from_file():
     # # TODO(jennings) the filename is changed after parsing
     # for element in elements:
     #     assert element.metadata.filename is None
-        
-        
+
+
 def test_partition_ppt_from_file_with_metadata_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.ppt")
     with open(filename, "rb") as f:

--- a/test_unstructured/partition/test_ppt.py
+++ b/test_unstructured/partition/test_ppt.py
@@ -46,7 +46,16 @@ def test_partition_ppt_from_file():
     assert elements == EXPECTED_PPT_OUTPUT
     # # TODO(jennings) the filename is changed after parsing
     # for element in elements:
-    #     assert element.metadata.filename == "fake-power-point.ppt"
+    #     assert element.metadata.filename is None
+        
+        
+def test_partition_ppt_from_file_with_metadata_filename():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.ppt")
+    with open(filename, "rb") as f:
+        elements = partition_ppt(file=f, metadata_filename="test")
+    assert elements == EXPECTED_PPT_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_ppt_raises_with_both_specified():

--- a/test_unstructured/partition/test_ppt.py
+++ b/test_unstructured/partition/test_ppt.py
@@ -23,6 +23,14 @@ def test_partition_ppt_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.ppt")
     elements = partition_ppt(filename=filename)
     assert elements == EXPECTED_PPT_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "fake-power-point.ppt"
+
+
+def test_partition_ppt_from_filename_with_metadata_filename():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.ppt")
+    elements = partition_ppt(filename=filename, metadata_filename="test")
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 def test_partition_ppt_raises_with_missing_file():
@@ -36,6 +44,9 @@ def test_partition_ppt_from_file():
     with open(filename, "rb") as f:
         elements = partition_ppt(file=f)
     assert elements == EXPECTED_PPT_OUTPUT
+    # # TODO(jennings) the filename is changed after parsing
+    # for element in elements:
+    #     assert element.metadata.filename == "fake-power-point.ppt"
 
 
 def test_partition_ppt_raises_with_both_specified():

--- a/test_unstructured/partition/test_ppt.py
+++ b/test_unstructured/partition/test_ppt.py
@@ -44,9 +44,8 @@ def test_partition_ppt_from_file():
     with open(filename, "rb") as f:
         elements = partition_ppt(file=f)
     assert elements == EXPECTED_PPT_OUTPUT
-    # # TODO(jennings) the filename is changed after parsing
-    # for element in elements:
-    #     assert element.metadata.filename is None
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_ppt_from_file_with_metadata_filename():

--- a/test_unstructured/partition/test_pptx.py
+++ b/test_unstructured/partition/test_pptx.py
@@ -32,8 +32,8 @@ def test_partition_pptx_from_filename():
     assert elements == EXPECTED_PPTX_OUTPUT
     for element in elements:
         assert element.metadata.filename == "fake-power-point.pptx"
-        
-        
+
+
 def test_partition_pptx_from_filename_with_metadata_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.pptx")
     elements = partition_pptx(filename=filename, metadata_filename="test")
@@ -55,7 +55,7 @@ def test_partition_pptx_with_spooled_file():
         assert elements == EXPECTED_PPTX_OUTPUT
         for element in elements:
             assert element.metadata.filename is None
-            
+
 
 def test_partition_pptx_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.pptx")
@@ -64,8 +64,8 @@ def test_partition_pptx_from_file():
     assert elements == EXPECTED_PPTX_OUTPUT
     for element in elements:
         assert element.metadata.filename is None
-        
-        
+
+
 def test_partition_pptx_from_file_with_metadata_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.pptx")
     with open(filename, "rb") as f:

--- a/test_unstructured/partition/test_pptx.py
+++ b/test_unstructured/partition/test_pptx.py
@@ -30,6 +30,8 @@ def test_partition_pptx_from_filename():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.pptx")
     elements = partition_pptx(filename=filename)
     assert elements == EXPECTED_PPTX_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "fake-power-point.pptx"
 
 
 def test_partition_pptx_with_spooled_file():
@@ -43,13 +45,17 @@ def test_partition_pptx_with_spooled_file():
         spooled_temp_file.seek(0)
         elements = partition_pptx(file=spooled_temp_file)
         assert elements == EXPECTED_PPTX_OUTPUT
-
+        for element in elements:
+            assert element.metadata.filename is None
+            
 
 def test_partition_pptx_from_file():
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.pptx")
     with open(filename, "rb") as f:
         elements = partition_pptx(file=f)
     assert elements == EXPECTED_PPTX_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_pptx_raises_with_both_specified():
@@ -90,6 +96,8 @@ def test_partition_pptx_adds_page_breaks(tmpdir):
         PageBreak(text=""),
         NarrativeText(text="This is the second slide."),
     ]
+    for element in elements:
+        assert element.metadata.filename == "test-page-breaks.pptx"
 
 
 def test_partition_pptx_page_breaks_toggle_off(tmpdir):
@@ -118,6 +126,8 @@ def test_partition_pptx_page_breaks_toggle_off(tmpdir):
         NarrativeText(text="This is the first slide."),
         NarrativeText(text="This is the second slide."),
     ]
+    for element in elements:
+        assert element.metadata.filename == "test-page-breaks.pptx"
 
 
 def test_partition_pptx_orders_elements(tmpdir):
@@ -162,6 +172,8 @@ def test_partition_pptx_orders_elements(tmpdir):
         NarrativeText("This is higher and should come first"),
         NarrativeText("This is lower and should come second"),
     ]
+    for element in elements:
+        assert element.metadata.filename == "test-ordering.pptx"
 
 
 EXPECTED_HTML_TABLE = """<table>
@@ -182,6 +194,7 @@ def test_partition_pptx_grabs_tables(filename="example-docs/fake-power-point-tab
     assert elements[1].text.startswith("Column 1")
     assert elements[1].text.strip().endswith("Aqua")
     assert elements[1].metadata.text_as_html == EXPECTED_HTML_TABLE
+    assert elements[1].metadata.filename == "fake-power-point-table.pptx"
 
 
 def test_partition_pptx_many_pages():
@@ -190,6 +203,8 @@ def test_partition_pptx_many_pages():
 
     # The page_number of PageBreak is None
     assert set(filter(None, (elt.metadata.page_number for elt in elements))) == {1, 2}
+    for element in elements:
+        assert element.metadata.filename == "fake-power-point-many-pages.pptx"
 
 
 def test_partition_pptx_malformed():
@@ -198,6 +213,8 @@ def test_partition_pptx_malformed():
 
     assert elements[0].text == "Problem Date Placeholder"
     assert elements[1].text == "Test Slide"
+    for element in elements:
+        assert element.metadata.filename == "fake-power-point-malformed.pptx"
 
 
 def test_partition_pptx_from_filename_exclude_metadata():

--- a/test_unstructured/partition/test_pptx.py
+++ b/test_unstructured/partition/test_pptx.py
@@ -32,6 +32,14 @@ def test_partition_pptx_from_filename():
     assert elements == EXPECTED_PPTX_OUTPUT
     for element in elements:
         assert element.metadata.filename == "fake-power-point.pptx"
+        
+        
+def test_partition_pptx_from_filename_with_metadata_filename():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.pptx")
+    elements = partition_pptx(filename=filename, metadata_filename="test")
+    assert elements == EXPECTED_PPTX_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_pptx_with_spooled_file():
@@ -56,6 +64,15 @@ def test_partition_pptx_from_file():
     assert elements == EXPECTED_PPTX_OUTPUT
     for element in elements:
         assert element.metadata.filename is None
+        
+        
+def test_partition_pptx_from_file_with_metadata_filename():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-power-point.pptx")
+    with open(filename, "rb") as f:
+        elements = partition_pptx(file=f, metadata_filename="test")
+    assert elements == EXPECTED_PPTX_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_pptx_raises_with_both_specified():

--- a/test_unstructured/partition/test_rst.py
+++ b/test_unstructured/partition/test_rst.py
@@ -22,6 +22,14 @@ def test_partition_rst_from_file(filename="example-docs/README.rst"):
     assert elements[0].metadata.filetype == "text/x-rst"
     for element in elements:
         assert element.metadata.filename is None
+        
+        
+def test_partition_rst_from_file(filename="example-docs/README.rst"):
+    with open(filename, "rb") as f:
+        elements = partition_rst(file=f, metadata_filename="test")
+    assert elements[0] == Title("Example Docs")
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_rst_from_filename_exclude_metadata(filename="example-docs/README.rst"):

--- a/test_unstructured/partition/test_rst.py
+++ b/test_unstructured/partition/test_rst.py
@@ -22,9 +22,9 @@ def test_partition_rst_from_file(filename="example-docs/README.rst"):
     assert elements[0].metadata.filetype == "text/x-rst"
     for element in elements:
         assert element.metadata.filename is None
-        
-        
-def test_partition_rst_from_file(filename="example-docs/README.rst"):
+
+
+def test_partition_rst_from_file_with_metadata_filename(filename="example-docs/README.rst"):
     with open(filename, "rb") as f:
         elements = partition_rst(file=f, metadata_filename="test")
     assert elements[0] == Title("Example Docs")

--- a/test_unstructured/partition/test_rst.py
+++ b/test_unstructured/partition/test_rst.py
@@ -4,17 +4,24 @@ from unstructured.partition.rst import partition_rst
 
 def test_partition_rst_from_filename(filename="example-docs/README.rst"):
     elements = partition_rst(filename=filename)
-
     assert elements[0] == Title("Example Docs")
     assert elements[0].metadata.filetype == "text/x-rst"
+    for element in elements:
+        assert element.metadata.filename == "README.rst"
+
+
+def test_partition_rst_from_filename_with_metadata_filename(filename="example-docs/README.rst"):
+    elements = partition_rst(filename=filename, metadata_filename="test")
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 def test_partition_rst_from_file(filename="example-docs/README.rst"):
     with open(filename, "rb") as f:
         elements = partition_rst(file=f)
-
     assert elements[0] == Title("Example Docs")
     assert elements[0].metadata.filetype == "text/x-rst"
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_rst_from_filename_exclude_metadata(filename="example-docs/README.rst"):

--- a/test_unstructured/partition/test_rtf.py
+++ b/test_unstructured/partition/test_rtf.py
@@ -12,6 +12,15 @@ def test_partition_rtf_from_filename():
     elements = partition_rtf(filename=filename)
     assert len(elements) > 0
     assert elements[0] == Title("My First Heading")
+    for element in elements:
+        assert element.metadata.filename == "fake-doc.rtf"
+
+
+def test_partition_rtf_from_filename_with_metadata_filename():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-doc.rtf")
+    elements = partition_rtf(filename=filename, metadata_filename="test")
+    assert len(elements) > 0
+    assert all(element.metadata.filename == "test" for element in elements)
 
 
 def test_partition_rtf_from_file():
@@ -20,6 +29,8 @@ def test_partition_rtf_from_file():
         elements = partition_rtf(file=f)
     assert len(elements) > 0
     assert elements[0] == Title("My First Heading")
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_rtf_from_filename_exclude_metadata():

--- a/test_unstructured/partition/test_rtf.py
+++ b/test_unstructured/partition/test_rtf.py
@@ -31,8 +31,8 @@ def test_partition_rtf_from_file():
     assert elements[0] == Title("My First Heading")
     for element in elements:
         assert element.metadata.filename is None
-        
-        
+
+
 def test_partition_rtf_from_file_with_metadata_filename():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-doc.rtf")
     with open(filename, "rb") as f:

--- a/test_unstructured/partition/test_rtf.py
+++ b/test_unstructured/partition/test_rtf.py
@@ -31,6 +31,15 @@ def test_partition_rtf_from_file():
     assert elements[0] == Title("My First Heading")
     for element in elements:
         assert element.metadata.filename is None
+        
+        
+def test_partition_rtf_from_file_with_metadata_filename():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-doc.rtf")
+    with open(filename, "rb") as f:
+        elements = partition_rtf(file=f, metadata_filename="test")
+    assert elements[0] == Title("My First Heading")
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_rtf_from_filename_exclude_metadata():

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -74,8 +74,8 @@ def test_partition_text_from_file():
     assert elements == EXPECTED_OUTPUT
     for element in elements:
         assert element.metadata.filename is None
-        
-        
+
+
 def test_partition_text_from_file_with_metadata_filename():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
     with open(filename) as f:

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -32,6 +32,14 @@ def test_partition_text_from_filename(filename, encoding):
         assert element.metadata.filename == filename
 
 
+def test_partition_text_from_filename_with_metadata_filename():
+    filename_path = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
+    elements = partition_text(filename=filename_path, encoding="utf-8", metadata_filename="test")
+    assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "test"
+
+
 @pytest.mark.parametrize(
     "filename",
     ["fake-text-utf-16.txt", "fake-text-utf-16-le.txt", "fake-text-utf-32.txt"],
@@ -66,6 +74,16 @@ def test_partition_text_from_file():
     assert elements == EXPECTED_OUTPUT
     for element in elements:
         assert element.metadata.filename is None
+        
+        
+def test_partition_text_from_file_with_metadata_filename():
+    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
+    with open(filename) as f:
+        elements = partition_text(file=f, metadata_filename="test")
+    assert len(elements) > 0
+    assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 @pytest.mark.parametrize(

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -24,10 +24,12 @@ EXPECTED_OUTPUT = [
     [("fake-text.txt", "utf-8"), ("fake-text.txt", None), ("fake-text-utf-16-be.txt", "utf-16-be")],
 )
 def test_partition_text_from_filename(filename, encoding):
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-    elements = partition_text(filename=filename, encoding=encoding)
+    filename_path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
+    elements = partition_text(filename=filename_path, encoding=encoding)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == filename
 
 
 @pytest.mark.parametrize(
@@ -35,10 +37,12 @@ def test_partition_text_from_filename(filename, encoding):
     ["fake-text-utf-16.txt", "fake-text-utf-16-le.txt", "fake-text-utf-32.txt"],
 )
 def test_partition_text_from_filename_default_encoding(filename):
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-    elements = partition_text(filename=filename)
+    filename_path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
+    elements = partition_text(filename=filename_path)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename == filename
 
 
 @pytest.mark.parametrize(
@@ -60,6 +64,8 @@ def test_partition_text_from_file():
         elements = partition_text(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 @pytest.mark.parametrize(
@@ -67,11 +73,13 @@ def test_partition_text_from_file():
     ["fake-text-utf-16.txt", "fake-text-utf-16-le.txt", "fake-text-utf-32.txt"],
 )
 def test_partition_text_from_file_default_encoding(filename):
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-    with open(filename) as f:
+    filename_path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
+    with open(filename_path) as f:
         elements = partition_text(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_text_from_bytes_file():
@@ -80,6 +88,8 @@ def test_partition_text_from_bytes_file():
         elements = partition_text(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 @pytest.mark.parametrize(
@@ -87,11 +97,13 @@ def test_partition_text_from_bytes_file():
     ["fake-text-utf-16.txt", "fake-text-utf-16-le.txt", "fake-text-utf-32.txt"],
 )
 def test_partition_text_from_bytes_file_default_encoding(filename):
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-    with open(filename, "rb") as f:
+    filename_path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
+    with open(filename_path, "rb") as f:
         elements = partition_text(file=f)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_text_from_text():
@@ -101,6 +113,8 @@ def test_partition_text_from_text():
     elements = partition_text(text=text)
     assert len(elements) > 0
     assert elements == EXPECTED_OUTPUT
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_text_from_text_works_with_empty_string():
@@ -131,6 +145,8 @@ def test_partition_text_captures_everything_even_with_linebreaks():
         Title(text="VERY IMPORTANT MEMO"),
         Address(text="DOYLESTOWN, PA 18901"),
     ]
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_text_groups_broken_paragraphs():
@@ -145,6 +161,8 @@ the fox met a bear."""
         NarrativeText(text="The big brown fox was walking down the lane."),
         NarrativeText(text="At the end of the lane, the fox met a bear."),
     ]
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_text_extract_regex_metadata():
@@ -154,6 +172,8 @@ def test_partition_text_extract_regex_metadata():
     assert elements[0].metadata.regex_metadata == {
         "speaker": [{"text": "SPEAKER 1", "start": 0, "end": 9}],
     }
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_text_splits_long_text(filename="example-docs/norwich-city.txt"):

--- a/test_unstructured/partition/test_tsv.py
+++ b/test_unstructured/partition/test_tsv.py
@@ -14,9 +14,11 @@ def test_partition_tsv_from_filename(filename="example-docs/stanley-cups.tsv"):
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     for element in elements:
         assert element.metadata.filename == "stanley-cups.tsv"
-        
-        
-def test_partition_tsv_from_filename_with_metadata_filename(filename="example-docs/stanley-cups.tsv"):
+
+
+def test_partition_tsv_from_filename_with_metadata_filename(
+    filename="example-docs/stanley-cups.tsv",
+):
     elements = partition_tsv(filename=filename, metadata_filename="test")
 
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
@@ -34,8 +36,8 @@ def test_partition_tsv_from_file(filename="example-docs/stanley-cups.tsv"):
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     for element in elements:
         assert element.metadata.filename is None
-        
-        
+
+
 def test_partition_tsv_from_file_with_metadata_filename(filename="example-docs/stanley-cups.tsv"):
     with open(filename, "rb") as f:
         elements = partition_tsv(file=f, metadata_filename="test")

--- a/test_unstructured/partition/test_tsv.py
+++ b/test_unstructured/partition/test_tsv.py
@@ -14,6 +14,14 @@ def test_partition_tsv_from_filename(filename="example-docs/stanley-cups.tsv"):
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     for element in elements:
         assert element.metadata.filename == "stanley-cups.tsv"
+        
+        
+def test_partition_tsv_from_filename_with_metadata_filename(filename="example-docs/stanley-cups.tsv"):
+    elements = partition_tsv(filename=filename, metadata_filename="test")
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_tsv_from_file(filename="example-docs/stanley-cups.tsv"):
@@ -26,6 +34,15 @@ def test_partition_tsv_from_file(filename="example-docs/stanley-cups.tsv"):
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     for element in elements:
         assert element.metadata.filename is None
+        
+        
+def test_partition_tsv_from_file_with_metadata_filename(filename="example-docs/stanley-cups.tsv"):
+    with open(filename, "rb") as f:
+        elements = partition_tsv(file=f, metadata_filename="test")
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    for element in elements:
+        assert element.metadata.filename == "test"
 
 
 def test_partition_tsv_filename_exclude_metadata(filename="example-docs/stanley-cups.tsv"):

--- a/test_unstructured/partition/test_tsv.py
+++ b/test_unstructured/partition/test_tsv.py
@@ -12,6 +12,8 @@ def test_partition_tsv_from_filename(filename="example-docs/stanley-cups.tsv"):
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
     assert elements[0].metadata.text_as_html == EXPECTED_TABLE
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
+    for element in elements:
+        assert element.metadata.filename == "stanley-cups.tsv"
 
 
 def test_partition_tsv_from_file(filename="example-docs/stanley-cups.tsv"):
@@ -22,6 +24,8 @@ def test_partition_tsv_from_file(filename="example-docs/stanley-cups.tsv"):
     assert isinstance(elements[0], Table)
     assert elements[0].metadata.text_as_html == EXPECTED_TABLE
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_tsv_filename_exclude_metadata(filename="example-docs/stanley-cups.tsv"):
@@ -31,6 +35,8 @@ def test_partition_tsv_filename_exclude_metadata(filename="example-docs/stanley-
     assert isinstance(elements[0], Table)
     assert elements[0].metadata.text_as_html is None
     assert elements[0].metadata.filetype is None
+    for element in elements:
+        assert element.metadata.filename is None
 
 
 def test_partition_tsv_from_file_exclude_metadata(filename="example-docs/stanley-cups.tsv"):

--- a/test_unstructured/partition/test_xlsx.py
+++ b/test_unstructured/partition/test_xlsx.py
@@ -19,6 +19,7 @@ def test_partition_xlsx_from_filename(filename="example-docs/stanley-cups.xlsx")
     assert elements[0].metadata.page_number == 1
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     assert elements[0].metadata.page_name == EXCEPTED_PAGE_NAME
+    assert elements[0].metadata.filename == "stanley-cups.xlsx"
 
 
 def test_partition_xlsx_from_file(filename="example-docs/stanley-cups.xlsx"):
@@ -27,12 +28,12 @@ def test_partition_xlsx_from_file(filename="example-docs/stanley-cups.xlsx"):
 
     assert all(isinstance(element, Table) for element in elements)
     assert len(elements) == 2
-
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
     assert elements[0].metadata.text_as_html == EXPECTED_TABLE
     assert elements[0].metadata.page_number == 1
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     assert elements[0].metadata.page_name == EXCEPTED_PAGE_NAME
+    assert elements[0].metadata.filename is None
 
 
 def test_partition_xlsx_filename_exclude_metadata(filename="example-docs/stanley-cups.xlsx"):
@@ -46,6 +47,7 @@ def test_partition_xlsx_filename_exclude_metadata(filename="example-docs/stanley
     assert elements[0].metadata.page_number is None
     assert elements[0].metadata.filetype is None
     assert elements[0].metadata.page_name is None
+    assert elements[0].metadata.filename is None
 
 
 def test_partition_xlsx_from_file_exclude_metadata(filename="example-docs/stanley-cups.xlsx"):
@@ -60,3 +62,4 @@ def test_partition_xlsx_from_file_exclude_metadata(filename="example-docs/stanle
     assert elements[0].metadata.page_number is None
     assert elements[0].metadata.filetype is None
     assert elements[0].metadata.page_name is None
+    assert elements[0].metadata.filename is None

--- a/test_unstructured/partition/test_xlsx.py
+++ b/test_unstructured/partition/test_xlsx.py
@@ -20,6 +20,14 @@ def test_partition_xlsx_from_filename(filename="example-docs/stanley-cups.xlsx")
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     assert elements[0].metadata.page_name == EXCEPTED_PAGE_NAME
     assert elements[0].metadata.filename == "stanley-cups.xlsx"
+    
+    
+def test_partition_xlsx_from_filename_with_metadata_filename(filename="example-docs/stanley-cups.xlsx"):
+    elements = partition_xlsx(filename=filename, metadata_filename="test")
+
+    assert all(isinstance(element, Table) for element in elements)
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert elements[0].metadata.filename == "test"
 
 
 def test_partition_xlsx_from_file(filename="example-docs/stanley-cups.xlsx"):
@@ -34,6 +42,15 @@ def test_partition_xlsx_from_file(filename="example-docs/stanley-cups.xlsx"):
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     assert elements[0].metadata.page_name == EXCEPTED_PAGE_NAME
     assert elements[0].metadata.filename is None
+    
+    
+def test_partition_xlsx_from_file_with_metadata_filename(filename="example-docs/stanley-cups.xlsx"):
+    with open(filename, "rb") as f:
+        elements = partition_xlsx(file=f, metadata_filename="test")
+
+    assert all(isinstance(element, Table) for element in elements)
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert elements[0].metadata.filename == "test"
 
 
 def test_partition_xlsx_filename_exclude_metadata(filename="example-docs/stanley-cups.xlsx"):

--- a/test_unstructured/partition/test_xlsx.py
+++ b/test_unstructured/partition/test_xlsx.py
@@ -20,9 +20,11 @@ def test_partition_xlsx_from_filename(filename="example-docs/stanley-cups.xlsx")
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     assert elements[0].metadata.page_name == EXCEPTED_PAGE_NAME
     assert elements[0].metadata.filename == "stanley-cups.xlsx"
-    
-    
-def test_partition_xlsx_from_filename_with_metadata_filename(filename="example-docs/stanley-cups.xlsx"):
+
+
+def test_partition_xlsx_from_filename_with_metadata_filename(
+    filename="example-docs/stanley-cups.xlsx",
+):
     elements = partition_xlsx(filename=filename, metadata_filename="test")
 
     assert all(isinstance(element, Table) for element in elements)
@@ -42,8 +44,8 @@ def test_partition_xlsx_from_file(filename="example-docs/stanley-cups.xlsx"):
     assert elements[0].metadata.filetype == EXPECTED_FILETYPE
     assert elements[0].metadata.page_name == EXCEPTED_PAGE_NAME
     assert elements[0].metadata.filename is None
-    
-    
+
+
 def test_partition_xlsx_from_file_with_metadata_filename(filename="example-docs/stanley-cups.xlsx"):
     with open(filename, "rb") as f:
         elements = partition_xlsx(file=f, metadata_filename="test")

--- a/test_unstructured/partition/test_xml_partition.py
+++ b/test_unstructured/partition/test_xml_partition.py
@@ -18,8 +18,7 @@ def test_partition_xml_from_filename(filename):
 
     assert elements[0].text == "United States"
     assert elements[0].metadata.filename == filename
-    
-    
+
 
 def test_partition_xml_from_filename_with_metadata_filename():
     file_path = os.path.join(DIRECTORY, "..", "..", "example-docs", "factbook.xml")
@@ -40,8 +39,8 @@ def test_partition_xml_from_file(filename):
 
     assert elements[0].text == "United States"
     assert elements[0].metadata.filename == filename
-    
-    
+
+
 def test_partition_xml_from_file_with_metadata_filename():
     file_path = os.path.join(DIRECTORY, "..", "..", "example-docs", "factbook.xml")
     with open(file_path) as f:

--- a/test_unstructured/partition/test_xml_partition.py
+++ b/test_unstructured/partition/test_xml_partition.py
@@ -18,6 +18,15 @@ def test_partition_xml_from_filename(filename):
 
     assert elements[0].text == "United States"
     assert elements[0].metadata.filename == filename
+    
+    
+
+def test_partition_xml_from_filename_with_metadata_filename():
+    file_path = os.path.join(DIRECTORY, "..", "..", "example-docs", "factbook.xml")
+    elements = partition_xml(filename=file_path, xml_keep_tags=False, metadata_filename="test")
+
+    assert elements[0].text == "United States"
+    assert elements[0].metadata.filename == "test"
 
 
 @pytest.mark.parametrize(
@@ -31,6 +40,15 @@ def test_partition_xml_from_file(filename):
 
     assert elements[0].text == "United States"
     assert elements[0].metadata.filename == filename
+    
+    
+def test_partition_xml_from_file_with_metadata_filename():
+    file_path = os.path.join(DIRECTORY, "..", "..", "example-docs", "factbook.xml")
+    with open(file_path) as f:
+        elements = partition_xml(file=f, xml_keep_tags=False, metadata_filename="test")
+
+    assert elements[0].text == "United States"
+    assert elements[0].metadata.filename == "test"
 
 
 @pytest.mark.parametrize(

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.13-dev0"  # pragma: no cover
+__version__ = "0.7.13-dev1"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -514,16 +514,6 @@ def _is_code_mime_type(mime_type: str) -> bool:
 
 def add_metadata_with_filetype(filetype: FileType):
     def decorator(func: Callable):
-        if (
-            func.__doc__
-            and "metadata_filename" in func.__code__.co_varnames
-            and "metadata_filename" not in func.__doc__
-        ):
-            func.__doc__ += (
-                "\nMetadata Parameters:\n\tmetadata_filename:"
-                + "\n\t\tThe filename to use in element metadata."
-            )
-
         @wraps(func)
         def wrapper(*args, **kwargs):
             elements = func(*args, **kwargs)

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -42,15 +42,13 @@ def partition_csv(
         f = spooled_to_bytes_io_if_needed(cast(Union[BinaryIO, SpooledTemporaryFile], file))
         table = pd.read_csv(f)
 
-    metadata_filename = filename or metadata_filename
-
     html_text = table.to_html(index=False, header=False, na_rep="")
     text = lxml.html.document_fromstring(html_text).text_content()
 
     if include_metadata:
         metadata = ElementMetadata(
             text_as_html=html_text,
-            filename=metadata_filename,
+            filename=metadata_filename or filename,
         )
     else:
         metadata = ElementMetadata()

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -31,8 +31,6 @@ def partition_csv(
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
-    metadata_filename
-        The filename to use for the metadata.
     include_metadata
         Determines whether or not metadata is included in the output.
     """

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -15,6 +15,7 @@ def partition_doc(
     file: Optional[IO] = None,
     include_page_breaks: bool = True,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions Microsoft Word Documents in .doc format into its document elements.
@@ -30,6 +31,7 @@ def partition_doc(
     if filename is None:
         filename = ""
     exactly_one(filename=filename, file=file)
+    metadata_filename = metadata_filename or filename
 
     if len(filename) > 0:
         _, filename_no_path = os.path.split(os.path.abspath(filename))
@@ -50,7 +52,7 @@ def partition_doc(
         docx_filename = os.path.join(tmpdir, f"{base_filename}.docx")
         elements = partition_docx(
             filename=docx_filename,
-            metadata_filename=filename,
+            metadata_filename=metadata_filename,
             include_page_breaks=include_page_breaks,
             include_metadata=include_metadata,
         )

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -57,6 +57,6 @@ def partition_doc(
         # remove tmp.name from filename if parsing file
         if file:
             for element in elements:
-                element.metadata.filename = metadata_filename 
+                element.metadata.filename = metadata_filename
 
     return elements

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -43,8 +43,7 @@ def partition_doc(
         tmp.close()
         filename = tmp.name
         _, filename_no_path = os.path.split(os.path.abspath(tmp.name))
-
-    base_filename, _ = os.path.splitext(filename_no_path)
+        base_filename, _ = os.path.splitext(filename_no_path)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         convert_office_doc(filename, tmpdir, target_format="docx")
@@ -55,5 +54,9 @@ def partition_doc(
             include_page_breaks=include_page_breaks,
             include_metadata=include_metadata,
         )
+        # remove tmp.name from filename if parsing file
+        if file:
+            for element in elements:
+                element.metadata.filename = metadata_filename 
 
     return elements

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -31,7 +31,6 @@ def partition_doc(
     if filename is None:
         filename = ""
     exactly_one(filename=filename, file=file)
-    metadata_filename = metadata_filename or filename
 
     if len(filename) > 0:
         _, filename_no_path = os.path.split(os.path.abspath(filename))

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -117,7 +117,7 @@ def partition_docx(
 
     Parameters
     ----------
-     filename
+    filename
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
@@ -129,7 +129,7 @@ def partition_docx(
 
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file)
-    metadata_filename = metadata_filename or filename
+    # metadata_filename = metadata_filename or filename
 
     if filename is not None:
         document = docx.Document(filename)
@@ -312,7 +312,6 @@ def convert_and_partition_docx(
     if filename is None:
         filename = ""
     exactly_one(filename=filename, file=file)
-    metadata_filename = metadata_filename or filename
 
     if len(filename) > 0:
         _, filename_no_path = os.path.split(os.path.abspath(filename))
@@ -338,7 +337,7 @@ def convert_and_partition_docx(
         )
         elements = partition_docx(
             filename=docx_filename,
-            metadata_filename=filename,
+            metadata_filename=metadata_filename,
             include_metadata=include_metadata,
         )
 

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -129,6 +129,7 @@ def partition_docx(
 
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file)
+    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         document = docx.Document(filename)
@@ -139,7 +140,6 @@ def partition_docx(
             ),
         )
 
-    metadata_filename = metadata_filename or filename
     elements: List[Element] = []
     table_index = 0
 
@@ -286,11 +286,13 @@ def _get_headers_and_footers(
     return headers_and_footers
 
 
+@add_metadata_with_filetype(FileType.ODT)
 def convert_and_partition_docx(
     source_format: str,
     filename: Optional[str] = None,
     file: Optional[IO] = None,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
 ) -> List[Element]:
     """Converts a document to DOCX and then partitions it using partition_html. Works with
     any file format support by pandoc.
@@ -310,6 +312,7 @@ def convert_and_partition_docx(
     if filename is None:
         filename = ""
     exactly_one(filename=filename, file=file)
+    metadata_filename = metadata_filename or filename
 
     if len(filename) > 0:
         _, filename_no_path = os.path.split(os.path.abspath(filename))

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -129,7 +129,6 @@ def partition_docx(
 
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file)
-    # metadata_filename = metadata_filename or filename
 
     if filename is not None:
         document = docx.Document(filename)
@@ -286,7 +285,6 @@ def _get_headers_and_footers(
     return headers_and_footers
 
 
-@add_metadata_with_filetype(FileType.ODT)
 def convert_and_partition_docx(
     source_format: str,
     filename: Optional[str] = None,

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -269,8 +269,8 @@ def partition_email(
 
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file, text=text)
-    
-    metadata_filename = metadata_filename or filename
+
+    # metadata_filename = metadata_filename or filename
 
     detected_encoding = "utf-8"
     if filename is not None:
@@ -349,7 +349,7 @@ def partition_email(
             text=content, 
             encoding=encoding, 
             max_partition=max_partition, 
-            metadata_filename=metadata_filename,
+            metadata_filename=metadata_filename or filename,
         )
 
     for idx, element in enumerate(elements):
@@ -364,7 +364,7 @@ def partition_email(
         header = partition_email_header(msg)
     all_elements = header + elements
 
-    metadata = build_email_metadata(msg, filename=metadata_filename)
+    metadata = build_email_metadata(msg, filename=metadata_filename or filename)
     for element in all_elements:
         element.metadata = metadata
 
@@ -382,25 +382,7 @@ def partition_email(
                 for element in attached_elements:
                     element.metadata.filename = attached_file
                     element.metadata.file_directory = None
-                    element.metadata.attached_to_filename = metadata_filename
-                    all_elements.append(element)
-
-
-    if process_attachments:
-        with TemporaryDirectory() as tmpdir:
-            extract_attachment_info(msg, tmpdir)
-            attached_files = os.listdir(tmpdir)
-            for attached_file in attached_files:
-                attached_filename = os.path.join(tmpdir, attached_file)
-                if attachment_partitioner is None:
-                    raise ValueError(
-                        "Specify the attachment_partitioner kwarg to process attachments.",
-                    )
-                attached_elements = attachment_partitioner(filename=attached_filename)
-                for element in attached_elements:
-                    element.metadata.filename = attached_file
-                    element.metadata.file_directory = None
-                    element.metadata.attached_to_filename = metadata_filename
+                    element.metadata.attached_to_filename = metadata_filename or attached_filename
                     all_elements.append(element)
 
     return all_elements

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -270,8 +270,6 @@ def partition_email(
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file, text=text)
 
-    # metadata_filename = metadata_filename or filename
-
     detected_encoding = "utf-8"
     if filename is not None:
         extracted_encoding, msg = parse_email(filename=filename)
@@ -290,7 +288,6 @@ def partition_email(
     elif text is not None:
         _text: str = str(text)
         msg = email.message_from_string(_text)
-
     if not encoding:
         encoding = detected_encoding
 
@@ -382,7 +379,7 @@ def partition_email(
                 for element in attached_elements:
                     element.metadata.filename = attached_file
                     element.metadata.file_directory = None
-                    element.metadata.attached_to_filename = metadata_filename or attached_filename
+                    element.metadata.attached_to_filename = metadata_filename or filename
                     all_elements.append(element)
 
     return all_elements

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -343,9 +343,9 @@ def partition_email(
     elif content_source == "text/plain":
         list_content = split_by_paragraph(content)
         elements = partition_text(
-            text=content, 
-            encoding=encoding, 
-            max_partition=max_partition, 
+            text=content,
+            encoding=encoding,
+            max_partition=max_partition,
             metadata_filename=metadata_filename or filename,
         )
 

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -27,7 +27,6 @@ def partition_epub(
     include_page_breaks
         If True, the output will include page breaks if the filetype supports it.
     """
-    metadata_filename = metadata_filename or filename
     return convert_and_partition_html(
         source_format="epub",
         filename=filename,

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -12,6 +12,7 @@ def partition_epub(
     file: Optional[IO] = None,
     include_page_breaks: bool = False,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions an EPUB document. The document is first converted to HTML and then
@@ -24,11 +25,13 @@ def partition_epub(
     file
         A file-like object using "rb" mode --> open(filename, "rb").
     include_page_breaks
-        If True, the output will include page breaks if the filetype supports it
+        If True, the output will include page breaks if the filetype supports it.
     """
+    metadata_filename = metadata_filename or filename
     return convert_and_partition_html(
         source_format="epub",
         filename=filename,
         file=file,
         include_page_breaks=include_page_breaks,
+        metadata_filename=metadata_filename,
     )

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -31,6 +31,7 @@ def partition_html(
     ssl_verify: bool = True,
     parser: VALID_PARSERS = None,
     html_assemble_articles: bool = False,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions an HTML document into its constituent elements.
@@ -62,9 +63,9 @@ def partition_html(
     """
     if text is not None and text.strip() == "" and not file and not filename and not url:
         return []
-
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file, text=text, url=url)
+    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         document = HTMLDocument.from_file(
@@ -109,6 +110,7 @@ def convert_and_partition_html(
     filename: Optional[str] = None,
     file: Optional[IO] = None,
     include_page_breaks: bool = False,
+    metadata_filename: Optional[str] = None,
 ) -> List[Element]:
     """Converts a document to HTML and then partitions it using partition_html. Works with
     any file format support by pandoc.
@@ -121,9 +123,10 @@ def convert_and_partition_html(
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
-
     include_page_breaks
-        If True, the output will include page breaks if the filetype supports it
+        If True, the output will include page breaks if the filetype supports it.
+    metadata_filename
+        The filename to use in element metadata.
     """
     html_text = convert_file_to_html_text(source_format=source_format, filename=filename, file=file)
     # NOTE(robinson) - pypandoc returns a text string with unicode encoding
@@ -132,4 +135,5 @@ def convert_and_partition_html(
         text=html_text,
         include_page_breaks=include_page_breaks,
         encoding="unicode",
+        metadata_filename=metadata_filename,
     )

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -65,7 +65,6 @@ def partition_html(
         return []
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file, text=text, url=url)
-    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         document = HTMLDocument.from_file(

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -34,7 +34,6 @@ def partition_json(
         return []
 
     exactly_one(filename=filename, file=file, text=text)
-    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         with open(filename, encoding="utf8") as f:

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -16,13 +16,25 @@ def partition_json(
     file: Optional[IO] = None,
     text: Optional[str] = None,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
-    """Partitions an .json document into its constituent elements."""
+    """Partitions an .json document into its constituent elements.
+
+    Parameters
+    ----------
+    filename
+        A string defining the target filename path.
+    file
+        A file-like object as bytes --> open(filename, "rb").
+    text
+        The string representation of the .json document.
+    """
     if text is not None and text.strip() == "" and not file and not filename:
         return []
 
     exactly_one(filename=filename, file=file, text=text)
+    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         with open(filename, encoding="utf8") as f:

--- a/unstructured/partition/md.py
+++ b/unstructured/partition/md.py
@@ -26,12 +26,33 @@ def partition_md(
     include_page_breaks: bool = False,
     include_metadata: bool = True,
     parser: VALID_PARSERS = None,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
+    """Partitions a markdown file into its constituent elements
+
+    Parameters
+    ----------
+    filename
+        A string defining the target filename path.
+    file
+        A file-like object using "rb" mode --> open(filename, "rb").
+    text
+        The string representation of the markdown document.
+    url
+        The URL of a webpage to parse. Only for URLs that return a markdown document.
+    include_page_breaks
+        If True, the output will include page breaks if the filetype supports it.
+    include_metadata
+        Determines whether or not metadata is included in the output.
+    parser
+        The parser to use for parsing the markdown document. If None, default parser will be used.
+    """
     # Verify that only one of the arguments was provided
     if text is None:
         text = ""
     exactly_one(filename=filename, file=file, text=text, url=url)
+    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         with open(filename, encoding="utf8") as f:
@@ -58,4 +79,5 @@ def partition_md(
         include_page_breaks=include_page_breaks,
         include_metadata=include_metadata,
         parser=parser,
+        metadata_filename=metadata_filename,
     )

--- a/unstructured/partition/md.py
+++ b/unstructured/partition/md.py
@@ -52,7 +52,6 @@ def partition_md(
     if text is None:
         text = ""
     exactly_one(filename=filename, file=file, text=text, url=url)
-    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         with open(filename, encoding="utf8") as f:

--- a/unstructured/partition/msg.py
+++ b/unstructured/partition/msg.py
@@ -44,7 +44,6 @@ def partition_msg(
         The partitioning function to use to process attachments.
     """
     exactly_one(filename=filename, file=file)
-    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         msg_obj = msg_parser.MsOxMessage(filename)
@@ -54,15 +53,13 @@ def partition_msg(
         tmp.close()
         msg_obj = msg_parser.MsOxMessage(tmp.name)
 
-    metadata_filename = metadata_filename or filename
-
     text = msg_obj.body
     if "<html>" in text or "</div>" in text:
         elements = partition_html(text=text)
     else:
         elements = partition_text(text=text, max_partition=max_partition)
 
-    metadata = build_msg_metadata(msg_obj, metadata_filename)
+    metadata = build_msg_metadata(msg_obj, metadata_filename or filename)
     for element in elements:
         element.metadata = metadata
 
@@ -80,7 +77,7 @@ def partition_msg(
                 for element in attached_elements:
                     element.metadata.filename = attached_file
                     element.metadata.file_directory = None
-                    element.metadata.attached_to_filename = metadata_filename
+                    element.metadata.attached_to_filename = metadata_filename or filename
                     elements.append(element)
 
     return elements

--- a/unstructured/partition/msg.py
+++ b/unstructured/partition/msg.py
@@ -44,6 +44,7 @@ def partition_msg(
         The partitioning function to use to process attachments.
     """
     exactly_one(filename=filename, file=file)
+    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         msg_obj = msg_parser.MsOxMessage(filename)
@@ -86,7 +87,7 @@ def partition_msg(
 
 
 def build_msg_metadata(msg_obj: msg_parser.MsOxMessage, filename: Optional[str]) -> ElementMetadata:
-    """Creates an ElementMetadata object from the header information in the emai."""
+    """Creates an ElementMetadata object from the header information in the email."""
     email_date = getattr(msg_obj, "sent_date", None)
     if email_date is not None:
         email_date = convert_to_iso_8601(email_date)

--- a/unstructured/partition/odt.py
+++ b/unstructured/partition/odt.py
@@ -11,6 +11,7 @@ def partition_odt(
     filename: Optional[str] = None,
     file: Optional[IO] = None,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions Open Office Documents in .odt format into its document elements.
@@ -22,4 +23,10 @@ def partition_odt(
     file
         A file-like object using "rb" mode --> open(filename, "rb").
     """
-    return convert_and_partition_docx(source_format="odt", filename=filename, file=file)
+    metadata_filename = metadata_filename or filename
+    return convert_and_partition_docx(
+        source_format="odt",
+        filename=filename,
+        file=file,
+        metadata_filename=metadata_filename,
+    )

--- a/unstructured/partition/odt.py
+++ b/unstructured/partition/odt.py
@@ -23,7 +23,6 @@ def partition_odt(
     file
         A file-like object using "rb" mode --> open(filename, "rb").
     """
-    metadata_filename = metadata_filename or filename
     return convert_and_partition_docx(
         source_format="odt",
         filename=filename,

--- a/unstructured/partition/org.py
+++ b/unstructured/partition/org.py
@@ -11,6 +11,7 @@ def partition_org(
     file: Optional[IO] = None,
     include_page_breaks: bool = False,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
 ) -> List[Element]:
     """Partitions an org document. The document is first converted to HTML and then
     partitioned using partition_html.
@@ -29,4 +30,5 @@ def partition_org(
         filename=filename,
         file=file,
         include_page_breaks=include_page_breaks,
+        metadata_filename=metadata_filename,
     )

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -89,7 +89,6 @@ def partition_pdf(
         infer_table_structure=infer_table_structure,
         ocr_languages=ocr_languages,
         max_partition=max_partition,
-        # metadata_filename=metadata_filename
     )
 
 
@@ -102,7 +101,6 @@ def partition_pdf_or_image(
     infer_table_structure: bool = False,
     ocr_languages: str = "eng",
     max_partition: Optional[int] = 1500,
-    # metadata_filename: Optional[str] = None
 ) -> List[Element]:
     """Parses a pdf or image document into a list of interpreted elements."""
     # TODO(alan): Extract information about the filetype to be processed from the template

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -48,6 +48,7 @@ def partition_pdf(
     ocr_languages: str = "eng",
     max_partition: Optional[int] = 1500,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Parses a pdf document into a list of interpreted elements.
@@ -88,6 +89,7 @@ def partition_pdf(
         infer_table_structure=infer_table_structure,
         ocr_languages=ocr_languages,
         max_partition=max_partition,
+        # metadata_filename=metadata_filename
     )
 
 
@@ -100,6 +102,7 @@ def partition_pdf_or_image(
     infer_table_structure: bool = False,
     ocr_languages: str = "eng",
     max_partition: Optional[int] = 1500,
+    # metadata_filename: Optional[str] = None
 ) -> List[Element]:
     """Parses a pdf or image document into a list of interpreted elements."""
     # TODO(alan): Extract information about the filetype to be processed from the template

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -15,6 +15,7 @@ def partition_ppt(
     file: Optional[IO] = None,
     include_page_breaks: bool = False,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions Microsoft PowerPoint Documents in .ppt format into their document elements.
@@ -32,6 +33,7 @@ def partition_ppt(
     if filename is None:
         filename = ""
     exactly_one(filename=filename, file=file)
+    metadata_filename = metadata_filename or filename
 
     if len(filename) > 0:
         _, filename_no_path = os.path.split(os.path.abspath(filename))
@@ -50,6 +52,6 @@ def partition_ppt(
     with tempfile.TemporaryDirectory() as tmpdir:
         convert_office_doc(filename, tmpdir, target_format="pptx")
         pptx_filename = os.path.join(tmpdir, f"{base_filename}.pptx")
-        elements = partition_pptx(filename=pptx_filename, metadata_filename=filename)
+        elements = partition_pptx(filename=pptx_filename, metadata_filename=metadata_filename)
 
     return elements

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -52,5 +52,10 @@ def partition_ppt(
         convert_office_doc(filename, tmpdir, target_format="pptx")
         pptx_filename = os.path.join(tmpdir, f"{base_filename}.pptx")
         elements = partition_pptx(filename=pptx_filename, metadata_filename=metadata_filename)
+    
+    # remove tmp.name from filename if parsing file
+    if file:
+        for element in elements:
+            element.metadata.filename = metadata_filename 
 
     return elements

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -52,10 +52,10 @@ def partition_ppt(
         convert_office_doc(filename, tmpdir, target_format="pptx")
         pptx_filename = os.path.join(tmpdir, f"{base_filename}.pptx")
         elements = partition_pptx(filename=pptx_filename, metadata_filename=metadata_filename)
-    
+
     # remove tmp.name from filename if parsing file
     if file:
         for element in elements:
-            element.metadata.filename = metadata_filename 
+            element.metadata.filename = metadata_filename
 
     return elements

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -33,7 +33,6 @@ def partition_ppt(
     if filename is None:
         filename = ""
     exactly_one(filename=filename, file=file)
-    metadata_filename = metadata_filename or filename
 
     if len(filename) > 0:
         _, filename_no_path = os.path.split(os.path.abspath(filename))

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -56,7 +56,6 @@ def partition_pptx(
 
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file)
-    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         presentation = pptx.Presentation(filename)
@@ -66,7 +65,7 @@ def partition_pptx(
         )
 
     elements: List[Element] = []
-    metadata = ElementMetadata(filename=metadata_filename)
+    metadata = ElementMetadata(filename=metadata_filename or filename)
     num_slides = len(presentation.slides)
     for i, slide in enumerate(presentation.slides):
         metadata = ElementMetadata(**metadata.to_dict())
@@ -79,7 +78,7 @@ def partition_pptx(
                 text_table = convert_ms_office_table_to_text(table, as_html=False)
                 if (text_table := text_table.strip()) != "":
                     metadata = ElementMetadata(
-                        filename=metadata_filename,
+                        filename=metadata_filename or filename,
                         text_as_html=html_table,
                         page_number=metadata.page_number,
                     )

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -56,6 +56,7 @@ def partition_pptx(
 
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file)
+    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         presentation = pptx.Presentation(filename)
@@ -65,7 +66,6 @@ def partition_pptx(
         )
 
     elements: List[Element] = []
-    metadata_filename = metadata_filename or filename
     metadata = ElementMetadata(filename=metadata_filename)
     num_slides = len(presentation.slides)
     for i, slide in enumerate(presentation.slides):

--- a/unstructured/partition/rst.py
+++ b/unstructured/partition/rst.py
@@ -12,6 +12,7 @@ def partition_rst(
     file: Optional[IO] = None,
     include_page_breaks: bool = False,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions an RST document. The document is first converted to HTML and then
@@ -24,11 +25,12 @@ def partition_rst(
     file
         A file-like object using "rb" mode --> open(filename, "rb").
     include_page_breaks
-        If True, the output will include page breaks if the filetype supports it
+        If True, the output will include page breaks if the filetype supports it.
     """
     return convert_and_partition_html(
         source_format="rst",
         filename=filename,
         file=file,
         include_page_breaks=include_page_breaks,
+        metadata_filename=metadata_filename,
     )

--- a/unstructured/partition/rtf.py
+++ b/unstructured/partition/rtf.py
@@ -12,6 +12,7 @@ def partition_rtf(
     file: Optional[IO] = None,
     include_page_breaks: bool = False,
     include_metadata: bool = True,
+    metadata_filename: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions an RTF document. The document is first converted to HTML and then
@@ -31,4 +32,5 @@ def partition_rtf(
         filename=filename,
         file=file,
         include_page_breaks=include_page_breaks,
+        metadata_filename=metadata_filename,
     )

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -128,7 +128,9 @@ def partition_text(
 
     elements: List[Element] = []
     metadata = (
-        ElementMetadata(filename=metadata_filename or filename) if include_metadata else ElementMetadata()
+        ElementMetadata(filename=metadata_filename or filename)
+        if include_metadata
+        else ElementMetadata()
     )
     for ctext in file_content:
         ctext = ctext.strip()

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -109,7 +109,6 @@ def partition_text(
 
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file, text=text)
-    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         encoding, file_text = read_txt_file(filename=filename, encoding=encoding)
@@ -127,11 +126,9 @@ def partition_text(
 
     file_content = split_by_paragraph(file_text, max_partition=max_partition)
 
-    metadata_filename = metadata_filename or filename
-
     elements: List[Element] = []
     metadata = (
-        ElementMetadata(filename=metadata_filename) if include_metadata else ElementMetadata()
+        ElementMetadata(filename=metadata_filename or filename) if include_metadata else ElementMetadata()
     )
     for ctext in file_content:
         ctext = ctext.strip()

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -109,6 +109,7 @@ def partition_text(
 
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file, text=text)
+    metadata_filename = metadata_filename or filename
 
     if filename is not None:
         encoding, file_text = read_txt_file(filename=filename, encoding=encoding)

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -31,8 +31,6 @@ def partition_tsv(
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
-    metadata_filename
-        The filename to use for the metadata.
     include_metadata
         Determines whether or not metadata is included in the output.
     """

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -42,15 +42,13 @@ def partition_tsv(
         f = spooled_to_bytes_io_if_needed(cast(Union[BinaryIO, SpooledTemporaryFile], file))
         table = pd.read_csv(f, sep="\t")
 
-    metadata_filename = filename or metadata_filename
-
     html_text = table.to_html(index=False, header=False, na_rep="")
     text = lxml.html.document_fromstring(html_text).text_content()
 
     if include_metadata:
         metadata = ElementMetadata(
             text_as_html=html_text,
-            filename=metadata_filename,
+            filename=metadata_filename or filename,
         )
     else:
         metadata = ElementMetadata()

--- a/unstructured/partition/xlsx.py
+++ b/unstructured/partition/xlsx.py
@@ -42,8 +42,6 @@ def partition_xlsx(
         f = spooled_to_bytes_io_if_needed(cast(Union[BinaryIO, SpooledTemporaryFile], file))
         sheets = pd.read_excel(f, sheet_name=None)
 
-    metadata_filename = metadata_filename or filename
-
     elements: List[Element] = []
     page_number = 0
     for sheet_name, table in sheets.items():
@@ -56,7 +54,7 @@ def partition_xlsx(
                 text_as_html=html_text,
                 page_name=sheet_name,
                 page_number=page_number,
-                filename=metadata_filename,
+                filename=metadata_filename or filename,
             )
         else:
             metadata = ElementMetadata()

--- a/unstructured/partition/xlsx.py
+++ b/unstructured/partition/xlsx.py
@@ -31,8 +31,6 @@ def partition_xlsx(
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
-    metadata_filename
-        The filename to use for the metadata.
     include_metadata
         Determines whether or not metadata is included in the output.
     """
@@ -44,7 +42,7 @@ def partition_xlsx(
         f = spooled_to_bytes_io_if_needed(cast(Union[BinaryIO, SpooledTemporaryFile], file))
         sheets = pd.read_excel(f, sheet_name=None)
 
-    metadata_filename = filename or metadata_filename
+    metadata_filename = metadata_filename or filename
 
     elements: List[Element] = []
     page_number = 0

--- a/unstructured/partition/xml.py
+++ b/unstructured/partition/xml.py
@@ -69,8 +69,6 @@ def partition_xml(
         the text from within the tags.
     xml_path
         The xml_path to use for extracting the text. Only used if xml_keep_tags=False
-    metadata_filename
-        The filename to use for the metadata.
     encoding
         The encoding method used to decode the text input. If None, utf-8 will be used.
     include_metadata

--- a/unstructured/partition/xml.py
+++ b/unstructured/partition/xml.py
@@ -79,7 +79,6 @@ def partition_xml(
         no maximum is applied.
     """
     exactly_one(filename=filename, file=file)
-    metadata_filename = metadata_filename or filename
 
     if xml_keep_tags:
         if filename:


### PR DESCRIPTION
## Summary
- Closes #589
- Adds `assert` statements to existing tests to test for `filename`
- Adds commented out `assert` statements to tests where the filename is not retained when a file is partitioned (`None` is returned)
- Creates new tests for when `metadata_filename` is defined as an argument when parsing files
- Adds some missing docstrings and mixes some typos

