### PR TITLE
feat: choose model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 0.7.10-dev1
+## 0.7.10-dev2
 
 ### Enhancements
 
 * DRY connector refactor
 
 ### Features
+
+* `hi_res` model for pdfs and images is selectable via environment variable.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.10-dev2
+## 0.7.10-dev3
 
 ### Enhancements
 

--- a/test_unstructured/partition/test_image.py
+++ b/test_unstructured/partition/test_image.py
@@ -3,7 +3,6 @@ import pathlib
 from unittest import mock
 
 import pytest
-import requests
 from pytesseract import TesseractError
 from unstructured_inference.inference import layout
 
@@ -78,29 +77,6 @@ class MockDocumentLayout(layout.DocumentLayout):
         ]
 
 
-def test_partition_image_api(monkeypatch, filename="example-docs/example.jpg"):
-    monkeypatch.setattr(requests, "post", mock_successful_post)
-    monkeypatch.setattr(requests, "get", mock_healthy_get)
-
-    partition_image_response = pdf._partition_via_api(filename)
-    assert partition_image_response[0]["type"] == "Title"
-    assert partition_image_response[0]["text"] == "Charlie Brown and the Great Pumpkin"
-    assert partition_image_response[1]["type"] == "Title"
-    assert partition_image_response[1]["text"] == "A Charlie Brown Christmas"
-
-
-def test_partition_image_api_page_break(monkeypatch, filename="example-docs/example.jpg"):
-    monkeypatch.setattr(requests, "post", mock_successful_post)
-    monkeypatch.setattr(requests, "get", mock_healthy_get)
-
-    partition_image_response = pdf._partition_via_api(filename, include_page_breaks=True)
-    assert partition_image_response[0]["type"] == "Title"
-    assert partition_image_response[0]["text"] == "Charlie Brown and the Great Pumpkin"
-    assert partition_image_response[1]["type"] == "PageBreak"
-    assert partition_image_response[2]["type"] == "Title"
-    assert partition_image_response[2]["text"] == "A Charlie Brown Christmas"
-
-
 @pytest.mark.parametrize(
     ("filename", "file"),
     [("example-docs/example.jpg", None), (None, b"0000")],
@@ -125,43 +101,6 @@ def test_partition_image_local(monkeypatch, filename, file):
 def test_partition_image_local_raises_with_no_filename():
     with pytest.raises(FileNotFoundError):
         pdf._partition_pdf_or_image_local(filename="", file=None, is_image=True)
-
-
-def test_partition_image_api_raises_with_failed_healthcheck(
-    monkeypatch,
-    filename="example-docs/example.jpg",
-):
-    monkeypatch.setattr(requests, "post", mock_successful_post)
-    monkeypatch.setattr(requests, "get", mock_unhealthy_get)
-
-    with pytest.raises(ValueError):
-        pdf._partition_via_api(filename=filename, url="http://ml.unstructured.io/layout/image")
-
-
-def test_partition_image_api_raises_with_failed_api_call(
-    monkeypatch,
-    filename="example-docs/example.jpg",
-):
-    monkeypatch.setattr(requests, "post", mock_unsuccessful_post)
-    monkeypatch.setattr(requests, "get", mock_healthy_get)
-
-    with pytest.raises(ValueError):
-        pdf._partition_via_api(filename=filename, url="http://ml.unstructured.io/layout/image")
-
-
-@pytest.mark.parametrize(
-    ("url", "api_called", "local_called"),
-    [("fakeurl", True, False), (None, False, True)],
-)
-def test_partition_image(url, api_called, local_called):
-    with mock.patch.object(
-        pdf,
-        attribute="_partition_via_api",
-        new=mock.MagicMock(),
-    ), mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
-        image.partition_image(filename="fake.pdf", strategy="hi_res", url=url)
-        assert pdf._partition_via_api.called == api_called
-        assert pdf._partition_pdf_or_image_local.called == local_called
 
 
 def test_partition_image_with_auto_strategy(filename="example-docs/layout-parser-paper-fast.jpg"):

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -122,6 +122,7 @@ def test_partition_pdf_with_spooled_file(
         assert {element.metadata.page_number for element in result} == {1, 2}
 
 
+@mock.patch.dict(os.environ, {"UNSTRUCTURED_HI_RES_MODEL_NAME": "checkbox"})
 def test_partition_pdf_with_model_name(
     monkeypatch,
     filename="example-docs/layout-parser-paper-fast.pdf",
@@ -131,10 +132,16 @@ def test_partition_pdf_with_model_name(
         "is_pdf_text_extractable",
         lambda *args, **kwargs: True,
     )
-    with mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
+    with mock.patch.object(layout, "process_file_with_model", mock.MagicMock()) as mock_process:
         pdf.partition_pdf(
             filename=filename,
             strategy="hi_res",
+        )
+        mock_process.assert_called_once_with(
+            filename,
+            is_image=False,
+            ocr_languages="eng",
+            extract_tables=False,
             model_name="checkbox",
         )
 

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -3,7 +3,6 @@ from tempfile import SpooledTemporaryFile
 from unittest import mock
 
 import pytest
-import requests
 from unstructured_inference.inference import layout
 
 from unstructured.documents.coordinates import PixelSpace
@@ -78,35 +77,6 @@ class MockDocumentLayout(layout.DocumentLayout):
         ]
 
 
-def test_partition_pdf_api(
-    monkeypatch,
-    filename="example-docs/layout-parser-paper-fast.pdf",
-):
-    monkeypatch.setattr(requests, "post", mock_successful_post)
-    monkeypatch.setattr(requests, "get", mock_healthy_get)
-
-    partition_pdf_response = pdf._partition_via_api(filename)
-    assert partition_pdf_response[0]["type"] == "Title"
-    assert partition_pdf_response[0]["text"] == "Charlie Brown and the Great Pumpkin"
-    assert partition_pdf_response[1]["type"] == "Title"
-    assert partition_pdf_response[1]["text"] == "A Charlie Brown Christmas"
-
-
-def test_partition_pdf_api_page_breaks(
-    monkeypatch,
-    filename="example-docs/layout-parser-paper-fast.pdf",
-):
-    monkeypatch.setattr(requests, "post", mock_successful_post)
-    monkeypatch.setattr(requests, "get", mock_healthy_get)
-
-    partition_pdf_response = pdf._partition_via_api(filename, include_page_breaks=True)
-    assert partition_pdf_response[0]["type"] == "Title"
-    assert partition_pdf_response[0]["text"] == "Charlie Brown and the Great Pumpkin"
-    assert partition_pdf_response[1]["type"] == "PageBreak"
-    assert partition_pdf_response[2]["type"] == "Title"
-    assert partition_pdf_response[2]["text"] == "A Charlie Brown Christmas"
-
-
 @pytest.mark.parametrize(
     ("filename", "file"),
     [("example-docs/layout-parser-paper-fast.pdf", None), (None, b"0000")],
@@ -127,65 +97,9 @@ def test_partition_pdf_local(monkeypatch, filename, file):
     assert partition_pdf_response[0].text == "Charlie Brown and the Great Pumpkin"
 
 
-def test_partition_pdf_api_raises_with_no_filename(monkeypatch):
-    monkeypatch.setattr(requests, "post", mock_successful_post)
-    monkeypatch.setattr(requests, "get", mock_healthy_get)
-
-    with pytest.raises(FileNotFoundError):
-        pdf._partition_via_api(filename=None, file=None)
-
-
 def test_partition_pdf_local_raises_with_no_filename():
     with pytest.raises(FileNotFoundError):
         pdf._partition_pdf_or_image_local(filename="", file=None, is_image=False)
-
-
-def test_partition_pdf_api_raises_with_failed_healthcheck(
-    monkeypatch,
-    filename="example-docs/layout-parser-paper-fast.pdf",
-):
-    monkeypatch.setattr(requests, "post", mock_successful_post)
-    monkeypatch.setattr(requests, "get", mock_unhealthy_get)
-
-    with pytest.raises(ValueError):
-        pdf._partition_via_api(filename=filename)
-
-
-def test_partition_pdf_api_raises_with_failed_api_call(
-    monkeypatch,
-    filename="example-docs/layout-parser-paper-fast.pdf",
-):
-    monkeypatch.setattr(requests, "post", mock_unsuccessful_post)
-    monkeypatch.setattr(requests, "get", mock_healthy_get)
-
-    with pytest.raises(ValueError):
-        pdf._partition_via_api(filename=filename)
-
-
-@pytest.mark.parametrize(
-    ("url", "api_called", "local_called"),
-    [("fakeurl", True, False), (None, False, True)],
-)
-def test_partition_pdf(
-    url,
-    api_called,
-    local_called,
-    monkeypatch,
-    filename="example-docs/layout-parser-paper-fast.pdf",
-):
-    monkeypatch.setattr(
-        strategies,
-        "is_pdf_text_extractable",
-        lambda *args, **kwargs: True,
-    )
-    with mock.patch.object(
-        pdf,
-        attribute="_partition_via_api",
-        new=mock.MagicMock(),
-    ), mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
-        pdf.partition_pdf(filename=filename, strategy="hi_res", url=url)
-        assert pdf._partition_via_api.called == api_called
-        assert pdf._partition_pdf_or_image_local.called == local_called
 
 
 @pytest.mark.parametrize(
@@ -208,14 +122,7 @@ def test_partition_pdf_with_spooled_file(
         assert {element.metadata.page_number for element in result} == {1, 2}
 
 
-@pytest.mark.parametrize(
-    ("url", "api_called", "local_called"),
-    [("fakeurl", True, False), (None, False, True)],
-)
-def test_partition_pdf_with_template(
-    url,
-    api_called,
-    local_called,
+def test_partition_pdf_with_model_name(
     monkeypatch,
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):
@@ -224,19 +131,12 @@ def test_partition_pdf_with_template(
         "is_pdf_text_extractable",
         lambda *args, **kwargs: True,
     )
-    with mock.patch.object(
-        pdf,
-        attribute="_partition_via_api",
-        new=mock.MagicMock(),
-    ), mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
+    with mock.patch.object(pdf, "_partition_pdf_or_image_local", mock.MagicMock()):
         pdf.partition_pdf(
             filename=filename,
             strategy="hi_res",
-            url=url,
-            template="checkbox",
+            model_name="checkbox",
         )
-        assert pdf._partition_via_api.called == api_called
-        assert pdf._partition_pdf_or_image_local.called == local_called
 
 
 def test_partition_pdf_with_auto_strategy(

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.10-dev1"  # pragma: no cover
+__version__ = "0.7.10-dev2"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.10-dev2"  # pragma: no cover
+__version__ = "0.7.10-dev3"  # pragma: no cover

--- a/unstructured/ingest/doc_processor/generalized.py
+++ b/unstructured/ingest/doc_processor/generalized.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
+import os
 from unstructured_inference.models.base import get_model
 
 from unstructured.ingest.interfaces import BaseIngestDoc as IngestDoc
@@ -9,9 +10,9 @@ from unstructured.ingest.logger import logger
 
 
 def initialize():
-    """Download default model (avoids subprocesses all doing the same)"""
-
-    get_model()
+    """Download default model or model specified by UNSTRUCTURED_HI_RES_MODEL_NAME environment
+    variable (avoids subprocesses all doing the same)"""
+    get_model(os.environ.get("UNSTRUCTURED_HI_RES_MODEL_NAME"))
 
 
 def process_document(doc: "IngestDoc", **partition_kwargs) -> Optional[List[Dict[str, Any]]]:

--- a/unstructured/ingest/doc_processor/generalized.py
+++ b/unstructured/ingest/doc_processor/generalized.py
@@ -1,8 +1,8 @@
 """Process aribritrary files with the Unstructured library"""
 
+import os
 from typing import Any, Dict, List, Optional
 
-import os
 from unstructured_inference.models.base import get_model
 
 from unstructured.ingest.interfaces import BaseIngestDoc as IngestDoc

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -21,11 +21,14 @@ from unstructured.logger import logger
 from unstructured.nlp.patterns import ENUMERATED_BULLETS_RE, UNICODE_BULLETS_RE
 
 if TYPE_CHECKING:
-    from unstructured_inference.inference.layoutelement import LayoutElement
+    from unstructured_inference.inference.layoutelement import (
+        LayoutElement,
+        LocationlessLayoutElement,
+    )
 
 
 def normalize_layout_element(
-    layout_element: Union["LayoutElement", Element, Dict[str, Any]],
+    layout_element: Union["LayoutElement", "LocationlessLayoutElement", Element, Dict[str, Any]],
 ) -> Union[Element, List[Element]]:
     """Converts an unstructured_inference LayoutElement object to an unstructured Element."""
 

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -22,11 +22,6 @@ def partition_image(
         A string defining the target filename path.
     file
         A file-like object as bytes --> open(filename, "rb").
-    url
-        A string endpoint to self-host an inference API, if desired. If None, local inference will
-        be used.
-    token
-        A string defining the authentication token for a self-host url, if applicable.
     ocr_languages
         The languages to use for the Tesseract agent. To use a language, you'll first need
         to install the appropriate Tesseract language pack.

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -12,7 +12,6 @@ def partition_image(
     include_page_breaks: bool = False,
     ocr_languages: str = "eng",
     strategy: str = "auto",
-    model_name: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Parses an image into a list of interpreted elements.
@@ -38,8 +37,6 @@ def partition_image(
         partition_image simply extracts the text from the document using OCR and processes it.
         The default strategy `auto` will determine when a image can be extracted using
         `ocr_only` mode, otherwise it will fall back to `hi_res`.
-    model_name
-        A string defining the model to be used. Default None uses default model.
     """
     exactly_one(filename=filename, file=file)
 
@@ -50,5 +47,4 @@ def partition_image(
         include_page_breaks=include_page_breaks,
         ocr_languages=ocr_languages,
         strategy=strategy,
-        model_name=model_name,
     )

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -23,9 +23,6 @@ def partition_image(
         A string defining the target filename path.
     file
         A file-like object as bytes --> open(filename, "rb").
-    template
-        A string defining the model to be used. Default None uses default model ("layout/image" url
-        if using the API).
     url
         A string endpoint to self-host an inference API, if desired. If None, local inference will
         be used.
@@ -41,12 +38,15 @@ def partition_image(
         partition_image simply extracts the text from the document using OCR and processes it.
         The default strategy `auto` will determine when a image can be extracted using
         `ocr_only` mode, otherwise it will fall back to `hi_res`.
+    model_name
+        A string defining the model to be used. Default None uses default model.
     """
     exactly_one(filename=filename, file=file)
 
     return partition_pdf_or_image(
         filename=filename,
         file=file,
+        is_image=True,
         include_page_breaks=include_page_breaks,
         ocr_languages=ocr_languages,
         strategy=strategy,

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -9,12 +9,10 @@ from unstructured.partition.pdf import partition_pdf_or_image
 def partition_image(
     filename: str = "",
     file: Optional[bytes] = None,
-    url: Optional[str] = None,
-    template: Optional[str] = None,
-    token: Optional[str] = None,
     include_page_breaks: bool = False,
     ocr_languages: str = "eng",
     strategy: str = "auto",
+    model_name: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Parses an image into a list of interpreted elements.
@@ -46,16 +44,11 @@ def partition_image(
     """
     exactly_one(filename=filename, file=file)
 
-    if template is None:
-        template = "layout/image"
-
     return partition_pdf_or_image(
         filename=filename,
         file=file,
-        url=url,
-        template=template,
-        token=token,
         include_page_breaks=include_page_breaks,
         ocr_languages=ocr_languages,
         strategy=strategy,
+        model_name=model_name,
     )

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -45,6 +45,7 @@ def partition_pdf(
     strategy: str = "auto",
     infer_table_structure: bool = False,
     ocr_languages: str = "eng",
+    model_name: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Parses a pdf document into a list of interpreted elements.
@@ -92,6 +93,7 @@ def partition_pdf(
         strategy=strategy,
         infer_table_structure=infer_table_structure,
         ocr_languages=ocr_languages,
+        model_name=model_name,
     )
 
 
@@ -106,6 +108,7 @@ def partition_pdf_or_image(
     strategy: str = "auto",
     infer_table_structure: bool = False,
     ocr_languages: str = "eng",
+    model_name: Optional[str] = None,
 ) -> List[Element]:
     """Parses a pdf or image document into a list of interpreted elements."""
     if url is None:
@@ -139,6 +142,7 @@ def partition_pdf_or_image(
                     infer_table_structure=infer_table_structure,
                     include_page_breaks=True,
                     ocr_languages=ocr_languages,
+                    model_name=model_name,
                 )
 
         elif strategy == "fast":
@@ -188,6 +192,7 @@ def _partition_pdf_or_image_local(
     infer_table_structure: bool = False,
     include_page_breaks: bool = False,
     ocr_languages: str = "eng",
+    model_name: Optional[str] = None,
 ) -> List[Element]:
     """Partition using package installed locally."""
     try:
@@ -217,6 +222,7 @@ def _partition_pdf_or_image_local(
             is_image=is_image,
             ocr_languages=ocr_languages,
             extract_tables=infer_table_structure,
+            model_name=model_name,
         )
     else:
         layout = process_data_with_model(
@@ -225,6 +231,7 @@ def _partition_pdf_or_image_local(
             is_image=is_image,
             ocr_languages=ocr_languages,
             extract_tables=infer_table_structure,
+            model_name=model_name,
         )
 
     return document_to_element_list(layout, include_page_breaks=include_page_breaks)

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -52,9 +52,6 @@ def partition_pdf(
         A string defining the target filename path.
     file
         A file-like object as bytes --> open(filename, "rb").
-    template
-        A string defining the model to be used. Default None uses default model ("layout/pdf" url
-        if using the API).
     url
         A string endpoint to self-host an inference API, if desired. If None, local inference will
         be used.
@@ -78,6 +75,8 @@ def partition_pdf(
     ocr_languages
         The languages to use for the Tesseract agent. To use a language, you'll first need
         to isntall the appropriate Tesseract language pack.
+    model_name
+        A string defining the model to be used. Default None uses default model.
     """
     exactly_one(filename=filename, file=file)
     return partition_pdf_or_image(

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -83,7 +83,6 @@ def partition_pdf(
     return partition_pdf_or_image(
         filename=filename,
         file=file,
-        token=token,
         include_page_breaks=include_page_breaks,
         strategy=strategy,
         infer_table_structure=infer_table_structure,

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -1,3 +1,4 @@
+import os
 import re
 import warnings
 from tempfile import SpooledTemporaryFile
@@ -37,12 +38,10 @@ from unstructured.utils import requires_dependencies
 def partition_pdf(
     filename: str = "",
     file: Optional[Union[BinaryIO, SpooledTemporaryFile]] = None,
-    token: Optional[str] = None,
     include_page_breaks: bool = False,
     strategy: str = "auto",
     infer_table_structure: bool = False,
     ocr_languages: str = "eng",
-    model_name: Optional[str] = None,
     **kwargs,
 ) -> List[Element]:
     """Parses a pdf document into a list of interpreted elements.
@@ -75,8 +74,6 @@ def partition_pdf(
     ocr_languages
         The languages to use for the Tesseract agent. To use a language, you'll first need
         to isntall the appropriate Tesseract language pack.
-    model_name
-        A string defining the model to be used. Default None uses default model.
     """
     exactly_one(filename=filename, file=file)
     return partition_pdf_or_image(
@@ -86,7 +83,6 @@ def partition_pdf(
         strategy=strategy,
         infer_table_structure=infer_table_structure,
         ocr_languages=ocr_languages,
-        model_name=model_name,
     )
 
 
@@ -98,7 +94,6 @@ def partition_pdf_or_image(
     strategy: str = "auto",
     infer_table_structure: bool = False,
     ocr_languages: str = "eng",
-    model_name: Optional[str] = None,
 ) -> List[Element]:
     """Parses a pdf or image document into a list of interpreted elements."""
     # TODO(alan): Extract information about the filetype to be processed from the template
@@ -125,7 +120,6 @@ def partition_pdf_or_image(
                 infer_table_structure=infer_table_structure,
                 include_page_breaks=True,
                 ocr_languages=ocr_languages,
-                model_name=model_name,
             )
 
     elif strategy == "fast":
@@ -157,7 +151,6 @@ def _partition_pdf_or_image_local(
     infer_table_structure: bool = False,
     include_page_breaks: bool = False,
     ocr_languages: str = "eng",
-    model_name: Optional[str] = None,
 ) -> List[Element]:
     """Partition using package installed locally."""
     try:
@@ -180,6 +173,7 @@ def _partition_pdf_or_image_local(
             "running make install-local-inference from the root directory of the repository.",
         ) from e
 
+    model_name = os.environ.get("UNSTRUCTURED_HI_RES_MODEL_NAME")
     if file is None:
         layout = process_file_with_model(
             filename,

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -51,11 +51,6 @@ def partition_pdf(
         A string defining the target filename path.
     file
         A file-like object as bytes --> open(filename, "rb").
-    url
-        A string endpoint to self-host an inference API, if desired. If None, local inference will
-        be used.
-    token
-        A string defining the authentication token for a self-host url, if applicable.
     strategy
         The strategy to use for partitioning the PDF. Valid strategies are "hi_res",
         "ocr_only", and "fast". When using the "hi_res" strategy, the function uses


### PR DESCRIPTION
Added the ability to select the `hi_res` model via the environment variable `UNSTRUCTURED_HI_RES_MODEL_NAME`. Variable must be a string that matches up with a model name defined in `unstructured_inference`.

Also removed code related to old `unstructured_inference` API which has been removed from currently pinned version of `unstructured-inference` and is no longer running as a service.

#### Testing:

```python
import os
from unstructured.partition.pdf import partition_pdf
# Default model
out = partition_pdf("example-docs/layout-parser-paper-fast.pdf", strategy="hi_res")
print(len(out))

os.environ["UNSTRUCTURED_HI_RES_MODEL_NAME"] = "yolox"
out_yolox = partition_pdf("example-docs/layout-parser-paper-fast.pdf", strategy="hi_res")
# Length should be different than above, indicating inference was done with a different model
print(len(out_yolox))

```