### PR TITLE
fix: local connector output filename when a single file is being processed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: check-json
       - id: check-xml
       - id: end-of-file-fixer
+        exclude: \.json$
         include: \.py$
       - id: trailing-whitespace
       - id: mixed-line-ending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 0.7.13-dev0
+## 0.7.13-dev1
 
 ### Enhancements
 
 ### Features
 
 ### Fixes
+
+* Fix _output_filename for local connector, allowing single files to be written correctly to the disk
 
 ## 0.7.12
 
@@ -28,7 +30,7 @@
 
 * More deterministic element ordering when using `hi_res` PDF parsing strategy (from unstructured-inference bump to 0.5.4)
 * Make large model available (from unstructured-inference bump to 0.5.3)
-* Combine inferred elements with extracted elements (from unstructured-inference bump to 0.5.2) 
+* Combine inferred elements with extracted elements (from unstructured-inference bump to 0.5.2)
 * `partition_email` and `partition_msg` will now process attachments if `process_attachments=True`
   and a attachment partitioning functions is passed through with `attachment_partitioner=partition`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@
 
 ### Fixes
 * Fix KeyError when `isd_to_elements` doesn't find a type
+* Fix _output_filename for local connector, allowing single files to be written correctly to the disk
 
 ### BREAKING CHANGES
 
 * Information about an element's location is no longer returned as top-level attributes of an element. Instead, it is returned in the `coordinates` attribute of the element's metadata.
 
-* Fix _output_filename for local connector, allowing single files to be written correctly to the disk
 
 ## 0.7.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 
 * Information about an element's location is no longer returned as top-level attributes of an element. Instead, it is returned in the `coordinates` attribute of the element's metadata.
 
-
 ## 0.7.12
 
 ### Enhancements

--- a/test_unstructured_ingest/expected-structured-output/local-single-file/english-and-korean.png.json
+++ b/test_unstructured_ingest/expected-structured-output/local-single-file/english-and-korean.png.json
@@ -28,12 +28,12 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "9854d0df4dceac0f09846f4f272f0703",
+    "element_id": "20479718ff54c137a6c7984d8a87bf81",
     "metadata": {
       "data_source": {},
       "filetype": "image/png"
     },
-    "text": "안녕하세요, 저 희 는 YGEAS 그룹 TREASUREMH HARUTOM| 2] 팬 입니다. 팬 으 로서, HARUTO 씨 받 는 대 우 에 대해 의 구 심 과 불 공 평 함 을 LRU, 이 메 일 을 통해 저 희 의 의 혹 을 전 달 하여 귀 사 의 진지한 고 민 과 적극적인 답 변 을 받을 수 있 기 를 바랍니다."
+    "text": "StS ofAl2, SIE YGEAS TB TREASUREWH HARUTOM|2] RHEULICH. BHO AY, HARUTO M BE = WSO Hol Mat SSBsts LRU, O| Wil BS SH ASP] ASS AZOpO} HAS] TAI St a Bat 4SAel SHS HS + U7/S LICH."
   },
   {
     "type": "NarrativeText",
@@ -46,11 +46,11 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "c37248b6d436997d36acc7852f502a8e",
+    "element_id": "da91cb5310386aafd5aaf6fd988b9616",
     "metadata": {
       "data_source": {},
       "filetype": "image/png"
     },
-    "text": "4. Use the hashtag of Haruto on your tweet to show that vou have sent your email]"
+    "text": "4. Use the hashtag of Haruto on your tweet to show that vou have sent vour email]"
   }
 ]

--- a/test_unstructured_ingest/expected-structured-output/local-single-file/english-and-korean.png.json
+++ b/test_unstructured_ingest/expected-structured-output/local-single-file/english-and-korean.png.json
@@ -28,12 +28,12 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "577b0ea5cd4f62a19b9d14dd0bd7272e",
+    "element_id": "9854d0df4dceac0f09846f4f272f0703",
     "metadata": {
       "data_source": {},
       "filetype": "image/png"
     },
-    "text": "안녕하세요, 저 희 는 YGEAS 그룹 TREASUREWH HARUTOM|2] 팬 입니다. 팬 으 로서, HARUTO 씨 받 는 대 우 에 대해 의 구 심 과 불 공 평 함 을 LRU, 이 메 일 을 통해 저 희 의 의 혹 을 전 달 하여 귀 사 의 진지한 고 민 과 적극적인 답 변 을 받을 수 있 기 를 바랍니다."
+    "text": "안녕하세요, 저 희 는 YGEAS 그룹 TREASUREMH HARUTOM| 2] 팬 입니다. 팬 으 로서, HARUTO 씨 받 는 대 우 에 대해 의 구 심 과 불 공 평 함 을 LRU, 이 메 일 을 통해 저 희 의 의 혹 을 전 달 하여 귀 사 의 진지한 고 민 과 적극적인 답 변 을 받을 수 있 기 를 바랍니다."
   },
   {
     "type": "NarrativeText",
@@ -46,11 +46,11 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "da91cb5310386aafd5aaf6fd988b9616",
+    "element_id": "c37248b6d436997d36acc7852f502a8e",
     "metadata": {
       "data_source": {},
       "filetype": "image/png"
     },
-    "text": "4. Use the hashtag of Haruto on your tweet to show that vou have sent vour email]"
+    "text": "4. Use the hashtag of Haruto on your tweet to show that vou have sent your email]"
   }
 ]

