### PR TITLE
chore: cleanup changelog for 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,3 @@
-## 0.8.3
-
-### Enhancements
-
-### Features
-
-* Adds Outlook connector
-* Add support for dpi parameter in inference library
-
-### Fixes
-
-* Fixes issue with email partitioning where From field was being assigned the To field value.
-
 ## 0.8.2
 
 ### Enhancements
@@ -27,12 +14,14 @@
 
 ### Features
 
+* Adds Outlook connector
+* Add support for dpi parameter in inference library
 * Adds Onedrive connector.
 * Add Confluence connector for ingest cli to pull the body text from all documents from all spaces in a confluence domain.
 
-
 ### Fixes
 
+* Fixes issue with email partitioning where From field was being assigned the To field value.
 * Use the `image_metadata` property of the `PageLayout` instance to get the page image info in the `document_to_element_list`
 * Add functionality to write images to computer storage temporarily instead of keeping them in memory for `ocr_only` strategy
 * Add functionality to convert a PDF in small chunks of pages at a time for `ocr_only` strategy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.8.3-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
 ## 0.8.2
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.3"  # pragma: no cover
+__version__ = "0.8.3-dev0"  # pragma: no cover


### PR DESCRIPTION
### Summary

Cleans up the CHANGELOG for the `0.8.2` release