### PR TITLE
docs: update table and API documentation

### DIFF
--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -753,27 +753,56 @@ You can disable ``max_partition`` by setting it to ``None``.
 ``partition_via_api`` allows users to partition documents using the hosted Unstructured API.
 The API partitions documents using the automatic ``partition`` function. Currently, the API
 supports all filetypes except for RTF and EPUBs.
-To use another URL for the API use the ``api_url`` kwarg. This is helpful if you're hosting
+This is helpful if you're hosting
 the API yourself or running it locally through a container. You can pass in your API key
 using the ``api_key`` kwarg. You can use the ``content_type`` kwarg to pass in the MIME
 type for the file. If you do not explicitly pass it, the MIME type will be inferred.
 
-See `here <https://api.unstructured.io/general/docs>`_ for the hosted API swagger documentation
-and `here <https://github.com/Unstructured-IO/unstructured-api#dizzy-instructions-for-using-the-docker-image>`_ for
-documentation on how to run the API as a container locally.
-
-Examples:
 
 .. code:: python
 
   from unstructured.partition.api import partition_via_api
 
-  filename = "example-docs/fake-email.eml"
+  filename = "example-docs/eml/fake-email.eml"
 
   elements = partition_via_api(filename=filename, api_key="MY_API_KEY", content_type="message/rfc822")
 
   with open(filename, "rb") as f:
     elements = partition_via_api(file=f, file_filename=filename, api_key="MY_API_KEY")
+
+
+You can pass additional settings such as ``strategy``, ``ocr_languages`` and ``encoding`` to the
+API through optional ``request_kwargs``. These options get added to the request body when the
+API is called.
+See `the API documentation <https://api.unstructured.io/general/docs>`_ for a full list of
+settings supported by the API.
+
+.. code:: python
+
+  from unstructured.partition.api import partition_via_api
+
+  filename = "example-docs/DA-1p.pdf"
+
+  elements = partition_via_api(
+    filename=filename, api_key=api_key, strategy="auto", pdf_infer_table_structure="true"
+  )
+
+If you are self-hosting or running the API locally, you can use the ``api_url`` kwarg
+to point the ``partition_via_api`` function at your self-hosted or local API.
+See `here <https://github.com/Unstructured-IO/unstructured-api#dizzy-instructions-for-using-the-docker-image>`_ for
+documentation on how to run the API as a container locally.
+
+
+.. code:: python
+
+  from unstructured.partition.api import partition_via_api
+
+  filename = "example-docs/eml/fake-email.eml"
+
+  elements = partition_via_api(
+    filename=filename, api_url="http://localhost:5000/general/v0/general"
+  )
+
 
 
 ``partition_xlsx``

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -751,8 +751,7 @@ You can disable ``max_partition`` by setting it to ``None``.
 ---------------------
 
 ``partition_via_api`` allows users to partition documents using the hosted Unstructured API.
-The API partitions documents using the automatic ``partition`` function. Currently, the API
-supports all filetypes except for RTF and EPUBs.
+The API partitions documents using the automatic ``partition`` function.
 This is helpful if you're hosting
 the API yourself or running it locally through a container. You can pass in your API key
 using the ``api_key`` kwarg. You can use the ``content_type`` kwarg to pass in the MIME

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -771,7 +771,7 @@ type for the file. If you do not explicitly pass it, the MIME type will be infer
 
 
 You can pass additional settings such as ``strategy``, ``ocr_languages`` and ``encoding`` to the
-API through optional ``request_kwargs``. These options get added to the request body when the
+API through optional kwargs. These options get added to the request body when the
 API is called.
 See `the API documentation <https://api.unstructured.io/general/docs>`_ for a full list of
 settings supported by the API.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -82,7 +82,6 @@ Different partitioning functions use different methods for determining the eleme
 Document elements have a ``str`` representation. You can print them using the snippet below.
 
 
-
 .. code:: python
 
 	elements = partition(filename="example-10k.html")
@@ -109,6 +108,43 @@ The following code shows how you can limit your output to only narrative text wi
 	        print(element)
 	        print("\n")
 
+
+######
+Tables
+######
+
+For ``Table`` elements, the raw text of the table will be stored in the ``text`` attribute for the Element, and HTML representation
+of the table will be available in the element metadat under ``element.metadata.text_as_html``. For most documents where
+table extraction is available, the ``partition`` function will extract tables automatically if they are present.
+For PDFs and images, table extraction requires a relatively expensive call to a table recognition model, and so for those
+document types table extraction is an option you need to enable. If you would like to extract tables for PDFs or images,
+pass in ``infer_table_structured=True``. Here is an example:
+
+.. code:: python
+
+    from unstructured.partition.pdf import partition_pdf
+
+    filename = "example-docs/layout-parser-paper.pdf"
+
+    elements = partition_pdf(filename=filename, infer_table_structure=True)
+    tables = [el for el in elements if el.category == "Table"]
+
+    print(tables[0].text)
+    print(tables[0].metadata.text_as_html)
+
+The text will look like this:
+
+
+.. code:: python
+
+	Dataset Base Model1 Large Model Notes PubLayNet [38] F / M M Layouts of modern scientific documents PRImA [3] M - Layouts of scanned modern magazines and scientific reports Newspaper [17] F - Layouts of scanned US newspapers from the 20th century TableBank [18] F F Table region on modern scientific and business document HJDataset [31] F / M - Layouts of history Japanese documents
+
+
+And the ``text_as_html`` metadata will look like this:
+
+.. code:: html
+
+	<table><thead><th>Dataset</th><th>| Base Model’</th><th>| Notes</th></thead><tr><td>PubLayNet</td><td>[38] F/M</td><td>Layouts of modern scientific documents</td></tr><tr><td>PRImA [3]</td><td>M</td><td>Layouts of scanned modern magazines and scientific reports</td></tr><tr><td>Newspaper</td><td>F</td><td>Layouts of scanned US newspapers from the 20th century</td></tr><tr><td>TableBank</td><td>F</td><td>Table region on modern scientific and business document</td></tr><tr><td>HJDataset [31]</td><td>F/M</td><td>Layouts of history Japanese documents</td></tr></table>
 
 ####################
 Serializing Elements

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -114,7 +114,7 @@ Tables
 ######
 
 For ``Table`` elements, the raw text of the table will be stored in the ``text`` attribute for the Element, and HTML representation
-of the table will be available in the element metadat under ``element.metadata.text_as_html``. For most documents where
+of the table will be available in the element metadata under ``element.metadata.text_as_html``. For most documents where
 table extraction is available, the ``partition`` function will extract tables automatically if they are present.
 For PDFs and images, table extraction requires a relatively expensive call to a table recognition model, and so for those
 document types table extraction is an option you need to enable. If you would like to extract tables for PDFs or images,


### PR DESCRIPTION
### Summary

Closes #693. Adds more detailed documentation on `partition_via_api` and table extraction capabilities.