### PR TITLE
build: enable merge_group checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+    branches: [ main ]
 
 env:
   GHA_CACHE_KEY_VERSION: "v1"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ main ]
+  merge_group:
+    branches: [ main ]
   schedule:
     - cron: '21 21 * * 5'
 


### PR DESCRIPTION
To enable merge queues for the unstructured repo, which will allow more users to commit changes simultaneously without having to manually upgrade their branches to latest.

Reference:
https://github.blog/changelog/2022-08-18-merge-group-webhook-event-and-github-actions-workflow-trigger/