### PR TITLE
Update `make check-version` script to fail if release version is unchanged

### DIFF
--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -108,17 +108,19 @@ for i in "${!FILES_TO_CHECK[@]}"; do
     RE_SEMVER=${RE_SEMVERS[$i]}
     UPDATED_VERSION=${UPDATED_VERSIONS[$i]}
     FILE_VERSION=$(grep -o -m 1 -E "${RE_SEMVER}" "$FILE_TO_CHANGE")
-    CURRENT_RELEASE=$(curl -sL https://api.github.com/repos/Unstructured-IO/unstructured/releases/latest | jq -r ".tag_name")
+    MAIN_VERSION=$(git show main:unstructured/__version__.py | grep -o -m 1 -E "${RE_SEMVER_FULL}")
+    MAIN_IS_RELEASE=false
+    [[ $MAIN_VERSION != *"-dev"* ]] && MAIN_IS_RELEASE=true
 
     if [ -z "$FILE_VERSION" ];
     then
         # No match to semver regex in VERSIONFILE, so nothing to replace
         printf "Error: No semver version found in file %s.\n" "$FILE_TO_CHANGE"
         exit 1
-    elif [ "$FILE_VERSION" == "$CURRENT_RELEASE" ]
+    elif [[ "$MAIN_IS_RELEASE" == true && "$FILE_VERSION" == "$MAIN_VERSION" ]];
     then 
-        # Only one commit should be associated with a particular non-dev release
-        printf "Error: there is already a commit associated with release version %s.\n" "$CURRENT_RELEASE"
+        # Only one commit should be associated with a particular non-dev version
+        printf "Error: there is already a commit associated with version %s.\n" "$MAIN_VERSION"
         exit 1
     else
         # Replace semver in VERSIONFILE with semver obtained from SOURCE_FILE

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -116,15 +116,10 @@ for i in "${!FILES_TO_CHECK[@]}"; do
         printf "Error: No semver version found in file %s.\n" "$FILE_TO_CHANGE"
         exit 1
     elif [ $FILE_VERSION == $CURRENT_RELEASE ]
-    then
-        # report error
-        # only one commit should be associated with a particular release
-        # echo "sed version must be >= ${REQUIRED_VERSION}" && exit 1
-        printf "Error: there is already a commit associated with release version ${CURRENT_RELEASE}"
+    then 
+        # Only one commit should be associated with a particular non-dev release
+        printf "Error: there is already a commit associated with release version ${CURRENT_RELEASE}.\n"
         exit 1
-
-        # this will compare __version__ version to main
-        # may need another case to compare changelog to main ?
     else
         # Replace semver in VERSIONFILE with semver obtained from SOURCE_FILE
         TMPFILE=$(mktemp /tmp/new_version.XXXXXX)

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -108,11 +108,27 @@ for i in "${!FILES_TO_CHECK[@]}"; do
     RE_SEMVER=${RE_SEMVERS[$i]}
     UPDATED_VERSION=${UPDATED_VERSIONS[$i]}
     FILE_VERSION=$(grep -o -m 1 -E "${RE_SEMVER}" "$FILE_TO_CHANGE")
+    # TODO SHREYA get version of previous commit in main here
+    # use git hub ?
+    # response=$(curl -sL https://api.github.com/repos/unstructured/unstructured/releases/latest | jq -r ".tag_name")
+    CURRENT_RELEASE=$(curl -sL https://api.github.com/repos/unstructured/unstructured/releases/latest | jq -r ".tag_name")
+    # maybe check if the result meets the RE_RELEASE pattern ?
+
     if [ -z "$FILE_VERSION" ];
     then
         # No match to semver regex in VERSIONFILE, so nothing to replace
         printf "Error: No semver version found in file %s.\n" "$FILE_TO_CHANGE"
         exit 1
+    # TODO SHREYA check file version against main commit
+    elif [ $FILE_VERSION == $CURRENT_RELEASE ]
+    then
+        # report error
+        # only one commit should be associated with a particular release
+        # echo "sed version must be >= ${REQUIRED_VERSION}" && exit 1
+        echo "only one commit should be associated with the latest release ${CURRENT_RELEASE}" && exit 1
+
+        # this will compare __version__ version to main
+        # may need another case to compare changelog to main ?
     else
         # Replace semver in VERSIONFILE with semver obtained from SOURCE_FILE
         TMPFILE=$(mktemp /tmp/new_version.XXXXXX)

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -108,24 +108,20 @@ for i in "${!FILES_TO_CHECK[@]}"; do
     RE_SEMVER=${RE_SEMVERS[$i]}
     UPDATED_VERSION=${UPDATED_VERSIONS[$i]}
     FILE_VERSION=$(grep -o -m 1 -E "${RE_SEMVER}" "$FILE_TO_CHANGE")
-    # TODO SHREYA get version of previous commit in main here
-    # use git hub ?
-    # response=$(curl -sL https://api.github.com/repos/unstructured/unstructured/releases/latest | jq -r ".tag_name")
-    CURRENT_RELEASE=$(curl -sL https://api.github.com/repos/unstructured/unstructured/releases/latest | jq -r ".tag_name")
-    # maybe check if the result meets the RE_RELEASE pattern ?
+    CURRENT_RELEASE=$(curl -sL https://api.github.com/repos/Unstructured-IO/unstructured/releases/latest | jq -r ".tag_name")
 
     if [ -z "$FILE_VERSION" ];
     then
         # No match to semver regex in VERSIONFILE, so nothing to replace
         printf "Error: No semver version found in file %s.\n" "$FILE_TO_CHANGE"
         exit 1
-    # TODO SHREYA check file version against main commit
     elif [ $FILE_VERSION == $CURRENT_RELEASE ]
     then
         # report error
         # only one commit should be associated with a particular release
         # echo "sed version must be >= ${REQUIRED_VERSION}" && exit 1
-        echo "only one commit should be associated with the latest release ${CURRENT_RELEASE}" && exit 1
+        printf "Error: there is already a commit associated with release version ${CURRENT_RELEASE}"
+        exit 1
 
         # this will compare __version__ version to main
         # may need another case to compare changelog to main ?

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -115,10 +115,10 @@ for i in "${!FILES_TO_CHECK[@]}"; do
         # No match to semver regex in VERSIONFILE, so nothing to replace
         printf "Error: No semver version found in file %s.\n" "$FILE_TO_CHANGE"
         exit 1
-    elif [ $FILE_VERSION == $CURRENT_RELEASE ]
+    elif [ "$FILE_VERSION" == "$CURRENT_RELEASE" ]
     then 
         # Only one commit should be associated with a particular non-dev release
-        printf "Error: there is already a commit associated with release version ${CURRENT_RELEASE}.\n"
+        printf "Error: there is already a commit associated with release version %s.\n" "$CURRENT_RELEASE"
         exit 1
     else
         # Replace semver in VERSIONFILE with semver obtained from SOURCE_FILE


### PR DESCRIPTION
## Summary
We only want one commit to correspond to a release, so this change checks if a non-dev version is identical to a previous commit release version.

## Test
Manual version changes to test the cases below. Print statements included temporarily for visibility.

### __version__ and CHANGELOG synced and dev version
no errors (Unaffected by current PR)
![checkversion3](https://github.com/Unstructured-IO/unstructured/assets/42684285/27fde63d-c480-4817-97e9-3780f771aa2e)

### __version__ and CHANGELOG out of sync and dev version
Error: out of sync (Unaffected by current PR)
![checkversion2](https://github.com/Unstructured-IO/unstructured/assets/42684285/df67aafb-f203-46e3-a5c5-c55478508a74)

### __version__ and CHANGELOG synced and same as current release version
Error: already a commit for this release version
<img width="551" alt="Screenshot 2023-08-03 at 3 32 14 PM" src="https://github.com/Unstructured-IO/unstructured/assets/42684285/d917ceaa-7ef3-47b5-8cd7-a90e129c89b8">

### __version__ and CHANGELOG out of sync and __version__ same as current release version
Error: already a commit for this release version
<img width="551" alt="Screenshot 2023-08-03 at 3 32 38 PM" src="https://github.com/Unstructured-IO/unstructured/assets/42684285/5bcaea87-821d-4bf4-9b71-07be35520378">


### __version__ and CHANGELOG out of sync and CHANGELOG version same as current release version
Error: out of sync
![checkversion1](https://github.com/Unstructured-IO/unstructured/assets/42684285/0836764b-b970-43d5-9326-4843235e9485)

### __version__ and CHANGELOG synced and ahead of current release version
no errors
<img width="564" alt="Screenshot 2023-08-03 at 3 33 58 PM" src="https://github.com/Unstructured-IO/unstructured/assets/42684285/3c2bffc7-337e-4c8a-bbc3-757fb6a0d1a4">

