### PR TITLE
Add slide notes to pptx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+* Add slide notes to pptx
+
 ### Fixes
 
 * Enables filters to be passed to `partition_doc` so it doesn't error with LibreOffice7.

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -36,13 +36,14 @@ def partition_pptx(
     include_page_breaks: bool = True,
     metadata_filename: Optional[str] = None,
     include_metadata: bool = True,
+    include_slide_notes: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Partitions Microsoft PowerPoint Documents in .pptx format into its document elements.
 
     Parameters
     ----------
-     filename
+    filename
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
@@ -52,6 +53,8 @@ def partition_pptx(
         The filename to use for the metadata. Relevant because partition_ppt converts the
         document .pptx before partition. We want the original source filename in the
         metadata.
+    include_slide_notes
+        If True, includes the slide notes as element
     """
 
     # Verify that only one of the arguments was provided
@@ -70,8 +73,7 @@ def partition_pptx(
     for i, slide in enumerate(presentation.slides):
         metadata = ElementMetadata.from_dict(metadata.to_dict())
         metadata.page_number = i + 1
-
-        if slide.has_notes_slide:
+        if include_slide_notes and slide.has_notes_slide:
             notes_slide = slide.notes_slide
             if notes_slide.notes_text_frame != None:
                 notes_text_frame = notes_slide.notes_text_frame

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -73,9 +73,9 @@ def partition_pptx(
     for i, slide in enumerate(presentation.slides):
         metadata = ElementMetadata.from_dict(metadata.to_dict())
         metadata.page_number = i + 1
-        if include_slide_notes and slide.has_notes_slide == True:
+        if include_slide_notes and slide.has_notes_slide is True:
             notes_slide = slide.notes_slide
-            if notes_slide.notes_text_frame != None:
+            if notes_slide.notes_text_frame is not None:
                 notes_text_frame = notes_slide.notes_text_frame
                 notes_text = notes_text_frame.text
                 if notes_text.strip() != "":

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -73,7 +73,7 @@ def partition_pptx(
     for i, slide in enumerate(presentation.slides):
         metadata = ElementMetadata.from_dict(metadata.to_dict())
         metadata.page_number = i + 1
-        if include_slide_notes and slide.has_notes_slide:
+        if include_slide_notes and slide.has_notes_slide == True:
             notes_slide = slide.notes_slide
             if notes_slide.notes_text_frame != None:
                 notes_text_frame = notes_slide.notes_text_frame

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -71,6 +71,14 @@ def partition_pptx(
         metadata = ElementMetadata.from_dict(metadata.to_dict())
         metadata.page_number = i + 1
 
+        if slide.has_notes_slide:
+            notes_slide = slide.notes_slide
+            if notes_slide.notes_text_frame != None:
+                notes_text_frame = notes_slide.notes_text_frame
+                notes_text = notes_text_frame.text
+                if notes_text.strip() != "":
+                    elements.append(NarrativeText(text=notes_text, metadata=metadata))
+
         for shape in _order_shapes(slide.shapes):
             if shape.has_table:
                 table: pptx.table.Table = shape.table


### PR DESCRIPTION
This adds the ability to gather the notes on the slides. 

Added a new argument `include_slide_notes` to `partition_pptx.` This defaults to `False` to stay backwards compatible.

PPTX API Reference https://python-pptx.readthedocs.io/en/latest/user/notes.html
