### PR TITLE
Kravetsmic/866 add document date for remaining file types

### DIFF
--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -98,7 +98,7 @@ def test_partition_csv_from_file_metadata_date(
     mocked_last_modification_date = "2029-07-05T09:24:28"
 
     mocker.patch(
-        "unstructured.partition.csv.get_last_modifile_date_from_file",
+        "unstructured.partition.csv.get_last_modified_date_from_file",
         return_value=mocked_last_modification_date,
     )
 
@@ -118,7 +118,7 @@ def test_partition_csv_from_file_custom_metadata_date(
     expected_last_modification_date = "2020-07-05T09:24:28"
 
     mocker.patch(
-        "unstructured.partition.csv.get_last_modifile_date_from_file",
+        "unstructured.partition.csv.get_last_modified_date_from_file",
         return_value=mocked_last_modification_date,
     )
 
@@ -130,7 +130,7 @@ def test_partition_csv_from_file_custom_metadata_date(
     assert elements[0].metadata.date == expected_last_modification_date
 
 
-def test_partition_csv_from_file_with_not_metadata(
+def test_partition_csv_from_file_without_metadata(
     mocker,
     filename="example-docs/stanley-cups.csv",
 ):

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -63,7 +63,6 @@ def test_partition_csv_metadata_date(mocker, filename="example-docs/stanley-cups
     )
     elements = partition_csv(filename=filename)
 
-    print(elements[0].metadata.date)
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
     assert isinstance(elements[0], Table)
     assert elements[0].metadata.date == mocked_last_modification_date

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -1,3 +1,5 @@
+from tempfile import SpooledTemporaryFile
+
 from test_unstructured.partition.test_constants import EXPECTED_TABLE, EXPECTED_TEXT
 from unstructured.cleaners.core import clean_extra_whitespace
 from unstructured.documents.elements import Table
@@ -68,7 +70,8 @@ def test_partition_csv_metadata_date(mocker, filename="example-docs/stanley-cups
 
 
 def test_partition_csv_custom_metadata_date(
-    mocker, filename="example-docs/stanley-cups.csv"
+    mocker,
+    filename="example-docs/stanley-cups.csv",
 ):
     mocked_last_modification_date = "2029-07-05T09:24:28"
     expected_last_modification_date = "2020-07-05T09:24:28"
@@ -79,7 +82,8 @@ def test_partition_csv_custom_metadata_date(
     )
 
     elements = partition_csv(
-        filename=filename, metadata_date=expected_last_modification_date
+        filename=filename,
+        metadata_date=expected_last_modification_date,
     )
 
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
@@ -88,12 +92,14 @@ def test_partition_csv_custom_metadata_date(
 
 
 def test_partition_csv_from_file_metadata_date(
-    mocker, filename="example-docs/stanley-cups.csv",
+    mocker,
+    filename="example-docs/stanley-cups.csv",
 ):
     mocked_last_modification_date = "2029-07-05T09:24:28"
 
     mocker.patch(
-        "unstructured.partition.csv.get_last_modifile_date_from_file", return_value=mocked_last_modification_date
+        "unstructured.partition.csv.get_last_modifile_date_from_file",
+        return_value=mocked_last_modification_date,
     )
 
     with open(filename, "rb") as f:
@@ -105,15 +111,16 @@ def test_partition_csv_from_file_metadata_date(
 
 
 def test_partition_csv_from_file_custom_metadata_date(
-    mocker, filename="example-docs/stanley-cups.csv",
+    mocker,
+    filename="example-docs/stanley-cups.csv",
 ):
     mocked_last_modification_date = "2029-07-05T09:24:28"
     expected_last_modification_date = "2020-07-05T09:24:28"
 
     mocker.patch(
-        "unstructured.partition.csv.get_last_modifile_date_from_file", return_value=mocked_last_modification_date
+        "unstructured.partition.csv.get_last_modifile_date_from_file",
+        return_value=mocked_last_modification_date,
     )
-
 
     with open(filename, "rb") as f:
         elements = partition_csv(file=f, metadata_date=expected_last_modification_date)
@@ -121,3 +128,20 @@ def test_partition_csv_from_file_custom_metadata_date(
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
     assert isinstance(elements[0], Table)
     assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_csv_from_file_with_not_metadata(
+    mocker,
+    filename="example-docs/stanley-cups.csv",
+):
+    """Test partition_csv() with file that are not possible to get last modified date"""
+
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_csv(file=sf)
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert isinstance(elements[0], Table)
+    assert elements[0].metadata.date == None

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -51,3 +51,73 @@ def test_partition_csv_can_exclude_metadata(filename="example-docs/stanley-cups.
     assert elements[0].metadata.text_as_html is None
     assert elements[0].metadata.filetype is None
     assert elements[0].metadata.filename is None
+
+
+def test_partition_csv_metadata_date(mocker, filename="example-docs/stanley-cups.csv"):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    mocker.patch(
+        "unstructured.partition.csv.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+    elements = partition_csv(filename=filename)
+
+    print(elements[0].metadata.date)
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert isinstance(elements[0], Table)
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_csv_custom_metadata_date(
+    mocker, filename="example-docs/stanley-cups.csv"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.csv.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_csv(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert isinstance(elements[0], Table)
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_csv_from_file_metadata_date(
+    mocker, filename="example-docs/stanley-cups.csv",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.csv.get_last_modifile_date_from_file", return_value=mocked_last_modification_date
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_csv(file=f)
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert isinstance(elements[0], Table)
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_csv_from_file_custom_metadata_date(
+    mocker, filename="example-docs/stanley-cups.csv",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.csv.get_last_modifile_date_from_file", return_value=mocked_last_modification_date
+    )
+
+
+    with open(filename, "rb") as f:
+        elements = partition_csv(file=f, metadata_date=expected_last_modification_date)
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert isinstance(elements[0], Table)
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -1,7 +1,9 @@
 import os
+from tempfile import SpooledTemporaryFile
 
 import docx
 import pytest
+
 
 from unstructured.documents.elements import (
     Address,
@@ -32,7 +34,9 @@ def mock_document():
     # NOTE(robinson) - this should get dropped because it is empty
     document.add_paragraph("", style="Normal")
     # NOTE(robinson) - this should get picked up as a narrative text
-    document.add_paragraph("This is my first thought. This is my second thought.", style="Normal")
+    document.add_paragraph(
+        "This is my first thought. This is my second thought.", style="Normal"
+    )
     document.add_paragraph("This is my third thought.", style="Body Text")
     # NOTE(robinson) - this should just be regular text
     document.add_paragraph("2023")
@@ -166,3 +170,86 @@ def test_partition_doc_from_filename_exclude_metadata(mock_document, tmpdir):
     assert elements[0].metadata.filetype is None
     assert elements[0].metadata.page_name is None
     assert elements[0].metadata.filename is None
+
+
+def test_partition_doc_metadata_date(
+    mocker,
+    filename="example-docs/fake.doc",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.doc.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_doc(filename=filename)
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_doc_metadata_date_with_custom_metadata(
+    mocker,
+    filename="example-docs/fake.doc",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modified_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.doc.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_doc(
+        filename=filename, metadata_date=expected_last_modified_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modified_date
+
+
+def test_partition_doc_from_file_metadata_date(
+    mocker,
+    filename="example-docs/fake.doc",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.doc.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_doc(file=f)
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_doc_from_file_metadata_date_with_custom_metadata(
+    mocker,
+    filename="example-docs/fake.doc",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modified_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.doc.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+    with open(filename, "rb") as f:
+        elements = partition_doc(file=f, metadata_date=expected_last_modified_date)
+
+    assert elements[0].metadata.date == expected_last_modified_date
+
+
+def test_partition_doc_from_file_without_metadata_date(
+    filename="example-docs/fake.doc",
+):
+    """Test partition_doc() with file that are not possible to get last modified date"""
+
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_doc(file=sf)
+
+    assert elements[0].metadata.date == None

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -1,4 +1,5 @@
 import os
+from tempfile import SpooledTemporaryFile
 
 import docx
 import pytest
@@ -80,7 +81,6 @@ def test_partition_docx_with_spooled_file(mock_document, expected_elements, tmpd
     filename = os.path.join(tmpdir.dirname, "mock_document.docx")
     mock_document.save(filename)
 
-    from tempfile import SpooledTemporaryFile
 
     with open(filename, "rb") as test_file:
         spooled_temp_file = SpooledTemporaryFile()
@@ -202,3 +202,85 @@ def test_partition_docx_from_file_exclude_metadata(mock_document, tmpdir):
     assert elements[0].metadata.filetype is None
     assert elements[0].metadata.page_name is None
     assert elements[0].metadata.filename is None
+
+def test_partition_docx_metadata_date(
+    mocker,
+    filename="example-docs/fake.docx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.docx.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_docx(filename=filename)
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_docx_metadata_date_with_custom_metadata(
+    mocker,
+    filename="example-docs/fake.docx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modified_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.docx.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_docx(
+        filename=filename, metadata_date=expected_last_modified_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modified_date
+
+
+def test_partition_docx_from_file_metadata_date(
+    mocker,
+    filename="example-docs/fake.docx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.docx.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_docx(file=f)
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_docx_from_file_metadata_date_with_custom_metadata(
+    mocker,
+    filename="example-docs/fake.docx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modified_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.docx.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+    with open(filename, "rb") as f:
+        elements = partition_docx(file=f, metadata_date=expected_last_modified_date)
+
+    assert elements[0].metadata.date == expected_last_modified_date
+
+
+def test_partition_docx_from_file_without_metadata_date(
+    filename="example-docs/fake.docx",
+):
+    """Test partition_docx() with file that are not possible to get last modified date"""
+
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_docx(file=sf)
+
+    assert elements[0].metadata.date == None

--- a/test_unstructured/partition/test_epub.py
+++ b/test_unstructured/partition/test_epub.py
@@ -58,12 +58,12 @@ def test_partition_epub_from_file_exlcude_metadata():
     assert elements[0].metadata.filename is None
 
 
-
-
-def test_partition_epub_metadata_date(mocker, filename="example-docs/winter-sports.epub"):
+def test_partition_epub_metadata_date(
+    mocker, filename="example-docs/winter-sports.epub"
+):
     mocked_last_modification_date = "2029-07-05T09:24:28"
     mocker.patch(
-        "unstructured.partition.epub.get_last_modified_date",
+        "unstructured.partition.html.get_last_modified_date",
         return_value=mocked_last_modification_date,
     )
     elements = partition_epub(filename=filename)
@@ -79,7 +79,7 @@ def test_partition_epub_custom_metadata_date(
     expected_last_modification_date = "2020-07-05T09:24:28"
 
     mocker.patch(
-        "unstructured.partition.epub.get_last_modified_date",
+        "unstructured.partition.html.get_last_modified_date",
         return_value=mocked_last_modification_date,
     )
 
@@ -87,7 +87,6 @@ def test_partition_epub_custom_metadata_date(
         filename=filename,
         metadata_date=expected_last_modification_date,
     )
-
 
     assert elements[0].metadata.date == expected_last_modification_date
 
@@ -99,7 +98,7 @@ def test_partition_epub_from_file_metadata_date(
     mocked_last_modification_date = "2029-07-05T09:24:28"
 
     mocker.patch(
-        "unstructured.partition.epub.get_last_modified_date_from_file",
+        "unstructured.partition.html.get_last_modified_date_from_file",
         return_value=mocked_last_modification_date,
     )
 
@@ -117,10 +116,10 @@ def test_partition_epub_from_file_custom_metadata_date(
     expected_last_modification_date = "2020-07-05T09:24:28"
 
     mocker.patch(
-        "unstructured.partition.epub.get_last_modified_date_from_file",
+        "unstructured.partition.html.get_last_modified_date_from_file",
         return_value=mocked_last_modification_date,
     )
-    
+
     with open(filename, "rb") as f:
         elements = partition_epub(file=f, metadata_date=expected_last_modification_date)
 

--- a/test_unstructured/partition/test_epub.py
+++ b/test_unstructured/partition/test_epub.py
@@ -56,3 +56,72 @@ def test_partition_epub_from_file_exlcude_metadata():
     assert elements[0].metadata.filetype is None
     assert elements[0].metadata.page_name is None
     assert elements[0].metadata.filename is None
+
+
+
+
+def test_partition_epub_metadata_date(mocker, filename="example-docs/winter-sports.epub"):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    mocker.patch(
+        "unstructured.partition.epub.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+    elements = partition_epub(filename=filename)
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_epub_custom_metadata_date(
+    mocker,
+    filename="example-docs/winter-sports.epub",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.epub.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_epub(
+        filename=filename,
+        metadata_date=expected_last_modification_date,
+    )
+
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_epub_from_file_metadata_date(
+    mocker,
+    filename="example-docs/winter-sports.epub",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.epub.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_epub(file=f)
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_epub_from_file_custom_metadata_date(
+    mocker,
+    filename="example-docs/winter-sports.epub",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.epub.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+    
+    with open(filename, "rb") as f:
+        elements = partition_epub(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -51,7 +51,11 @@ def test_partition_html_from_filename_raises_encoding_error(filename, encoding, 
 
 @pytest.mark.parametrize(
     "filename",
-    ["example-10k-utf-16.html", "example-steelJIS-datasheet-utf-16.html", "fake-html-lang-de.html"],
+    [
+        "example-10k-utf-16.html",
+        "example-steelJIS-datasheet-utf-16.html",
+        "fake-html-lang-de.html",
+    ],
 )
 def test_partition_html_from_filename_default_encoding(filename):
     filename_path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
@@ -114,7 +118,11 @@ def test_partition_html_from_file_raises_encoding_error(filename, encoding, erro
 
 @pytest.mark.parametrize(
     "filename",
-    ["example-10k-utf-16.html", "example-steelJIS-datasheet-utf-16.html", "fake-html-lang-de.html"],
+    [
+        "example-10k-utf-16.html",
+        "example-steelJIS-datasheet-utf-16.html",
+        "fake-html-lang-de.html",
+    ],
 )
 def test_partition_html_from_file_default_encoding(filename):
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
@@ -141,7 +149,11 @@ def test_partition_html_from_file_rb_raises_encoding_error(filename, encoding, e
 
 @pytest.mark.parametrize(
     "filename",
-    ["example-10k-utf-16.html", "example-steelJIS-datasheet-utf-16.html", "fake-html-lang-de.html"],
+    [
+        "example-10k-utf-16.html",
+        "example-steelJIS-datasheet-utf-16.html",
+        "fake-html-lang-de.html",
+    ],
 )
 def test_partition_html_from_file_rb_default_encoding(filename):
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
@@ -177,7 +189,9 @@ def test_partition_html_from_url():
     with open(filename) as f:
         text = f.read()
 
-    response = MockResponse(text=text, status_code=200, headers={"Content-Type": "text/html"})
+    response = MockResponse(
+        text=text, status_code=200, headers={"Content-Type": "text/html"}
+    )
     with patch.object(requests, "get", return_value=response) as _:
         elements = partition_html(url="https://fake.url")
 
@@ -189,7 +203,9 @@ def test_partition_html_from_url_raises_with_bad_status_code():
     with open(filename) as f:
         text = f.read()
 
-    response = MockResponse(text=text, status_code=500, headers={"Content-Type": "text/html"})
+    response = MockResponse(
+        text=text, status_code=500, headers={"Content-Type": "text/html"}
+    )
     with patch.object(requests, "get", return_value=response) as _:
         with pytest.raises(ValueError):
             partition_html(url="https://fake.url")
@@ -216,9 +232,7 @@ def test_partition_from_url_uses_headers(mocker):
 
     response = Response()
     response.status_code = 200
-    response._content = (
-        b"<html><head></head><body><p>What do i know? Who needs to know it?</p></body></html>"
-    )
+    response._content = b"<html><head></head><body><p>What do i know? Who needs to know it?</p></body></html>"
     response.headers = {"Content-Type": "text/html"}
 
     mock_get = mocker.patch("requests.get", return_value=response)
@@ -252,7 +266,9 @@ def test_partition_html_on_ideas_page():
 
 
 def test_user_without_file_write_permission_can_partition_html(tmp_path, monkeypatch):
-    example_filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-10k.html")
+    example_filename = os.path.join(
+        DIRECTORY, "..", "..", "example-docs", "example-10k.html"
+    )
 
     # create a file with no write permissions
     read_only_file = tmp_path / "example-10k-readonly.html"
@@ -319,3 +335,91 @@ def test_partition_html_from_filename_exclude_metadata():
     assert "PageBreak" not in [elem.category for elem in elements]
     assert elements[0].metadata.filename is None
     assert elements[0].metadata.file_directory is None
+
+
+def test_partition_html_metadata_date(mocker, filename="example-docs/fake-html.html"):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+    elements = partition_html(filename=filename)
+
+    assert isinstance(elements[0], Title)
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_html_from_file_metadata_date(
+    mocker, filename="example-docs/fake-html.html"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modifile_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename) as f:
+        elements = partition_html(file=f)
+
+    assert isinstance(elements[0], Title)
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_html_custom_metadata_date(
+    mocker, filename="example-docs/fake-html.html"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_html(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert isinstance(elements[0], Title)
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_html_from_file_custom_metadata_date(
+    mocker, filename="example-docs/fake-html.html"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modifile_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename) as f:
+        elements = partition_html(file=f, metadata_date=expected_last_modification_date)
+
+    assert isinstance(elements[0], Title)
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_html_from_text_metadata_date(filename="example-docs/fake-html.html"):
+    elements = partition_html(text="<html><div><p>TEST</p></div></html>")
+
+    assert isinstance(elements[0], Title)
+    assert elements[0].metadata.date is None
+
+
+def test_partition_html_from_text_custom_metadata_date(
+    filename="example-docs/fake-html.html",
+):
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    elements = partition_html(
+        text="<html><div><p>TEST</p></div></html>",
+        metadata_date=expected_last_modification_date,
+    )
+
+    assert isinstance(elements[0], Title)
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -356,7 +356,7 @@ def test_partition_html_from_file_metadata_date(
     mocked_last_modification_date = "2029-07-05T09:24:28"
 
     mocker.patch(
-        "unstructured.partition.html.get_last_modifile_date_from_file",
+        "unstructured.partition.html.get_last_modified_date_from_file",
         return_value=mocked_last_modification_date,
     )
 
@@ -393,7 +393,7 @@ def test_partition_html_from_file_custom_metadata_date(
     expected_last_modification_date = "2020-07-05T09:24:28"
 
     mocker.patch(
-        "unstructured.partition.html.get_last_modifile_date_from_file",
+        "unstructured.partition.html.get_last_modified_date_from_file",
         return_value=mocked_last_modification_date,
     )
 

--- a/test_unstructured/partition/test_image.py
+++ b/test_unstructured/partition/test_image.py
@@ -39,7 +39,9 @@ def mock_successful_post(url, **kwargs):
         "pages": [
             {
                 "number": 0,
-                "elements": [{"type": "Title", "text": "Charlie Brown and the Great Pumpkin"}],
+                "elements": [
+                    {"type": "Title", "text": "Charlie Brown and the Great Pumpkin"}
+                ],
             },
             {
                 "number": 1,
@@ -93,7 +95,9 @@ def test_partition_image_local(monkeypatch, filename, file):
         lambda *args, **kwargs: MockDocumentLayout(),
     )
 
-    partition_image_response = pdf._partition_pdf_or_image_local(filename, file, is_image=True)
+    partition_image_response = pdf._partition_pdf_or_image_local(
+        filename, file, is_image=True
+    )
     assert partition_image_response[0].text == "Charlie Brown and the Great Pumpkin"
 
 
@@ -103,35 +107,53 @@ def test_partition_image_local_raises_with_no_filename():
         pdf._partition_pdf_or_image_local(filename="", file=None, is_image=True)
 
 
-def test_partition_image_with_auto_strategy(filename="example-docs/layout-parser-paper-fast.jpg"):
+def test_partition_image_with_auto_strategy(
+    filename="example-docs/layout-parser-paper-fast.jpg",
+):
     elements = image.partition_image(filename=filename, strategy="auto")
-    titles = [el for el in elements if el.category == "Title" and len(el.text.split(" ")) > 10]
+    titles = [
+        el for el in elements if el.category == "Title" and len(el.text.split(" ")) > 10
+    ]
     title = "LayoutParser: A Unified Toolkit for Deep Learning Based Document Image Analysis"
     assert titles[0].text == title
 
 
 def test_partition_image_with_language_passed(filename="example-docs/example.jpg"):
-    with mock.patch.object(layout, "process_file_with_model", mock.MagicMock()) as mock_partition:
-        image.partition_image(filename=filename, strategy="hi_res", ocr_languages="eng+swe")
+    with mock.patch.object(
+        layout, "process_file_with_model", mock.MagicMock()
+    ) as mock_partition:
+        image.partition_image(
+            filename=filename, strategy="hi_res", ocr_languages="eng+swe"
+        )
 
     assert mock_partition.call_args.kwargs.get("ocr_languages") == "eng+swe"
 
 
-def test_partition_image_from_file_with_language_passed(filename="example-docs/example.jpg"):
-    with mock.patch.object(layout, "process_data_with_model", mock.MagicMock()) as mock_partition:
+def test_partition_image_from_file_with_language_passed(
+    filename="example-docs/example.jpg",
+):
+    with mock.patch.object(
+        layout, "process_data_with_model", mock.MagicMock()
+    ) as mock_partition:
         with open(filename, "rb") as f:
             image.partition_image(file=f, strategy="hi_res", ocr_languages="eng+swe")
 
     assert mock_partition.call_args.kwargs.get("ocr_languages") == "eng+swe"
 
 
-def test_partition_image_raises_with_invalid_language(filename="example-docs/example.jpg"):
+def test_partition_image_raises_with_invalid_language(
+    filename="example-docs/example.jpg",
+):
     with pytest.raises(TesseractError):
-        image.partition_image(filename=filename, strategy="hi_res", ocr_languages="fakeroo")
+        image.partition_image(
+            filename=filename, strategy="hi_res", ocr_languages="fakeroo"
+        )
 
 
 def test_partition_image_with_ocr_detects_korean():
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "english-and-korean.png")
+    filename = os.path.join(
+        DIRECTORY, "..", "..", "example-docs", "english-and-korean.png"
+    )
     elements = image.partition_image(
         filename=filename,
         ocr_languages="eng+kor",
@@ -143,7 +165,9 @@ def test_partition_image_with_ocr_detects_korean():
 
 
 def test_partition_image_with_ocr_detects_korean_from_file():
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "english-and-korean.png")
+    filename = os.path.join(
+        DIRECTORY, "..", "..", "example-docs", "english-and-korean.png"
+    )
 
     with open(filename, "rb") as f:
         elements = image.partition_image(
@@ -157,6 +181,135 @@ def test_partition_image_with_ocr_detects_korean_from_file():
 
 
 def test_partition_image_raises_with_bad_strategy():
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "english-and-korean.png")
+    filename = os.path.join(
+        DIRECTORY, "..", "..", "example-docs", "english-and-korean.png"
+    )
     with pytest.raises(ValueError):
         image.partition_image(filename=filename, strategy="fakeroo")
+
+
+def test_partition_image_metadata_date(
+    mocker, filename="example-docs/english-and-korean.png"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+    elements = image.partition_image(filename=filename)
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_image_with_hi_res_strategy_metadata_date(
+    mocker, filename="example-docs/english-and-korean.png"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+    elements = image.partition_image(filename=filename, stratefy="hi_res")
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_image_metadata_date_custom_metadata_date(
+    mocker, filename="example-docs/english-and-korean.png"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2009-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+    elements = image.partition_image(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_image_with_hi_res_strategy_metadata_date_custom_metadata_date(
+    mocker, filename="example-docs/english-and-korean.png"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2009-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+    elements = image.partition_image(
+        filename=filename,
+        stratefy="hi_res",
+        metadata_date=expected_last_modification_date,
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_image_from_file_metadata_date(
+    mocker, filename="example-docs/english-and-korean.png"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+    with open(filename, "rb") as f:
+        elements = image.partition_image(file=f)
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_image_from_file_with_hi_res_strategy_metadata_date(
+    mocker, filename="example-docs/english-and-korean.png"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = image.partition_image(file=f, stratefy="hi_res")
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_image_from_file_metadata_date_custom_metadata_date(
+    mocker, filename="example-docs/english-and-korean.png"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2009-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+    with open(filename, "rb") as f:
+        elements = image.partition_image(
+            file=f, metadata_date=expected_last_modification_date
+        )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_image_from_file_with_hi_res_strategy_metadata_date_custom_metadata_date(
+    mocker, filename="example-docs/english-and-korean.png"
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2009-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+    with open(filename, "rb") as f:
+        elements = image.partition_image(
+            file=f, metadata_date=expected_last_modification_date, stratefy="hi_res"
+        )
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -20,7 +20,9 @@ test_files = [
     "eml/fake-email.eml",
     pytest.param(
         "fake-power-point.ppt",
-        marks=pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container"),
+        marks=pytest.mark.skipif(
+            is_in_docker, reason="Skipping this test in Docker container"
+        ),
     ),
     "fake.docx",
     "fake-power-point.pptx",
@@ -204,3 +206,108 @@ def test_partition_json_from_text_exclude_metadata(filename: str):
 
     for i in range(len(test_elements)):
         assert any(test_elements[i].metadata.to_dict()) is False
+
+
+########################
+
+
+def test_partition_json_metadata_date(
+    mocker,
+    filename="example-docs/spring-weather.html.json",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    # expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.json.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_json(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_json_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/spring-weather.html.json",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.json.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_json(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_json_from_file_metadata_date(
+    mocker,
+    filename="example-docs/spring-weather.html.json",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    # expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.json.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_json(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_json_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/spring-weather.html.json",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.json.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_json(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_json_from_text_metadata_date(
+    filename="example-docs/spring-weather.html.json",
+):
+    with open(filename) as f:
+        text = f.read()
+
+    elements = partition_json(
+        text=text,
+    )
+
+    assert elements[0].metadata.date is None
+
+
+def test_partition_json_from_text_with_custom_metadata_date(
+    filename="example-docs/spring-weather.html.json",
+):
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    with open(filename) as f:
+        text = f.read()
+
+    elements = partition_json(text=text, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -208,15 +208,11 @@ def test_partition_json_from_text_exclude_metadata(filename: str):
         assert any(test_elements[i].metadata.to_dict()) is False
 
 
-########################
-
-
 def test_partition_json_metadata_date(
     mocker,
     filename="example-docs/spring-weather.html.json",
 ):
     mocked_last_modification_date = "2029-07-05T09:24:28"
-    # expected_last_modification_date = "2020-07-05T09:24:28"
 
     mocker.patch(
         "unstructured.partition.json.get_last_modified_date",
@@ -254,7 +250,6 @@ def test_partition_json_from_file_metadata_date(
     filename="example-docs/spring-weather.html.json",
 ):
     mocked_last_modification_date = "2029-07-05T09:24:28"
-    # expected_last_modification_date = "2020-07-05T09:24:28"
 
     mocker.patch(
         "unstructured.partition.json.get_last_modified_date_from_file",

--- a/test_unstructured/partition/test_md.py
+++ b/test_unstructured/partition/test_md.py
@@ -68,7 +68,9 @@ def test_partition_md_from_url():
     with open(filename) as f:
         text = f.read()
 
-    response = MockResponse(text=text, status_code=200, headers={"Content-Type": "text/markdown"})
+    response = MockResponse(
+        text=text, status_code=200, headers={"Content-Type": "text/markdown"}
+    )
     with patch.object(requests, "get", return_value=response) as _:
         elements = partition_md(url="https://fake.url")
 
@@ -82,7 +84,9 @@ def test_partition_md_from_url_raises_with_bad_status_code():
     with open(filename) as f:
         text = f.read()
 
-    response = MockResponse(text=text, status_code=500, headers={"Content-Type": "text/html"})
+    response = MockResponse(
+        text=text, status_code=500, headers={"Content-Type": "text/html"}
+    )
     with patch.object(requests, "get", return_value=response) as _:
         with pytest.raises(ValueError):
             partition_md(url="https://fake.url")
@@ -139,3 +143,103 @@ def test_partition_md_from_text_exclude_metadata():
     elements = partition_md(text=text, include_metadata=False)
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+
+def test_partition_md_metadata_date(
+    mocker,
+    filename="example-docs/README.md",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.md.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_md(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_md_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/README.md",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.md.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_md(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_md_from_file_metadata_date(
+    mocker,
+    filename="example-docs/README.md",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.md.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_md(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_md_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/README.md",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.md.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_md(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_md_from_text_metadata_date(
+    filename="example-docs/README.md",
+):
+    with open(filename) as f:
+        text = f.read()
+
+    elements = partition_md(
+        text=text,
+    )
+
+    assert elements[0].metadata.date is None
+
+
+def test_partition_md_from_text_with_custom_metadata_date(
+    filename="example-docs/README.md",
+):
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    with open(filename) as f:
+        text = f.read()
+
+    elements = partition_md(text=text, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_odt.py
+++ b/test_unstructured/partition/test_odt.py
@@ -53,3 +53,76 @@ def test_partition_odt_from_file_exclude_metadata():
 
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+def test_partition_odt_metadata_date(
+    mocker,
+    filename="example-docs/fake.odt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.odt.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_odt(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_odt_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake.odt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.odt.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_odt(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_odt_from_file_metadata_date(
+    mocker,
+    filename="example-docs/fake.odt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.odt.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_odt(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_odt_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake.odt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.odt.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_odt(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_org.py
+++ b/test_unstructured/partition/test_org.py
@@ -45,3 +45,76 @@ def test_partition_org_from_file_exclude_metadata(filename="example-docs/README.
 
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+def test_partition_org_metadata_date(
+    mocker,
+    filename="example-docs/README.org",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_org(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_org_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/README.org",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_org(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_org_from_file_metadata_date(
+    mocker,
+    filename="example-docs/README.org",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_org(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_org_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/README.org",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_org(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -479,10 +479,6 @@ def test_partition_pdf_with_fast_strategy_from_file_exclude_metadata(
         assert elements[i].metadata.to_dict() == {}
 
 
-#######################################
-#######################################
-
-
 def test_partition_pdf_with_auto_strategy_metadata_date(
     mocker,
     filename="example-docs/copy-protected.pdf",

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -134,7 +134,9 @@ def test_partition_pdf_with_model_name_env_var(
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     monkeypatch.setattr(pdf, "extractable_elements", lambda *args, **kwargs: [])
-    with mock.patch.object(layout, "process_file_with_model", mock.MagicMock()) as mock_process:
+    with mock.patch.object(
+        layout, "process_file_with_model", mock.MagicMock()
+    ) as mock_process:
         pdf.partition_pdf(filename=filename, strategy="hi_res")
         mock_process.assert_called_once_with(
             filename,
@@ -150,7 +152,9 @@ def test_partition_pdf_with_model_name(
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     monkeypatch.setattr(pdf, "extractable_elements", lambda *args, **kwargs: [])
-    with mock.patch.object(layout, "process_file_with_model", mock.MagicMock()) as mock_process:
+    with mock.patch.object(
+        layout, "process_file_with_model", mock.MagicMock()
+    ) as mock_process:
         pdf.partition_pdf(filename=filename, strategy="hi_res", model_name="checkbox")
         mock_process.assert_called_once_with(
             filename,
@@ -165,7 +169,9 @@ def test_partition_pdf_with_auto_strategy(
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     elements = pdf.partition_pdf(filename=filename, strategy="auto")
-    title = "LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis"
+    title = (
+        "LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis"
+    )
     assert elements[0].text == title
     assert elements[0].metadata.filename == "layout-parser-paper-fast.pdf"
     assert elements[0].metadata.file_directory == "example-docs"
@@ -346,12 +352,16 @@ def test_partition_pdf_uses_table_extraction():
 def test_partition_pdf_with_copy_protection():
     filename = os.path.join("example-docs", "copy-protected.pdf")
     elements = pdf.partition_pdf(filename=filename, strategy="hi_res")
-    elements[0] == Title("LayoutParser: A Uniﬁed Toolkit for Deep Based Document Image Analysis")
+    elements[0] == Title(
+        "LayoutParser: A Uniﬁed Toolkit for Deep Based Document Image Analysis"
+    )
     # check that the pdf has multiple different page numbers
     assert {element.metadata.page_number for element in elements} == {1, 2}
 
 
-def test_partition_pdf_requiring_recursive_text_grab(filename="example-docs/reliance.pdf"):
+def test_partition_pdf_requiring_recursive_text_grab(
+    filename="example-docs/reliance.pdf",
+):
     elements = pdf.partition_pdf(filename=filename, strategy="fast")
     assert len(elements) > 50
     assert elements[0].metadata.page_number == 1
@@ -397,7 +407,9 @@ def test_partition_pdf_fast_groups_text_in_text_box():
             system=expected_coordinate_system_0,
         ),
     )
-    assert elements[0] == Title("eastern mediterranean", metadata=expected_elem_metadata_0)
+    assert elements[0] == Title(
+        "eastern mediterranean", metadata=expected_elem_metadata_0
+    )
     assert isinstance(elements[1], NarrativeText)
     assert str(elements[1]).startswith("We")
     assert str(elements[1]).endswith("Jordan and Egypt.")
@@ -435,7 +447,9 @@ def test_partition_pdf_with_fast_strategy_from_file_with_metadata_filename(
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     with open(filename, "rb") as f:
-        elements = pdf.partition_pdf(file=f, url=None, strategy="fast", metadata_filename="test")
+        elements = pdf.partition_pdf(
+            file=f, url=None, strategy="fast", metadata_filename="test"
+        )
     for element in elements:
         assert element.metadata.filename == "test"
 
@@ -443,8 +457,12 @@ def test_partition_pdf_with_fast_strategy_from_file_with_metadata_filename(
 def test_partition_pdf_with_auto_strategy_exclude_metadata(
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):
-    elements = pdf.partition_pdf(filename=filename, strategy="auto", include_metadata=False)
-    title = "LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis"
+    elements = pdf.partition_pdf(
+        filename=filename, strategy="auto", include_metadata=False
+    )
+    title = (
+        "LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis"
+    )
     assert elements[0].text == title
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
@@ -454,6 +472,236 @@ def test_partition_pdf_with_fast_strategy_from_file_exclude_metadata(
     filename="example-docs/layout-parser-paper-fast.pdf",
 ):
     with open(filename, "rb") as f:
-        elements = pdf.partition_pdf(file=f, url=None, strategy="fast", include_metadata=False)
+        elements = pdf.partition_pdf(
+            file=f, url=None, strategy="fast", include_metadata=False
+        )
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+
+#######################################
+#######################################
+
+
+def test_partition_pdf_with_auto_strategy_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = pdf.partition_pdf(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_pdf_with_auto_strategy_custom_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = pdf.partition_pdf(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_pdf_with_orc_only_strategy_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = pdf.partition_pdf(filename=filename, strategy="ocr_only")
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_pdf_with_ocr_only_strategy_custom_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = pdf.partition_pdf(
+        filename=filename,
+        metadata_date=expected_last_modification_date,
+        strategy="ocr_only",
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_pdf_with_hi_res_strategy_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = pdf.partition_pdf(filename=filename, strategy="hi_res")
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_pdf_with_hi_res_strategy_custom_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = pdf.partition_pdf(
+        filename=filename,
+        metadata_date=expected_last_modification_date,
+        strategy="hi_res",
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_pdf_from_file_with_auto_strategy_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = pdf.partition_pdf(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_pdf_from_file_with_auto_strategy_custom_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = pdf.partition_pdf(
+            file=f, metadata_date=expected_last_modification_date
+        )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_pdf_from_file_with_ocr_only_strategy_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = pdf.partition_pdf(file=f, strategy="ocr_only")
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_pdf_from_file_with_ocr_only_strategy_custom_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = pdf.partition_pdf(
+            file=f, metadata_date=expected_last_modification_date, strategy="ocr_only"
+        )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_pdf_from_file_with_hi_res_strategy_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = pdf.partition_pdf(file=f, strategy="hi_res")
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_pdf_from_file_with_hi_res_strategy_custom_metadata_date(
+    mocker,
+    filename="example-docs/copy-protected.pdf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = pdf.partition_pdf(
+            file=f, metadata_date=expected_last_modification_date, strategy="hi_res"
+        )
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_ppt.py
+++ b/test_unstructured/partition/test_ppt.py
@@ -81,3 +81,77 @@ def test_partition_ppt_from_file_exclude_metadata():
         elements = partition_ppt(file=f, include_metadata=False)
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+
+def test_partition_ppt_metadata_date(
+    mocker,
+    filename="example-docs/fake-power-point.ppt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.ppt.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_ppt(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_ppt_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake-power-point.ppt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.ppt.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_ppt(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_ppt_from_file_metadata_date(
+    mocker,
+    filename="example-docs/fake-power-point.ppt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.ppt.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_ppt(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_ppt_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake-power-point.ppt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.ppt.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_ppt(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_pptx.py
+++ b/test_unstructured/partition/test_pptx.py
@@ -205,7 +205,9 @@ EXPECTED_HTML_TABLE = """<table>
 </table>"""
 
 
-def test_partition_pptx_grabs_tables(filename="example-docs/fake-power-point-table.pptx"):
+def test_partition_pptx_grabs_tables(
+    filename="example-docs/fake-power-point-table.pptx",
+):
     elements = partition_pptx(filename=filename)
 
     assert elements[1].text.startswith("Column 1")
@@ -245,3 +247,77 @@ def test_partition_pptx_from_file_exclude_metadata():
     with open(filename, "rb") as f:
         elements = partition_pptx(file=f, include_metadata=False)
     assert elements == EXPECTED_PPTX_OUTPUT
+
+
+def test_partition_pptx_metadata_date(
+    mocker,
+    filename="example-docs/fake-power-point-malformed.pptx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pptx.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_pptx(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_pptx_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake-power-point-malformed.pptx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pptx.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_pptx(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_pptx_from_file_metadata_date(
+    mocker,
+    filename="example-docs/fake-power-point-malformed.pptx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pptx.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_pptx(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_pptx_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake-power-point-malformed.pptx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.pptx.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_pptx(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_rst.py
+++ b/test_unstructured/partition/test_rst.py
@@ -10,7 +10,9 @@ def test_partition_rst_from_filename(filename="example-docs/README.rst"):
         assert element.metadata.filename == "README.rst"
 
 
-def test_partition_rst_from_filename_with_metadata_filename(filename="example-docs/README.rst"):
+def test_partition_rst_from_filename_with_metadata_filename(
+    filename="example-docs/README.rst",
+):
     elements = partition_rst(filename=filename, metadata_filename="test")
     assert all(element.metadata.filename == "test" for element in elements)
 
@@ -24,7 +26,9 @@ def test_partition_rst_from_file(filename="example-docs/README.rst"):
         assert element.metadata.filename is None
 
 
-def test_partition_rst_from_file_with_metadata_filename(filename="example-docs/README.rst"):
+def test_partition_rst_from_file_with_metadata_filename(
+    filename="example-docs/README.rst",
+):
     with open(filename, "rb") as f:
         elements = partition_rst(file=f, metadata_filename="test")
     assert elements[0] == Title("Example Docs")
@@ -32,7 +36,9 @@ def test_partition_rst_from_file_with_metadata_filename(filename="example-docs/R
         assert element.metadata.filename == "test"
 
 
-def test_partition_rst_from_filename_exclude_metadata(filename="example-docs/README.rst"):
+def test_partition_rst_from_filename_exclude_metadata(
+    filename="example-docs/README.rst",
+):
     elements = partition_rst(filename=filename, include_metadata=False)
 
     for i in range(len(elements)):
@@ -45,3 +51,77 @@ def test_partition_rst_from_file_exclude_metadata(filename="example-docs/README.
 
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+
+def test_partition_rst_metadata_date(
+    mocker,
+    filename="example-docs/README.rst",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_rst(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_rst_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/README.rst",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_rst(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_rst_from_file_metadata_date(
+    mocker,
+    filename="example-docs/README.rst",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_rst(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_rst_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/README.rst",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_rst(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_rtf.py
+++ b/test_unstructured/partition/test_rtf.py
@@ -55,3 +55,76 @@ def test_partition_rtf_from_file_exclude_metadata():
         elements = partition_rtf(file=f, include_metadata=False)
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+def test_partition_rtf_metadata_date(
+    mocker,
+    filename="example-docs/fake-doc.rtf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_rtf(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_rtf_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake-doc.rtf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_rtf(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_rtf_from_file_metadata_date(
+    mocker,
+    filename="example-docs/fake-doc.rtf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_rtf(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_rtf_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake-doc.rtf",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_rtf(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -21,7 +21,11 @@ EXPECTED_OUTPUT = [
 
 @pytest.mark.parametrize(
     ("filename", "encoding"),
-    [("fake-text.txt", "utf-8"), ("fake-text.txt", None), ("fake-text-utf-16-be.txt", "utf-16-be")],
+    [
+        ("fake-text.txt", "utf-8"),
+        ("fake-text.txt", None),
+        ("fake-text-utf-16-be.txt", "utf-16-be"),
+    ],
 )
 def test_partition_text_from_filename(filename, encoding):
     filename_path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
@@ -34,7 +38,9 @@ def test_partition_text_from_filename(filename, encoding):
 
 def test_partition_text_from_filename_with_metadata_filename():
     filename_path = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
-    elements = partition_text(filename=filename_path, encoding="utf-8", metadata_filename="test")
+    elements = partition_text(
+        filename=filename_path, encoding="utf-8", metadata_filename="test"
+    )
     assert elements == EXPECTED_OUTPUT
     for element in elements:
         assert element.metadata.filename == "test"
@@ -211,11 +217,17 @@ def test_partition_text_doesnt_get_page_breaks():
 
 @pytest.mark.parametrize(
     ("filename", "encoding"),
-    [("fake-text.txt", "utf-8"), ("fake-text.txt", None), ("fake-text-utf-16-be.txt", "utf-16-be")],
+    [
+        ("fake-text.txt", "utf-8"),
+        ("fake-text.txt", None),
+        ("fake-text-utf-16-be.txt", "utf-16-be"),
+    ],
 )
 def test_partition_text_from_filename_exclude_metadata(filename, encoding):
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-    elements = partition_text(filename=filename, encoding=encoding, include_metadata=False)
+    elements = partition_text(
+        filename=filename, encoding=encoding, include_metadata=False
+    )
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
 
@@ -226,3 +238,102 @@ def test_partition_text_from_file_exclude_metadata():
         elements = partition_text(file=f, include_metadata=False)
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+
+def test_partition_text_metadata_date(
+    mocker,
+    filename="example-docs/fake-text.txt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.text.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_text(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_text_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake-text.txt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.text.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_text(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_text_from_file_metadata_date(
+    mocker,
+    filename="example-docs/fake-text.txt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.text.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_text(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_text_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/fake-text.txt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.text.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_text(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_text_from_text_metadata_date(
+    filename="example-docs/fake-text.txt",
+):
+    with open(filename) as f:
+        text = f.read()
+
+    elements = partition_text(
+        text=text,
+    )
+    assert elements[0].metadata.date == None
+
+
+def test_partition_text_from_file_with_custom_metadata_date(
+    filename="example-docs/fake-text.txt",
+):
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    with open(filename) as f:
+        text = f.read()
+
+    elements = partition_text(text=text, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_tsv.py
+++ b/test_unstructured/partition/test_tsv.py
@@ -38,7 +38,9 @@ def test_partition_tsv_from_file(filename="example-docs/stanley-cups.tsv"):
         assert element.metadata.filename is None
 
 
-def test_partition_tsv_from_file_with_metadata_filename(filename="example-docs/stanley-cups.tsv"):
+def test_partition_tsv_from_file_with_metadata_filename(
+    filename="example-docs/stanley-cups.tsv",
+):
     with open(filename, "rb") as f:
         elements = partition_tsv(file=f, metadata_filename="test")
 
@@ -47,7 +49,9 @@ def test_partition_tsv_from_file_with_metadata_filename(filename="example-docs/s
         assert element.metadata.filename == "test"
 
 
-def test_partition_tsv_filename_exclude_metadata(filename="example-docs/stanley-cups.tsv"):
+def test_partition_tsv_filename_exclude_metadata(
+    filename="example-docs/stanley-cups.tsv",
+):
     elements = partition_tsv(filename=filename, include_metadata=False)
 
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
@@ -58,9 +62,85 @@ def test_partition_tsv_filename_exclude_metadata(filename="example-docs/stanley-
         assert element.metadata.filename is None
 
 
-def test_partition_tsv_from_file_exclude_metadata(filename="example-docs/stanley-cups.tsv"):
+def test_partition_tsv_from_file_exclude_metadata(
+    filename="example-docs/stanley-cups.tsv",
+):
     with open(filename, "rb") as f:
         elements = partition_tsv(file=f, include_metadata=False)
 
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+
+def test_partition_tsv_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.tsv",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.tsv.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_tsv(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_tsv_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.tsv",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.tsv.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_tsv(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_tsv_from_file_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.tsv",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.tsv.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_tsv(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_tsv_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.tsv",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.tsv.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_tsv(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_xlsx.py
+++ b/test_unstructured/partition/test_xlsx.py
@@ -82,3 +82,77 @@ def test_partition_xlsx_from_file_exclude_metadata(filename="example-docs/stanle
     assert elements[0].metadata.filetype is None
     assert elements[0].metadata.page_name is None
     assert elements[0].metadata.filename is None
+
+
+def test_partition_xlsx_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.xlsx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.xlsx.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_xlsx(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_xlsx_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.xlsx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.xlsx.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_xlsx(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_xlsx_from_file_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.xlsx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.xlsx.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_xlsx(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_xlsx_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.xlsx",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.xlsx.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_xlsx(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/test_unstructured/partition/test_xml_partition.py
+++ b/test_unstructured/partition/test_xml_partition.py
@@ -156,3 +156,77 @@ def test_partition_xml_from_file_exclude_metadata(filename):
     assert elements[0].text == "United States"
     for i in range(len(elements)):
         assert elements[i].metadata.to_dict() == {}
+
+
+def test_partition_xml_metadata_date(
+    mocker,
+    filename="example-docs/factbook.xml",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.xml.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_xml(
+        filename=filename,
+    )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_xml_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/factbook.xml",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.xml.get_last_modified_date",
+        return_value=mocked_last_modification_date,
+    )
+
+    elements = partition_xml(
+        filename=filename, metadata_date=expected_last_modification_date
+    )
+
+    assert elements[0].metadata.date == expected_last_modification_date
+
+
+def test_partition_xml_from_file_metadata_date(
+    mocker,
+    filename="example-docs/factbook.xml",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.xml.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_xml(
+            file=f,
+        )
+
+    assert elements[0].metadata.date == mocked_last_modification_date
+
+
+def test_partition_xml_from_file_with_custom_metadata_date(
+    mocker,
+    filename="example-docs/factbook.xml",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    expected_last_modification_date = "2020-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.xml.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_xml(file=f, metadata_date=expected_last_modification_date)
+
+    assert elements[0].metadata.date == expected_last_modification_date

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -500,8 +500,6 @@ def document_to_element_list(
             element = normalize_layout_element(
                 layout_element, coordinate_system=coordinate_system
             )
-            if last_modification_date:
-                element.metadata.date = last_modification_date
             if isinstance(element, List):
                 for el in element:
                     if last_modification_date:

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -504,10 +504,14 @@ def document_to_element_list(
                 element.metadata.date = last_modification_date
             if isinstance(element, List):
                 for el in element:
+                    if last_modification_date:
+                        el.metadata.date = last_modification_date
                     el.metadata.page_number = i + 1
                 page_elements.extend(element)
                 continue
             else:
+                if last_modification_date:
+                    element.metadata.date = last_modification_date
                 element.metadata.text_as_html = (
                     layout_element.text_as_html
                     if hasattr(layout_element, "text_as_html")

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -37,7 +37,7 @@ def get_last_modified_date(filename: str) -> str:
     return modify_date
 
 
-def get_last_modifile_date_from_file(
+def get_last_modified_date_from_file(
     file: Union[IO, SpooledTemporaryFile]
 ) -> Union[str, None]:
     filename = file.name

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -51,6 +51,7 @@ def normalize_layout_element(
     layout_element: Union[
         "LayoutElement", "LocationlessLayoutElement", Element, Dict[str, Any]
     ],
+    coordinate_system: Optional[CoordinateSystem] = None,
 ) -> Union[Element, List[Element]]:
     """Converts an unstructured_inference LayoutElement object to an unstructured Element."""
 

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import os
+from datetime import datetime
 
 import subprocess
 from io import BufferedReader, BytesIO, TextIOWrapper
@@ -29,9 +31,22 @@ if TYPE_CHECKING:
     )
 
 
+def get_last_modified_date(filename: str) -> str:
+    modify_date = datetime.fromtimestamp(os.path.getmtime(filename))
+    modify_date = modify_date.strftime("%Y-%m-%dT%H:%M:%S%z")
+    return modify_date
+
+
+def get_last_modifile_date_from_file(file: Union[IO, SpooledTemporaryFile]) -> str:
+    filename = file.name
+    modify_date = get_last_modified_date(filename)
+    return modify_date
+
+
 def normalize_layout_element(
-    layout_element: Union["LayoutElement", "LocationlessLayoutElement", Element, Dict[str, Any]],
-    coordinate_system: Optional[CoordinateSystem] = None,
+    layout_element: Union[
+        "LayoutElement", "LocationlessLayoutElement", Element, Dict[str, Any]
+    ],
 ) -> Union[Element, List[Element]]:
     """Converts an unstructured_inference LayoutElement object to an unstructured Element."""
 
@@ -66,11 +81,17 @@ def normalize_layout_element(
             coordinate_system=coordinate_system,
         )
     elif element_type == "Checked":
-        return CheckBox(checked=True, coordinates=coordinates, coordinate_system=coordinate_system)
+        return CheckBox(
+            checked=True, coordinates=coordinates, coordinate_system=coordinate_system
+        )
     elif element_type == "Unchecked":
-        return CheckBox(checked=False, coordinates=coordinates, coordinate_system=coordinate_system)
+        return CheckBox(
+            checked=False, coordinates=coordinates, coordinate_system=coordinate_system
+        )
     else:
-        return Text(text=text, coordinates=coordinates, coordinate_system=coordinate_system)
+        return Text(
+            text=text, coordinates=coordinates, coordinate_system=coordinate_system
+        )
 
 
 def layout_list_to_list_items(

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -37,8 +37,12 @@ def get_last_modified_date(filename: str) -> str:
     return modify_date
 
 
-def get_last_modifile_date_from_file(file: Union[IO, SpooledTemporaryFile]) -> str:
+def get_last_modifile_date_from_file(
+    file: Union[IO, SpooledTemporaryFile]
+) -> Union[str, None]:
     filename = file.name
+    if not filename:
+        return
     modify_date = get_last_modified_date(filename)
     return modify_date
 

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -40,9 +40,14 @@ def get_last_modified_date(filename: str) -> str:
 def get_last_modified_date_from_file(
     file: Union[IO, SpooledTemporaryFile]
 ) -> Union[str, None]:
-    filename = file.name
+    try:
+        filename = file.name
+    except:
+        return
+
     if not filename:
         return
+
     modify_date = get_last_modified_date(filename)
     return modify_date
 

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -3,6 +3,7 @@ from typing import IO, BinaryIO, List, Optional, Union, cast
 
 import lxml.html
 import pandas as pd
+from datetime import datetime
 
 from unstructured.documents.elements import (
     Element,
@@ -11,7 +12,12 @@ from unstructured.documents.elements import (
     process_metadata,
 )
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.common import exactly_one, spooled_to_bytes_io_if_needed
+from unstructured.partition.common import (
+    exactly_one,
+    spooled_to_bytes_io_if_needed,
+    get_last_modified_date,
+    get_last_modifile_date_from_file,
+)
 
 
 @process_metadata()
@@ -20,26 +26,39 @@ def partition_csv(
     filename: Optional[str] = None,
     file: Optional[Union[IO[bytes], SpooledTemporaryFile]] = None,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None,
     include_metadata: bool = True,
     **kwargs,
 ) -> List[Element]:
     """Partitions Microsoft Excel Documents in .csv format into its document elements.
 
-    Parameters
-    ----------
-    filename
-        A string defining the target filename path.
-    file
-        A file-like object using "rb" mode --> open(filename, "rb").
-    include_metadata
-        Determines whether or not metadata is included in the output.
+        Parameters
+        ----------
+        filename
+            A string defining the target filename path.
+        file
+            A file-like object using "rb" mode --> open(filename, "rb").
+    <<<<<<< HEAD
+    =======
+        metadata_filename
+            The filename to use for the metadata.
+        metadata_date
+            The last modified date for the document.
+    >>>>>>> feat: add date field to metadata from csv file
+        include_metadata
+            Determines whether or not metadata is included in the output.
     """
     exactly_one(filename=filename, file=file)
 
     if filename:
         table = pd.read_csv(filename)
+        last_modification_date = get_last_modified_date(filename)
+
     else:
-        f = spooled_to_bytes_io_if_needed(cast(Union[BinaryIO, SpooledTemporaryFile], file))
+        last_modification_date = get_last_modifile_date_from_file(file)
+        f = spooled_to_bytes_io_if_needed(
+            cast(Union[BinaryIO, SpooledTemporaryFile], file)
+        )
         table = pd.read_csv(f)
 
     html_text = table.to_html(index=False, header=False, na_rep="")
@@ -49,6 +68,7 @@ def partition_csv(
         metadata = ElementMetadata(
             text_as_html=html_text,
             filename=metadata_filename or filename,
+            date=metadata_date if metadata_date else last_modification_date,
         )
     else:
         metadata = ElementMetadata()

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -68,7 +68,7 @@ def partition_csv(
         metadata = ElementMetadata(
             text_as_html=html_text,
             filename=metadata_filename or filename,
-            date=metadata_date if metadata_date else last_modification_date,
+            date=metadata_date or last_modification_date,
         )
     else:
         metadata = ElementMetadata()

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -16,7 +16,7 @@ from unstructured.partition.common import (
     exactly_one,
     spooled_to_bytes_io_if_needed,
     get_last_modified_date,
-    get_last_modifile_date_from_file,
+    get_last_modified_date_from_file,
 )
 
 
@@ -55,7 +55,7 @@ def partition_csv(
         last_modification_date = get_last_modified_date(filename)
 
     else:
-        last_modification_date = get_last_modifile_date_from_file(file)
+        last_modification_date = get_last_modified_date_from_file(file)
         f = spooled_to_bytes_io_if_needed(
             cast(Union[BinaryIO, SpooledTemporaryFile], file)
         )

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -67,7 +67,7 @@ def partition_doc(
             metadata_filename=metadata_filename,
             include_page_breaks=include_page_breaks,
             include_metadata=include_metadata,
-            metadata_date=metadata_date if metadata_date else last_modification_date,
+            metadata_date=metadata_date or last_modification_date,
         )
         # remove tmp.name from filename if parsing file
         if file:

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -42,12 +42,13 @@ def partition_doc(
     exactly_one(filename=filename, file=file)
 
     if len(filename) > 0:
-        last_modification_date = get_last_modified_date(filename)
-
         _, filename_no_path = os.path.split(os.path.abspath(filename))
         base_filename, _ = os.path.splitext(filename_no_path)
         if not os.path.exists(filename):
             raise ValueError(f"The file {filename} does not exist.")
+        
+        last_modification_date = get_last_modified_date(filename)
+
     elif file is not None:
         tmp = tempfile.NamedTemporaryFile(delete=False)
         tmp.write(file.read())

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -173,7 +173,7 @@ def partition_docx(
                     text_as_html=html_table,
                     filename=metadata_filename,
                     page_number=page_number,
-                    date=metadata_date if metadata_date else last_modification_date,
+                    date=metadata_date or last_modification_date,
 
                 )
                 elements.append(element)
@@ -187,7 +187,7 @@ def partition_docx(
                 para_element.metadata = ElementMetadata(
                     filename=metadata_filename,
                     page_number=page_number,
-                    date=metadata_date if metadata_date else last_modification_date,
+                    date=metadata_date or last_modification_date,
 
                 )
                 elements.append(para_element)

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -315,6 +315,7 @@ def convert_and_partition_docx(
     file: Optional[IO[bytes]] = None,
     include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None
 ) -> List[Element]:
     """Converts a document to DOCX and then partitions it using partition_html. Works with
     any file format support by pandoc.
@@ -361,6 +362,7 @@ def convert_and_partition_docx(
             filename=docx_filename,
             metadata_filename=metadata_filename,
             include_metadata=include_metadata,
+            metadata_date=metadata_date
         )
 
     return elements

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -1,8 +1,13 @@
 from typing import IO, List, Optional
+from datetime import datetime
 
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.html import convert_and_partition_html
+from unstructured.partition.common import (
+    get_last_modified_date,
+    get_last_modified_date_from_file,
+)
 
 
 @process_metadata()
@@ -13,6 +18,7 @@ def partition_epub(
     include_page_breaks: bool = False,
     include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions an EPUB document. The document is first converted to HTML and then
@@ -25,12 +31,22 @@ def partition_epub(
     file
         A file-like object using "rb" mode --> open(filename, "rb").
     include_page_breaks
-        If True, the output will include page breaks if the filetype supports it.
+        If True, the output will include page breaks if the filetype supports it
+    metadata_date
+        The last modified date for the document.
+
     """
+    last_modification_date = None
+    if filename:
+        last_modification_date = get_last_modified_date(filename)
+    elif file:
+        last_modification_date = get_last_modified_date_from_file(file)
+
     return convert_and_partition_html(
         source_format="epub",
         filename=filename,
         file=file,
         include_page_breaks=include_page_breaks,
         metadata_filename=metadata_filename,
+        last_modication_date=metadata_date if metadata_date else last_modification_date,
     )

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -36,17 +36,11 @@ def partition_epub(
         The last modified date for the document.
 
     """
-    last_modification_date = None
-    if filename:
-        last_modification_date = get_last_modified_date(filename)
-    elif file:
-        last_modification_date = get_last_modified_date_from_file(file)
-
     return convert_and_partition_html(
         source_format="epub",
         filename=filename,
         file=file,
         include_page_breaks=include_page_breaks,
         metadata_filename=metadata_filename,
-        last_modication_date=metadata_date if metadata_date else last_modification_date,
+        metadata_date=metadata_date
     )

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -16,7 +16,7 @@ from unstructured.file_utils.filetype import (
 from unstructured.partition.common import (
     exactly_one,
     get_last_modified_date,
-    get_last_modifile_date_from_file,
+    get_last_modified_date_from_file,
 )
 
 
@@ -89,7 +89,7 @@ def partition_html(
         )
 
     elif file is not None:
-        last_modification_date = get_last_modifile_date_from_file(file)
+        last_modification_date = get_last_modified_date_from_file(file)
         _, file_text = read_txt_file(file=file, encoding=encoding)
         document = HTMLDocument.from_string(
             file_text,
@@ -131,6 +131,7 @@ def convert_and_partition_html(
     file: Optional[IO[bytes]] = None,
     include_page_breaks: bool = False,
     metadata_filename: Optional[str] = None,
+    last_modication_date: Optional[datetime] = None,
 ) -> List[Element]:
     """Converts a document to HTML and then partitions it using partition_html. Works with
     any file format support by pandoc.
@@ -147,6 +148,8 @@ def convert_and_partition_html(
         If True, the output will include page breaks if the filetype supports it.
     metadata_filename
         The filename to use in element metadata.
+    last_modication_date
+        The last modified date for the document.
     """
     html_text = convert_file_to_html_text(
         source_format=source_format, filename=filename, file=file
@@ -158,4 +161,5 @@ def convert_and_partition_html(
         include_page_breaks=include_page_breaks,
         encoding="unicode",
         metadata_filename=metadata_filename,
+        metadata_date=last_modication_date,
     )

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -131,7 +131,7 @@ def convert_and_partition_html(
     file: Optional[IO[bytes]] = None,
     include_page_breaks: bool = False,
     metadata_filename: Optional[str] = None,
-    last_modication_date: Optional[datetime] = None,
+    metadata_date: Optional[datetime] = None,
 ) -> List[Element]:
     """Converts a document to HTML and then partitions it using partition_html. Works with
     any file format support by pandoc.
@@ -151,6 +151,12 @@ def convert_and_partition_html(
     last_modication_date
         The last modified date for the document.
     """
+
+    last_modification_date = None
+    if filename:
+        last_modification_date = get_last_modified_date(filename)
+    elif file:
+        last_modification_date = get_last_modified_date_from_file(file)
     html_text = convert_file_to_html_text(
         source_format=source_format, filename=filename, file=file
     )
@@ -161,5 +167,5 @@ def convert_and_partition_html(
         include_page_breaks=include_page_breaks,
         encoding="unicode",
         metadata_filename=metadata_filename,
-        metadata_date=last_modication_date,
+        metadata_date=metadata_date if metadata_date else last_modification_date,
     )

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -119,9 +119,7 @@ def partition_html(
     return document_to_element_list(
         document,
         include_page_breaks=include_page_breaks,
-        last_modification_date=metadata_date
-        if metadata_date
-        else last_modification_date,
+        last_modification_date=metadata_date or last_modification_date,
     )
 
 
@@ -167,5 +165,5 @@ def convert_and_partition_html(
         include_page_breaks=include_page_breaks,
         encoding="unicode",
         metadata_filename=metadata_filename,
-        metadata_date=metadata_date if metadata_date else last_modification_date,
+        metadata_date=metadata_date or last_modification_date,
     )

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-
+from datetime import datetime
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.partition.common import exactly_one
 from unstructured.partition.pdf import partition_pdf_or_image
@@ -12,6 +12,7 @@ def partition_image(
     include_page_breaks: bool = False,
     ocr_languages: str = "eng",
     strategy: str = "auto",
+    metadata_date: Optional[datetime] = None,
     **kwargs,
 ) -> List[Element]:
     """Parses an image into a list of interpreted elements.
@@ -32,6 +33,9 @@ def partition_image(
         partition_image simply extracts the text from the document using OCR and processes it.
         The default strategy `auto` will determine when a image can be extracted using
         `ocr_only` mode, otherwise it will fall back to `hi_res`.
+    metadata_date
+        The last modified date for the document.
+
     """
     exactly_one(filename=filename, file=file)
 
@@ -42,4 +46,5 @@ def partition_image(
         include_page_breaks=include_page_breaks,
         ocr_languages=ocr_languages,
         strategy=strategy,
+        metadata_date=metadata_date,
     )

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -73,7 +73,7 @@ def partition_json(
         raise ValueError("Not a valid json")
 
     for element in elements:
-        element.metadata.date = metadata_date if metadata_date else last_modification_date
+        element.metadata.date = metadata_date or last_modification_date
     # NOTE(Nathan): in future PR, try extracting items that look like text
     #               if file_text is a valid json but not an unstructured json
 

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -41,14 +41,14 @@ def partition_json(
 
     exactly_one(filename=filename, file=file, text=text)
 
-    last_modified_date = None
+    last_modification_date = None
     if filename is not None:
-        last_modified_date = get_last_modified_date(filename)
+        last_modification_date = get_last_modified_date(filename)
         with open(filename, encoding="utf8") as f:
             file_text = f.read()
 
     elif file is not None:
-        last_modified_date = get_last_modified_date_from_file(file)
+        last_modification_date = get_last_modified_date_from_file(file)
 
         file_content = file.read()
         if isinstance(file_content, str):
@@ -71,7 +71,7 @@ def partition_json(
         raise ValueError("Not a valid json")
 
     for element in elements:
-        element.metadata.date = metadata_date if metadata_date else last_modified_date
+        element.metadata.date = metadata_date if metadata_date else last_modification_date
     # NOTE(Nathan): in future PR, try extracting items that look like text
     #               if file_text is a valid json but not an unstructured json
 

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -35,6 +35,8 @@ def partition_json(
         A file-like object as bytes --> open(filename, "rb").
     text
         The string representation of the .json document.
+    metadata_date
+        The last modified date for the document.
     """
     if text is not None and text.strip() == "" and not file and not filename:
         return []

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -1,11 +1,16 @@
 import json
+from datetime import datetime
 import re
 from typing import IO, List, Optional
 
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.nlp.patterns import LIST_OF_DICTS_PATTERN
-from unstructured.partition.common import exactly_one
+from unstructured.partition.common import (
+    exactly_one,
+    get_last_modified_date,
+    get_last_modified_date_from_file,
+)
 from unstructured.staging.base import dict_to_elements
 
 
@@ -17,6 +22,7 @@ def partition_json(
     text: Optional[str] = None,
     include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions an .json document into its constituent elements.
@@ -35,16 +41,22 @@ def partition_json(
 
     exactly_one(filename=filename, file=file, text=text)
 
+    last_modified_date = None
     if filename is not None:
+        last_modified_date = get_last_modified_date(filename)
         with open(filename, encoding="utf8") as f:
             file_text = f.read()
+
     elif file is not None:
+        last_modified_date = get_last_modified_date_from_file(file)
+
         file_content = file.read()
         if isinstance(file_content, str):
             file_text = file_content
         else:
             file_text = file_content.decode()
         file.seek(0)
+
     elif text is not None:
         file_text = str(text)
 
@@ -58,6 +70,8 @@ def partition_json(
     except json.JSONDecodeError:
         raise ValueError("Not a valid json")
 
+    for element in elements:
+        element.metadata.date = metadata_date if metadata_date else last_modified_date
     # NOTE(Nathan): in future PR, try extracting items that look like text
     #               if file_text is a valid json but not an unstructured json
 

--- a/unstructured/partition/md.py
+++ b/unstructured/partition/md.py
@@ -53,6 +53,8 @@ def partition_md(
         Determines whether or not metadata is included in the output.
     parser
         The parser to use for parsing the markdown document. If None, default parser will be used.
+    metadata_date
+        The last modified date for the document.
     """
     # Verify that only one of the arguments was provided
     if text is None:

--- a/unstructured/partition/md.py
+++ b/unstructured/partition/md.py
@@ -92,5 +92,5 @@ def partition_md(
         include_metadata=include_metadata,
         parser=parser,
         metadata_filename=metadata_filename,
-        metadata_date=metadata_date if metadata_date else last_modification_date,
+        metadata_date=metadata_date or last_modification_date,
     )

--- a/unstructured/partition/odt.py
+++ b/unstructured/partition/odt.py
@@ -40,5 +40,5 @@ def partition_odt(
         filename=filename,
         file=file,
         metadata_filename=metadata_filename,
-        metadata_date=metadata_date if metadata_date else last_modification_date
+        metadata_date=metadata_date or last_modification_date
     )

--- a/unstructured/partition/odt.py
+++ b/unstructured/partition/odt.py
@@ -1,8 +1,10 @@
 from typing import IO, List, Optional
+from datetime import datetime
 
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.docx import convert_and_partition_docx
+from unstructured.partition.common import get_last_modified_date, get_last_modified_date_from_file
 
 
 @process_metadata()
@@ -12,6 +14,7 @@ def partition_odt(
     file: Optional[IO[bytes]] = None,
     include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions Open Office Documents in .odt format into its document elements.
@@ -22,10 +25,20 @@ def partition_odt(
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
+    metadata_date
+        The last modified date for the document.
     """
+    
+    last_modification_date = None
+    if filename:
+        last_modification_date = get_last_modified_date(filename)
+    elif file:
+        last_modification_date = get_last_modified_date_from_file(file)
+
     return convert_and_partition_docx(
         source_format="odt",
         filename=filename,
         file=file,
         metadata_filename=metadata_filename,
+        metadata_date=metadata_date if metadata_date else last_modification_date
     )

--- a/unstructured/partition/org.py
+++ b/unstructured/partition/org.py
@@ -1,4 +1,5 @@
 from typing import IO, List, Optional
+from datetime import datetime
 
 from unstructured.documents.elements import Element
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
@@ -12,6 +13,7 @@ def partition_org(
     include_page_breaks: bool = False,
     include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None,
 ) -> List[Element]:
     """Partitions an org document. The document is first converted to HTML and then
     partitioned using partition_html.
@@ -24,6 +26,8 @@ def partition_org(
         A file-like object using "rb" mode --> open(filename, "rb").
     include_page_breaks
         If True, the output will include page breaks if the filetype supports it
+    metadata_date
+        The last modified date for the document.
     """
     return convert_and_partition_html(
         source_format="org",
@@ -31,4 +35,5 @@ def partition_org(
         file=file,
         include_page_breaks=include_page_breaks,
         metadata_filename=metadata_filename,
+        metadata_date=metadata_date,
     )

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -433,7 +433,7 @@ def _partition_pdf_or_image_with_ocr(
         else:
             text = pytesseract.image_to_string(filename, config=f"-l '{ocr_languages}'")
         elements = partition_text(
-            text=text, max_partition=max_partition, modification_date=metadata_date
+            text=text, max_partition=max_partition, metadata_date=metadata_date
         )
     else:
         elements = []

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -153,7 +153,7 @@ def partition_pdf_or_image(
             filename=filename,
             file=spooled_to_bytes_io_if_needed(file),
             include_page_breaks=include_page_breaks,
-            metadata_date=metadata_date if metadata_date else last_modification_date,
+            metadata_date=metadata_date or last_modification_date,
         )
         pdf_text_extractable = any(
             isinstance(el, Text) and el.text.strip() for el in extracted_elements
@@ -181,9 +181,7 @@ def partition_pdf_or_image(
                 infer_table_structure=infer_table_structure,
                 include_page_breaks=include_page_breaks,
                 ocr_languages=ocr_languages,
-                metadata_date=metadata_date
-                if metadata_date
-                else last_modification_date,
+                metadata_date=metadata_date or last_modification_date,
                 **kwargs,
             )
 
@@ -200,9 +198,7 @@ def partition_pdf_or_image(
                 ocr_languages=ocr_languages,
                 is_image=is_image,
                 max_partition=max_partition,
-                metadata_date=metadata_date
-                if metadata_date
-                else last_modification_date,
+                metadata_date=metadata_date or last_modification_date,
             )
 
 

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -67,7 +67,7 @@ def partition_ppt(
         elements = partition_pptx(
             filename=pptx_filename,
             metadata_filename=metadata_filename,
-            metadata_date=metadata_date if metadata_date else last_modification_date,
+            metadata_date=metadata_date or last_modification_date,
         )
 
     # remove tmp.name from filename if parsing file

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -1,10 +1,16 @@
 import os
 import tempfile
+from datetime import datetime
 from typing import IO, List, Optional
 
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.common import convert_office_doc, exactly_one
+from unstructured.partition.common import (
+    convert_office_doc,
+    exactly_one,
+    get_last_modified_date,
+    get_last_modified_date_from_file,
+)
 from unstructured.partition.pptx import partition_pptx
 
 
@@ -16,6 +22,7 @@ def partition_ppt(
     include_page_breaks: bool = False,
     include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions Microsoft PowerPoint Documents in .ppt format into their document elements.
@@ -28,18 +35,24 @@ def partition_ppt(
         A file-like object using "rb" mode --> open(filename, "rb").
     include_page_breaks
         If True, includes a PageBreak element between slides
+    metadata_date
+        The last modified date for the document.
     """
     # Verify that only one of the arguments was provided
     if filename is None:
         filename = ""
     exactly_one(filename=filename, file=file)
 
+    last_modification_date = None
     if len(filename) > 0:
         _, filename_no_path = os.path.split(os.path.abspath(filename))
         base_filename, _ = os.path.splitext(filename_no_path)
         if not os.path.exists(filename):
             raise ValueError(f"The file {filename} does not exist.")
+        last_modification_date = get_last_modified_date(filename)
+
     elif file is not None:
+        last_modification_date = get_last_modified_date_from_file(file)
         tmp = tempfile.NamedTemporaryFile(delete=False)
         tmp.write(file.read())
         tmp.close()
@@ -51,7 +64,11 @@ def partition_ppt(
     with tempfile.TemporaryDirectory() as tmpdir:
         convert_office_doc(filename, tmpdir, target_format="pptx")
         pptx_filename = os.path.join(tmpdir, f"{base_filename}.pptx")
-        elements = partition_pptx(filename=pptx_filename, metadata_filename=metadata_filename)
+        elements = partition_pptx(
+            filename=pptx_filename,
+            metadata_filename=metadata_filename,
+            metadata_date=metadata_date if metadata_date else last_modification_date,
+        )
 
     # remove tmp.name from filename if parsing file
     if file:

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -83,7 +83,7 @@ def partition_pptx(
     num_slides = len(presentation.slides)
     for i, slide in enumerate(presentation.slides):
         metadata = ElementMetadata.from_dict(metadata.to_dict())
-        metadata.date = metadata_date if metadata_date else last_modification_date
+        metadata.date = metadata_date or last_modification_date
         metadata.page_number = i + 1
 
         for shape in _order_shapes(slide.shapes):
@@ -96,7 +96,7 @@ def partition_pptx(
                         filename=metadata_filename or filename,
                         text_as_html=html_table,
                         page_number=metadata.page_number,
-                        date=metadata_date if metadata_date else last_modification_date,
+                        date=metadata_date or last_modification_date,
                     )
                     elements.append(Table(text=text_table, metadata=metadata))
                 continue

--- a/unstructured/partition/rst.py
+++ b/unstructured/partition/rst.py
@@ -1,4 +1,5 @@
 from typing import IO, List, Optional
+from datetime import datetime
 
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
@@ -13,6 +14,7 @@ def partition_rst(
     include_page_breaks: bool = False,
     include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions an RST document. The document is first converted to HTML and then
@@ -33,4 +35,5 @@ def partition_rst(
         file=file,
         include_page_breaks=include_page_breaks,
         metadata_filename=metadata_filename,
+        metadata_date=metadata_date,
     )

--- a/unstructured/partition/rst.py
+++ b/unstructured/partition/rst.py
@@ -28,6 +28,8 @@ def partition_rst(
         A file-like object using "rb" mode --> open(filename, "rb").
     include_page_breaks
         If True, the output will include page breaks if the filetype supports it.
+    metadata_date
+        The last modified date for the document.
     """
     return convert_and_partition_html(
         source_format="rst",

--- a/unstructured/partition/rtf.py
+++ b/unstructured/partition/rtf.py
@@ -1,4 +1,5 @@
 from typing import IO, List, Optional
+from datetime import datetime
 
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
@@ -13,6 +14,8 @@ def partition_rtf(
     include_page_breaks: bool = False,
     include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None,
+
     **kwargs,
 ) -> List[Element]:
     """Partitions an RTF document. The document is first converted to HTML and then
@@ -26,6 +29,8 @@ def partition_rtf(
         A file-like object using "rb" mode --> open(filename, "rb").
     include_page_breaks
         If True, the output will include page breaks if the filetype supports it
+    metadata_date
+        The last modified date for the document.
     """
     return convert_and_partition_html(
         source_format="rtf",
@@ -33,4 +38,5 @@ def partition_rtf(
         file=file,
         include_page_breaks=include_page_breaks,
         metadata_filename=metadata_filename,
+        metadata_date=metadata_date
     )

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -1,5 +1,6 @@
 import re
 from typing import IO, Callable, List, Optional, Tuple
+from datetime import datetime
 
 from unstructured.cleaners.core import clean_bullets, group_broken_paragraphs
 from unstructured.documents.coordinates import CoordinateSystem
@@ -17,7 +18,11 @@ from unstructured.file_utils.encoding import read_txt_file
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.nlp.patterns import PARAGRAPH_PATTERN
 from unstructured.nlp.tokenize import sent_tokenize
-from unstructured.partition.common import exactly_one
+from unstructured.partition.common import (
+    exactly_one,
+    get_last_modified_date,
+    get_last_modified_date_from_file,
+)
 from unstructured.partition.text_type import (
     is_bulleted_text,
     is_possible_narrative_text,
@@ -83,6 +88,7 @@ def partition_text(
     metadata_filename: Optional[str] = None,
     include_metadata: bool = True,
     max_partition: Optional[int] = 1500,
+    metadata_date: Optional[datetime] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions an .txt documents into its constituent elements.
@@ -104,6 +110,8 @@ def partition_text(
     max_partition
         The maximum number of characters to include in a partition. If None is passed,
         no maximum is applied.
+    modification_date
+        The day of the last modification
     """
     if text is not None and text.strip() == "" and not file and not filename:
         return []
@@ -111,11 +119,14 @@ def partition_text(
     # Verify that only one of the arguments was provided
     exactly_one(filename=filename, file=file, text=text)
 
+    last_modification_date = None
     if filename is not None:
         encoding, file_text = read_txt_file(filename=filename, encoding=encoding)
+        last_modification_date = get_last_modified_date(filename)
 
     elif file is not None:
         encoding, file_text = read_txt_file(file=file, encoding=encoding)
+        last_modification_date = get_last_modified_date_from_file(file)
 
     elif text is not None:
         file_text = str(text)
@@ -129,7 +140,10 @@ def partition_text(
 
     elements: List[Element] = []
     metadata = (
-        ElementMetadata(filename=metadata_filename or filename)
+        ElementMetadata(
+            filename=metadata_filename or filename,
+            date=metadata_date or last_modification_date,
+        )
         if include_metadata
         else ElementMetadata()
     )
@@ -156,7 +170,9 @@ def element_from_text(
             coordinate_system=coordinate_system,
         )
     elif is_us_city_state_zip(text):
-        return Address(text=text, coordinates=coordinates, coordinate_system=coordinate_system)
+        return Address(
+            text=text, coordinates=coordinates, coordinate_system=coordinate_system
+        )
     elif is_possible_narrative_text(text):
         return NarrativeText(
             text=text,
@@ -164,6 +180,10 @@ def element_from_text(
             coordinate_system=coordinate_system,
         )
     elif is_possible_title(text):
-        return Title(text=text, coordinates=coordinates, coordinate_system=coordinate_system)
+        return Title(
+            text=text, coordinates=coordinates, coordinate_system=coordinate_system
+        )
     else:
-        return Text(text=text, coordinates=coordinates, coordinate_system=coordinate_system)
+        return Text(
+            text=text, coordinates=coordinates, coordinate_system=coordinate_system
+        )

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -1,4 +1,5 @@
 from tempfile import SpooledTemporaryFile
+from datetime import datetime
 from typing import IO, BinaryIO, List, Optional, Union, cast
 
 import lxml.html
@@ -11,7 +12,12 @@ from unstructured.documents.elements import (
     process_metadata,
 )
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.common import exactly_one, spooled_to_bytes_io_if_needed
+from unstructured.partition.common import (
+    exactly_one,
+    spooled_to_bytes_io_if_needed,
+    get_last_modified_date,
+    get_last_modified_date_from_file,
+)
 
 
 @process_metadata()
@@ -20,6 +26,7 @@ def partition_tsv(
     filename: Optional[str] = None,
     file: Optional[Union[IO[bytes], SpooledTemporaryFile]] = None,
     metadata_filename: Optional[str] = None,
+    metadata_date: Optional[datetime] = None,
     include_metadata: bool = True,
     **kwargs,
 ) -> List[Element]:
@@ -33,14 +40,20 @@ def partition_tsv(
         A file-like object using "rb" mode --> open(filename, "rb").
     include_metadata
         Determines whether or not metadata is included in the output.
+    modification_date
+        The day of the last modification
     """
     exactly_one(filename=filename, file=file)
-
+    last_modification_date = None
     if filename:
         table = pd.read_csv(filename, sep="\t")
+        last_modification_date = get_last_modified_date(filename)
     else:
-        f = spooled_to_bytes_io_if_needed(cast(Union[BinaryIO, SpooledTemporaryFile], file))
+        f = spooled_to_bytes_io_if_needed(
+            cast(Union[BinaryIO, SpooledTemporaryFile], file)
+        )
         table = pd.read_csv(f, sep="\t")
+        last_modification_date = get_last_modified_date_from_file(file)
 
     html_text = table.to_html(index=False, header=False, na_rep="")
     text = lxml.html.document_fromstring(html_text).text_content()
@@ -49,6 +62,7 @@ def partition_tsv(
         metadata = ElementMetadata(
             text_as_html=html_text,
             filename=metadata_filename or filename,
+            date=metadata_date or last_modification_date,
         )
     else:
         metadata = ElementMetadata()

--- a/unstructured/partition/xlsx.py
+++ b/unstructured/partition/xlsx.py
@@ -1,4 +1,5 @@
 from tempfile import SpooledTemporaryFile
+from datetime import datetime
 from typing import IO, BinaryIO, List, Optional, Union, cast
 
 import lxml.html
@@ -11,7 +12,12 @@ from unstructured.documents.elements import (
     process_metadata,
 )
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.common import exactly_one, spooled_to_bytes_io_if_needed
+from unstructured.partition.common import (
+    exactly_one,
+    spooled_to_bytes_io_if_needed,
+    get_last_modified_date,
+    get_last_modified_date_from_file,
+)
 
 
 @process_metadata()
@@ -21,6 +27,7 @@ def partition_xlsx(
     file: Optional[Union[IO[bytes], SpooledTemporaryFile]] = None,
     metadata_filename: Optional[str] = None,
     include_metadata: bool = True,
+    metadata_date: Optional[datetime] = None,
     **kwargs,
 ) -> List[Element]:
     """Partitions Microsoft Excel Documents in .xlsx format into its document elements.
@@ -33,14 +40,21 @@ def partition_xlsx(
         A file-like object using "rb" mode --> open(filename, "rb").
     include_metadata
         Determines whether or not metadata is included in the output.
+    modification_date
+        The day of the last modification
     """
     exactly_one(filename=filename, file=file)
-
+    last_modification_date = None
     if filename:
         sheets = pd.read_excel(filename, sheet_name=None)
+        last_modification_date = get_last_modified_date(filename)
+
     else:
-        f = spooled_to_bytes_io_if_needed(cast(Union[BinaryIO, SpooledTemporaryFile], file))
+        f = spooled_to_bytes_io_if_needed(
+            cast(Union[BinaryIO, SpooledTemporaryFile], file)
+        )
         sheets = pd.read_excel(f, sheet_name=None)
+        last_modification_date = get_last_modified_date_from_file(file)
 
     elements: List[Element] = []
     page_number = 0
@@ -55,6 +69,7 @@ def partition_xlsx(
                 page_name=sheet_name,
                 page_number=page_number,
                 filename=metadata_filename or filename,
+                date=metadata_date or last_modification_date,
             )
         else:
             metadata = ElementMetadata()


### PR DESCRIPTION
##Summary

Added possibility to add the date of the last modification of the file to the metadata object

It can be done in two ways:
1. passed parameter `metadata_date` - by this, you can set your own date
2. passed the `file` or `filename` - the date field going to be taken from the file (if possible)

### New Parameters

<details open>
<summary>metadata_date</summary>
Not required parameter. Accepts the date of your own  last modification date
Default value: None

---

Closes issue #866 

