### PR TITLE
Dynamically import modules for ingest cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.1-dev6
+## 0.9.1-dev7
 
 ### Enhancements
 
@@ -8,6 +8,7 @@
 * Update `XMLDocument._read_xml` to create `<p>` tag element for the text enclosed in the `<pre>` tag
 * Track emphasized texts in `partition_html` output
 * Add parameter `include_tail_text` to `_construct_text` to enable (skip) tail text inclusion
+* Optimize how imports are handled for ingest cli modules
 
 ### Features
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.1-dev6"  # pragma: no cover
+__version__ = "0.9.1-dev7"  # pragma: no cover

--- a/unstructured/ingest/cli/cli.py
+++ b/unstructured/ingest/cli/cli.py
@@ -8,37 +8,10 @@ def ingest():
     pass
 
 
-# Dynamically update shared options for supported subcommands
-subcommands = [
-    cli_cmds.box,
-    cli_cmds.s3,
-    cli_cmds.gcs,
-    cli_cmds.dropbox,
-    cli_cmds.azure,
-    cli_cmds.fsspec,
-    cli_cmds.github,
-    cli_cmds.gitlab,
-    cli_cmds.reddit,
-    cli_cmds.slack,
-    cli_cmds.discord,
-    cli_cmds.wikipedia,
-    cli_cmds.gdrive,
-    cli_cmds.biomed,
-    cli_cmds.onedrive,
-    cli_cmds.outlook,
-    cli_cmds.local,
-    cli_cmds.elasticsearch,
-    cli_cmds.confluence,
-]
-
-for subcommand in subcommands:
-    ingest.add_command(subcommand())
-
-
 def get_cmd() -> click.Command:
     cmd = ingest
     # Add all subcommands
-    for subcommand in subcommands:
-        # add_shared_options(cmd)
-        cmd.add_command(subcommand())
+    for subcommand in cli_cmds.__all__:
+        sub = getattr(cli_cmds, subcommand)
+        cmd.add_command(sub())
     return cmd

--- a/unstructured/ingest/cli/cmds/__init__.py
+++ b/unstructured/ingest/cli/cmds/__init__.py
@@ -1,41 +1,36 @@
-from .azure import get_cmd as azure
-from .biomed import get_cmd as biomed
-from .box import get_cmd as box
-from .confluence import get_cmd as confluence
-from .discord import get_cmd as discord
-from .dropbox import get_cmd as dropbox
-from .elasticsearch import get_cmd as elasticsearch
-from .fsspec import get_cmd as fsspec
-from .gcs import get_cmd as gcs
-from .github import get_cmd as github
-from .gitlab import get_cmd as gitlab
-from .google_drive import get_cmd as gdrive
-from .local import get_cmd as local
-from .onedrive import get_cmd as onedrive
-from .outlook import get_cmd as outlook
-from .reddit import get_cmd as reddit
-from .s3 import get_cmd as s3
-from .slack import get_cmd as slack
-from .wikipedia import get_cmd as wikipedia
+import importlib.util as import_utils
+import pkgutil
+import sys
+from importlib.machinery import ModuleSpec, SourceFileLoader
+from typing import Optional
 
-__all__ = [
-    "azure",
-    "biomed",
-    "box",
-    "confluence",
-    "discord",
-    "dropbox",
-    "elasticsearch",
-    "fsspec",
-    "gcs",
-    "gdrive",
-    "github",
-    "gitlab",
-    "local",
-    "onedrive",
-    "outlook",
-    "reddit",
-    "s3",
-    "slack",
-    "wikipedia",
-]
+__all__ = []
+
+
+def _import_modules():
+    module_name: str
+    is_pkg: bool
+    for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
+        if is_pkg:
+            # Ignore packages from being dynamically added
+            return
+
+        spec: Optional[ModuleSpec] = import_utils.spec_from_loader(
+            module_name,
+            loader.find_module(module_name),  # type: ignore
+        )
+        if not spec:
+            return
+        module = import_utils.module_from_spec(spec)
+        spec_loader: Optional[SourceFileLoader] = spec.loader  # type: ignore
+        if not spec_loader:
+            return
+        spec_loader.exec_module(module)
+        if hasattr(module, "get_cmd"):
+            __all__.append(module_name)
+            sys.modules[module_name] = module.get_cmd
+            current_module = sys.modules[__name__]
+            setattr(current_module, module_name, module.get_cmd)
+
+
+_import_modules()

