### PR TITLE
Roman/expose dpi param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 ### Features
 
 * Adds Outlook connector
+* Add support for dpi parameter in inference library
 
 ### Fixes
 
 * Fixes issue with email partitioning where From field was being assigned the To field value.
 
-## 0.8.2-dev7
+## 0.8.2
 
 ### Enhancements
 

--- a/requirements/local-inference.in
+++ b/requirements/local-inference.in
@@ -1,3 +1,3 @@
 -c constraints.in
 -c base.txt
-unstructured-inference==0.5.5
+unstructured-inference==0.5.6

--- a/requirements/local-inference.in
+++ b/requirements/local-inference.in
@@ -1,3 +1,3 @@
 -c constraints.in
 -c base.txt
-unstructured-inference==0.5.6
+unstructured-inference==0.5.7

--- a/requirements/local-inference.txt
+++ b/requirements/local-inference.txt
@@ -215,7 +215,7 @@ tzdata==2023.3
     # via
     #   -c requirements/base.txt
     #   pandas
-unstructured-inference==0.5.5
+unstructured-inference==0.5.6
     # via -r requirements/local-inference.in
 urllib3==1.26.16
     # via

--- a/requirements/local-inference.txt
+++ b/requirements/local-inference.txt
@@ -215,7 +215,7 @@ tzdata==2023.3
     # via
     #   -c requirements/base.txt
     #   pandas
-unstructured-inference==0.5.6
+unstructured-inference==0.5.7
     # via -r requirements/local-inference.in
 urllib3==1.26.16
     # via

--- a/test_unstructured/file_utils/test_exploration.py
+++ b/test_unstructured/file_utils/test_exploration.py
@@ -39,7 +39,7 @@ def test_get_directory_file_info(tmpdir):
     assert isinstance(file_info, pd.DataFrame)
     assert set(file_info["filename"].to_list()) == {"filename1.txt", "filename2.txt"}
 
-    means = file_info.groupby("filetype").mean()
+    means = file_info.groupby("filetype").mean(numeric_only=True)
     assert means.columns.to_list() == ["filesize"]
 
 

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -386,10 +386,16 @@ def test_partition_pdf_with_copy_protection():
 
 def test_partition_pdf_with_dpi():
     filename = os.path.join("example-docs", "copy-protected.pdf")
-    elements = pdf.partition_pdf(filename=filename, strategy="hi_res", pdf_image_dpi=100)
-    elements[0] == Title("LayoutParser: A Uniﬁed Toolkit for Deep Based Document Image Analysis")
-    # check that the pdf has multiple different page numbers
-    assert {element.metadata.page_number for element in elements} == {1, 2}
+    with mock.patch.object(layout, "process_file_with_model", mock.MagicMock()) as mock_process:
+        pdf.partition_pdf(filename=filename, strategy="hi_res", pdf_image_dpi=100)
+        mock_process.assert_called_once_with(
+            filename,
+            is_image=False,
+            ocr_languages="eng",
+            extract_tables=False,
+            model_name=None,
+            pdf_image_dpi=100,
+        )
 
 
 def test_partition_pdf_requiring_recursive_text_grab(filename="example-docs/reliance.pdf"):

--- a/test_unstructured/partition/test_pdf.py
+++ b/test_unstructured/partition/test_pdf.py
@@ -384,6 +384,14 @@ def test_partition_pdf_with_copy_protection():
     assert {element.metadata.page_number for element in elements} == {1, 2}
 
 
+def test_partition_pdf_with_dpi():
+    filename = os.path.join("example-docs", "copy-protected.pdf")
+    elements = pdf.partition_pdf(filename=filename, strategy="hi_res", pdf_image_dpi=100)
+    elements[0] == Title("LayoutParser: A Uniﬁed Toolkit for Deep Based Document Image Analysis")
+    # check that the pdf has multiple different page numbers
+    assert {element.metadata.page_number for element in elements} == {1, 2}
+
+
 def test_partition_pdf_requiring_recursive_text_grab(filename="example-docs/reliance.pdf"):
     elements = pdf.partition_pdf(filename=filename, strategy="fast")
     assert len(elements) > 50

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -203,12 +203,18 @@ def _partition_pdf_or_image_local(
 
     model_name = model_name if model_name else os.environ.get("UNSTRUCTURED_HI_RES_MODEL_NAME")
     if file is None:
+        pdf_image_dpi = kwargs.pop("pdf_image_dpi", None)
+        process_file_with_model_kwargs = {
+            "is_image": is_image,
+            "ocr_languages": ocr_languages,
+            "extract_tables": infer_table_structure,
+            "model_name": model_name,
+        }
+        if pdf_image_dpi:
+            process_file_with_model_kwargs["pdf_image_dpi"] = pdf_image_dpi
         layout = process_file_with_model(
             filename,
-            is_image=is_image,
-            ocr_languages=ocr_languages,
-            extract_tables=infer_table_structure,
-            model_name=model_name,
+            **process_file_with_model_kwargs,
         )
     else:
         layout = process_data_with_model(


### PR DESCRIPTION
### Description
Bump the inference library version to `0.5.6` which exposes the new dpi parameter. Check for this in the kwargs being passed through and set it on the kwargs being used my the method that had that added only if it exists to avoid passing `None` for the value. 

Also update how the image metadata is worked with given the refactor that was implemented in the inference library. 

Update `CHANGELOG` to be ready to cut new release