### PR TITLE
fix: ingest test check num files in smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.1-dev9
+## 0.9.1-dev10
 
 ### Enhancements
 
@@ -24,6 +24,7 @@
 * Adds new element type `EmailAddress` for recognising email address in the  text
 * Simplifies `min_partition` logic; makes partitions falling below the `min_partition`
   less likely.
+* Fix bug where ingest test check for number of files fails in smoke test
 
 ## 0.9.0
 

--- a/test_unstructured_ingest/check-num-files-output.sh
+++ b/test_unstructured_ingest/check-num-files-output.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR=$(dirname "$(realpath "$0")")
 OUTPUT_DIR=$SCRIPT_DIR/structured-output/$OUTPUT_FOLDER_NAME
 num_files_created="$(find "$OUTPUT_DIR" -type f -exec printf '.' \; | wc -c | xargs)"
 
-if [[ num_files_created != "$EXPECTED_NUM_FILES" ]]; then
+if [[ num_files_created -ne "$EXPECTED_NUM_FILES" ]]; then
    echo
    echo "ERROR: $num_files_created files created. $EXPECTED_NUM_FILES files should have been created."
    exit 1

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.1-dev9"  # pragma: no cover
+__version__ = "0.9.1-dev10"  # pragma: no cover


### PR DESCRIPTION
Comparing variable values with `-ne` rather than `!=` fixes issue where matching expected values fails specifically for ingest tests in a Docker container.

I validated this by running this before and after the change:
`make docker-build`
`make docker-smoke-test`

Before this change, the comparison failed despite comparing equal values. Now it succeeds.