### PR TITLE
fix: validate encodings from email headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 0.7.13-dev0
+## 0.7.13-dev1
 
 ### Enhancements
 
 ### Features
 
 ### Fixes
+
+* Fix for cases where an invalid encoding is extracted from an email header.
 
 ## 0.7.12
 
@@ -28,7 +30,7 @@
 
 * More deterministic element ordering when using `hi_res` PDF parsing strategy (from unstructured-inference bump to 0.5.4)
 * Make large model available (from unstructured-inference bump to 0.5.3)
-* Combine inferred elements with extracted elements (from unstructured-inference bump to 0.5.2) 
+* Combine inferred elements with extracted elements (from unstructured-inference bump to 0.5.2)
 * `partition_email` and `partition_msg` will now process attachments if `process_attachments=True`
   and a attachment partitioning functions is passed through with `attachment_partitioner=partition`.
 

--- a/example-docs/eml/fake-email-malformed-encoding.eml
+++ b/example-docs/eml/fake-email-malformed-encoding.eml
@@ -1,0 +1,24 @@
+MIME-Version: 1.0
+Date: Fri, 16 Dec 2022 17:04:16 -0500
+Message-ID: <CADc-_xaLB2FeVQ7mNsoX+NJb_7hAJhBKa_zet-rtgPGenj0uVw@mail.gmail.com>
+Subject: Test Email
+From: Matthew Robinson <mrobinson@unstructured.io>
+To: Matthew Robinson <mrobinson@unstructured.io>
+Content-Type: multipart/alternative; boundary="00000000000095c9b205eff92630"
+
+--00000000000095c9b205eff92630
+Content-Type: text/plain; charset = "UTF-8"Content-Transfer-Encoding: 8bit
+
+This is a test email to use for unit tests.
+
+Important points:
+
+   - Roses are red
+   - Violets are blue
+
+--00000000000095c9b205eff92630
+Content-Type: text/html; charset = "UTF-8"Content-Transfer-Encoding: 8bit
+
+<div dir="ltr"><div>This is a test email to use for unit tests.</div><div><br></div><div>Important points:</div><div><ul><li>Roses are red</li><li>Violets are blue</li></ul></div></div>
+
+--00000000000095c9b205eff92630--

--- a/test_file.html
+++ b/test_file.html
@@ -1,1 +1,0 @@
-<h3 class="l_titel">Jahresabschluss zum Geschäftsjahr vom 01.01.2020 bis zum 31.12.2020</h3>

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -108,6 +108,13 @@ def test_partition_email_from_filename():
     assert elements == EXPECTED_OUTPUT
 
 
+def test_partition_email_from_filename_malformed_encoding():
+    filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "fake-email-malformed-encoding.eml")
+    elements = partition_email(filename=filename)
+    assert len(elements) > 0
+    assert elements == EXPECTED_OUTPUT
+
+
 @pytest.mark.parametrize(
     ("filename", "expected_output"),
     [

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.7.13-dev0"  # pragma: no cover
+__version__ = "0.7.13-dev1"  # pragma: no cover

--- a/unstructured/file_utils/encoding.py
+++ b/unstructured/file_utils/encoding.py
@@ -49,6 +49,15 @@ def format_encoding_str(encoding: str) -> str:
     return formatted_encoding
 
 
+def validate_encoding(encoding: str) -> bool:
+    """Checks if an encoding string is valid. Helps to avoid errors in cases where
+    invalid encodings are extracted from malformed documents."""
+    for common_encoding in COMMON_ENCODINGS:
+        if format_encoding_str(common_encoding) == format_encoding_str(encoding):
+            return True
+    return False
+
+
 def detect_file_encoding(
     filename: str = "",
     file: Optional[Union[bytes, IO]] = None,

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -12,6 +12,7 @@ from unstructured.file_utils.encoding import (
     COMMON_ENCODINGS,
     format_encoding_str,
     read_txt_file,
+    validate_encoding,
 )
 from unstructured.partition.common import (
     convert_to_bytes,
@@ -208,7 +209,7 @@ def parse_email(
     encoding = None
     charsets = msg.get_charsets() or []
     for charset in charsets:
-        if charset and charset.strip():
+        if charset and charset.strip() and validate_encoding(charset):
             encoding = charset
             break
 


### PR DESCRIPTION
### Summary

Closes #848. Adds validation to the encoding extracted from email headers to avoid errors if the email is malformed. In the case where the encoding is invalid, the encoding is detected instead of using the extracted encoding.

### Testing

Using the email from the issue that caused the error. This should work now. On `main` it raises and error.

```python
from unstructured.partition.email import partition_email

filename = "2017-11-02 180015 cf4101f1b3.eml"
elements = partition_email(filename=filename)
```