### PR TITLE
fix: add api key to image publishing workflow tests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Build And Push Docker Image
 
 on:
   push:
-    branches:
-      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -58,13 +56,14 @@ jobs:
       uses: docker/setup-qemu-action@v2
     - name: Test images
       run: |
+        echo "UNS_API_KEY=${{ secrets.UNS_API_KEY }}" > uns_test_env_file
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         if [ "$ARCH" = "amd64" ]; then
         DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-          make docker-test
+          make docker-test CI=true
         else
           DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-            make docker-test TEST_NAME=partition/test_text.py
+            make docker-test CI=true TEST_NAME=partition/test_text.py
         fi
         DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
     - name: Push images
@@ -72,41 +71,41 @@ jobs:
         # write to the build repository to cache for the publish-images job
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  publish-images:
-    runs-on: ubuntu-latest
-    needs: [set-short-sha, build-images]
-    env:
-      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-    steps:
-    - uses: docker/setup-buildx-action@v1
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Login to Quay.io
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-    - name: Pull AMD image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-    - name: Pull ARM image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-    - name: Push latest build tags for AMD and ARM
-      run: |
-        # these are used to construct the final manifest but also cache-from in subsequent runs
-        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-        docker push $DOCKER_BUILD_REPOSITORY:amd64
-        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-        docker push $DOCKER_BUILD_REPOSITORY:arm64
-    - name: Push multiarch manifest
-      run: |
-        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
-        docker manifest push $DOCKER_REPOSITORY:latest
-        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$VERSION
+  # publish-images:
+  #   runs-on: ubuntu-latest
+  #   needs: [set-short-sha, build-images]
+  #   env:
+  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+  #   steps:
+  #   - uses: docker/setup-buildx-action@v1
+  #   - name: Checkout code
+  #     uses: actions/checkout@v3
+  #   - name: Login to Quay.io
+  #     uses: docker/login-action@v1
+  #     with:
+  #       registry: quay.io
+  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+  #   - name: Pull AMD image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+  #   - name: Pull ARM image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+  #   - name: Push latest build tags for AMD and ARM
+  #     run: |
+  #       # these are used to construct the final manifest but also cache-from in subsequent runs
+  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
+  #   - name: Push multiarch manifest
+  #     run: |
+  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker manifest push $DOCKER_REPOSITORY:latest
+  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
+    branches:
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -71,41 +73,41 @@ jobs:
         # write to the build repository to cache for the publish-images job
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  # publish-images:
-  #   runs-on: ubuntu-latest
-  #   needs: [set-short-sha, build-images]
-  #   env:
-  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-  #   steps:
-  #   - uses: docker/setup-buildx-action@v1
-  #   - name: Checkout code
-  #     uses: actions/checkout@v3
-  #   - name: Login to Quay.io
-  #     uses: docker/login-action@v1
-  #     with:
-  #       registry: quay.io
-  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-  #   - name: Pull AMD image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-  #   - name: Pull ARM image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-  #   - name: Push latest build tags for AMD and ARM
-  #     run: |
-  #       # these are used to construct the final manifest but also cache-from in subsequent runs
-  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
-  #   - name: Push multiarch manifest
-  #     run: |
-  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker manifest push $DOCKER_REPOSITORY:latest
-  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
+  publish-images:
+    runs-on: ubuntu-latest
+    needs: [set-short-sha, build-images]
+    env:
+      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+    steps:
+    - uses: docker/setup-buildx-action@v1
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+    - name: Pull AMD image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+    - name: Pull ARM image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+    - name: Push latest build tags for AMD and ARM
+      run: |
+        # these are used to construct the final manifest but also cache-from in subsequent runs
+        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+        docker push $DOCKER_BUILD_REPOSITORY:amd64
+        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+        docker push $DOCKER_BUILD_REPOSITORY:arm64
+    - name: Push multiarch manifest
+      run: |
+        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:amd64
+        docker manifest push $DOCKER_REPOSITORY:latest
+        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$VERSION
 


### PR DESCRIPTION
Similar to the change [here](https://github.com/Unstructured-IO/unstructured/pull/843) to add api keys to ci testing, this adds the api key to the publish flow which tests the built images. Triggered a test publish flow (minus the final push of images) [here](https://github.com/Unstructured-IO/unstructured/actions/runs/5416102827/jobs/9845358298) to validate this change..