### PR TITLE
Don't instantiate an element with a coordinate system when there isn't a way to get its location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fixed `auto` strategy detected scanned document as having extractable text and using `fast` strategy, resulting in no output.
 * Fix list detection in MS Word documents.
+* Don't instantiate an element with a coordinate system when there isn't a way to get its location data.
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.1-dev1
+## 0.8.1-dev2
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.1-dev1"  # pragma: no cover
+__version__ = "0.8.1-dev2"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -451,7 +451,7 @@ def document_to_element_list(
     for i, page in enumerate(document.pages):
         page_elements: List[Element] = []
         for layout_element in page.elements:
-            if hasattr(page, "image"):
+            if hasattr(page, "image") and hasattr(layout_element, "coordinates"):
                 image_format = page.image.format
                 coordinate_system = PixelSpace(width=page.image.width, height=page.image.height)
             else:

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -326,12 +326,16 @@ def _process_pdfminer_pages(
                 _text = clean_extra_whitespace(_text)
                 if _text.strip():
                     text_segments.append(_text)
-                    element = element_from_text(_text)
                     coordinate_system = PixelSpace(
                         width=width,
                         height=height,
                     )
                     points = ((x1, y1), (x1, y2), (x2, y2), (x2, y1))
+                    element = element_from_text(
+                        _text,
+                        coordinates=points,
+                        coordinate_system=coordinate_system,
+                    )
                     coordinates_metadata = CoordinatesMetadata(
                         points=points,
                         system=coordinate_system,

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -1,7 +1,8 @@
 import re
-from typing import IO, Callable, List, Optional
+from typing import IO, Callable, List, Optional, Tuple
 
 from unstructured.cleaners.core import clean_bullets, group_broken_paragraphs
+from unstructured.documents.coordinates import CoordinateSystem
 from unstructured.documents.elements import (
     Address,
     Element,
@@ -143,14 +144,26 @@ def partition_text(
     return elements
 
 
-def element_from_text(text: str) -> Element:
+def element_from_text(
+    text: str,
+    coordinates: Optional[Tuple[Tuple[float, float], ...]] = None,
+    coordinate_system: Optional[CoordinateSystem] = None,
+) -> Element:
     if is_bulleted_text(text):
-        return ListItem(text=clean_bullets(text))
+        return ListItem(
+            text=clean_bullets(text),
+            coordinates=coordinates,
+            coordinate_system=coordinate_system,
+        )
     elif is_us_city_state_zip(text):
-        return Address(text=text)
+        return Address(text=text, coordinates=coordinates, coordinate_system=coordinate_system)
     elif is_possible_narrative_text(text):
-        return NarrativeText(text=text)
+        return NarrativeText(
+            text=text,
+            coordinates=coordinates,
+            coordinate_system=coordinate_system,
+        )
     elif is_possible_title(text):
-        return Title(text=text)
+        return Title(text=text, coordinates=coordinates, coordinate_system=coordinate_system)
     else:
-        return Text(text=text)
+        return Text(text=text, coordinates=coordinates, coordinate_system=coordinate_system)


### PR DESCRIPTION
https://github.com/Unstructured-IO/unstructured/pull/827 introduced an optional CoordinatesMetadata for each Element. As a safeguard, its constructor raises a ValueError on attempts to instantiate it with coordinate points and no coordinate system, or vice versa.

As a result, the following code raises a ValueError:

```
s.environ["UNSTRUCTURED_HI_RES_MODEL_NAME"] = "chipper"
os.environ["UNSTRUCTURED_HF_TOKEN"] = "redacted"
from unstructured.partition.auto import partition
filename = "/path/to/chevron-page.pdf"
elements = partition(filename=filename, strategy="hi_res") 
```

It goes through this code path:
In unstructured_inference, `process_file_with_model` returns a PageLayout object that has an image attribute. Therefore, the unstructured library resolves a coordinate system here:
https://github.com/Unstructured-IO/unstructured/blob/b3936893b89743bfdf011e97e08074fbea5966ce/unstructured/file_utils/filetype.py#L456

But then `document_to_element_list` proceeds to call `normalize_layout_element` with layout_element being a LocationlessLayoutElement, so this library calls the Text constructor with a coordinate system but no points and the ValueError is raised when attempting to instantiate CoordinatesMetadata.

If we don’t have a way of getting the location data for the elements (as is the case in the code snippet above), we don’t need a coordinate system either. This PR does not resolve a coordinate system when a page's element does not have its bounding box coordinates.