### PR TITLE
feat: track links from anchor tags in `partition_html`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.8.2-dev3
+## 0.8.2-dev4
 
 ### Enhancements
 
-* set the file's current position to the beginning after reading the file in `convert_to_bytes`
+* Links are now tracked in `partition_html` output.
+* Set the file's current position to the beginning after reading the file in `convert_to_bytes`
 * Add slide notes to pptx
 
 ### Features

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -358,6 +358,11 @@ is the same as ``html_assemble_articles=False``.
 
 For more information about the ``partition_html`` brick, you can check the `source code here <https://github.com/Unstructured-IO/unstructured/blob/a583d47b841bdd426b9058b7c34f6aa3ed8de152/unstructured/partition/html.py>`_.
 
+If a section of text in the HTML document contains links, they will be tracked in the ``links``
+attribute in the element metadata. Each link in the list is a dictionary that contains
+``text`` and ``url`` keys. Links are tracked in other partitioning functions that call ``partition_html``
+as well, such as ``partition_email`` and ``partition_rst``.
+
 
 ``partition_image``
 ---------------------
@@ -1530,7 +1535,7 @@ Examples:
   elements = [Title(text="Title"), NarrativeText(text="Narrative")]
   df = convert_to_dataframe(elements)
 
-  For more information about the ``convert_to_dataframe`` brick, you can check the `source code here <https://github.com/Unstructured-IO/unstructured/blob/a583d47b841bdd426b9058b7c34f6aa3ed8de152/unstructured/staging/base.py>`_.
+For more information about the ``convert_to_dataframe`` brick, you can check the `source code here <https://github.com/Unstructured-IO/unstructured/blob/a583d47b841bdd426b9058b7c34f6aa3ed8de152/unstructured/staging/base.py>`_.
 
 
 ``convert_to_dict``

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -7,7 +7,7 @@ import requests
 from requests.models import Response
 
 from unstructured.cleaners.core import clean_extra_whitespace
-from unstructured.documents.elements import ListItem, NarrativeText, Text, Title
+from unstructured.documents.elements import ListItem, NarrativeText, Title
 from unstructured.partition.html import partition_html
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -7,7 +7,7 @@ import requests
 from requests.models import Response
 
 from unstructured.cleaners.core import clean_extra_whitespace
-from unstructured.documents.elements import Title
+from unstructured.documents.elements import ListItem, NarrativeText, Title
 from unstructured.partition.html import partition_html
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
@@ -319,3 +319,37 @@ def test_partition_html_from_filename_exclude_metadata():
     assert "PageBreak" not in [elem.category for elem in elements]
     assert elements[0].metadata.filename is None
     assert elements[0].metadata.file_directory is None
+
+
+def test_partition_html_grabs_links():
+    html_text = """<html>
+        <p>Hello there I am a <a href="/link">very important link!</a></p>
+        <p>Here is a list of my favorite things</p>
+        <ul>
+            <li><a href="https://en.wikipedia.org/wiki/Parrot">Parrots</a></li>
+            <li>Dogs</li>
+        </ul>
+    </html>"""
+    elements = partition_html(text=html_text)
+
+    assert elements[0] == NarrativeText("Hello there I am a very important link!")
+    assert elements[0].metadata.links == [
+        {
+            "text": "very important link!",
+            "url": "/link",
+        },
+    ]
+
+    assert elements[1] == NarrativeText("Here is a list of my favorite things")
+    assert elements[1].metadata.links == []
+
+    assert elements[2] == ListItem("Parrots")
+    assert elements[2].metadata.links == [
+        {
+            "text": "Parrots",
+            "url": "https://en.wikipedia.org/wiki/Parrot",
+        },
+    ]
+
+    assert elements[3] == ListItem("Dogs")
+    assert elements[3].metadata.links == []

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -342,7 +342,7 @@ def test_partition_html_grabs_links():
     ]
 
     assert elements[1] == NarrativeText("Here is a list of my favorite things")
-    assert elements[1].metadata.links == []
+    assert elements[1].metadata.links is None
 
     assert elements[2] == ListItem("Parrots")
     assert elements[2].metadata.links == [
@@ -353,7 +353,7 @@ def test_partition_html_grabs_links():
     ]
 
     assert elements[3] == ListItem("Dogs")
