### PR TITLE
build(image): docker build tweak for arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,9 @@ name: Build And Push Docker Image
 
 on:
   push:
-    - main
+    branches:
+      - main
+
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,6 @@ name: Build And Push Docker Image
 
 on:
   push:
-    branches:
-      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -36,7 +34,8 @@ jobs:
       # Use the `docker-container` driver for ARM builds because it may otherwise intermittently fail with: `exec /bin/sh: exec format error`
       uses: docker/setup-buildx-action@v1
       with:
-        driver: ${{ matrix.docker-platform == 'linux/amd64' && 'docker' || 'docker-container' }}
+        #driver: ${{ matrix.docker-platform == 'linux/amd64' && 'docker' || 'docker-container' }}
+        driver: 'docker'
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Login to Quay.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build And Push Docker Image
 
 on:
   push:
-
+    - main
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
   DOCKER_BUILD_REPOSITORY: quay.io/unstructured-io/build-unstructured
@@ -29,12 +29,9 @@ jobs:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
     steps:
     - name: Set up Docker
-      # Use the `docker` driver for AMD builds because the `docker-container` driver may fail to locally load the built image.
-      # This could be due to the larger size of the AMD build and the `docker-container` driver needing to load the tarball.
-      # Use the `docker-container` driver for ARM builds because it may otherwise intermittently fail with: `exec /bin/sh: exec format error`
+      # Use the `docker` driver because the `docker-container` driver may fail to locally load the built image.
       uses: docker/setup-buildx-action@v1
       with:
-        #driver: ${{ matrix.docker-platform == 'linux/amd64' && 'docker' || 'docker-container' }}
         driver: 'docker'
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
Fixes issue where arm64 docker builds were failing and preventing images from being published.
The latest main commit plus this branch (1st commit) has already been published in CI here: https://github.com/Unstructured-IO/unstructured/actions/runs/5428719470/jobs/9873272705