--- a/unstructured/ingest/cli/cmds/azure.py
+++ b/unstructured/ingest/cli/cmds/azure.py
@@ -40,7 +40,11 @@ def azure(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        azure_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        azure_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/biomed.py
+++ b/unstructured/ingest/cli/cmds/biomed.py
@@ -59,7 +59,11 @@ def biomed(
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        biomed_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        biomed_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/box.py
+++ b/unstructured/ingest/cli/cmds/box.py
@@ -29,7 +29,11 @@ def box(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        box_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        box_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/confluence.py
+++ b/unstructured/ingest/cli/cmds/confluence.py
@@ -66,7 +66,7 @@ def confluence(
             connector_config=connector_config,
             processor_config=processor_config,
             **options,
-        )
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/discord.py
+++ b/unstructured/ingest/cli/cmds/discord.py
@@ -38,7 +38,11 @@ def discord(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        discord_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        discord_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/dropbox.py
+++ b/unstructured/ingest/cli/cmds/dropbox.py
@@ -29,7 +29,11 @@ def dropbox(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        dropbox_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        dropbox_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/elasticsearch.py
+++ b/unstructured/ingest/cli/cmds/elasticsearch.py
@@ -44,7 +44,7 @@ def elasticsearch(**options):
             connector_config=connector_config,
             processor_config=processor_config,
             **options,
-        )
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/fsspec.py
+++ b/unstructured/ingest/cli/cmds/fsspec.py
@@ -24,7 +24,11 @@ def fsspec(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        fsspec_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        fsspec_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/gcs.py
+++ b/unstructured/ingest/cli/cmds/gcs.py
@@ -30,7 +30,11 @@ def gcs(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        gcs_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        gcs_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/github.py
+++ b/unstructured/ingest/cli/cmds/github.py
@@ -46,7 +46,11 @@ def github(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        github_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        github_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/gitlab.py
+++ b/unstructured/ingest/cli/cmds/gitlab.py
@@ -46,7 +46,11 @@ def gitlab(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        gitlab_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        gitlab_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/google_drive.py
+++ b/unstructured/ingest/cli/cmds/google_drive.py
@@ -11,7 +11,7 @@ from unstructured.ingest.cli.common import (
     run_init_checks,
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
-from unstructured.ingest.runner import gdrive as gdrive_fn
+from unstructured.ingest.runner import google_drive as google_drive_fn
 
 
 @click.command()
@@ -38,7 +38,11 @@ def gdrive(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        gdrive_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        google_drive_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/local.py
+++ b/unstructured/ingest/cli/cmds/local.py
@@ -34,7 +34,11 @@ def local(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        local_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        local_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/onedrive.py
+++ b/unstructured/ingest/cli/cmds/onedrive.py
@@ -54,7 +54,11 @@ def onedrive(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        onedrive_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        onedrive_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/outlook.py
+++ b/unstructured/ingest/cli/cmds/outlook.py
@@ -55,7 +55,11 @@ def outlook(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        outlook_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        outlook_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/reddit.py
+++ b/unstructured/ingest/cli/cmds/reddit.py
@@ -55,7 +55,11 @@ def reddit(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        reddit_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        reddit_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/s3.py
+++ b/unstructured/ingest/cli/cmds/s3.py
@@ -30,7 +30,11 @@ def s3(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        s3_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        s3_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/slack.py
+++ b/unstructured/ingest/cli/cmds/slack.py
@@ -45,7 +45,11 @@ def slack(**options):
         run_init_checks(**options)
         connector_config = map_to_standard_config(options)
         processor_config = map_to_processor_config(options)
-        slack_fn(connector_config=connector_config, processor_config=processor_config, **options)
+        slack_fn(
+            connector_config=connector_config,
+            processor_config=processor_config,
+            **options,
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/cli/cmds/wikipedia.py
+++ b/unstructured/ingest/cli/cmds/wikipedia.py
@@ -37,7 +37,7 @@ def wikipedia(**options):
             connector_config=connector_config,
             processor_config=processor_config,
             **options,
-        )
+        )  # type: ignore
     except Exception as e:
         logger.error(e, exc_info=True)
         raise click.ClickException(str(e)) from e

--- a/unstructured/ingest/runner/__init__.py
+++ b/unstructured/ingest/runner/__init__.py
@@ -1,41 +1,36 @@
-from .azure import azure
-from .biomed import biomed
-from .box import box
-from .confluence import confluence
-from .discord import discord
-from .dropbox import dropbox
-from .elasticsearch import elasticsearch
-from .fsspec import fsspec
-from .gcs import gcs
-from .github import github
-from .gitlab import gitlab
-from .google_drive import gdrive
-from .local import local
-from .onedrive import onedrive
-from .outlook import outlook
-from .reddit import reddit
-from .s3 import s3
-from .slack import slack
-from .wikipedia import wikipedia
+import importlib.util as import_utils
+import pkgutil
+import sys
+from importlib.machinery import ModuleSpec, SourceFileLoader
+from typing import Optional
 
-__all__ = [
-    "azure",
-    "biomed",
-    "box",
-    "confluence",
-    "discord",
-    "dropbox",
-    "elasticsearch",
-    "fsspec",
-    "gcs",
-    "gdrive",
-    "github",
-    "gitlab",
-    "local",
-    "onedrive",
-    "outlook",
-    "reddit",
-    "s3",
-    "slack",
-    "wikipedia",
-]
+__all__ = []
+
+
+def _import_modules():
+    module_name: str
+    is_pkg: bool
+    for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
+        if is_pkg:
+            # Ignore packages from being dynamically added
+            return
+
+        spec: Optional[ModuleSpec] = import_utils.spec_from_loader(
+            module_name,
+            loader.find_module(module_name),  # type: ignore
+        )
+        if not spec:
+            return
+        module = import_utils.module_from_spec(spec)
+        spec_loader: Optional[SourceFileLoader] = spec.loader  # type: ignore
+        if not spec_loader:
+            return
+        spec_loader.exec_module(module)
+        if hasattr(module, module_name):
+            __all__.append(module_name)
+            sys.modules[module_name] = getattr(module, module_name)
+            current_module = sys.modules[__name__]
+            setattr(current_module, module_name, getattr(module, module_name))
+
+
+_import_modules()

--- a/unstructured/ingest/runner/google_drive.py
+++ b/unstructured/ingest/runner/google_drive.py
@@ -8,7 +8,7 @@ from unstructured.ingest.processor import process_documents
 from unstructured.ingest.runner.utils import update_download_dir_hash
 
 
-def gdrive(
+def google_drive(
     verbose: bool,
     connector_config: StandardConnectorConfig,
     processor_config: ProcessorConfigs,


### PR DESCRIPTION
### Description
To ease developer experience with adding new connectors and therefore new cli subcommands, have them dynamically added in the `__init__.py` file. This does remove IDE support since it no longer has concrete information on the dynamically added modules/methods and mypy needed to be ignored in all places these are imported since it can't check typing information either. 