### PR TITLE
fix: Fix KeyError in isd_to_elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 ### Fixes
+* Fix KeyError when `isd_to_elements` doesn't find a type
 
 ## 0.7.12
 

--- a/test_unstructured/staging/test_base_staging.py
+++ b/test_unstructured/staging/test_base_staging.py
@@ -46,6 +46,7 @@ def test_isd_to_elements():
         {"text": "Blurb2", "type": "Title"},
         {"text": "Blurb3", "type": "ListItem"},
         {"text": "Blurb4", "type": "BulletedText"},
+        {"text": "No Type"},
     ]
 
     elements = base.isd_to_elements(isd)

--- a/unstructured/staging/base.py
+++ b/unstructured/staging/base.py
@@ -90,7 +90,7 @@ def isd_to_elements(isd: List[Dict[str, Any]]) -> List[Element]:
         if _metadata_dict is not None:
             metadata = ElementMetadata.from_dict(_metadata_dict)
 
-        if item["type"] in TYPE_TO_TEXT_ELEMENT_MAP:
+        if item.get("type") in TYPE_TO_TEXT_ELEMENT_MAP:
             _text_class = TYPE_TO_TEXT_ELEMENT_MAP[item["type"]]
             elements.append(
                 _text_class(
@@ -101,10 +101,10 @@ def isd_to_elements(isd: List[Dict[str, Any]]) -> List[Element]:
                     coordinate_system=coordinate_system,
                 ),
             )
-        elif item["type"] == "CheckBox":
+        elif item.get("type") == "CheckBox":
             elements.append(
                 CheckBox(
-                    checked=item["checked"],
+                    checked=item.get("checked"),
                     element_id=element_id,
                     metadata=metadata,
                     coordinates=coordinates,

--- a/unstructured/staging/base.py
+++ b/unstructured/staging/base.py
@@ -104,7 +104,7 @@ def isd_to_elements(isd: List[Dict[str, Any]]) -> List[Element]:
         elif item.get("type") == "CheckBox":
             elements.append(
                 CheckBox(
-                    checked=item.get("checked"),
+                    checked=item["checked"],
                     element_id=element_id,
                     metadata=metadata,
                     coordinates=coordinates,


### PR DESCRIPTION
I don't have a reproducible example, but we continue to get API errors with the following stack. I suppose the safest thing is to skip an item that has no type, but happy to consider other behavior if we don't want to be silently ignoring data. Any suggestions for how to track down where these items are coming from?

![Screenshot 2023-06-09 at 11 48 50 AM](https://github.com/Unstructured-IO/unstructured/assets/3846783/34d727e1-775d-42b3-a827-9e18298fe3b9)
