### PR TITLE
fix: ingest download skipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.11-dev1
+## 0.7.11-dev2
 
 ### Enhancements
 
@@ -8,6 +8,7 @@
 
 * Fix tests that call unstructured-api by passing through an api-key
 * Fixed page breaks being given (incorrect) page numbers
+* Fix skipping download on ingest when a source document exists locally
 
 ## 0.7.10
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.11-dev1"  # pragma: no cover
+__version__ = "0.7.11-dev2"  # pragma: no cover

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -156,7 +156,11 @@ class BaseIngestDoc(ABC):
 
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
-            if not self.standard_config.re_download and self.has_output():
+            if (
+                not self.standard_config.re_download
+                and self.filename.is_file()
+                and self.filename.stat().st_size
+            ):
                 logger.debug(f"File exists: {self.filename}, skipping {func.__name__}")
                 return None
             return func(self, *args, **kwargs)


### PR DESCRIPTION
The skip_if_file_exists ingest decorator should skip downloading a file if it has already been downloaded. Currently, instead of checking if the source document exists in the download location, it's checking if the output file exists. This pr updates to check for the latter.

To test: 
* remove previous s3 outputs and any downloaded content `~/.cache/unstructured` and `./files-ingest-download`
* run `./test_unstructured_ingest/test-ingest-s3.sh`
* it should succeed
* remove downloaded content `~/.cache/unstructured` and `./files-ingest-download`
* run it again `./test_unstructured_ingest/test-ingest-s3.sh`
* before this pr: it should fail because it doesn't have the downloaded content
* after this pr: it should succeed because it downloads the content after recognizing it is not there