### PR TITLE
Add a missing space in a warning message in filetype.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.13-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
 ## 0.7.12
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.12"  # pragma: no cover
+__version__ = "0.7.13-dev0"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -258,7 +258,7 @@ def detect_filetype(
             mime_type = ft.guess_mime(file.read(4096))
         if mime_type is None:
             logger.warning(
-                "libmagic is unavailable but assists in filetype detection on file-like objects."
+                "libmagic is unavailable but assists in filetype detection on file-like objects. "
                 "Please consider installing libmagic for better results.",
             )
             return EXT_TO_FILETYPE.get(extension, FileType.UNK)


### PR DESCRIPTION
This PR adds a missing space in a warning message in the `filetype.py` file.