-    assert elements[3].metadata.links == []
+    assert elements[3].metadata.links is None
 
     assert elements[4] == Title("A lone link!")
     assert elements[4].metadata.links == [

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -7,7 +7,7 @@ import requests
 from requests.models import Response
 
 from unstructured.cleaners.core import clean_extra_whitespace
-from unstructured.documents.elements import ListItem, NarrativeText, Title
+from unstructured.documents.elements import ListItem, NarrativeText, Text, Title
 from unstructured.partition.html import partition_html
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
@@ -329,6 +329,7 @@ def test_partition_html_grabs_links():
             <li><a href="https://en.wikipedia.org/wiki/Parrot">Parrots</a></li>
             <li>Dogs</li>
         </ul>
+        <a href="/loner">A lone link!</a>
     </html>"""
     elements = partition_html(text=html_text)
 
@@ -353,3 +354,11 @@ def test_partition_html_grabs_links():
 
     assert elements[3] == ListItem("Dogs")
     assert elements[3].metadata.links == []
+
+    assert elements[4] == Title("A lone link!")
+    assert elements[4].metadata.links == [
+        {
+            "text": "A lone link!",
+            "url": "/loner",
+        },
+    ]

--- a/test_unstructured_ingest/expected-structured-output/azure/spring-weather.html.json
+++ b/test_unstructured_ingest/expected-structured-output/azure/spring-weather.html.json
@@ -35,7 +35,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Weather.gov",
+          "url": "https://www.weather.gov"
+        }
+      ]
     },
     "text": "Weather.gov >"
   },
@@ -45,7 +51,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "News Around NOAA",
+          "url": "https://www.weather.gov/news"
+        }
+      ]
     },
     "text": "News Around NOAA > Are You Weather-Ready for the Spring?"
   },
@@ -55,7 +67,93 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Weather Safety",
+          "url": "http://www.weather.gov/safetycampaign"
+        },
+        {
+          "text": "Air Quality",
+          "url": "https://www.weather.gov/safety/airquality"
+        },
+        {
+          "text": "Beach Hazards",
+          "url": "https://www.weather.gov/safety/beachhazards"
+        },
+        {
+          "text": "Cold",
+          "url": "https://www.weather.gov/safety/cold"
+        },
+        {
+          "text": "Cold Water",
+          "url": "https://www.weather.gov/safety/coldwater"
+        },
+        {
+          "text": "Drought",
+          "url": "https://www.weather.gov/safety/drought"
+        },
+        {
+          "text": "Floods",
+          "url": "https://www.weather.gov/safety/flood"
+        },
+        {
+          "text": "Fog",
+          "url": "https://www.weather.gov/safety/fog"
+        },
+        {
+          "text": "Heat",
+          "url": "https://www.weather.gov/safety/heat"
+        },
+        {
+          "text": " Hurricanes",
+          "url": "https://www.weather.gov/safety/hurricane"
+        },
+        {
+          "text": " Lightning Safety",
+          "url": "https://www.weather.gov/safety/lightning"
+        },
+        {
+          "text": "Rip Currents",
+          "url": "https://www.weather.gov/safety/ripcurrent"
+        },
+        {
+          "text": "Safe Boating",
+          "url": "https://www.weather.gov/safety/safeboating"
+        },
+        {
+          "text": "Space Weather",
+          "url": "https://www.weather.gov/safety/space"
+        },
+        {
+          "text": "Sun (Ultraviolet Radiation)",
+          "url": "https://www.weather.gov/safety/heat-uv"
+        },
+        {
+          "text": " Thunderstorms & Tornadoes",
+          "url": "https://www.weather.gov/safety/thunderstorm"
+        },
+        {
+          "text": "Tornado",
+          "url": "https://www.weather.gov/safety/tornado"
+        },
+        {
+          "text": "Tsunami",
+          "url": "https://www.weather.gov/safety/tsunami"
+        },
+        {
+          "text": "Wildfire",
+          "url": "https://www.weather.gov/safety/wildfire"
+        },
+        {
+          "text": "Wind",
+          "url": "https://www.weather.gov/safety/wind"
+        },
+        {
+          "text": "Winter",
+          "url": "https://www.weather.gov/safety/winter "
+        }
+      ]
     },
     "text": "Weather Safety                                                                                                        Air Quality                                                                            Beach Hazards                                                                            Cold                                                                            Cold Water                                                                            Drought                                                                            Floods                                                                            Fog                                                                            Heat                                                                             Hurricanes                                                                             Lightning Safety                                                                            Rip Currents                                                                            Safe Boating                                                                            Space Weather                                                                            Sun (Ultraviolet Radiation)                                                                             Thunderstorms & Tornadoes                                                                            Tornado                                                                            Tsunami                                                                            Wildfire                                                                            Wind                                                                            Winter"
   },
@@ -65,7 +163,37 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Safety Campaigns",
+          "url": "https://www.weather.gov/safetycampaign"
+        },
+        {
+          "text": "Seasonal Safety Campaigns",
+          "url": "https://www.weather.gov/safetycampaign"
+        },
+        {
+          "text": "#SafePlaceSelfie",
+          "url": "https://www.weather.gov/wrn/safeplaceselfie"
+        },
+        {
+          "text": "Deaf & Hard of Hearing",
+          "url": "https://www.weather.gov/wrn/dhh-safety"
+        },
+        {
+          "text": "Intellectual Disabilities",
+          "url": "https://www.weather.gov/wrn/intellectualdisabilities"
+        },
+        {
+          "text": "Spanish-language Content",
+          "url": "https://www.weather.gov/wrn/fall2020-espanol-sm"
+        },
+        {
+          "text": "The Great Outdoors",
+          "url": "https://www.noaa.gov/explainers/great-outdoors-weather-safety"
+        }
+      ]
     },
     "text": "Safety Campaigns                                                                                                        Seasonal Safety Campaigns                                                                            #SafePlaceSelfie                                                                            Deaf & Hard of Hearing                                                                            Intellectual Disabilities                                                                            Spanish-language Content                                                                            The Great Outdoors"
   },
@@ -75,7 +203,61 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Ambassador",
+          "url": "https://www.weather.gov/wrn/ambassadors"
+        },
+        {
+          "text": "About WRN Ambassadors",
+          "url": "https://www.weather.gov/wrn/ambassadors"
+        },
+        {
+          "text": "Become an Ambassador",
+          "url": "https://www.weather.gov/wrn/amb-tou"
+        },
+        {
+          "text": "Ambassadors of Excellence",
+          "url": "https://www.weather.gov/wrn/ambassador_recognition"
+        },
+        {
+          "text": "People of WRN",
+          "url": "https://www.weather.gov/people/"
+        },
+        {
+          "text": " FAQS",
+          "url": "https://www.weather.gov/wrn/amb-faqs"
+        },
+        {
+          "text": "Tell Your Success Story",
+          "url": "https://docs.google.com/forms/d/e/1FAIpQLScPHee5WAyC5K1LZ3pWLa2zjaM1HZSKN4_AxGUc6RaCy_gxLA/viewform"
+        },
+        {
+          "text": " Success Stories",
+          "url": " https://www.weather.gov/wrn/success-stories"
+        },
+        {
+          "text": "Tri-fold",
+          "url": "http://www.weather.gov/media/wrn/WRN_Ambassador_Trifold.pdf"
+        },
+        {
+          "text": "Aviation",
+          "url": "https://www.weather.gov/wrn/aviation"
+        },
+        {
+          "text": " Current Ambassadors",
+          "url": " http://www.weather.gov/wrn/current-ambassadors"
+        },
+        {
+          "text": "Brochure",
+          "url": "http://www.weather.gov/media/wrn/WRN_Ambassador_Flyer.pdf"
+        },
+        {
+          "text": "En Español",
+          "url": "https://www.weather.gov/wrn/en-espanol"
+        }
+      ]
     },
     "text": "Ambassador                                                                                                        About WRN Ambassadors                                                                            Become an Ambassador                                                                            Ambassadors of Excellence                                                                            People of WRN                                                                             FAQS                                                                            Tell Your Success Story                                                                             Success Stories                                                                            Tri-fold                                                                            Aviation                                                                             Current Ambassadors                                                                            Brochure                                                                            En Español"
   },
@@ -85,7 +267,53 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Education",
+          "url": "http://www.weather.gov/owlie/"
+        },
+        {
+          "text": "NWS Education Home",
+          "url": "http://www.weather.gov/owlie/"
+        },
+        {
+          "text": "Be A Force Of Nature",
+          "url": "https://www.weather.gov/wrn/force"
+        },
+        {
+          "text": "WRN Kids Flyer",
+          "url": " http://www.weather.gov/media/owlie/nws_kids_fact_sheet2.pdf"
+        },
+        {
+          "text": "Wireless Emergency Alerts",
+          "url": "https://www.weather.gov/wrn/wea"
+        },
+        {
+          "text": "NOAA Weather Radio",
+          "url": "http://www.nws.noaa.gov/nwr/"
+        },
+        {
+          "text": "Mobile Weather",
+          "url": "https://www.weather.gov/wrn/mobile-phone"
+        },
+        {
+          "text": "Brochures",
+          "url": "http://www.weather.gov/owlie/publication_brochures"
+        },
+        {
+          "text": "Hourly Weather Forecast",
+          "url": "https://www.weather.gov/wrn/hourly-weather-graph"
+        },
+        {
+          "text": "Citizen Science",
+          "url": "http://www.weather.gov/media/wrn/citizen_science_page.pdf"
+        },
+        {
+          "text": "Intellectual Disabilities",
+          "url": "https://www.weather.gov/wrn/intellectualdisabilities"
+        }
+      ]
     },
     "text": "Education                                                                                                        NWS Education Home                                                                            Be A Force Of Nature                                                                            WRN Kids Flyer                                                                            Wireless Emergency Alerts                                                                            NOAA Weather Radio                                                                            Mobile Weather                                                                            Brochures                                                                            Hourly Weather Forecast                                                                            Citizen Science                                                                            Intellectual Disabilities"
   },
@@ -95,7 +323,49 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Collaboration",
+          "url": "https://www.weather.gov/wrn/collaborate"
+        },
+        {
+          "text": "Get Involved ",
+          "url": "https://www.weather.gov/wrn/get-involved"
+        },
+        {
+          "text": "Social Media",
+          "url": "http://www.weather.gov/socialmedia"
+        },
+        {
+          "text": "WRN Ambassadors ​",
+          "url": "https://www.weather.gov/wrn/ambassadors"
+        },
+        {
+          "text": "Enterprise Resources",
+          "url": "https://www.weather.gov/enterprise/"
+        },
+        {
+          "text": "StormReady",
+          "url": "http://www.weather.gov/stormready/"
+        },
+        {
+          "text": "TsunamiReady",
+          "url": "https://www.weather.gov/tsunamiready/"
+        },
+        {
+          "text": "NWSChat (core partners only)",
+          "url": "https://nwschat.weather.gov/"
+        },
+        {
+          "text": "InteractiveNWS (iNWS) (core partners only)​",
+          "url": "https://inws.ncep.noaa.gov/"
+        },
+        {
+          "text": "SKYWARN",
+          "url": "https://www.weather.gov/SKYWARN"
+        }
+      ]
     },
     "text": "Collaboration                                                                                                        Get Involved                                                                             Social Media                                                                            WRN Ambassadors ​                                                                            Enterprise Resources                                                                            StormReady                                                                            TsunamiReady                                                                            NWSChat (core partners only)                                                                            InteractiveNWS (iNWS) (core partners only)​                                                                            SKYWARN"
   },
@@ -105,7 +375,29 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": " News & Events",
+          "url": "http://www.weather.gov/news/"
+        },
+        {
+          "text": "Latest News",
+          "url": " http://www.weather.gov/news/"
+        },
+        {
+          "text": "Calendar",
+          "url": "https://www.weather.gov/wrn/calendar"
+        },
+        {
+          "text": "Meetings & Workshops",
+          "url": " https://www.weather.gov/wrn/workshops"
+        },
+        {
+          "text": "NWS Aware Newsletter",
+          "url": "https://www.weather.gov/publications/aware"
+        }
+      ]
     },
     "text": "News & Events                                                                                                        Latest News                                                                            Calendar                                                                            Meetings & Workshops                                                                            NWS Aware Newsletter"
   },
@@ -115,7 +407,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "International",
+          "url": "https://www.weather.gov/wrn/wrns"
+        }
+      ]
     },
     "text": "International"
   },
@@ -125,7 +423,53 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "About",
+          "url": "https://www.weather.gov/wrn/about"
+        },
+        {
+          "text": "Contact Us",
+          "url": " https://www.weather.gov/wrn/contact"
+        },
+        {
+          "text": " What is WRN?",
+          "url": "https://www.weather.gov/wrn/about"
+        },
+        {
+          "text": " WRN FAQ",
+          "url": "https://www.weather.gov/wrn/faqs"
+        },
+        {
+          "text": "WRN Brochure",
+          "url": "http://www.weather.gov/media/wrn/WRN_Ambassador_Flyer.pdf"
+        },
+        {
+          "text": "Hazard Simplification",
+          "url": "https://www.weather.gov/hazardsimplification/"
+        },
+        {
+          "text": "IDSS Brochure",
+          "url": "https://www.weather.gov/media/wrn/2018-IDSS2-Pager.pdf"
+        },
+        {
+          "text": "Roadmap",
+          "url": "http://www.weather.gov/media/wrn/nws_wrn_roadmap_final_april17.pdf"
+        },
+        {
+          "text": "Strategic Plan",
+          "url": "https://www.weather.gov/media/wrn/NWS_Weather-Ready-Nation_Strategic_Plan_2019-2022.pdf"
+        },
+        {
+          "text": "WRN International",
+          "url": " https://www.weather.gov/wrn/international"
+        },
+        {
+          "text": "Social Science",
+          "url": "https://vlab.noaa.gov/web/nws-social-science"
+        }
+      ]
     },
     "text": "About                                                                                                        Contact Us                                                                             What is WRN?                                                                             WRN FAQ                                                                            WRN Brochure                                                                            Hazard Simplification                                                                            IDSS Brochure                                                                            Roadmap                                                                            Strategic Plan                                                                            WRN International                                                                            Social Science"
   },
@@ -165,7 +509,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Spring Safety website",
+          "url": "https://www.weather.gov/wrn/spring-safety"
+        }
+      ]
     },
     "text": "Second, encourage others to become Weather-Ready as well. Share the message by taking advantage of our vast array of weather safety content – everything posted on our Spring Safety website is freely available, and we encourage sharing on social media networks. Also remember those who are most vulnerable, like an elderly family member or neighbor who might have limited mobility or is isolated. Reach out to those who are at higher risk of being impacted by extreme weather, and help them get prepared. This simple act of caring could become heroic."
   },
@@ -175,7 +525,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "infographics",
+          "url": "https://www.weather.gov/wrn/spring-infographics"
+        }
+      ]
     },
     "text": "This spring, the campaign is focused on heat dangers. Heat illness and death can occur even in spring’s moderately warm weather. The majority of all heat-related deaths occur outside of heat waves and roughly a third of child hot car deaths occur outside of the summer months. Learn more by viewing the infographics that are now available."
   },
@@ -195,7 +551,25 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "US Dept of Commerce",
+          "url": "http://www.commerce.gov"
+        },
+        {
+          "text": "National Oceanic and Atmospheric Administration",
+          "url": "http://www.noaa.gov"
+        },
+        {
+          "text": "National Weather Service",
+          "url": "https://www.weather.gov"
+        },
+        {
+          "text": "Comments? Questions? Please Contact Us.",
+          "url": "https://www.weather.gov/news/contact"
+        }
+      ]
     },
     "text": "US Dept of Commerce\n                        National Oceanic and Atmospheric Administration\n                        National Weather Service\n                        News Around NOAA1325 East West HighwaySilver Spring, MD 20910Comments? Questions? Please Contact Us."
   },
@@ -205,7 +579,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Disclaimer",
+          "url": "https://www.weather.gov/disclaimer"
+        }
+      ]
     },
     "text": "Disclaimer"
   },
@@ -215,7 +595,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Information Quality",
+          "url": "http://www.cio.noaa.gov/services_programs/info_quality.html"
+        }
+      ]
     },
     "text": "Information Quality"
   },
@@ -225,7 +611,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Help",
+          "url": "https://www.weather.gov/help"
+        }
+      ]
     },
     "text": "Help"
   },
@@ -235,7 +627,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Glossary",
+          "url": "http://www.weather.gov/glossary"
+        }
+      ]
     },
     "text": "Glossary"
   },
@@ -245,7 +643,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Privacy Policy",
+          "url": "https://www.weather.gov/privacy"
+        }
+      ]
     },
     "text": "Privacy Policy"
   },
@@ -255,7 +659,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Freedom of Information Act (FOIA)",
+          "url": "https://www.noaa.gov/foia-freedom-of-information-act"
+        }
+      ]
     },
     "text": "Freedom of Information Act (FOIA)"
   },
@@ -265,7 +675,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "About Us",
+          "url": "https://www.weather.gov/about"
+        }
+      ]
     },
     "text": "About Us"
   },
@@ -275,7 +691,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Career Opportunities",
+          "url": "https://www.weather.gov/careers"
+        }
+      ]
     },
     "text": "Career Opportunities"
   }

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1605956.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1605956.json
@@ -45,7 +45,21 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "OKRs",
+          "url": "https://www.atlassian.com/software/confluence/templates/okrs"
+        },
+        {
+          "text": "project plans",
+          "url": "https://www.atlassian.com/software/confluence/templates/project-plan"
+        },
+        {
+          "text": "product roadmaps",
+          "url": "https://www.atlassian.com/software/confluence/templates/product-roadmap"
+        }
+      ]
     },
     "text": "Share team goals. Add links to your team's OKRs, project plans, and product roadmaps so visitors can quickly get a sense of your team's goals."
   },
@@ -95,7 +109,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": null,
+          "url": "https://support.atlassian.com/confluence-cloud/docs/comment-on-pages-and-blog-posts/"
+        }
+      ]
     },
     "text": "Thoughtful responses can get lost and lose context as email replies pile up. And if you neglect to copy someone or want to add them later on, it's difficult for them to get up to speed. Inline comments allow anyone (or everyone) to huddle around an idea while referencing key information on the project page."
   },
@@ -135,7 +155,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": null,
+          "url": "https://support.atlassian.com/confluence-cloud/docs/mention-a-person-or-team/"
+        }
+      ]
     },
     "text": "@mentions on Confluence function like @mentions on social media platforms like Twitter, Instagram, and Slack. Type the @ symbol on a Confluence page or in a comment, begin spelling a team member's first name, and a list will appear. Select the individual to ask a question or assign a task."
   },
@@ -255,7 +281,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "user profiles",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/insert-the-user-profile-macro/"
+        }
+      ]
     },
     "text": "Add user profiles to display a short summary of a given Confluence user's profile with their role, profile photo and contact details."
   },
@@ -275,7 +307,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "blog posts",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/insert-the-blog-posts-macro/"
+        }
+      ]
     },
     "text": "Display a stream of latest blog posts so your team can easily see what's been going on."
   },
@@ -295,7 +333,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "content report table",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/insert-the-content-report-table-macro/"
+        }
+      ]
     },
     "text": "Paste in page URLs to create smart links, or use the content report table to create a list of all the pages in the space."
   }

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/229477.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/229477.json
@@ -25,7 +25,21 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Template - Project plan",
+          "url": "/wiki/spaces/MFS/pages/1540126/Template+-+Project+plan"
+        },
+        {
+          "text": "Template - Meeting notes",
+          "url": "/wiki/spaces/MFS/pages/1605928/Template+-+Meeting+notes"
+        },
+        {
+          "text": "Template - Weekly status report",
+          "url": "/wiki/spaces/MFS/pages/1605942/Template+-+Weekly+status+report"
+        }
+      ]
     },
     "text": "Get started with page templates:Template - Project planTemplate - Meeting notesTemplate - Weekly status report"
   },
@@ -35,7 +49,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Get the most out of your team space",
+          "url": "/wiki/spaces/MFS/pages/1605956/Get+the+most+out+of+your+team+space"
+        }
+      ]
     },
     "text": "Check out Get the most out of your team space for more tips."
   },
@@ -215,7 +235,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": null,
+          "url": "mailto:team@email.com"
+        }
+      ]
     },
     "text": "team@email.com"
   },

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1605859.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1605859.json
@@ -25,7 +25,21 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Template - Project plan",
+          "url": "/wiki/spaces/MFS/pages/1540126/Template+-+Project+plan"
+        },
+        {
+          "text": "Template - Meeting notes",
+          "url": "/wiki/spaces/MFS/pages/1605928/Template+-+Meeting+notes"
+        },
+        {
+          "text": "Template - Weekly status report",
+          "url": "/wiki/spaces/MFS/pages/1605942/Template+-+Weekly+status+report"
+        }
+      ]
     },
     "text": "Get started with page templates:Template - Project planTemplate - Meeting notesTemplate - Weekly status report"
   },
@@ -35,7 +49,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Get the most out of your team space",
+          "url": "/wiki/spaces/MFS/pages/1605956/Get+the+most+out+of+your+team+space"
+        }
+      ]
     },
     "text": "Check out Get the most out of your team space for more tips."
   },
@@ -215,7 +235,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": null,
+          "url": "mailto:team@email.com"
+        }
+      ]
     },
     "text": "team@email.com"
   },

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1605989.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1605989.json
@@ -195,7 +195,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "This is the link for unstructured . io.",
+          "url": "https://www.unstructured.io/"
+        }
+      ]
     },
     "text": "This is the link for unstructured . io."
   },

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1802252.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1802252.json
@@ -195,7 +195,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "This is the link for unstructured . io.",
+          "url": "https://www.unstructured.io/"
+        }
+      ]
     },
     "text": "This is the link for unstructured . io."
   },

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/~64083457896d10ebd4738661/65627.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/~64083457896d10ebd4738661/65627.json
@@ -55,7 +55,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "https://www.youtube.com/embed/kaNPNbAT-as%22",
+          "url": "https://www.youtube.com/embed/kaNPNbAT-as%22"
+        }
+      ]
     },
     "text": "https://www.youtube.com/embed/kaNPNbAT-as%22"
   },
@@ -75,7 +81,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Create",
+          "url": "https://confluence.atlassian.com/conf73/create-a-space-991927526.html"
+        }
+      ]
     },
     "text": "Spaces are places for individuals, teams, and companies to organize and work on ideas, projects, documentation, and announcements. Spaces can be customized and integrated with both Atlassian tools and others. Create as many spaces as you need to get things done:"
   },
@@ -155,7 +167,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Learn more about spaces",
+          "url": "https://www.atlassian.com/software/confluence/guides/get-started/set-up"
+        }
+      ]
     },
     "text": "Learn more about spaces"
   },
@@ -205,7 +223,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Learn more about pages",
+          "url": "https://www.atlassian.com/software/confluence/guides/get-started/create-content"
+        }
+      ]
     },
     "text": "Learn more about pages"
   },
@@ -225,7 +249,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Back to top ⤴",
+          "url": "#On-this-page"
+        }
+      ]
     },
     "text": "Back to top ⤴"
   },
@@ -295,7 +325,17 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 2
+      "page_number": 2,
+      "links": [
+        {
+          "text": "Learn more about page templates",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/create-a-page-from-a-template"
+        },
+        {
+          "text": "Browse space templates",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/create-a-space-from-a-template"
+        }
+      ]
     },
     "text": "Learn more about page templates | Browse space templates"
   },
@@ -335,7 +375,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 2
+      "page_number": 2,
+      "links": [
+        {
+          "text": "Learn more about elements",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/create-a-space-from-a-template"
+        }
+      ]
     },
     "text": "Learn more about elements"
   },
@@ -375,7 +421,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 2
+      "page_number": 2,
+      "links": [
+        {
+          "text": "Learn more about page header images",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/make-your-page-and-its-title-more-memorable"
+        }
+      ]
     },
     "text": "Learn more about page header images"
   },
@@ -385,7 +437,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 2
+      "page_number": 2,
+      "links": [
+        {
+          "text": "Back to top ⤴",
+          "url": "#On-this-page"
+        }
+      ]
     },
     "text": "Back to top ⤴"
   },
@@ -435,7 +493,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 3
+      "page_number": 3,
+      "links": [
+        {
+          "text": "Learn more about collaborative editing",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/create-edit-and-publish-a-page/#Collaborative-editing"
+        }
+      ]
     },
     "text": "Learn more about collaborative editing"
   },
@@ -515,7 +579,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 3
+      "page_number": 3,
+      "links": [
+        {
+          "text": "Learn more about comments",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/comment-on-pages-and-blog-posts/"
+        }
+      ]
     },
     "text": "Learn more about comments"
   },
@@ -525,7 +595,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 3
+      "page_number": 3,
+      "links": [
+        {
+          "text": "Back to top ⤴",
+          "url": "#On-this-page"
+        }
+      ]
     },
     "text": "Back to top ⤴"
   },
@@ -565,7 +641,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 4
+      "page_number": 4,
+      "links": [
+        {
+          "text": "Learn more about the page tree",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/move-copy-and-hide-pages/"
+        }
+      ]
     },
     "text": "Learn more about the page tree"
   },
@@ -605,7 +687,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 4
+      "page_number": 4,
+      "links": [
+        {
+          "text": "Learn more about space overview",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/set-up-your-space-homepage/"
+        }
+      ]
     },
     "text": "Learn more about space overview"
   },
@@ -675,7 +763,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 4
+      "page_number": 4,
+      "links": [
+        {
+          "text": "Learn more about sharing pages and blog posts",
+          "url": "https://support.atlassian.com/confluence-cloud/docs/share-a-page-or-blog-post/"
+        }
+      ]
     },
     "text": "Learn more about sharing pages and blog posts"
   },
@@ -715,7 +809,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 4
+      "page_number": 4,
+      "links": [
+        {
+          "text": "Learn more about tables",
+          "url": "https://confluence.atlassian.com/conf73/tables-991927743.html"
+        }
+      ]
     },
     "text": "Learn more about tables"
   },
@@ -755,7 +855,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 4
+      "page_number": 4,
+      "links": [
+        {
+          "text": "Learn more about drafts",
+          "url": "https://confluence.atlassian.com/doc/drafts-149040.html"
+        }
+      ]
     },
     "text": "Learn more about drafts"
   },
@@ -765,7 +871,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 4
+      "page_number": 4,
+      "links": [
+        {
+          "text": "Back to top ⤴",
+          "url": "#On-this-page"
+        }
+      ]
     },
     "text": "Back to top ⤴"
   },
@@ -855,7 +967,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 5
+      "page_number": 5,
+      "links": [
+        {
+          "text": "https://www.youtube.com/watch?v=ohtDFXNAUns",
+          "url": "https://www.youtube.com/watch?v=ohtDFXNAUns"
+        }
+      ]
     },
     "text": "https://www.youtube.com/watch?v=ohtDFXNAUns"
   },
@@ -865,7 +983,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 5
+      "page_number": 5,
+      "links": [
+        {
+          "text": "Back to top ⤴",
+          "url": "#On-this-page"
+        }
+      ]
     },
     "text": "Back to top ⤴"
   }

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/~64083457896d10ebd4738661/65628.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/~64083457896d10ebd4738661/65628.json
@@ -35,7 +35,17 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Overview",
+          "url": "/wiki/spaces/~64083457896d10ebd4738661/overview"
+        },
+        {
+          "text": "ryan",
+          "url": "/wiki/display/~64083457896d10ebd4738661"
+        }
+      ]
     },
     "text": "Overview\n            \n            \n                Jun 30, 2023 • contributed by ryan"
   },
@@ -45,7 +55,17 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Getting started in Confluence",
+          "url": "/wiki/spaces/~64083457896d10ebd4738661/pages/65627/Getting+started+in+Confluence"
+        },
+        {
+          "text": "ryan",
+          "url": "/wiki/display/~64083457896d10ebd4738661"
+        }
+      ]
     },
     "text": "Getting started in Confluence\n            \n            \n                Jun 30, 2023 • contributed by ryan"
   },
@@ -55,7 +75,17 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "ryan",
+          "url": "/wiki/spaces/~64083457896d10ebd4738661"
+        },
+        {
+          "text": "ryan",
+          "url": "/wiki/display/~64083457896d10ebd4738661"
+        }
+      ]
     },
     "text": "ryan\n            \n            \n                Jun 30, 2023 • contributed by ryan"
   },

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/~7120205368eedfcecd43e18b25b2221316ee6f/2130016.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/~7120205368eedfcecd43e18b25b2221316ee6f/2130016.json
@@ -35,7 +35,17 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Overview",
+          "url": "/wiki/spaces/~7120205368eedfcecd43e18b25b2221316ee6f/overview"
+        },
+        {
+          "text": "ahmet",
+          "url": "/wiki/display/~712020%3A5368eedf-cecd-43e1-8b25-b2221316ee6f"
+        }
+      ]
     },
     "text": "Overview\n            \n            \n                Jul 12, 2023 • contributed by ahmet"
   },
@@ -45,7 +55,17 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "ahmet",
+          "url": "/wiki/spaces/~7120205368eedfcecd43e18b25b2221316ee6f"
+        },
+        {
+          "text": "ahmet",
+          "url": "/wiki/display/~712020%3A5368eedf-cecd-43e1-8b25-b2221316ee6f"
+        }
+      ]
     },
     "text": "ahmet\n            \n            \n                Jul 12, 2023 • contributed by ahmet"
   },

--- a/test_unstructured_ingest/expected-structured-output/gcs/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/gcs/ideas-page.html.json
@@ -5,7 +5,17 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": null,
+          "url": "index.html"
+        },
+        {
+          "text": null,
+          "url": "https://twitter.com/stef/status/1617222428727586816"
+        }
+      ]
     },
     "text": "January 2023(Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.)The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge.Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds."
   }

--- a/test_unstructured_ingest/expected-structured-output/gcs/nested-1/nested/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/gcs/nested-1/nested/ideas-page.html.json
@@ -5,7 +5,17 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": null,
+          "url": "index.html"
+        },
+        {
+          "text": null,
+          "url": "https://twitter.com/stef/status/1617222428727586816"
+        }
+      ]
     },
     "text": "January 2023(Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.)The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge.Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds."
   }

--- a/test_unstructured_ingest/expected-structured-output/gcs/nested-2/nested/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/gcs/nested-2/nested/ideas-page.html.json
@@ -5,7 +5,17 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": null,
+          "url": "index.html"
+        },
+        {
+          "text": null,
+          "url": "https://twitter.com/stef/status/1617222428727586816"
+        }
+      ]
     },
     "text": "January 2023(Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.)The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge.Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds."
   }

--- a/test_unstructured_ingest/expected-structured-output/github/test.html.json
+++ b/test_unstructured_ingest/expected-structured-output/github/test.html.json
@@ -15,7 +15,13 @@
     "metadata": {
       "data_source": {},
       "filetype": "text/html",
-      "page_number": 1
+      "page_number": 1,
+      "links": [
+        {
+          "text": "Github Project Page",
+          "url": "http://github.com/dcneiner/Downloadify"
+        }
+      ]
     },
     "text": "More info available at the Github Project Page"
   },

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.2-dev3"  # pragma: no cover
+__version__ = "0.8.2-dev4"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -136,6 +136,7 @@ class ElementMetadata:
 
     # Webpage specific metadata fields
     url: Optional[str] = None
+    links: Optional[List[Link]] = None
 
     # E-mail specific metadata fields
     sent_from: Optional[List[str]] = None

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -111,6 +111,13 @@ class RegexMetadata(TypedDict):
     end: int
 
 
+class Link(TypedDict):
+    """Metadata related to extracted links"""
+
+    text: Optional[str]
+    url: str
+
+
 @dataclass
 class ElementMetadata:
     coordinates: Optional[CoordinatesMetadata] = None

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -221,6 +221,10 @@ class HTMLDocument(XMLDocument):
 
 def _get_links_from_tag(tag_elem: etree.Element) -> List[Link]:
     links: List[Link] = []
+    href = tag_elem.get("href")
+    if href:
+        links.append({"text": tag_elem.text, "url": href})
+
     for tag in tag_elem.iterdescendants():
         href = tag.get("href")
         if href:
@@ -346,7 +350,8 @@ def _process_list_item(
     we can skip processing if bullets are found in a div element."""
     if tag_elem.tag in LIST_ITEM_TAGS:
         text = _construct_text(tag_elem)
-        return HTMLListItem(text=text, tag=tag_elem.tag), tag_elem
+        links = _get_links_from_tag(tag_elem)
+        return HTMLListItem(text=text, tag=tag_elem.tag, links=links), tag_elem
 
     elif tag_elem.tag == "div":
         text = _construct_text(tag_elem)

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -120,6 +120,7 @@ def _add_element_metadata(
         if coordinates is not None and coordinate_system is not None
         else None
     )
+    links = element.links if hasattr(element, "links") else []
     metadata = ElementMetadata(
         coordinates=coordinates_metadata,
         filename=filename,
@@ -127,6 +128,7 @@ def _add_element_metadata(
         page_number=page_number,
         url=url,
         text_as_html=text_as_html,
+        links=links,
     )
     element.metadata = metadata.merge(element.metadata)
     return element

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -120,7 +120,7 @@ def _add_element_metadata(
         if coordinates is not None and coordinate_system is not None
         else None
     )
-    links = element.links if hasattr(element, "links") else []
+    links = element.links if hasattr(element, "links") and len(element.links) > 0 else None
     metadata = ElementMetadata(
         coordinates=coordinates_metadata,
         filename=filename,

--- a/unstructured/staging/weaviate.py
+++ b/unstructured/staging/weaviate.py
@@ -8,7 +8,7 @@ class Properties(TypedDict):
     dataType: List[str]
 
 
-exclude_metadata_keys = ("data_source", "coordinates")
+exclude_metadata_keys = ("data_source", "coordinates", "links", "regex_metadata")
 
 
 def stage_for_weaviate(elements: List[Text]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
### Summary

Closes #556. Updates `partition_html` to track links in metadata when anchor tags are present. 

### Testing

```python
    from unstructured.partition.html import partition_html

    html_text = """<html>
        <p>Hello there I am a <a href="/link">very important link!</a></p>
        <p>Here is a list of my favorite things</p>
        <ul>
            <li><a href="https://en.wikipedia.org/wiki/Parrot">Parrots</a></li>
            <li>Dogs</li>
        </ul>
        <a href="/loner">A lone link!</a>
    </html>"""
    elements = partition_html(text=html_text)
```