--- a/test_unstructured_ingest/expected-structured-output/local-single-file/english-and-korean.png.json
+++ b/test_unstructured_ingest/expected-structured-output/local-single-file/english-and-korean.png.json
@@ -28,12 +28,12 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "20479718ff54c137a6c7984d8a87bf81",
+    "element_id": "577b0ea5cd4f62a19b9d14dd0bd7272e",
     "metadata": {
       "data_source": {},
       "filetype": "image/png"
     },
-    "text": "StS ofAl2, SIE YGEAS TB TREASUREWH HARUTOM|2] RHEULICH. BHO AY, HARUTO M BE = WSO Hol Mat SSBsts LRU, O| Wil BS SH ASP] ASS AZOpO} HAS] TAI St a Bat 4SAel SHS HS + U7/S LICH."
+    "text": "안녕하세요, 저 희 는 YGEAS 그룹 TREASUREWH HARUTOM|2] 팬 입니다. 팬 으 로서, HARUTO 씨 받 는 대 우 에 대해 의 구 심 과 불 공 평 함 을 LRU, 이 메 일 을 통해 저 희 의 의 혹 을 전 달 하여 귀 사 의 진지한 고 민 과 적극적인 답 변 을 받을 수 있 기 를 바랍니다."
   },
   {
     "type": "NarrativeText",

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.13-dev0"  # pragma: no cover
+__version__ = "0.7.13-dev1"  # pragma: no cover

--- a/unstructured/ingest/connector/local.py
+++ b/unstructured/ingest/connector/local.py
@@ -51,7 +51,11 @@ class LocalIngestDoc(BaseIngestDoc):
         pass
 
     @property
-    def _output_filename(self):
+    def _output_filename(self) -> Path:
+        """Returns output filename for the doc.
+        If input path argument is a file itself, it returns the filename of the doc.
+        If input path argument is a folder, it returns the relative path of the doc.
+        """
         input_path = Path(self.config.input_path)
         basename = (
             f"{Path(self.path).name}.json"

--- a/unstructured/ingest/connector/local.py
+++ b/unstructured/ingest/connector/local.py
@@ -52,10 +52,13 @@ class LocalIngestDoc(BaseIngestDoc):
 
     @property
     def _output_filename(self):
-        return (
-            Path(self.standard_config.output_dir)
-            / f"{self.path.replace(f'{self.config.input_path}/', '')}.json"
+        input_path = Path(self.config.input_path)
+        basename = (
+            f"{Path(self.path).name}.json"
+            if input_path.is_file()
+            else f"{Path(self.path).relative_to(input_path)}.json"
         )
+        return Path(self.standard_config.output_dir) / basename
 
 
 class LocalConnector(BaseConnector):

--- a/unstructured/ingest/connector/local.py
+++ b/unstructured/ingest/connector/local.py
@@ -52,7 +52,7 @@ class LocalIngestDoc(BaseIngestDoc):
 
     @property
     def _output_filename(self) -> Path:
-        """Returns output filename for the doc.
+        """Returns output filename for the doc
         If input path argument is a file itself, it returns the filename of the doc.
         If input path argument is a folder, it returns the relative path of the doc.
         """


### PR DESCRIPTION
Fix _output_filename for local connector, allowing single files to be written correctly to the disk

To test, try ingesting a local file and a local folder. Expected outputs below.

```
python unstructured/ingest/main.py --local-input-path /Users/ahmet/Downloads/sample_pdf.pdf \
--verbose --partition-strategy fast --reprocess \
--structured-output-dir ~/output_dir
2023-07-04 14:00:05,176 SpawnPoolWorker-1 INFO     Processing /Users/ahmet/Downloads/sample_pdf.pdf
2023-07-04 14:00:05,176 SpawnPoolWorker-1 DEBUG    Using local partition
2023-07-04 14:00:05,225 SpawnPoolWorker-1 INFO     Wrote /Users/ahmet/output_dir/sample_pdf.pdf.json
```

```
python unstructured/ingest/main.py --local-input-path /Users/ahmet/Downloads/sample_folder \ 
--verbose --partition-strategy fast --reprocess \
--structured-output-dir ~/output_dir
2023-07-04 14:00:18,409 SpawnPoolWorker-1 INFO     Processing /Users/ahmet/Downloads/sample_folder/sample_pdf1.pdf
2023-07-04 14:00:18,409 SpawnPoolWorker-1 DEBUG    Using local partition
2023-07-04 14:00:18,418 SpawnPoolWorker-2 INFO     Processing /Users/ahmet/Downloads/sample_folder/sample_pdf2.pdf
2023-07-04 14:00:18,418 SpawnPoolWorker-2 DEBUG    Using local partition
2023-07-04 14:00:18,456 SpawnPoolWorker-1 INFO     Wrote /Users/ahmet/output_dir/sample_pdf1.pdf.json
2023-07-04 14:00:18,466 SpawnPoolWorker-2 INFO     Wrote /Users/ahmet/output_dir/sample_pdf2.pdf.json
```