### PR TITLE
fix: simplify `min_partition` logic for `partition_text`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.1-dev0
+## 0.9.1-dev1
 
 ### Enhancements
 
@@ -8,6 +8,9 @@
 ### Features
 
 ### Fixes
+
+* Simplifies `min_partition` logic; makes partitions falling below the `min_partition`
+  less likely.
 
 ## 0.9.0
 

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -245,13 +245,22 @@ def test_partition_text_splits_long_text_max_partition(filename="example-docs/no
     for element in elements_max_part:
         assert len(element.text) <= 500
 
+    # Make sure combined text is all the same
+    assert " ".join([el.text for el in elements]) == " ".join([el.text for el in elements_max_part])
+
 
 def test_partition_text_splits_max_min_partition(filename="example-docs/norwich-city.txt"):
     elements = partition_text(filename=filename)
     elements_max_part = partition_text(filename=filename, min_partition=1000, max_partition=1500)
-    for element in elements_max_part:
-        assert len(element.text) <= 1500
-        assert len(element.text) >= 1000
+    for i, element in enumerate(elements_max_part):
+        # NOTE(robinson) - the last element does not have a next element to merge with,
+        # so it can be short
+        if i < len(elements_max_part) - 1:
+            assert len(element.text) <= 1500
+            assert len(element.text) >= 1000
+
+    # Make sure combined text is all the same
+    assert " ".join([el.text for el in elements]) == " ".join([el.text for el in elements_max_part])
 
 
 def test_partition_text_min_max(filename="example-docs/norwich-city.txt"):
@@ -259,17 +268,23 @@ def test_partition_text_min_max(filename="example-docs/norwich-city.txt"):
         text=SHORT_PARAGRAPHS,
         min_partition=6,
     )
-    for segment in segments:
-        assert len(segment.text) >= 6
+    for i, segment in enumerate(segments):
+        # NOTE(robinson) - the last element does not have a next element to merge with,
+        # so it can be short
+        if i < len(segments) - 1:
+            assert len(segment.text) >= 6
 
     segments = partition_text(
         text=SHORT_PARAGRAPHS,
         max_partition=20,
         min_partition=7,
     )
