### PR TITLE
Don't instantiate an element with a coordinate system when there isn't a way to get its location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Fixed `auto` strategy detected scanned document as having extractable text and using `fast` strategy, resulting in no output.
 * Fix list detection in MS Word documents.
+* Don't instantiate an element with a coordinate system when there isn't a way to get its location data.
 
 ## 0.8.0
 

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -8,6 +8,8 @@ from enum import Enum
 from functools import wraps
 from typing import IO, TYPE_CHECKING, Callable, List, Optional
 
+from unstructured_inference.inference.layoutelement import LocationlessLayoutElement
+
 from unstructured.documents.coordinates import PixelSpace
 from unstructured.documents.elements import Element, PageBreak
 from unstructured.file_utils.encoding import detect_file_encoding, format_encoding_str
@@ -451,7 +453,7 @@ def document_to_element_list(
     for i, page in enumerate(document.pages):
         page_elements: List[Element] = []
         for layout_element in page.elements:
-            if hasattr(page, "image"):
+            if hasattr(page, "image") and not isinstance(layout_element, LocationlessLayoutElement):
                 image_format = page.image.format
                 coordinate_system = PixelSpace(width=page.image.width, height=page.image.height)
             else:


### PR DESCRIPTION
https://github.com/Unstructured-IO/unstructured/pull/827 introduced an optional `CoordinatesMetadata` for each Element. As a safeguard, its constructor raises a ValueError on attempts to instantiate it with coordinate points and no coordinate system, or vice versa.

As a result, the following code raises a ValueError:
```
s.environ["UNSTRUCTURED_HI_RES_MODEL_NAME"] = "chipper"
os.environ["UNSTRUCTURED_HF_TOKEN"] = "redacted"
from unstructured.partition.auto import partition
filename = "/path/to/chevron-page.pdf"
elements = partition(filename=filename, strategy="hi_res") 
```

In `unstructured_inference`, `process_file_with_model` returns a `PageLayout` object that has an image attribute. Therefore, the unstructured library resolves a coordinate system here:
https://github.com/Unstructured-IO/unstructured/blob/b3936893b89743bfdf011e97e08074fbea5966ce/unstructured/file_utils/filetype.py#L456

But then `document_to_element_list` proceeds to call `normalize_layout_element` with `layout_element` being a LocationlessLayoutElement, so this library calls the Text constructor with a coordinate system but no points and the ValueError is raised when attempting to instantiate CoordinatesMetadata.

If we don’t have a way of getting the location data for the elements (as is the case in the code snippet above), we don’t need a coordinate system either. This PR does not resolve a coordinate system when a page's element does not have its bounding box coordinates.