### PR TITLE
fix: don't detect line breaks as list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.10-dev3
+## 0.7.10-dev4
 
 ### Enhancements
 
@@ -10,6 +10,8 @@
 
 ### Fixes
 
+* Adds negative lookahead to bullet pattern to avoid detecting plain text line
+  breaks like `-------` as list items.
 * Fix pre tag parsing for `partition_html`
 * Fix lookup error for annotated Arabic and Hebrew encodings
 

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -154,3 +154,10 @@ def test_partition_text_extract_regex_metadata():
     assert elements[0].metadata.regex_metadata == {
         "speaker": [{"text": "SPEAKER 1", "start": 0, "end": 9}],
     }
+
+
+def test_partition_text_doesnt_get_page_breaks():
+    text = "--------------------"
+    elements = partition_text(text=text)
+    assert len(elements) == 1
+    assert elements[0].text == text

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -165,6 +165,7 @@ def test_contains_us_phone_number(text, expected):
         ("- This is a fine point!", True),
         ("This is NOT a fine point!", False),  # No bullet point
         ("I love morse code! ● ● ● --- ● ● ●", False),  # Not at the beginning
+        ("----------------------------", False),  # Too long
     ],
 )
 def test_is_bulletized_text(text, expected):

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.10-dev3"  # pragma: no cover
+__version__ = "0.7.10-dev4"  # pragma: no cover

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -71,7 +71,9 @@ EMAIL_HEAD_RE = re.compile(EMAIL_HEAD_PATTERN)
 # (incluing \r and \n chars) on either side
 PARAGRAPH_PATTERN = r"\s*\n\s*"  # noqa: W605 NOTE(harrell)
 
-PARAGRAPH_PATTERN_RE = re.compile(f"((?:{'|'.join(UNICODE_BULLETS)})|{PARAGRAPH_PATTERN})")
+PARAGRAPH_PATTERN_RE = re.compile(
+    f"((?:{BULLETS_PATTERN})|{PARAGRAPH_PATTERN})(?!{BULLETS_PATTERN}|$)",
+)
 DOUBLE_PARAGRAPH_PATTERN_RE = re.compile("(" + PARAGRAPH_PATTERN + "){2}")
 
 # IP Address examples: ba23::58b5:2236:45g2:88h2 or 10.0.2.01

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -57,7 +57,8 @@ UNICODE_BULLETS: Final[List[str]] = [
     "\x95",
     "·",
 ]
-UNICODE_BULLETS_RE = re.compile(f"(?:{'|'.join(UNICODE_BULLETS)})")
+BULLETS_PATTERN = "|".join(UNICODE_BULLETS)
+UNICODE_BULLETS_RE = re.compile(f"(?:{BULLETS_PATTERN})(?!{BULLETS_PATTERN})")
 
 ENUMERATED_BULLETS_RE = re.compile(r"(?:(?:\d{1,3}|[a-z][A-Z])\.?){1,3}")
 


### PR DESCRIPTION
### Summary

Closes #786. Updates the bulleted text regex so that line breaks are not detect as list items.

### Testing

```python
from unstructured.partition.text import partition_text

text = "-------------------"
# Should be one element that isn't a list item
elements = partition_text(text=text)
elements[0].text
```

```python
from unstructured.partition.text_type import is_bulleted_text

text = "-------------------"
# Should be False
is_bulleted_text(text)
```