-    for segment in segments:
-        assert segment.text >= 7
-        assert segment.text <= 20
+    for i, segment in enumerate(segments):
+        # NOTE(robinson) - the last element does not have a next element to merge with,
+        # so it can be short
+        if i < len(segments) - 1:
+            assert len(segment.text) >= 7
+            assert len(segment.text) <= 20
 
 
 def test_split_content_to_fit_max():

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -242,50 +242,34 @@ def test_partition_text_splits_long_text_max_partition(filename="example-docs/no
     elements = partition_text(filename=filename)
     elements_max_part = partition_text(filename=filename, max_partition=500)
     assert len(elements) < len(elements_max_part)
+    for element in elements_max_part:
+        assert len(element.text) <= 500
 
 
-def test_partition_text_min_max():
+def test_partition_text_splits_max_min_partition(filename="example-docs/norwich-city.txt"):
+    elements = partition_text(filename=filename)
+    elements_max_part = partition_text(filename=filename, min_partition=1000, max_partition=1500)
+    for element in elements_max_part:
+        assert len(element.text) <= 1500
+        assert len(element.text) >= 1000
+
+
+def test_partition_text_min_max(filename="example-docs/norwich-city.txt"):
     segments = partition_text(
         text=SHORT_PARAGRAPHS,
         min_partition=6,
     )
-    expected = [
-        "This is a story.",
-        "This is a story that doesn't matter because it is just being used as an example.",
-        "Hi. Hello.",
-        "Howdy.",
-        """Hola. The example is simple and repetitive and long and somewhat boring,
- but it serves a purpose. End.""".replace(
-            "\n",
-            "",
-        ),
-    ]
-    for segment, test_segment in zip(segments, expected):
-        assert segment.text == test_segment
+    for segment in segments:
+        assert len(segment.text) >= 6
 
     segments = partition_text(
         text=SHORT_PARAGRAPHS,
         max_partition=20,
         min_partition=7,
     )
-    expected = [
-        "This is a story.",
-        "This is a story that",
-        "doesn't matter",
-        "because it is just",
-        "being used as an",
-        "example.",
-        "Hi. Hello.",
-        "Howdy. Hola.",
-        "The example is",
-        "simple and",
-        "repetitive and long",
-        "and somewhat boring,",
-        "but it serves a",
-        "purpose. End.",
-    ]
-    for segment, test_segment in zip(segments, expected):
-        assert segment.text == test_segment
+    for segment in segments:
+        assert segment.text >= 7
+        assert segment.text <= 20
 
 
 def test_split_content_to_fit_max():

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.1-dev0"  # pragma: no cover
+__version__ = "0.9.1-dev1"  # pragma: no cover

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -124,7 +124,8 @@ def combine_paragraphs_less_than_min(
 ) -> List[str]:
     """Combine paragraphs less than `min_partition` while not exceeding `max_partition`."""
     min_partition = min_partition or 0
-    max_partition = max_partition or 1500
+    max_possible_partition = len(" ".join(split_paragraphs))
+    max_partition = max_partition or max_possible_partition
 
     combined_paras = []
     combined_idxs = []

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -124,56 +124,31 @@ def combine_paragraphs_less_than_min(
     min_partition: Optional[int] = 0,
 ) -> List[str]:
     """Combine paragraphs less than `min_partition` while not exceeding `max_partition`."""
-    if type(split_paragraphs) is not list:
-        raise ValueError("`split_paragraphs` is not a list")
-    file_content: List[str] = []
-    tmp_paragraph = ""
-    next_index = 0
-    for current_index, paragraph in enumerate(split_paragraphs):
-        if next_index > current_index:
-            continue  # Skip the current iteration if `next_index`` is already updated
-        if min_partition is not None and len(paragraph) < min_partition:
-            # Combine paragraphs that are less than `min_partition``
-            # while not exceeding `max_partition``
-            tmp_paragraph += paragraph + "\n"
+    min_partition = min_partition or 0
+    combined_paras = []
+    combined_idxs = []
+    for i, para in enumerate(split_paragraphs):
+        if i in combined_idxs:
+            continue
 
-            while len(tmp_paragraph.strip()) < min_partition:
-                if current_index + 1 == len(split_paragraphs):
-                    # If it's the last paragraph, append the paragraph
-                    # to the previous content
-                    file_content[-1] += " " + tmp_paragraph.rstrip()
-                    tmp_paragraph = ""
-                    break
-                for offset_index, para in enumerate(
-                    split_paragraphs[current_index + 1 :], start=1  # noqa
-                ):
-                    if (
-                        max_partition is not None
-                        and len(tmp_paragraph + "\n" + para) < max_partition
-                    ):
-                        tmp_paragraph += "\n" + para
-                        # Update `next_index` to skip already combined paragraphs
-                        next_index = offset_index + current_index + 1
-
-                    if len(tmp_paragraph.strip()) > min_partition:
-                        break  # Stop combining if the combined paragraphs
-                        # meet the `min_partition`` requirement
-                    elif (
-                        max_partition is not None
-                        and len(tmp_paragraph) < min_partition
-                        and len(tmp_paragraph + "\n" + para) > max_partition
-                    ):
-                        raise ValueError(
-                            "`min_partition` and `max_partition` are defined too close together",
-                        )
-            # Add the combined paragraph to the final result
-            file_content.append(
-                tmp_paragraph.strip(),
-            )
-            tmp_paragraph = ""
+        if len(para) >= min_partition:
+            combined_paras.append(para)
         else:
-            file_content.append(paragraph)
-    return file_content
+            combined_para = para
+            for j, next_para in enumerate(split_paragraphs[i + 1 :]):  # noqa
+                if len(combined_para) >= min_partition:
+                    break
+                elif (
+                    max_partition is not None
+                    and len(combined_para) + len(next_para) + 1 <= max_partition
+                ):
+                    combined_idxs.append(i + j + 1)
+                    combined_para += " " + next_para
+                else:
+                    break
+            combined_paras.append(combined_para)
+
+    return combined_paras
 
 
 @process_metadata()

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -36,25 +36,24 @@ def split_by_paragraph(
     min_partition: Optional[int] = 0,
     max_partition: Optional[int] = 1500,
 ) -> List[str]:
-    split_paragraphs = re.split(PARAGRAPH_PATTERN, file_text.strip())
+    paragraphs = re.split(PARAGRAPH_PATTERN, file_text.strip())
 
-    paragraphs = combine_paragraphs_less_than_min(
-        split_paragraphs=split_paragraphs,
-        max_partition=max_partition,
-        min_partition=min_partition,
-    )
-
-    file_content = []
-
+    split_paragraphs = []
     for paragraph in paragraphs:
-        file_content.extend(
+        split_paragraphs.extend(
             split_content_to_fit_max(
                 content=paragraph,
                 max_partition=max_partition,
             ),
         )
 
-    return file_content
+    combined_paragraphs = combine_paragraphs_less_than_min(
+        split_paragraphs=split_paragraphs,
+        max_partition=max_partition,
+        min_partition=min_partition,
+    )
+
+    return combined_paragraphs
 
 
 def _split_in_half_at_breakpoint(
@@ -125,6 +124,8 @@ def combine_paragraphs_less_than_min(
 ) -> List[str]:
     """Combine paragraphs less than `min_partition` while not exceeding `max_partition`."""
     min_partition = min_partition or 0
+    max_partition = max_partition or 1500
+
     combined_paras = []
     combined_idxs = []
     for i, para in enumerate(split_paragraphs):
@@ -136,12 +137,7 @@ def combine_paragraphs_less_than_min(
         else:
             combined_para = para
             for j, next_para in enumerate(split_paragraphs[i + 1 :]):  # noqa
-                if len(combined_para) >= min_partition:
-                    break
-                elif (
-                    max_partition is not None
-                    and len(combined_para) + len(next_para) + 1 <= max_partition
-                ):
+                if len(combined_para) + len(next_para) + 1 <= max_partition:
                     combined_idxs.append(i + j + 1)
                     combined_para += " " + next_para
                 else:


### PR DESCRIPTION
### Summary

Simplifies `min_partition` logic in `partition_text`.  Fixes an issue where segments exceeding the min partition were observed in an example file.

### Testing

The following should show all segments having a length greater than 1000, except for the last one which doesn't have a subsequent segment to merge with.

```python
from unstructured.partition.text import partition_text

elements = partition_text(filename=filename, min_partition=1000, max_partition=1500)
filename = "example-docs/norwich-city.txt"
[len(el.text) for el in elements]
```