### PR TITLE
fix: handling for empty tables in word docs and powerpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.5-dev0
+## 0.8.5-dev1
 
 ### Enhancements
 
@@ -7,6 +7,8 @@
 ### Features
 
 ### Fixes
+
+* Handling for empty tables in Word Documents and PowerPoints.
 
 ## 0.8.4
 

--- a/test_unstructured/partition/test_common.py
+++ b/test_unstructured/partition/test_common.py
@@ -219,3 +219,14 @@ def test_convert_office_doc_captures_errors(monkeypatch, caplog):
     monkeypatch.setattr(subprocess, "Popen", MockPopenWithError)
     common.convert_office_doc("no-real.docx", "fake-directory", target_format="docx")
     assert "an error occurred" in caplog.text
+
+
+class MockDocxEmptyTable:
+    def __init__(self):
+        self.rows = []
+
+
+def test_convert_ms_office_table_to_text_works_with_empty_tables():
+    table = MockDocxEmptyTable()
+    assert common.convert_ms_office_table_to_text(table, as_html=True) == ""
+    assert common.convert_ms_office_table_to_text(table, as_html=False) == ""

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.5-dev0"  # pragma: no cover
+__version__ = "0.8.5-dev1"  # pragma: no cover

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -318,6 +318,10 @@ def convert_ms_office_table_to_text(table: docxtable.Table, as_html: bool = True
     """
     fmt = "html" if as_html else "plain"
     rows = list(table.rows)
-    headers = [cell.text for cell in rows[0].cells]
-    data = [[cell.text for cell in row.cells] for row in rows[1:]]
-    return tabulate(data, headers=headers, tablefmt=fmt)
+    if len(rows) > 0:
+        headers = [cell.text for cell in rows[0].cells]
+        data = [[cell.text for cell in row.cells] for row in rows[1:]]
+        table_text = tabulate(data, headers=headers, tablefmt=fmt)
+    else:
+        table_text = ""
+    return table_text


### PR DESCRIPTION
### Summary

Closes #709. Adds handling so table conversion does not fail for empty tables in Word docs and PowerPoints.

### Testing

On this branch, `pip install unstructured==0.8.4` and run `test_unstructured/partition/test_common.py::test_convert_ms_office_table_to_text_works_with_empty_tables`. You'll get the `IndexError` indicated in the issue.

Run `pip install -e .`. Re run the test, this time it should pass.