### PR TITLE
Chore[ingest]: adding parameter --partition-pdf-infer-table-structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.9.1-dev10
+## 0.9.1-dev11
 
 ### Enhancements
 
+* Adds --partition-pdf-infer-table-structure to unstructured-ingest.
 * Enable `partition_html` to skip headers and footers with the `skip_headers_and_footers` flag.
 * Update `partition_doc` and `partition_docx` to track emphasized texts in the output
 * Adds post processing function `filter_element_types`

--- a/test_unstructured_ingest/expected-structured-output/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.json
+++ b/test_unstructured_ingest/expected-structured-output/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.json
@@ -1,0 +1,7561 @@
+[
+  {
+    "type": "Title",
+    "element_id": "2f7cc75f6467bba468022c4c2875335e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            437.83888888888885,
+            314.99337164100245
+          ],
+          [
+            437.83888888888885,
+            413.1229949803744
+          ],
+          [
+            1275.7076416015625,
+            413.1229949803744
+          ],
+          [
+            1275.7076416015625,
+            314.99337164100245
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "7d5d472da16528a310bc18c9682ed62d",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.46944444444443,
+            468.4452761333334
+          ],
+          [
+            374.46944444444443,
+            534.0326233333333
+          ],
+          [
+            1334.8511664111113,
+            534.0326233333333
+          ],
+          [
+            1334.8511664111113,
+            468.4452761333334
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "Zejiang Shen1 ((cid:0)), Ruochen Zhang2, Melissa Dell3, Benjamin Charles Germain Lee4, Jacob Carlson3, and Weining Li5"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "d598892f792aa3f81bde483737ac163e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            575.6388888888889,
+            556.8422415175876
+          ],
+          [
+            575.6388888888889,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            556.8422415175876
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "Allen Institute for AI shannons@allenai.org"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "c44dd169d4120fc474358e959bc32f27",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            575.6388888888889,
+            556.8422415175876
+          ],
+          [
+            575.6388888888889,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            556.8422415175876
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "Brown University ruochen zhang@brown.edu"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "69ce85202ad89819bf6a6687c34c04a0",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            575.6388888888889,
+            556.8422415175876
+          ],
+          [
+            575.6388888888889,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            556.8422415175876
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "Harvard University {melissadell,jacob carlson}@fas.harvard.edu"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "ee43ace21caffc7f3e421e0d25282863",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            575.6388888888889,
+            556.8422415175876
+          ],
+          [
+            575.6388888888889,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            556.8422415175876
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "University of Washington bcgl@cs.washington.edu"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "91e84c77f84bea17e45f12fe8d612afa",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            575.6388888888889,
+            556.8422415175876
+          ],
+          [
+            575.6388888888889,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            556.8422415175876
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "University of Waterloo w"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "a02bbc7d83b04c67fcac3ae66b21b824",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            575.6388888888889,
+            556.8422415175876
+          ],
+          [
+            575.6388888888889,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            874.4119218466939
+          ],
+          [
+            1133.6854444444443,
+            556.8422415175876
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "li@uwaterloo.ca"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "7dce5432959ba3ffb1edad16bc3f458c",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            45.388888888888886,
+            592.6666666666666
+          ],
+          [
+            45.388888888888886,
+            703.7777777777778
+          ],
+          [
+            100.94444444444446,
+            703.7777777777778
+          ],
+          [
+            100.94444444444446,
+            592.6666666666666
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "1 2 0 2"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "c8d21c806367081195dd372b58005d48",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            45.388888888888886,
+            717.6666666666666
+          ],
+          [
+            45.388888888888886,
+            794.8333333333333
+          ],
+          [
+            100.94444444444446,
+            794.8333333333333
+          ],
+          [
+            100.94444444444446,
+            717.6666666666666
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "n u J"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "a6e2b7a040683432de03a18fd8a1939a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            45.388888888888886,
+            808.7222222222222
+          ],
+          [
+            45.388888888888886,
+            864.2777777777777
+          ],
+          [
+            100.94444444444446,
+            864.2777777777777
+          ],
+          [
+            100.94444444444446,
+            808.7222222222222
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "1 2"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "f9416e09f78ba316c032568213b855ee",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            45.388888888888886,
+            892.0555555555554
+          ],
+          [
+            45.388888888888886,
+            910.5555555555555
+          ],
+          [
+            100.94444444444446,
+            910.5555555555555
+          ],
+          [
+            100.94444444444446,
+            892.0555555555554
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "]"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "20f7b3c9b9ca29dbbf5c1975fb8894a9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            45.388888888888886,
+            910.5555555555555
+          ],
+          [
+            45.388888888888886,
+            1066.3888888888887
+          ],
+          [
+            100.94444444444446,
+            1066.3888888888887
+          ],
+          [
+            100.94444444444446,
+            910.5555555555555
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "V C . s c ["
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "be90d2640470e975e3402d19ba2c66cf",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            444.49250411987305,
+            940.1391155555556
+          ],
+          [
+            444.49250411987305,
+            1584.0870791817633
+          ],
+          [
+            1261.2144504231107,
+            1584.0870791817633
+          ],
+          [
+            1261.2144504231107,
+            940.1391155555556
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "Abstract. Recent advances in document image analysis (DIA) have been primarily driven by the application of neural networks. Ideally, research outcomes could be easily deployed in production and extended for further investigation. However, various factors like loosely organized codebases and sophisticated model conﬁgurations complicate the easy reuse of im- portant innovations by a wide audience. Though there have been on-going eﬀorts to improve reusability and simplify deep learning (DL) model development in disciplines like natural language processing and computer vision, none of them are optimized for challenges in the domain of DIA. This represents a major gap in the existing toolkit, as DIA is central to academic research across a wide range of disciplines in the social sciences and humanities. This paper introduces LayoutParser, an open-source library for streamlining the usage of DL in DIA research and applica- tions. The core LayoutParser library comes with a set of simple and intuitive interfaces for applying and customizing DL models for layout de- tection, character recognition, and many other document processing tasks. To promote extensibility, LayoutParser also incorporates a community platform for sharing both pre-trained models and full document digiti- zation pipelines. We demonstrate that LayoutParser is helpful for both lightweight and large-scale digitization pipelines in real-word use cases. The library is publicly available at https://layout-parser.github.io."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "12529cdcfd90d0bf95ff502804e61a16",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            45.388888888888886,
+            1094.1666666666665
+          ],
+          [
+            45.388888888888886,
+            1555.5555555555554
+          ],
+          [
+            100.94444444444446,
+            1555.5555555555554
+          ],
+          [
+            100.94444444444446,
+            1094.1666666666665
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "2 v 8 4 3 5 1 . 3 0 1 2 : v i X r a"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "e66a3d2b6c9a872c53e226d8e0cc0a0e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            444.8290100097656,
+            1603.7655555555555
+          ],
+          [
+            444.8290100097656,
+            1665.2347052385267
+          ],
+          [
+            1257.1887283325195,
+            1665.2347052385267
+          ],
+          [
+            1257.1887283325195,
+            1603.7655555555555
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "Keywords: Document Image Analysis · Deep Learning · Layout Analysis · Character Recognition · Open Source library · Toolkit."
+  },
+  {
+    "type": "Title",
+    "element_id": "3fa53fc0dab8ef96d05d8fd4c7e41b49",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            413.9729633331299,
+            1718.8177224864132
+          ],
+          [
+            413.9729633331299,
+            1755.218948143116
+          ],
+          [
+            635.9834533333334,
+            1755.218948143116
+          ],
+          [
+            635.9834533333334,
+            1718.8177224864132
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "Introduction"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4355a46b19d348dc2f57c046f8ef63d4",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.34722222222223,
+            1720.066968888889
+          ],
+          [
+            374.34722222222223,
+            1753.2758577777777
+          ],
+          [
+            393.02722222222224,
+            1753.2758577777777
+          ],
+          [
+            393.02722222222224,
+            1720.066968888889
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "1"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "bca638b88125eed8a8003e46a6055618",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.5987243652344,
+            1785.9365122222223
+          ],
+          [
+            372.5987243652344,
+            1848.6797417534724
+          ],
+          [
+            1338.8229390955555,
+            1848.6797417534724
+          ],
+          [
+            1338.8229390955555,
+            1785.9365122222223
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 1
+    },
+    "text": "Deep Learning(DL)-based approaches are the state-of-the-art for a wide range of document image analysis (DIA) tasks including document image classiﬁcation [11,"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "53c234e5e8472b6ac51c1ae1cab3fe06",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            257.4113377777776
+          ],
+          [
+            374.3472222222222,
+            282.31800444444434
+          ],
+          [
+            387.14675822222216,
+            282.31800444444434
+          ],
+          [
+            387.14675822222216,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "2"
+  },
+  {
+    "type": "Title",
+    "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            464.5448570251465,
+            257.4113377777776
+          ],
+          [
+            464.5448570251465,
+            285.674692052574
+          ],
+          [
+            616.9257022222222,
+            285.674692052574
+          ],
+          [
+            616.9257022222222,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "Z. Shen et al."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "82d5520be5fd847464727f56151d316c",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            369.18904876708984,
+            320.6916285712938
+          ],
+          [
+            369.18904876708984,
+            491.92897335918633
+          ],
+          [
+            1340.3470138088887,
+            491.92897335918633
+          ],
+          [
+            1340.3470138088887,
+            320.6916285712938
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "37], layout detection [38, 22], table detection [26], and scene text detection [4]. A generalized learning-based framework dramatically reduces the need for the manual speciﬁcation of complicated rules, which is the status quo with traditional methods. DL has the potential to transform DIA pipelines and beneﬁt a broad spectrum of large-scale document digitization projects."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "c1f1ba1630bc19bd24c1dfbc1548f2d8",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.225,
+            493.1781788888887
+          ],
+          [
+            372.225,
+            1085.4020677777778
+          ],
+          [
+            1339.607430018889,
+            1085.4020677777778
+          ],
+          [
+            1339.607430018889,
+            493.1781788888887
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "However, there are several practical diﬃculties for taking advantages of re- cent advances in DL-based methods: 1) DL models are notoriously convoluted for reuse and extension. Existing models are developed using distinct frame- works like TensorFlow [1] or PyTorch [24], and the high-level parameters can be obfuscated by implementation details [8]. It can be a time-consuming and frustrating experience to debug, reproduce, and adapt existing models for DIA, and many researchers who would beneﬁt the most from using these methods lack the technical background to implement them from scratch. 2) Document images contain diverse and disparate patterns across domains, and customized training is often required to achieve a desirable detection accuracy. Currently there is no full-ﬂedged infrastructure for easily curating the target document image datasets and ﬁne-tuning or re-training the models. 3) DIA usually requires a sequence of models and other processing to obtain the ﬁnal outputs. Often research teams use DL models and then perform further document analyses in separate processes, and these pipelines are not documented in any central location (and often not documented at all). This makes it diﬃcult for research teams to learn about how full pipelines are implemented and leads them to invest signiﬁcant resources in reinventing the DIA wheel."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "836e6ef5cecc9a73356c0d5bee181829",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.5436668395996,
+            1090.936512222222
+          ],
+          [
+            372.5436668395996,
+            1187.2160538383152
+          ],
+          [
+            1340.7606048583984,
+            1187.2160538383152
+          ],
+          [
+            1340.7606048583984,
+            1090.936512222222
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "LayoutParser provides a uniﬁed toolkit to support DL-based document image analysis and processing. To address the aforementioned challenges, LayoutParser is built with the following components:"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "71c0c5ffbb8105ccb9f3bd1543f59007",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            386.03055555555545,
+            1207.097623333333
+          ],
+          [
+            386.03055555555545,
+            1234.771512222222
+          ],
+          [
+            1335.5285158244444,
+            1234.771512222222
+          ],
+          [
+            1335.5285158244444,
+            1207.097623333333
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "1. An oﬀ-the-shelf toolkit for applying DL models for layout detection, character"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "798b60ffa3907be6de6b739de4b6ae6b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            421.39166666666665,
+            1240.3059566666666
+          ],
+          [
+            421.39166666666665,
+            1267.9798455555556
+          ],
+          [
+            961.884855777778,
+            1267.9798455555556
+          ],
+          [
+            961.884855777778,
+            1240.3059566666666
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "recognition, and other DIA tasks (Section 3)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "5e547c7cebdde2107f00c9d51402dbe6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            386.03055555555557,
+            1272.3920677777778
+          ],
+          [
+            386.03055555555557,
+            1300.0659566666666
+          ],
+          [
+            1335.7155913133333,
+            1300.0659566666666
+          ],
+          [
+            1335.7155913133333,
+            1272.3920677777778
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "2. A rich repository of pre-trained neural network models (Model Zoo) that"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "a755646a34c86b2fb223ed3040821c4b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            421.39166666666665,
+            1305.600401111111
+          ],
+          [
+            421.39166666666665,
+            1333.2742899999998
+          ],
+          [
+            803.2138464444444,
+            1333.2742899999998
+          ],
+          [
+            803.2138464444444,
+            1305.600401111111
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "underlies the oﬀ-the-shelf usage"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "beba83994ae4b4055cfc52903455a858",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            386.03055555555557,
+            1337.68929
+          ],
+          [
+            386.03055555555557,
+            1365.3631788888888
+          ],
+          [
+            1334.9671233144445,
+            1365.3631788888888
+          ],
+          [
+            1334.9671233144445,
+            1337.68929
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "3. Comprehensive tools for eﬃcient document image data annotation and model"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "3ecbd234f3fb48c8974ca103ce412060",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            421.39166666666665,
+            1370.8976233333333
+          ],
+          [
+            421.39166666666665,
+            1398.571512222222
+          ],
+          [
+            1027.7597808888893,
+            1398.571512222222
+          ],
+          [
+            1027.7597808888893,
+            1370.8976233333333
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "tuning to support diﬀerent levels of customization"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "18b1855acfb386ae6e6a253da566e93b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            386.03055555555557,
+            1402.9865122222222
+          ],
+          [
+            386.03055555555557,
+            1497.0770677777775
+          ],
+          [
+            1339.5996769666667,
+            1497.0770677777775
+          ],
+          [
+            1339.5996769666667,
+            1402.9865122222222
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "4. A DL model hub and community platform for the easy sharing, distribu- tion, and discussion of DIA models and pipelines, to promote reusability, reproducibility, and extensibility (Section 4)"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "1f0f5df7c23d4f8e8de4de3085abd7d8",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            370.3133182525635,
+            1519.5807621905194
+          ],
+          [
+            370.3133182525635,
+            1714.7136360205316
+          ],
+          [
+            1335.7142673300004,
+            1714.7136360205316
+          ],
+          [
+            1335.7142673300004,
+            1519.5807621905194
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "The library implements simple and intuitive Python APIs without sacriﬁcing generalizability and versatility, and can be easily installed via pip. Its convenient functions for handling document image data can be seamlessly integrated with existing DIA pipelines. With detailed documentations and carefully curated tutorials, we hope this tool will beneﬁt a variety of end-users, and will lead to advances in applications in both industry and academic research."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "aebca7fedab12541cd5af93183b619e9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            368.1235980987549,
+            1719.5198455555555
+          ],
+          [
+            368.1235980987549,
+            1848.6279768644324
+          ],
+          [
+            1339.5998601505555,
+            1848.6279768644324
+          ],
+          [
+            1339.5998601505555,
+            1719.5198455555555
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 2
+    },
+    "text": "LayoutParser is well aligned with recent eﬀorts for improving DL model reusability in other disciplines like natural language processing [8, 34] and com- puter vision [35], but with a focus on unique challenges in DIA. We show LayoutParser can be applied in sophisticated and large-scale digitization projects"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4c2478cf439baab6ace34761eda527d9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            658.7111111111111,
+            257.4113377777776
+          ],
+          [
+            658.7111111111111,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "1121cfccd5913f0a63fec40a6ffd44ea",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            1322.1886657777777,
+            257.4113377777776
+          ],
+          [
+            1322.1886657777777,
+            282.31800444444434
+          ],
+          [
+            1334.9882017777777,
+            282.31800444444434
+          ],
+          [
+            1334.9882017777777,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "3"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "74a7758f83612467af8eea9d20e4a6f7",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            373.35,
+            327.13373444444437
+          ],
+          [
+            373.35,
+            493.4703410420441
+          ],
+          [
+            1340.341159733667,
+            493.4703410420441
+          ],
+          [
+            1340.341159733667,
+            327.13373444444437
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "that require precision, eﬃciency, and robustness, as well as simple and light- weight document processing tasks focusing on eﬃcacy and ﬂexibility (Section 5). LayoutParser is being actively maintained, and support for more deep learning models and novel methods in text-based layout analysis methods [37, 34] is planned."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "9b8fc4816306f4f1b31874d53134979b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.87650871276855,
+            493.3290579238376
+          ],
+          [
+            372.87650871276855,
+            658.1393830672555
+          ],
+          [
+            1339.5969360802223,
+            658.1393830672555
+          ],
+          [
+            1339.5969360802223,
+            493.3290579238376
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "The rest of the paper is organized as follows. Section 2 provides an overview of related work. The core LayoutParser library, DL Model Zoo, and customized model training are described in Section 3, and the DL model hub and commu- nity platform are detailed in Section 4. Section 5 shows two examples of how LayoutParser can be used in practical DIA projects, and Section 6 concludes."
+  },
+  {
+    "type": "Title",
+    "element_id": "1513104c7bf6cd40223a7cc23798378f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            706.4619069859601
+          ],
+          [
+            374.3472222222222,
+            749.1161755548007
+          ],
+          [
+            662.1954727172852,
+            749.1161755548007
+          ],
+          [
+            662.1954727172852,
+            706.4619069859601
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "2 Related Work"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "181670e0d50864954486b337b1d19118",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            368.8820171356201,
+            784.4587344444444
+          ],
+          [
+            368.8820171356201,
+            1011.385401111111
+          ],
+          [
+            1339.5917217947222,
+            1011.385401111111
+          ],
+          [
+            1339.5917217947222,
+            784.4587344444444
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "Recently, various DL models and datasets have been developed for layout analysis tasks. The dhSegment [22] utilizes fully convolutional networks [20] for segmen- tation tasks on historical documents. Object detection-based methods like Faster R-CNN [28] and Mask R-CNN [12] are used for identifying document elements [38] and detecting tables [30, 26]. Most recently, Graph Neural Networks [29] have also been used in table detection [27]. However, these models are usually implemented individually and there is no uniﬁed framework to load and use such models."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "0ebd432f2495d0bfc8303eca930cc9e5",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.79019355773926,
+            1005.2570199275362
+          ],
+          [
+            372.79019355773926,
+            1543.0409566666665
+          ],
+          [
+            1340.3434336982218,
+            1543.0409566666665
+          ],
+          [
+            1340.3434336982218,
+            1005.2570199275362
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "There has been a surge of interest in creating open-source tools for document image processing: a search of document image analysis in Github leads to 5M relevant code pieces 6; yet most of them rely on traditional rule-based methods or provide limited functionalities. The closest prior research to our work is the OCR-D project7, which also tries to build a complete toolkit for DIA. However, similar to the platform developed by Neudecker et al. [21], it is designed for analyzing historical documents, and provides no supports for recent DL models. The DocumentLayoutAnalysis project8 focuses on processing born-digital PDF documents via analyzing the stored PDF data. Repositories like DeepLayout9 and Detectron2-PubLayNet10 are individual deep learning models trained on layout analysis datasets without support for the full DIA pipeline. The Document Analysis and Exploitation (DAE) platform [15] and the DeepDIVA project [2] aim to improve the reproducibility of DIA methods (or DL models), yet they are not actively maintained. OCR engines like Tesseract [14], easyOCR11 and paddleOCR12 usually do not come with comprehensive functionalities for other DIA tasks like layout analysis."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "19c6112edbf782bfc4f5cf04829f57ad",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            362.7286739349365,
+            1548.8920677777778
+          ],
+          [
+            362.7286739349365,
+            1613.4519125528382
+          ],
+          [
+            1340.2214431762695,
+            1613.4519125528382
+          ],
+          [
+            1340.2214431762695,
+            1548.8920677777778
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "Recent years have also seen numerous eﬀorts to create libraries for promoting reproducibility and reusability in the ﬁeld of DL. Libraries like Dectectron2 [35],"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "27494431886c5be0e1b0dbeb2831a1e6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "The number shown is obtained by specifying the search type as ‘code’."
+  },
+  {
+    "type": "ListItem",
+    "element_id": "193e03893373b61e7354231571171b6f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "https://ocr-d.de/en/about"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "a180bff913a0059538fe3609d9db6832",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "https://github.com/Bo"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "3be8a9f080762eb3b89459c83b9dc0cc",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "d/Documen"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "c84915bf4d12c1d1794529a2197c8f7e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "ayou"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "96811996068f19e87f4fc6944d2534c0",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "nalysis"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "9b41ceaccf9f13d73692f2e1f5ec87ca",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "https://github.com/leonlulu/Dee"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "fcec4cb3f8a40c9c97f67564ef7b01cf",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "ayout"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "85932d11fa05437c5aca785378fe8b88",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "https://github.com/hpanwar"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "0c4475e4ef576fc3ba91edb83ac90529",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "/detectron"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "f12bcd1c4c95f968487ef1d92f721777",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "https://github.com/Jaide"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "c9a7576974bf76f87205a547952012b9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "I/Eas"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "c13539d1568999137c4e0354795cd37b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "CR"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "f6adbb1b29c00a0317d87307ea7349c0",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "https://github.com/Paddl"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "a52d4e55ffcecbb2b7e10950d6e3d2ff",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "addle/Paddl"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "c13539d1568999137c4e0354795cd37b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.80833333333334,
+            1634.8390399999998
+          ],
+          [
+            371.80833333333334,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1849.8120824841487
+          ],
+          [
+            1193.6330124444444,
+            1634.8390399999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 3
+    },
+    "text": "CR"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "7de1555df0c2700329e815b93b32c571",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            257.4113377777776
+          ],
+          [
+            374.3472222222222,
+            282.31800444444434
+          ],
+          [
+            387.14675822222216,
+            282.31800444444434
+          ],
+          [
+            387.14675822222216,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 4
+    },
+    "text": "4"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            466.1507048888888,
+            257.4113377777776
+          ],
+          [
+            466.1507048888888,
+            282.31800444444434
+          ],
+          [
+            616.9257022222222,
+            282.31800444444434
+          ],
+          [
+            616.9257022222222,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 4
+    },
+    "text": "Z. Shen et al."
+  },
+  {
+    "type": "FigureCaption",
+    "element_id": "00401461c83b8b07511a4864781d8f8d",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            470.40833333333336,
+            312.29459163647346
+          ],
+          [
+            470.40833333333336,
+            700.0444444444444
+          ],
+          [
+            1238.9138333333335,
+            700.0444444444444
+          ],
+          [
+            1238.9138333333335,
+            312.29459163647346
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 4
+    },
+    "text": "Model Customization Community PlatformEfficient Data Annotation ¥y DIA Model HubCustomized Model Training] === | Layout Detection Models | ===OCR Module =— | Layout Data Structure | ==The Core LayoutParser LibraryDIA Pipeline SharingStorage & Visualizationi"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "3fd5be2cdc473424f58b9da0192dec01",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            373.2944444444444,
+            728.6587344444443
+          ],
+          [
+            373.2944444444444,
+            1022.7797144444444
+          ],
+          [
+            1344.4991989135742,
+            1022.7797144444444
+          ],
+          [
+            1344.4991989135742,
+            728.6587344444443
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 4
+    },
+    "text": "Fig. 1: The overall architecture of LayoutParser. For an input document image, the core LayoutParser library provides a set of oﬀ-the-shelf tools for layout detection, OCR, visualization, and storage, backed by a carefully designed layout data structure. LayoutParser also supports high level customization via eﬃcient layout annotation and model training functions. These improve model accuracy on the target samples. The community platform enables the easy sharing of DIA models and whole digitization pipelines to promote reusability and reproducibility. A collection of detailed documentation, tutorials and exemplar projects make LayoutParser easy to learn and use."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "cd924e18fd419111b4ead552fb7cc36b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            373.2944444444444,
+            1095.6754011111111
+          ],
+          [
+            373.2944444444444,
+            1323.638332201087
+          ],
+          [
+            1341.1008071899414,
+            1323.638332201087
+          ],
+          [
+            1341.1008071899414,
+            1095.6754011111111
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 4
+    },
+    "text": "AllenNLP [8] and transformers [34] have provided the community with complete DL-based support for developing and deploying models for general computer vision and natural language processing problems. LayoutParser, on the other hand, specializes speciﬁcally in DIA tasks. LayoutParser is also equipped with a community platform inspired by established model hubs such as Torch Hub [23] and TensorFlow Hub [1]. It enables the sharing of pretrained models as well as full document processing pipelines that are unique to DIA tasks."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "de9b76ca2c36f4a1cc39c9bc69b75a45",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            370.2226905822754,
+            1327.8977133340882
+          ],
+          [
+            370.2226905822754,
+            1555.42429
+          ],
+          [
+            1341.0319366455078,
+            1555.42429
+          ],
+          [
+            1341.0319366455078,
+            1327.8977133340882
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 4
+    },
+    "text": "There have been a variety of document data collections to facilitate the development of DL models. Some examples include PRImA [3](magazine layouts), PubLayNet [38](academic paper layouts), Table Bank [18](tables in academic papers), Newspaper Navigator Dataset [16, 17](newspaper ﬁgure layouts) and HJDataset [31](historical Japanese document layouts). A spectrum of models trained on these datasets are currently available in the LayoutParser model zoo to support diﬀerent use cases."
+  },
+  {
+    "type": "Title",
+    "element_id": "740238ba10202556c962840e5c882446",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            1612.7707955917874
+          ],
+          [
+            374.3472222222222,
+            1650.5428177838164
+          ],
+          [
+            938.0814056396484,
+            1650.5428177838164
+          ],
+          [
+            938.0814056396484,
+            1612.7707955917874
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 4
+    },
+    "text": "3 The Core LayoutParser Library"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "1f4bc06117d2be9d9e297dbe07aa05cd",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            365.80923652648926,
+            1685.8329795063407
+          ],
+          [
+            365.80923652648926,
+            1848.3114196482488
+          ],
+          [
+            1339.8717727661133,
+            1848.3114196482488
+          ],
+          [
+            1339.8717727661133,
+            1685.8329795063407
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 4
+    },
+    "text": "At the core of LayoutParser is an oﬀ-the-shelf toolkit that streamlines DL- based document image analysis. Five components support a simple interface with comprehensive functionalities: 1) The layout detection models enable using pre-trained or self-trained DL models for layout detection with just four lines of code. 2) The detected layout information is stored in carefully engineered"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "4c2478cf439baab6ace34761eda527d9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            650.706672668457,
+            255.94129332021816
+          ],
+          [
+            650.706672668457,
+            284.3267940207956
+          ],
+          [
+            1247.0069122314453,
+            284.3267940207956
+          ],
+          [
+            1247.0069122314453,
+            255.94129332021816
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "f0b5c2c2211c8d67ed15e75e656c7862",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            1322.1886657777777,
+            257.4113377777776
+          ],
+          [
+            1322.1886657777777,
+            282.31800444444434
+          ],
+          [
+            1334.9882017777777,
+            282.31800444444434
+          ],
+          [
+            1334.9882017777777,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "5"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "b51f99cb953082a922ba43c09d4492b3",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            401.9820957183838,
+            350.3809566666667
+          ],
+          [
+            401.9820957183838,
+            378.8297144444445
+          ],
+          [
+            1309.883644104004,
+            378.8297144444445
+          ],
+          [
+            1309.883644104004,
+            350.3809566666667
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "Table 1: Current layout detection models in the LayoutParser model zoo"
+  },
+  {
+    "type": "Table",
+    "element_id": "71e289a268220c21575bb55a73980b83",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            355.1971092224121,
+            368.17813007152023
+          ],
+          [
+            355.1971092224121,
+            569.5523380887681
+          ],
+          [
+            1330.2684173583984,
+            569.5523380887681
+          ],
+          [
+            1330.2684173583984,
+            368.17813007152023
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5,
+      "text_as_html": "<table><thead><th>Dataset</th><th>| Base Model'|</th><th>| Notes</th></thead><tr><td>PubLayNet</td><td>[38] F/M</td><td>Layouts of modern scientific documents</td></tr><tr><td>PRImA [3]</td><td>M</td><td>Layouts of scanned modern magazines and scientific reports</td></tr><tr><td>Newspaper</td><td>F</td><td>Layouts of scanned US newspapers from the 20th century</td></tr><tr><td>TableBank</td><td>F</td><td>Table region on modern scientific and business document</td></tr><tr><td>HJDataset [31]</td><td>F/M</td><td>Layouts of history Japanese documents</td></tr></table>"
+    },
+    "text": "Dataset Base Model1 Large Model Notes PubLayNet [38]PRImA [3]Newspaper [17]TableBank [18]HJDataset [31] F / MMFFF / M M--F- Layouts of modern scientiﬁc documentsLayouts of scanned modern magazines and scientiﬁc reportsLayouts of scanned US newspapers from the 20th centuryTable region on modern scientiﬁc and business documentLayouts of history Japanese documents"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "654021138cc8eb1409b192c9c6bc9cad",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            541.4931199722222,
+            391.3053386788448
+          ],
+          [
+            541.4931199722222,
+            412.8620360849333
+          ],
+          [
+            871.8039053105956,
+            412.8620360849333
+          ],
+          [
+            871.8039053105956,
+            391.3053386788448
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "Base Model1 Large Model Notes"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "396f3bb3ac3873b5455050e2beb7c68d",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            419.1515307222222,
+            394.21665635159997
+          ],
+          [
+            419.1515307222222,
+            412.8620360849333
+          ],
+          [
+            493.49438879496887,
+            412.8620360849333
+          ],
+          [
+            493.49438879496887,
+            394.21665635159997
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "Dataset"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "d994f2b2f63ea8768ac77b181d3621f6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.3154894166666,
+            431.9653156016001
+          ],
+          [
+            390.3154894166666,
+            559.9971726404887
+          ],
+          [
+            522.3322360805599,
+            559.9971726404887
+          ],
+          [
+            522.3322360805599,
+            431.9653156016001
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "PubLayNet [38] PRImA [3] Newspaper [17] TableBank [18] HJDataset [31]"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "7c22bd490699f4fe4b4e3f22088ec82e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            572.1050305555555,
+            431.9653156016001
+          ],
+          [
+            572.1050305555555,
+            559.9971726404887
+          ],
+          [
+            624.5302447517689,
+            559.9971726404887
+          ],
+          [
+            624.5302447517689,
+            431.9653156016001
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "F / M M F F F / M"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "3497cc19ecfddb5f0e0453223d71c3c5",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            726.855194388889,
+            431.9653156016001
+          ],
+          [
+            726.855194388889,
+            559.9971726404887
+          ],
+          [
+            744.4191420976889,
+            559.9971726404887
+          ],
+          [
+            744.4191420976889,
+            431.9653156016001
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "M - - F -"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "3556a4a4ab68c8f8ffb7c40de795b758",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            816.1269368888888,
+            431.9653156016001
+          ],
+          [
+            816.1269368888888,
+            559.9971726404887
+          ],
+          [
+            1319.0580871259556,
+            559.9971726404887
+          ],
+          [
+            1319.0580871259556,
+            431.9653156016001
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "Layouts of modern scientiﬁc documents Layouts of scanned modern magazines and scientiﬁc reports Layouts of scanned US newspapers from the 20th century Table region on modern scientiﬁc and business document Layouts of history Japanese documents"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "c24bcb2cf98d6226bd805b6f99d3b61a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            380.2362875555556,
+            574.6586429288442
+          ],
+          [
+            380.2362875555556,
+            711.3043242376208
+          ],
+          [
+            1330.5515779047234,
+            711.3043242376208
+          ],
+          [
+            1330.5515779047234,
+            574.6586429288442
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "1 For each dataset, we train several models of diﬀerent sizes for diﬀerent needs (the trade-oﬀ between accuracy vs. computational cost). For “base model” and “large model”, we refer to using the ResNet 50 or ResNet 101 backbones [13], respectively. One can train models of diﬀerent architectures, like Faster R-CNN [28] (F) and Mask R-CNN [12] (M). For example, an F in the Large Model column indicates it has a Faster R-CNN model trained using the ResNet 101 backbone. The platform is maintained and a number of additions will be made to the model zoo in coming months."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "9fb9573af5bf767f81cdaf2cf1a72cd9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.225,
+            774.672267747962
+          ],
+          [
+            372.225,
+            1002.0131788888888
+          ],
+          [
+            1339.891616821289,
+            1002.0131788888888
+          ],
+          [
+            1339.891616821289,
+            774.672267747962
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "layout data structures, which are optimized for eﬃciency and versatility. 3) When necessary, users can employ existing or customized OCR models via the uniﬁed API provided in the OCR module. 4) LayoutParser comes with a set of utility functions for the visualization and storage of the layout data. 5) LayoutParser is also highly customizable, via its integration with functions for layout data annotation and model training. We now provide detailed descriptions for each component."
+  },
+  {
+    "type": "Title",
+    "element_id": "9f26ca353a2c130a2e32f457d71c1350",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            1051.4504370942784
+          ],
+          [
+            374.3472222222222,
+            1083.4622855808425
+          ],
+          [
+            801.6733703613281,
+            1083.4622855808425
+          ],
+          [
+            801.6733703613281,
+            1051.4504370942784
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "3.1 Layout Detection Models"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "11dff8778699e76422be6b86c9eaa62a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            357.58715057373047,
+            1105.8309566666667
+          ],
+          [
+            357.58715057373047,
+            1401.395293157458
+          ],
+          [
+            1340.338518815556,
+            1401.395293157458
+          ],
+          [
+            1340.338518815556,
+            1105.8309566666667
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "In LayoutParser, a layout model takes a document image as an input and generates a list of rectangular boxes for the target content regions. Diﬀerent from traditional methods, it relies on deep convolutional neural networks rather than manually curated rules to identify content regions. It is formulated as an object detection problem and state-of-the-art models like Faster R-CNN [28] and Mask R-CNN [12] are used. This yields prediction results of high accuracy and makes it possible to build a concise, generalized interface for layout detection. LayoutParser, built upon Detectron2 [35], provides a minimal API that can perform layout detection with only four lines of code in Python:"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "f0c7e55ad98b18409dc6885d710fb288",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            351.09166666666664,
+            1419.7531688888887
+          ],
+          [
+            351.09166666666664,
+            1505.5431688888887
+          ],
+          [
+            1093.8868133333328,
+            1505.5431688888887
+          ],
+          [
+            1093.8868133333328,
+            1419.7531688888887
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "1 import layoutparser as lp 2 image = cv2 . imread ( \" image_file \" ) # load images 3 model = lp . De t e c tro n2 Lay outM odel ("
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4b27636ffb1723123a6cfbf67a2aa183",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            438.4194444444444,
+            1511.0781688888887
+          ],
+          [
+            438.4194444444444,
+            1535.9848355555555
+          ],
+          [
+            1188.9818444444438,
+            1535.9848355555555
+          ],
+          [
+            1188.9818444444438,
+            1511.0781688888887
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "\" lp :// PubLayNet / f as t er _ r c nn _ R _ 50 _ F P N_ 3 x / config \" )"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "ac9c43a46f1221e9cc7611e910c88b58",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            351.09166666666664,
+            1519.3029783333334
+          ],
+          [
+            351.09166666666664,
+            1566.426502222222
+          ],
+          [
+            812.3808355555553,
+            1566.426502222222
+          ],
+          [
+            812.3808355555553,
+            1519.3029783333334
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "4 5 layout = model . detect ( image )"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "3aff40c86aa58c0362102802f4ef172f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.4021472930908,
+            1586.6837344444443
+          ],
+          [
+            371.4021472930908,
+            1847.9433570161534
+          ],
+          [
+            1341.3696746826172,
+            1847.9433570161534
+          ],
+          [
+            1341.3696746826172,
+            1586.6837344444443
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 5
+    },
+    "text": "LayoutParser provides a wealth of pre-trained model weights using various datasets covering diﬀerent languages, time periods, and document types. Due to domain shift [7], the prediction performance can notably drop when models are ap- plied to target samples that are signiﬁcantly diﬀerent from the training dataset. As document structures and layouts vary greatly in diﬀerent domains, it is important to select models trained on a dataset similar to the test samples. A semantic syntax is used for initializing the model weights in LayoutParser, using both the dataset name and model name lp://<dataset-name>/<model-architecture-name>."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "06e9d52c1720fca412803e3b07c4b228",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            257.4113377777776
+          ],
+          [
+            374.3472222222222,
+            282.31800444444434
+          ],
+          [
+            387.14675822222216,
+            282.31800444444434
+          ],
+          [
+            387.14675822222216,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 6
+    },
+    "text": "6"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            466.1507048888888,
+            257.4113377777776
+          ],
+          [
+            466.1507048888888,
+            282.31800444444434
+          ],
+          [
+            616.9257022222222,
+            282.31800444444434
+          ],
+          [
+            616.9257022222222,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 6
+    },
+    "text": "Z. Shen et al."
+  },
+  {
+    "type": "FigureCaption",
+    "element_id": "2f498bdd91739a7083490999507420a5",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            542.4583333333333,
+            313.84669502000304
+          ],
+          [
+            542.4583333333333,
+            826.1194444444445
+          ],
+          [
+            1166.8136666666664,
+            826.1194444444445
+          ],
+          [
+            1166.8136666666664,
+            313.84669502000304
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 6
+    },
+    "text": "33§3 fectange vada8883 Coordinate83 +*Block | [Block | [Read8 Extra features Tet | [Tye | [oder[ coordinatel textblock1 |» , see383 , textblock2 , layout] ]4A list of the layout elementsThe same transformation and operation APIs"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "cafae07120d714f0822e89865adf62da",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.78160095214844,
+            854.6140573105375
+          ],
+          [
+            372.78160095214844,
+            1048.4520677777778
+          ],
+          [
+            1340.3582779722226,
+            1048.4520677777778
+          ],
+          [
+            1340.3582779722226,
+            854.6140573105375
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 6
+    },
+    "text": "Fig. 2: The relationship between the three types of layout data structures. Coordinate supports three kinds of variation; TextBlock consists of the co- ordinate information and extra features like block text, types, and reading orders; a Layout object is a list of all possible layout elements, including other Layout objects. They all support the same set of transformation and operation APIs for maximum ﬂexibility."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "7461d30ee7c51c91bca8003792d43bfe",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.0301856994629,
+            1126.0781788888887
+          ],
+          [
+            372.0301856994629,
+            1327.0712914213466
+          ],
+          [
+            1338.8324310627222,
+            1327.0712914213466
+          ],
+          [
+            1338.8324310627222,
+            1126.0781788888887
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 6
+    },
+    "text": "Shown in Table 1, LayoutParser currently hosts 9 pre-trained models trained on 5 diﬀerent datasets. Description of the training dataset is provided alongside with the trained models such that users can quickly identify the most suitable models for their tasks. Additionally, when such a model is not readily available, LayoutParser also supports training customized layout models and community sharing of the models (detailed in Section 3.5)."
+  },
+  {
+    "type": "Title",
+    "element_id": "acd4f4584a990134d927e19b6d7e5f88",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.82355880737305,
+            1385.1623947954408
+          ],
+          [
+            372.82355880737305,
+            1418.93360082654
+          ],
+          [
+            782.437931060791,
+            1418.93360082654
+          ],
+          [
+            782.437931060791,
+            1385.1623947954408
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 6
+    },
+    "text": "3.2 Layout Data Structures"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "fb271c99cdcfca1001a1a7d56425c5b4",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.66898918151855,
+            1452.4335277022947
+          ],
+          [
+            372.66898918151855,
+            1852.6438424667876
+          ],
+          [
+            1339.812370300293,
+            1852.6438424667876
+          ],
+          [
+            1339.812370300293,
+            1452.4335277022947
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 6
+    },
+    "text": "A critical feature of LayoutParser is the implementation of a series of data structures and operations that can be used to eﬃciently process and manipulate the layout elements. In document image analysis pipelines, various post-processing on the layout analysis model outputs is usually required to obtain the ﬁnal outputs. Traditionally, this requires exporting DL model outputs and then loading the results into other pipelines. All model outputs from LayoutParser will be stored in carefully engineered data types optimized for further processing, which makes it possible to build an end-to-end document digitization pipeline within LayoutParser. There are three key components in the data structure, namely the Coordinate system, the TextBlock, and the Layout. They provide diﬀerent levels of abstraction for the layout data, and a set of APIs are supported for transformations or operations on these classes."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4c2478cf439baab6ace34761eda527d9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            658.7111111111111,
+            257.4113377777776
+          ],
+          [
+            658.7111111111111,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "10159baf262b43a92d95db59dae1f72c",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            1322.1886657777777,
+            257.4113377777776
+          ],
+          [
+            1322.1886657777777,
+            282.31800444444434
+          ],
+          [
+            1334.9882017777777,
+            282.31800444444434
+          ],
+          [
+            1334.9882017777777,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "7"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "f2a3e5fbb983d9132dddecc381ed6e0b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            373.35,
+            327.13373444444437
+          ],
+          [
+            373.35,
+            824.8397104751662
+          ],
+          [
+            1338.822654916667,
+            824.8397104751662
+          ],
+          [
+            1338.822654916667,
+            327.13373444444437
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "Coordinates are the cornerstones for storing layout information. Currently, three types of Coordinate data structures are provided in LayoutParser, shown in Figure 2. Interval and Rectangle are the most common data types and support specifying 1D or 2D regions within a document. They are parameterized with 2 and 4 parameters. A Quadrilateral class is also implemented to support a more generalized representation of rectangular regions when the document is skewed or distorted, where the 4 corner points can be speciﬁed and a total of 8 degrees of freedom are supported. A wide collection of transformations like shift, pad, and scale, and operations like intersect, union, and is_in, are supported for these classes. Notably, it is common to separate a segment of the image and analyze it individually. LayoutParser provides full support for this scenario via image cropping operations crop_image and coordinate transformations like relative_to and condition_on that transform coordinates to and from their relative representations. We refer readers to Table 2 for a more detailed description of these operations13."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "eec800eef6e395c21feacd729868dd18",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            369.50525665283203,
+            825.2670677777776
+          ],
+          [
+            369.50525665283203,
+            1052.9686033333335
+          ],
+          [
+            1336.0764999389648,
+            1052.9686033333335
+          ],
+          [
+            1336.0764999389648,
+            825.2670677777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "Based on Coordinates, we implement the TextBlock class that stores both the positional and extra features of individual layout elements. It also supports specifying the reading orders via setting the parent ﬁeld to the index of the parent object. A Layout class is built that takes in a list of TextBlocks and supports processing the elements in batch. Layout can also be nested to support hierarchical layout structures. They support the same operations and transformations as the Coordinate classes, minimizing both learning and deployment eﬀort."
+  },
+  {
+    "type": "Title",
+    "element_id": "89c6cd1d893f782ea68d75737e3393fd",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.09101486206055,
+            1098.9602911760267
+          ],
+          [
+            372.09101486206055,
+            1131.8007670969203
+          ],
+          [
+            517.5983406666666,
+            1131.8007670969203
+          ],
+          [
+            517.5983406666666,
+            1098.9602911760267
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "3.3 OCR"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "e284bd66511cfa064681253e7ac57a9a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            358.57750511169434,
+            1152.600401111111
+          ],
+          [
+            358.57750511169434,
+            1445.9437344444445
+          ],
+          [
+            1338.0908660888672,
+            1445.9437344444445
+          ],
+          [
+            1338.0908660888672,
+            1152.600401111111
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "LayoutParser provides a uniﬁed interface for existing OCR tools. Though there are many OCR tools available, they are usually conﬁgured diﬀerently with distinct APIs or protocols for using them. It can be ineﬃcient to add new OCR tools into an existing pipeline, and diﬃcult to make direct comparisons among the available tools to ﬁnd the best option for a particular project. To this end, LayoutParser builds a series of wrappers among existing OCR engines, and provides nearly the same syntax for using them. It supports a plug-and-play style of using OCR engines, making it eﬀortless to switch, evaluate, and compare diﬀerent OCR modules:"
+  },
+  {
+    "type": "Image",
+    "element_id": "65ac0f9ae348b12ed9484b8af7296617",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            1463.7416666666666
+          ],
+          [
+            374.3472222222222,
+            1494.1833333333332
+          ],
+          [
+            1334.9777777777776,
+            1494.1833333333332
+          ],
+          [
+            1334.9777777777776,
+            1463.7416666666666
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "ocr_agent = lp.TesseractAgent ()pOi"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "bebbb4e94f1f97edeb5b96e252720a93",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            351.09166666666664,
+            1465.6726133333332
+          ],
+          [
+            351.09166666666664,
+            1555.0638888888889
+          ],
+          [
+            1334.9777777777776,
+            1555.0638888888889
+          ],
+          [
+            1334.9777777777776,
+            1465.6726133333332
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "ocr_agent = lp . Tesserac"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "38ad08d5b34f8a5030d33d6e23aaf335",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            351.09166666666664,
+            1465.6726133333332
+          ],
+          [
+            351.09166666666664,
+            1555.0638888888889
+          ],
+          [
+            1334.9777777777776,
+            1555.0638888888889
+          ],
+          [
+            1334.9777777777776,
+            1465.6726133333332
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "gent ()"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "3277e23329a3e4d08d021cac5d0609c7",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            351.09166666666664,
+            1465.6726133333332
+          ],
+          [
+            351.09166666666664,
+            1555.0638888888889
+          ],
+          [
+            1334.9777777777776,
+            1555.0638888888889
+          ],
+          [
+            1334.9777777777776,
+            1465.6726133333332
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "# Can be easily switched to other OCR software"
+  },
+  {
+    "type": "ListItem",
+    "element_id": "33c490deb7d22ca00a760f2d0c1a30e6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            351.09166666666664,
+            1465.6726133333332
+          ],
+          [
+            351.09166666666664,
+            1555.0638888888889
+          ],
+          [
+            1334.9777777777776,
+            1555.0638888888889
+          ],
+          [
+            1334.9777777777776,
+            1465.6726133333332
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "tokens = ocr_agent . detect ( image )"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "7a151dbbe8b26ccdcb264ab005be5a36",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.4558753967285,
+            1570.6919086843297
+          ],
+          [
+            371.4558753967285,
+            1701.2823987583033
+          ],
+          [
+            1340.3498097622223,
+            1701.2823987583033
+          ],
+          [
+            1340.3498097622223,
+            1570.6919086843297
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "The OCR outputs will also be stored in the aforementioned layout data structures and can be seamlessly incorporated into the digitization pipeline. Currently LayoutParser supports the Tesseract and Google Cloud Vision OCR engines."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "77ccbf022ce60ecfc6bac26bc6306a1d",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.0273971557617,
+            1703.703178888889
+          ],
+          [
+            372.0273971557617,
+            1803.840320237017
+          ],
+          [
+            1334.9857759125555,
+            1803.840320237017
+          ],
+          [
+            1334.9857759125555,
+            1703.703178888889
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "LayoutParser also comes with a DL-based CNN-RNN OCR model [6] trained with the Connectionist Temporal Classiﬁcation (CTC) loss [10]. It can be used like the other OCR modules, and can be easily trained on customized datasets."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "8bcb4c948fda07d2fdbf7d582983b93e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.81111111111113,
+            1817.4862622222222
+          ],
+          [
+            371.81111111111113,
+            1848.0536330955617
+          ],
+          [
+            1127.412109375,
+            1848.0536330955617
+          ],
+          [
+            1127.412109375,
+            1817.4862622222222
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 7
+    },
+    "text": "13 This is also available in the LayoutParser documentation pages."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "aa67a169b0bba217aa0aa88a65346920",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            257.4113377777776
+          ],
+          [
+            374.3472222222222,
+            282.31800444444434
+          ],
+          [
+            387.14675822222216,
+            282.31800444444434
+          ],
+          [
+            387.14675822222216,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "8"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            466.1507048888888,
+            257.4113377777776
+          ],
+          [
+            466.1507048888888,
+            282.31800444444434
+          ],
+          [
+            616.9257022222222,
+            282.31800444444434
+          ],
+          [
+            616.9257022222222,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Z. Shen et al."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "6727ba436ddf5e47087d005ded6c049f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.7822322845459,
+            349.4496840324955
+          ],
+          [
+            371.7822322845459,
+            445.2463811111111
+          ],
+          [
+            1338.8222740077777,
+            445.2463811111111
+          ],
+          [
+            1338.8222740077777,
+            349.4496840324955
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Table 2: All operations supported by the layout elements. The same APIs are supported across diﬀerent layout element classes including Coordinate types, TextBlock and Layout."
+  },
+  {
+    "type": "Table",
+    "element_id": "548c38f86edc295baf869abe37a0d1cf",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.5897750854492,
+            447.425569543516
+          ],
+          [
+            372.5897750854492,
+            1042.987526419082
+          ],
+          [
+            1326.7686004638672,
+            1042.987526419082
+          ],
+          [
+            1326.7686004638672,
+            447.425569543516
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8,
+      "text_as_html": "<table><thead><th>Operation Name</th><th></th><th>|</th><th>Description</th></thead><tr><td>block.pad(top, bottom,</td><td>right,</td><td>left) |</td><td>Enlarge the current block according to the input</td></tr><tr><td>block.scale(fx, fy)</td><td></td><td></td><td>Scale the current block given the ratio in x and y direction</td></tr><tr><td>block.shift(dx, dy)</td><td></td><td></td><td>Move the current block with the shift distances in x and y direction</td></tr><tr><td>blocki.is_in(block2)</td><td></td><td>|</td><td>Whether block] is inside of block2</td></tr><tr><td>blocki.intersect (block2)</td><td></td><td></td><td>Return the intersection region of blockl and block2. Coordinate type to be determined based on the inputs.</td></tr><tr><td>block1i.union(block2)</td><td></td><td></td><td>Return the union region of blockl and block2. Coordinate type to be determined based on the inputs.</td></tr><tr><td>blocki.relative_to(block2)</td><td></td><td></td><td>Convert the absolute coordinates of block] to relative coordinates to block2</td></tr><tr><td>blocki.condition_on(block2)</td><td></td><td></td><td>Calculate the absolute coordinates of blockl given the canvas block2’s absolute coordinates</td></tr></table>"
+    },
+    "text": "Operation Name Description block.pad(top, bottom, right, left) Enlarge the current block according to the input block.scale(fx, fy) block.shift(dx, dy) Scale the current block given the ratioin x and y direction Move the current block with the shiftdistances in x and y direction block1.is in(block2) Whether block1 is inside of block2 block1.intersect(block2) block1.union(block2) block1.relative to(block2) block1.condition on(block2) Return the intersection region of block1 and block2.Coordinate type to be determined based on the inputs. Return the union region of block1 and block2.Coordinate type to be determined based on the inputs. Convert the absolute coordinates of block1 torelative coordinates to block2 Calculate the absolute coordinates of block1 giventhe canvas block2’s absolute coordinates Obtain the image segments in the block region"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "88f06b9b69e717a8a691e10387779bcf",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            462.0395871290665
+          ],
+          [
+            392.25507683333325,
+            482.94973006239996
+          ],
+          [
+            573.0504456778133,
+            482.94973006239996
+          ],
+          [
+            573.0504456778133,
+            462.0395871290665
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Operation Name"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "c43500c63a83847bc5dd317182f0eaeb",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            797.9651138888887,
+            462.0395871290665
+          ],
+          [
+            797.9651138888887,
+            482.94973006239996
+          ],
+          [
+            922.474559985422,
+            482.94973006239996
+          ],
+          [
+            922.474559985422,
+            462.0395871290665
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Description"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4606a3cb33e7e6857f77dda2c1daf535",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            504.37339162906636
+          ],
+          [
+            392.25507683333325,
+            525.869018564533
+          ],
+          [
+            1255.7634192141152,
+            525.869018564533
+          ],
+          [
+            1255.7634192141152,
+            504.37339162906636
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "block.pad(top, bottom, right, left) Enlarge the current block according to the input"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "97f87287f36dbf6c636a3017ae0879fb",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            797.9651138888887,
+            546.7048640735113
+          ],
+          [
+            797.9651138888887,
+            598.2838696179556
+          ],
+          [
+            1158.717354846222,
+            598.2838696179556
+          ],
+          [
+            1158.717354846222,
+            546.7048640735113
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Scale the current block given the ratio in x and y direction"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "7cd6132d1ae515ab6d484f1b74e1c7e6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            561.7187757978668
+          ],
+          [
+            392.25507683333325,
+            582.6289187312
+          ],
+          [
+            600.8337525933332,
+            582.6289187312
+          ],
+          [
+            600.8337525933332,
+            561.7187757978668
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "block.scale(fx, fy)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "25dc86fe689dee9f82609342e44e5ce3",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            797.9651138888887,
+            619.7075311846223
+          ],
+          [
+            797.9651138888887,
+            671.2842046735112
+          ],
+          [
+            1151.026604275342,
+            671.2842046735112
+          ],
+          [
+            1151.026604275342,
+            619.7075311846223
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Move the current block with the shift distances in x and y direction"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "06c072cc8c8ed04ca343b16beb144048",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            634.721442908978
+          ],
+          [
+            392.25507683333325,
+            655.6315858423112
+          ],
+          [
+            600.8337525933332,
+            655.6315858423112
+          ],
+          [
+            600.8337525933332,
+            634.721442908978
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "block.shift(dx, dy)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4e5821785ee2be3e8c853010a6ad0b76",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            797.9651138888887,
+            692.7078662401776
+          ],
+          [
+            797.9651138888887,
+            713.6180091735112
+          ],
+          [
+            1121.8360447404086,
+            713.6180091735112
+          ],
+          [
+            1121.8360447404086,
+            692.7078662401776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Whether block1 is inside of block2"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "9281c2571853bd5e586a12067782746d",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            693.2933502423111
+          ],
+          [
+            392.25507683333325,
+            714.2034931756443
+          ],
+          [
+            608.7365291777778,
+            714.2034931756443
+          ],
+          [
+            608.7365291777778,
+            693.2933502423111
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "block1.is in(block2)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "6afa487379762db34fc58d243c408566",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            797.9651138888887,
+            735.0416707401776
+          ],
+          [
+            797.9651138888887,
+            786.6183442290666
+          ],
+          [
+            1317.1263246662752,
+            786.6183442290666
+          ],
+          [
+            1317.1263246662752,
+            735.0416707401776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Return the intersection region of block1 and block2. Coordinate type to be determined based on the inputs."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "517de49526055a51ab0e815fe66a5c73",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            750.0555824645334
+          ],
+          [
+            392.25507683333325,
+            770.9657253978665
+          ],
+          [
+            655.7228777933332,
+            770.9657253978665
+          ],
+          [
+            655.7228777933332,
+            750.0555824645334
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "block1.intersect(block2)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "8bdb5b868be61ec346e052b25ed4022a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            797.9651138888887,
+            808.0420057957332
+          ],
+          [
+            797.9651138888887,
+            859.6210113401778
+          ],
+          [
+            1317.1263246662752,
+            859.6210113401778
+          ],
+          [
+            1317.1263246662752,
+            808.0420057957332
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Return the union region of block1 and block2. Coordinate type to be determined based on the inputs."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "fdbeffff8c43aaf3bbeb4791175c4e43",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            823.0559175200889
+          ],
+          [
+            392.25507683333325,
+            843.9660604534222
+          ],
+          [
+            611.8115776333332,
+            843.9660604534222
+          ],
+          [
+            611.8115776333332,
+            823.0559175200889
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "block1.union(block2)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "46e8fb35b2888c35a00033faaa4851d9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            797.9651138888887,
+            881.0423408512887
+          ],
+          [
+            797.9651138888887,
+            932.6213463957333
+          ],
+          [
+            1226.9638793520353,
+            932.6213463957333
+          ],
+          [
+            1226.9638793520353,
+            881.0423408512887
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Convert the absolute coordinates of block1 to relative coordinates to block2"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "1e09f3ee1bda1e38a11dbc80108923f1",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            896.0562525756445
+          ],
+          [
+            392.25507683333325,
+            916.9663955089778
+          ],
+          [
+            674.603106288889,
+            916.9663955089778
+          ],
+          [
+            674.603106288889,
+            896.0562525756445
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "block1.relative to(block2)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "b8a944f0af3a0a8cfc854d5c9b186900",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            797.9651138888887,
+            954.0450079623998
+          ],
+          [
+            797.9651138888887,
+            1005.6216814512887
+          ],
+          [
+            1270.4925238963551,
+            1005.6216814512887
+          ],
+          [
+            1270.4925238963551,
+            954.0450079623998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Calculate the absolute coordinates of block1 given the canvas block2’s absolute coordinates"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "bc47d0cd9d800d84cd9aefa2d9ec63ec",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            969.0565876312
+          ],
+          [
+            392.25507683333325,
+            989.9667305645333
+          ],
+          [
+            685.5800917888889,
+            989.9667305645333
+          ],
+          [
+            685.5800917888889,
+            969.0565876312
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "block1.condition on(block2)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "9ba6cbc77549790313b84b62a781a1f9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            797.9651138888887,
+            1027.0453430179555
+          ],
+          [
+            797.9651138888887,
+            1047.9554859512887
+          ],
+          [
+            1237.6677815196085,
+            1047.9554859512887
+          ],
+          [
+            1237.6677815196085,
+            1027.0453430179555
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Obtain the image segments in the block region"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "e2d920d1b163490b690e3730fda41064",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            392.25507683333325,
+            1027.6308270200889
+          ],
+          [
+            392.25507683333325,
+            1048.5409699534223
+          ],
+          [
+            641.6691647577778,
+            1048.5409699534223
+          ],
+          [
+            641.6691647577778,
+            1027.6308270200889
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "block.crop image(image)"
+  },
+  {
+    "type": "Title",
+    "element_id": "709c2d8cd3b15512f8452715fab45e4f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            1126.438754906401
+          ],
+          [
+            374.3472222222222,
+            1158.6261369640702
+          ],
+          [
+            798.060131072998,
+            1158.6261369640702
+          ],
+          [
+            798.060131072998,
+            1126.438754906401
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "3.4 Storage and visualization"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "ef65f87405f1fd8a11b79bdde8aa10d1",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            373.35,
+            1187.3754011111112
+          ],
+          [
+            373.35,
+            1547.810401111111
+          ],
+          [
+            1335.8427039055555,
+            1547.810401111111
+          ],
+          [
+            1335.8427039055555,
+            1187.3754011111112
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "The end goal of DIA is to transform the image-based document data into a structured database. LayoutParser supports exporting layout data into diﬀerent formats like JSON, csv, and will add the support for the METS/ALTO XML format 14 . It can also load datasets from layout analysis-speciﬁc formats like COCO [38] and the Page Format [25] for training layout models (Section 3.5). Visualization of the layout detection results is critical for both presentation and debugging. LayoutParser is built with an integrated API for displaying the layout information along with the original document image. Shown in Figure 3, it enables presenting layout data with rich meta information and features in diﬀerent modes. More detailed information can be found in the online LayoutParser documentation page."
+  },
+  {
+    "type": "Title",
+    "element_id": "d57c26aad19349fc98ee8822f24f19d9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            1602.8955078125
+          ],
+          [
+            374.3472222222222,
+            1636.3631302838164
+          ],
+          [
+            842.0438957214355,
+            1636.3631302838164
+          ],
+          [
+            842.0438957214355,
+            1602.8955078125
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "3.5 Customized Model Training"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "e07a3053a112880cf693f019d010cc19",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            369.1406059265137,
+            1665.2337344444443
+          ],
+          [
+            369.1406059265137,
+            1803.490939670139
+          ],
+          [
+            1339.596139072222,
+            1803.490939670139
+          ],
+          [
+            1339.596139072222,
+            1665.2337344444443
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "Besides the oﬀ-the-shelf library, LayoutParser is also highly customizable with supports for highly unique and challenging document analysis tasks. Target document images can be vastly diﬀerent from the existing datasets for train- ing layout models, which leads to low layout detection accuracy. Training data"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "1ef9621705354b738772d2108d0fb6ab",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            370.98292541503906,
+            1817.4862622222222
+          ],
+          [
+            370.98292541503906,
+            1848.7453884548613
+          ],
+          [
+            682.7208404541016,
+            1848.7453884548613
+          ],
+          [
+            682.7208404541016,
+            1817.4862622222222
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 8
+    },
+    "text": "14 https://altoxml.github.io"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "4c2478cf439baab6ace34761eda527d9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            652.2080764770508,
+            254.59611975628397
+          ],
+          [
+            652.2080764770508,
+            283.4609970608771
+          ],
+          [
+            1244.548843383789,
+            283.4609970608771
+          ],
+          [
+            1244.548843383789,
+            254.59611975628397
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 9
+    },
+    "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "2e6d31a5983a91251bfae5aefa1c0a19",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            1322.1886657777777,
+            257.4113377777776
+          ],
+          [
+            1322.1886657777777,
+            282.31800444444434
+          ],
+          [
+            1334.9882017777777,
+            282.31800444444434
+          ],
+          [
+            1334.9882017777777,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 9
+    },
+    "text": "9"
+  },
+  {
+    "type": "FigureCaption",
+    "element_id": "6df6057f894a166cf24fd34f64267f09",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            470.40833333333336,
+            321.77152329596925
+          ],
+          [
+            470.40833333333336,
+            853.9777777777778
+          ],
+          [
+            1238.8140833333332,
+            853.9777777777778
+          ],
+          [
+            1238.8140833333332,
+            321.77152329596925
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 9
+    },
+    "text": "a ESStee eaeoooMode I: Showing Layout on the Original ImageMode Il: Drawing OCR'd Text at the Correspoding Position10g Bpunog vayoy feyds1q :1 vondo‘xog Burpunog vay apiH z word"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "cc8ad6e0f933633a37b82200e6724f9e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            369.6209487915039,
+            882.5920677777776
+          ],
+          [
+            369.6209487915039,
+            1077.2100210880888
+          ],
+          [
+            1348.1226196289062,
+            1077.2100210880888
+          ],
+          [
+            1348.1226196289062,
+            882.5920677777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 9
+    },
+    "text": "Fig. 3: Layout detection and OCR results visualization generated by the LayoutParser APIs. Mode I directly overlays the layout region bounding boxes and categories over the original image. Mode II recreates the original document via drawing the OCR’d texts at their corresponding positions on the image canvas. In this ﬁgure, tokens in textual regions are ﬁltered using the API and then displayed."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "19cc210888c40b3403e1992b335bccf7",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.52964210510254,
+            1185.325401111111
+          ],
+          [
+            371.52964210510254,
+            1284.3024654664855
+          ],
+          [
+            1339.6642532348633,
+            1284.3024654664855
+          ],
+          [
+            1339.6642532348633,
+            1185.325401111111
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 9
+    },
+    "text": "can also be highly sensitive and not sharable publicly. To overcome these chal- lenges, LayoutParser is built with rich features for eﬃcient data annotation and customized model training."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "60c0620e0e68ad30f5cff23dd0ef53c5",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.4169006347656,
+            1302.9837344444443
+          ],
+          [
+            371.4169006347656,
+            1533.1710564802236
+          ],
+          [
+            1339.5860188733889,
+            1533.1710564802236
+          ],
+          [
+            1339.5860188733889,
+            1302.9837344444443
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 9
+    },
+    "text": "LayoutParser incorporates a toolkit optimized for annotating document lay- outs using object-level active learning [32]. With the help from a layout detection model trained along with labeling, only the most important layout objects within each image, rather than the whole image, are required for labeling. The rest of the regions are automatically annotated with high conﬁdence predictions from the layout detection model. This allows a layout dataset to be created more eﬃciently with only around 60% of the labeling budget."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "7cc706ff50f3746845f312c011318d84",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.5060691833496,
+            1553.475401111111
+          ],
+          [
+            371.5060691833496,
+            1846.8187344444443
+          ],
+          [
+            1338.8221180155556,
+            1846.8187344444443
+          ],
+          [
+            1338.8221180155556,
+            1553.475401111111
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 9
+    },
+    "text": "After the training dataset is curated, LayoutParser supports diﬀerent modes for training the layout models. Fine-tuning can be used for training models on a small newly-labeled dataset by initializing the model with existing pre-trained weights. Training from scratch can be helpful when the source dataset and target are signiﬁcantly diﬀerent and a large training set is available. However, as suggested in Studer et al.’s work[33], loading pre-trained weights on large-scale datasets like ImageNet [5], even from totally diﬀerent domains, can still boost model performance. Through the integrated API provided by LayoutParser, users can easily compare model performances on the benchmark datasets."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "917df3320d778ddbaa5c5c7742bc4046",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            257.4113377777776
+          ],
+          [
+            374.3472222222222,
+            282.31800444444434
+          ],
+          [
+            399.94629422222215,
+            282.31800444444434
+          ],
+          [
+            399.94629422222215,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 10
+    },
+    "text": "10"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            466.1482142222221,
+            257.4113377777776
+          ],
+          [
+            466.1482142222221,
+            282.31800444444434
+          ],
+          [
+            616.9232115555554,
+            282.31800444444434
+          ],
+          [
+            616.9232115555554,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 10
+    },
+    "text": "Z. Shen et al."
+  },
+  {
+    "type": "FigureCaption",
+    "element_id": "42aa5660e30073a0282c086fe4f29fce",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            336.74460220336914,
+            269.01225214419156
+          ],
+          [
+            336.74460220336914,
+            760.8166666666666
+          ],
+          [
+            1346.8375549316406,
+            760.8166666666666
+          ],
+          [
+            1346.8375549316406,
+            269.01225214419156
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 10
+    },
+    "text": "Column reading orderMaximum Allowed HeightZ. Shen et al.Intra-column reading order(b) Illustration of the recreated document with dense text structure for better OCR performance‘Token CategoriesMoteAddresstetNumberVaribiecompany typeColumn Categories(J tite| Aatress(tee[7] section adr"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "f6d1c03644c4866a2dd06f8e432f6286",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.62012481689453,
+            789.4309566666667
+          ],
+          [
+            372.62012481689453,
+            949.9409566666666
+          ],
+          [
+            1338.0015029907227,
+            949.9409566666666
+          ],
+          [
+            1338.0015029907227,
+            789.4309566666667
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 10
+    },
+    "text": "Fig. 4: Illustration of (a) the original historical Japanese document with layout detection results and (b) a recreated version of the document image that achieves much better character recognition recall. The reorganization algorithm rearranges the tokens based on the their detected bounding boxes given a maximum allowed height."
+  },
+  {
+    "type": "Title",
+    "element_id": "a84f27645308850514566b3bb9d3efa0",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            1012.7086355555556
+          ],
+          [
+            374.3472222222222,
+            1049.631465598581
+          ],
+          [
+            1002.1017646789551,
+            1049.631465598581
+          ],
+          [
+            1002.1017646789551,
+            1012.7086355555556
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 10
+    },
+    "text": "4 LayoutParser Community Platform"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "ea475aba47ae4b4db2eeb1a96bc30797",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            370.64836502075195,
+            1077.8642899999998
+          ],
+          [
+            370.64836502075195,
+            1306.2935914855072
+          ],
+          [
+            1342.7489013671875,
+            1306.2935914855072
+          ],
+          [
+            1342.7489013671875,
+            1077.8642899999998
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 10
+    },
+    "text": "Another focus of LayoutParser is promoting the reusability of layout detection models and full digitization pipelines. Similar to many existing deep learning libraries, LayoutParser comes with a community model hub for distributing layout models. End-users can upload their self-trained models to the model hub, and these models can be loaded into a similar interface as the currently available LayoutParser pre-trained models. For example, the model trained on the News Navigator dataset [17] has been incorporated in the model hub."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "966440df8a08ef481c35486bdb301d6a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            359.5111484527588,
+            1310.325401111111
+          ],
+          [
+            359.5111484527588,
+            1670.0854011111112
+          ],
+          [
+            1340.3437215066665,
+            1670.0854011111112
+          ],
+          [
+            1340.3437215066665,
+            1310.325401111111
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 10
+    },
+    "text": "Beyond DL models, LayoutParser also promotes the sharing of entire doc- ument digitization pipelines. For example, sometimes the pipeline requires the combination of multiple DL models to achieve better accuracy. Currently, pipelines are mainly described in academic papers and implementations are often not pub- licly available. To this end, the LayoutParser community platform also enables the sharing of layout pipelines to promote the discussion and reuse of techniques. For each shared pipeline, it has a dedicated project page, with links to the source code, documentation, and an outline of the approaches. A discussion panel is provided for exchanging ideas. Combined with the core LayoutParser library, users can easily build reusable components based on the shared pipelines and apply them to solve their unique problems."
+  },
+  {
+    "type": "Title",
+    "element_id": "0e654d0b0bc44cbd58f1cb7c7b02c3c5",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            1717.9037283929651
+          ],
+          [
+            374.3472222222222,
+            1756.6726463428442
+          ],
+          [
+            595.0036844444444,
+            1756.6726463428442
+          ],
+          [
+            595.0036844444444,
+            1717.9037283929651
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 10
+    },
+    "text": "5 Use Cases"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "9d4feeabd8c04d4b33897afb58e46f55",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            351.7041015625,
+            1785.9365122222223
+          ],
+          [
+            351.7041015625,
+            1847.5650451955014
+          ],
+          [
+            1343.1623840332031,
+            1847.5650451955014
+          ],
+          [
+            1343.1623840332031,
+            1785.9365122222223
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 10
+    },
+    "text": "The core objective of LayoutParser is to make it easier to create both large-scale and light-weight document digitization pipelines. Large-scale document processing"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4c2478cf439baab6ace34761eda527d9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            658.7111111111111,
+            257.4113377777776
+          ],
+          [
+            658.7111111111111,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "25d4f2a86deb5e2574bb3210b67bb24f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            1309.386639111111,
+            257.4113377777776
+          ],
+          [
+            1309.386639111111,
+            282.31800444444434
+          ],
+          [
+            1334.985711111111,
+            282.31800444444434
+          ],
+          [
+            1334.985711111111,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "11"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "5cdbcea58a81d8f7de9a4fa841107be1",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            361.9180507659912,
+            327.13373444444437
+          ],
+          [
+            361.9180507659912,
+            658.9452417346015
+          ],
+          [
+            1340.3336205372223,
+            658.9452417346015
+          ],
+          [
+            1340.3336205372223,
+            327.13373444444437
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "focuses on precision, eﬃciency, and robustness. The target documents may have complicated structures, and may require training multiple layout detection models to achieve the optimal accuracy. Light-weight pipelines are built for relatively simple documents, with an emphasis on development ease, speed and ﬂexibility. Ideally one only needs to use existing resources, and model training should be avoided. Through two exemplar projects, we show how practitioners in both academia and industry can easily build such pipelines using LayoutParser and extract high-quality structured document data for their downstream tasks. The source code for these projects will be publicly available in the LayoutParser community hub."
+  },
+  {
+    "type": "Title",
+    "element_id": "1fe1cb84a12b8216ea9d734262b3e4ec",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            720.5787371206975
+          ],
+          [
+            374.3472222222222,
+            754.6290065009813
+          ],
+          [
+            1297.6990051269531,
+            754.6290065009813
+          ],
+          [
+            1297.6990051269531,
+            720.5787371206975
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "5.1 A Comprehensive Historical Document Digitization Pipeline"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "a5a6fe2f9e40a8e2b2fe290d51094b4d",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            373.35,
+            792.9698455555556
+          ],
+          [
+            373.35,
+            1318.77429
+          ],
+          [
+            1339.592486118889,
+            1318.77429
+          ],
+          [
+            1339.592486118889,
+            792.9698455555556
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "The digitization of historical documents can unlock valuable data that can shed light on many important social, economic, and historical questions. Yet due to scan noises, page wearing, and the prevalence of complicated layout structures, ob- taining a structured representation of historical document scans is often extremely complicated. In this example, LayoutParser was used to develop a comprehensive pipeline, shown in Figure 5, to gener- ate high-quality structured data from historical Japanese ﬁrm ﬁnancial ta- bles with complicated layouts. The pipeline applies two layout models to identify diﬀerent levels of document structures and two customized OCR engines for optimized character recog- nition accuracy."
+  },
+  {
+    "type": "FigureCaption",
+    "element_id": "55f2474c66877608ca9b463a7076573e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            854.661111111111,
+            1040.4540956653834
+          ],
+          [
+            854.661111111111,
+            1562.3222222222223
+          ],
+          [
+            1334.9642777777776,
+            1562.3222222222223
+          ],
+          [
+            1334.9642777777776,
+            1040.4540956653834
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "(spe peepee,Active Learning Layout=Annotate Layout Dataset parte4zi Deep Learning LayoutLayout Detection Model Training & Inference,Post-processin Handy Data Structures &pl 9 APIs for Layout DataText Recognition Default and Customized: r OCR Models4Visualization & Export | <——Layout StructureVisualization & StorageThe Japanese Document Helpful LayoutParserDigitization Pipeline Modules"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "fa19ab2536cbbb48c09de29fdebd52bd",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.93611111111113,
+            1327.1670677777777
+          ],
+          [
+            372.93611111111113,
+            1753.3465122222221
+          ],
+          [
+            832.3503600722222,
+            1753.3465122222221
+          ],
+          [
+            832.3503600722222,
+            1327.1670677777777
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "As shown in Figure 4 (a), the document contains columns of text written vertically 15, a common style in Japanese. Due to scanning noise and archaic printing technology, the columns can be skewed or have vari- able widths, and hence cannot be eas- ily identiﬁed via rule-based methods. Within each column, words are sepa- rated by white spaces of variable size, and the vertical positions of objects can be an indicator of their layout type."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "3cbd8234ac0c6d29feb24e6202144aa8",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            854.661111111111,
+            1618.6115122222222
+          ],
+          [
+            854.661111111111,
+            1712.7048455555555
+          ],
+          [
+            1339.5826849615555,
+            1712.7048455555555
+          ],
+          [
+            1339.5826849615555,
+            1618.6115122222222
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "Fig. 5: Illustration of how LayoutParser helps with the historical document digi- tization pipeline."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "6382276306254e0b0d045fb230db668a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.81111111111113,
+            1787.0445955555554
+          ],
+          [
+            371.81111111111113,
+            1815.8402266666667
+          ],
+          [
+            1335.8948114844447,
+            1815.8402266666667
+          ],
+          [
+            1335.8948114844447,
+            1787.0445955555554
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "15 A document page consists of eight rows like this. For simplicity we skip the row"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "30c13a2facbda6a7391ac1656e832db4",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            402.01944444444445,
+            1821.3752266666665
+          ],
+          [
+            402.01944444444445,
+            1846.2818933333333
+          ],
+          [
+            1258.6668097777776,
+            1846.2818933333333
+          ],
+          [
+            1258.6668097777776,
+            1821.3752266666665
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 11
+    },
+    "text": "segmentation discussion and refer readers to the source code when available."
+  },
+  {
+    "type": "Title",
+    "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            464.2409381866455,
+            256.27799213796425
+          ],
+          [
+            464.2409381866455,
+            285.17215747188254
+          ],
+          [
+            616.9232115555554,
+            285.17215747188254
+          ],
+          [
+            616.9232115555554,
+            256.27799213796425
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "Z. Shen et al."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "a1fb50e6c86fae1679ef3351296fd671",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            257.4113377777776
+          ],
+          [
+            374.3472222222222,
+            282.31800444444434
+          ],
+          [
+            399.94629422222215,
+            282.31800444444434
+          ],
+          [
+            399.94629422222215,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "12"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "7174760d4c8d9b7b13da3918015312dc",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            415.85833333333335,
+            327.13373444444437
+          ],
+          [
+            415.85833333333335,
+            354.8076233333335
+          ],
+          [
+            827.7333048366664,
+            354.8076233333335
+          ],
+          [
+            827.7333048366664,
+            327.13373444444437
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "To decipher the complicated layout"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "9b51c55d2dd4ffd289138fc4f66e11e6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            373.37777777777774,
+            348.63957649267815
+          ],
+          [
+            373.37777777777774,
+            755.7774345655948
+          ],
+          [
+            1343.92138671875,
+            755.7774345655948
+          ],
+          [
+            1343.92138671875,
+            348.63957649267815
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "structure, two object detection models have been trained to recognize individual columns and tokens, respectively. A small training set (400 images with approxi- mately 100 annotations each) is curated via the active learning based annotation tool [32] in LayoutParser. The models learn to identify both the categories and regions for each token or column via their distinct visual features. The layout data structure enables easy grouping of the tokens within each column, and rearranging columns to achieve the correct reading orders based on the horizontal position. Errors are identiﬁed and rectiﬁed via checking the consistency of the model predictions. Therefore, though trained on a small dataset, the pipeline achieves a high level of layout detection accuracy: it achieves a 96.97 AP [19] score across 5 categories for the column detection model, and a 89.23 AP across 4 categories for the token detection model."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "888b9c9ec4431146d744bc6f39e16fd0",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            370.57433891296387,
+            766.3677654174215
+          ],
+          [
+            370.57433891296387,
+            1093.1076233333333
+          ],
+          [
+            1347.6912384033203,
+            1093.1076233333333
+          ],
+          [
+            1347.6912384033203,
+            766.3677654174215
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "A combination of character recognition methods is developed to tackle the unique challenges in this document. In our experiments, we found that irregular spacing between the tokens led to a low character recognition recall rate, whereas existing OCR models tend to perform better on densely-arranged texts. To overcome this challenge, we create a document reorganization algorithm that rearranges the text based on the token bounding boxes detected in the layout analysis step. Figure 4 (b) illustrates the generated image of dense text, which is sent to the OCR APIs as a whole to reduce the transaction costs. The ﬂexible coordinate system in LayoutParser is used to transform the OCR results relative to their original positions on the page."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "07be9fda679b805e67cf5e563eada033",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.0198097229004,
+            1103.1441656287743
+          ],
+          [
+            372.0198097229004,
+            1503.410526588919
+          ],
+          [
+            1341.46435546875,
+            1503.410526588919
+          ],
+          [
+            1341.46435546875,
+            1103.1441656287743
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "Additionally, it is common for historical documents to use unique fonts with diﬀerent glyphs, which signiﬁcantly degrades the accuracy of OCR models trained on modern texts. In this document, a special ﬂat font is used for printing numbers and could not be detected by oﬀ-the-shelf OCR engines. Using the highly ﬂexible functionalities from LayoutParser, a pipeline approach is constructed that achieves a high recognition accuracy with minimal eﬀort. As the characters have unique visual structures and are usually clustered together, we train the layout model to identify number regions with a dedicated category. Subsequently, LayoutParser crops images within these regions, and identiﬁes characters within them using a self-trained OCR model based on a CNN-RNN [6]. The model detects a total of 15 possible categories, and achieves a 0.98 Jaccard score16 and a 0.17 average Levinstein distances17 for token prediction on the test set."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "069379b2abcf2bed44f13bdaea90ec2d",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            359.488094329834,
+            1509.9235615753323
+          ],
+          [
+            359.488094329834,
+            1673.071512222222
+          ],
+          [
+            1335.0079040527344,
+            1673.071512222222
+          ],
+          [
+            1335.0079040527344,
+            1509.9235615753323
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "Overall, it is possible to create an intricate and highly accurate digitization pipeline for large-scale digitization using LayoutParser. The pipeline avoids specifying the complicated rules used in traditional methods, is straightforward to develop, and is robust to outliers. The DL models also generate ﬁne-grained results that enable creative approaches like page reorganization for OCR."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "0575dcbfd82c79a56a8028d0af3cbe07",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.81111111111113,
+            1726.16404
+          ],
+          [
+            371.81111111111113,
+            1754.9596711111112
+          ],
+          [
+            1334.9801016977776,
+            1754.9596711111112
+          ],
+          [
+            1334.9801016977776,
+            1726.16404
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "16 This measures the overlap between the detected and ground-truth characters, and"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "59ad9914d41efc63dfb974146f279fa6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            402.01944444444445,
+            1760.491893333333
+          ],
+          [
+            402.01944444444445,
+            1785.3985599999999
+          ],
+          [
+            611.222991111111,
+            1785.3985599999999
+          ],
+          [
+            611.222991111111,
+            1760.491893333333
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "the maximum is 1."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "3b2feff30ba56d2407ebe555afc5858a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            371.81111111111113,
+            1787.0445955555554
+          ],
+          [
+            371.81111111111113,
+            1815.8402266666667
+          ],
+          [
+            1338.5435906524442,
+            1815.8402266666667
+          ],
+          [
+            1338.5435906524442,
+            1787.0445955555554
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "17 This measures the number of edits from the ground-truth text to the predicted text,"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "72bbddd6bb0b167876e1be851d281caf",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            402.01944444444445,
+            1821.3752266666665
+          ],
+          [
+            402.01944444444445,
+            1846.2818933333333
+          ],
+          [
+            619.1806711111111,
+            1846.2818933333333
+          ],
+          [
+            619.1806711111111,
+            1821.3752266666665
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 12
+    },
+    "text": "and lower is better."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4c2478cf439baab6ace34761eda527d9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            658.7111111111111,
+            257.4113377777776
+          ],
+          [
+            658.7111111111111,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 13
+    },
+    "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "1a252402972f6057fa53cc172b52b9ff",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            1309.386639111111,
+            257.4113377777776
+          ],
+          [
+            1309.386639111111,
+            282.31800444444434
+          ],
+          [
+            1334.985711111111,
+            282.31800444444434
+          ],
+          [
+            1334.985711111111,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 13
+    },
+    "text": "13"
+  },
+  {
+    "type": "FigureCaption",
+    "element_id": "f58d47bde7ebddd81c4a678c918a8f1b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            364.207088470459,
+            286.4425703408062
+          ],
+          [
+            364.207088470459,
+            659.1314785722374
+          ],
+          [
+            1347.2821655273438,
+            659.1314785722374
+          ],
+          [
+            1347.2821655273438,
+            286.4425703408062
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 13
+    },
+    "text": "(2) Partial table atthe bottom (&) Full page table (6) Partial table at the top (d) Mis-detected tet line"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "1a2b9e59d53ac38ee6affb3ffcda6b8c",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            675.5019625603865
+          ],
+          [
+            374.3472222222222,
+            806.0270677777778
+          ],
+          [
+            1336.2064590454102,
+            806.0270677777778
+          ],
+          [
+            1336.2064590454102,
+            675.5019625603865
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 13
+    },
+    "text": "Fig. 6: This lightweight table detector can identify tables (outlined in red) and cells (shaded in blue) in diﬀerent locations on a page. In very few cases (d), it might generate minor error predictions, e.g, failing to capture the top text line of a table."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "76c98240da7b06b4b3fcf8109edbbaba",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            901.6198455555555
+          ],
+          [
+            374.3472222222222,
+            929.2937344444443
+          ],
+          [
+            975.0228175,
+            929.2937344444443
+          ],
+          [
+            975.0228175,
+            901.6198455555555
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 13
+    },
+    "text": "5.2 A light-weight Visual Table Extractor"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "0f6c572efe499db5f3a396c3f898b39a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            367.0137252807617,
+            1013.5670677777777
+          ],
+          [
+            367.0137252807617,
+            1246.013572803442
+          ],
+          [
+            1347.2739944458008,
+            1246.013572803442
+          ],
+          [
+            1347.2739944458008,
+            1013.5670677777777
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 13
+    },
+    "text": "Detecting tables and parsing their structures (table extraction) are of central im- portance for many document digitization tasks. Many previous works [26, 30, 27] and tools 18 have been developed to identify and parse table structures. Yet they might require training complicated models from scratch, or are only applicable for born-digital PDF documents. In this section, we show how LayoutParser can help build a light-weight accurate visual table extractor for legal docket tables using the existing resources with minimal eﬀort."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "d423e43627591688a7a55d37adbf14e7",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            372.09555435180664,
+            1253.305546120169
+          ],
+          [
+            372.09555435180664,
+            1755.742045969203
+          ],
+          [
+            1339.50537109375,
+            1755.742045969203
+          ],
+          [
+            1339.50537109375,
+            1253.305546120169
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 13
+    },
+    "text": "The extractor uses a pre-trained layout detection model for identifying the table regions and some simple rules for pairing the rows and the columns in the PDF image. Mask R-CNN [12] trained on the PubLayNet dataset [38] from the LayoutParser Model Zoo can be used for detecting table regions. By ﬁltering out model predictions of low conﬁdence and removing overlapping predictions, LayoutParser can identify the tabular regions on each page, which signiﬁcantly simpliﬁes the subsequent steps. By applying the line detection functions within the tabular segments, provided in the utility module from LayoutParser, the pipeline can identify the three distinct columns in the tables. A row clustering method is then applied via analyzing the y coordinates of token bounding boxes in the left-most column, which are obtained from the OCR engines. A non-maximal suppression algorithm is used to remove duplicated rows with extremely small gaps. Shown in Figure 6, the built pipeline can detect tables at diﬀerent positions on a page accurately. Continued tables from diﬀerent pages are concatenated, and a structured table representation has been easily created."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "8ff0f0a5b4e520b95b6d74614366af1e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            370.06954765319824,
+            1817.4862622222222
+          ],
+          [
+            370.06954765319824,
+            1849.237868451842
+          ],
+          [
+            1257.1753692626953,
+            1849.237868451842
+          ],
+          [
+            1257.1753692626953,
+            1817.4862622222222
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 13
+    },
+    "text": "18 https://github.com/atlanhq/camelot, https://github.com/tabulapdf/tabula"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "9a92adbc0cee38ef658c71ce1b1bf8c6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            257.4113377777776
+          ],
+          [
+            374.3472222222222,
+            282.31800444444434
+          ],
+          [
+            399.94629422222215,
+            282.31800444444434
+          ],
+          [
+            399.94629422222215,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "14"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            466.1482142222221,
+            257.4113377777776
+          ],
+          [
+            466.1482142222221,
+            282.31800444444434
+          ],
+          [
+            616.9232115555554,
+            282.31800444444434
+          ],
+          [
+            616.9232115555554,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "Z. Shen et al."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "a2a71736439cbc5e1445bddd40712b9b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            322.6725244444446
+          ],
+          [
+            374.3472222222222,
+            355.88141333333346
+          ],
+          [
+            609.094216,
+            355.88141333333346
+          ],
+          [
+            609.094216,
+            322.6725244444446
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "6 Conclusion"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "ad29b99d522a90b8084b53f55ca78e02",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            365.2317810058594,
+            399.22159241017516
+          ],
+          [
+            365.2317810058594,
+            737.0763629415761
+          ],
+          [
+            1335.72186516,
+            737.0763629415761
+          ],
+          [
+            1335.72186516,
+            399.22159241017516
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "LayoutParser provides a comprehensive toolkit for deep learning-based document image analysis. The oﬀ-the-shelf library is easy to install, and can be used to build ﬂexible and accurate pipelines for processing documents with complicated structures. It also supports high-level customization and enables easy labeling and training of DL models on unique document image datasets. The LayoutParser community platform facilitates sharing DL models and DIA pipelines, inviting discussion and promoting code reproducibility and reusability. The LayoutParser team is committed to keeping the library updated continuously and bringing the most recent advances in DL-based DIA, such as multi-modal document modeling [37, 36, 9] (an upcoming priority), to a diverse audience of end-users."
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "f85505b114cf50b99bc0ae7c3805774d",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            367.7756462097168,
+            787.3087344444442
+          ],
+          [
+            367.7756462097168,
+            914.6076233333333
+          ],
+          [
+            1340.3328733422225,
+            914.6076233333333
+          ],
+          [
+            1340.3328733422225,
+            787.3087344444442
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "Acknowledgements We thank the anonymous reviewers for their comments and suggestions. This project is supported in part by NSF Grant OIA-2033558 and funding from the Harvard Data Science Initiative and Harvard Catalyst. Zejiang Shen thanks Doug Downey for suggestions."
+  },
+  {
+    "type": "Title",
+    "element_id": "e56261e0bd30965b8e68ed2abb15b141",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            975.375575558575
+          ],
+          [
+            374.3472222222222,
+            1010.3268653759059
+          ],
+          [
+            549.1687759999999,
+            1010.3268653759059
+          ],
+          [
+            549.1687759999999,
+            975.375575558575
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "References"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "f7e8d95a8f2b84a4461e037b0a7b9704",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.375,
+            1053.2280044444444
+          ],
+          [
+            390.375,
+            1291.9209466666666
+          ],
+          [
+            1338.5426637155554,
+            1291.9209466666666
+          ],
+          [
+            1338.5426637155554,
+            1053.2280044444444
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "[1] Abadi, M., Agarwal, A., Barham, P., Brevdo, E., Chen, Z., Citro, C., Corrado, G.S., Davis, A., Dean, J., Devin, M., Ghemawat, S., Goodfellow, I., Harp, A., Irving, G., Isard, M., Jia, Y., Jozefowicz, R., Kaiser, L., Kudlur, M., Levenberg, J., Man´e, D., Monga, R., Moore, S., Murray, D., Olah, C., Schuster, M., Shlens, J., Steiner, B., Sutskever, I., Talwar, K., Tucker, P., Vanhoucke, V., Vasudevan, V., Vi´egas, F., Vinyals, O., Warden, P., Wattenberg, M., Wicke, M., Yu, Y., Zheng, X.: TensorFlow: Large-scale machine learning on heterogeneous systems (2015), https://www.tensorflow.org/, software available from tensorﬂow.org"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "24862433f743a0910da62ec3fb4f537c",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.3749999999999,
+            1297.9446711111111
+          ],
+          [
+            390.3749999999999,
+            1414.1763377777777
+          ],
+          [
+            1339.9368193635553,
+            1414.1763377777777
+          ],
+          [
+            1339.9368193635553,
+            1297.9446711111111
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "[2] Alberti, M., Pondenkandath, V., W¨ursch, M., Ingold, R., Liwicki, M.: Deepdiva: a highly-functional python framework for reproducible experiments. In: 2018 16th International Conference on Frontiers in Handwriting Recognition (ICFHR). pp. 423–428. IEEE (2018)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "79a1f55a3945eb6304697ec72847ed35",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.375,
+            1420.894671111111
+          ],
+          [
+            390.375,
+            1537.126337777778
+          ],
+          [
+            1339.9424681955552,
+            1537.126337777778
+          ],
+          [
+            1339.9424681955552,
+            1420.894671111111
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "[3] Antonacopoulos, A., Bridson, D., Papadopoulos, C., Pletschacher, S.: A realistic dataset for performance evaluation of document layout analysis. In: 2009 10th International Conference on Document Analysis and Recognition. pp. 296–300. IEEE (2009)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "cafb24e03d3f74ce81ba82312af7bfc2",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.375,
+            1543.847448888889
+          ],
+          [
+            390.375,
+            1629.637448888889
+          ],
+          [
+            1335.6571068302223,
+            1629.637448888889
+          ],
+          [
+            1335.6571068302223,
+            1543.847448888889
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "[4] Baek, Y., Lee, B., Han, D., Yun, S., Lee, H.: Character region awareness for text detection. In: Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. pp. 9365–9374 (2019)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "117fc6b27c81b420f6e0fa2c6e3f6b92",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.375,
+            1636.3557822222222
+          ],
+          [
+            390.375,
+            1661.262448888889
+          ],
+          [
+            1334.976029048889,
+            1661.262448888889
+          ],
+          [
+            1334.976029048889,
+            1636.3557822222222
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "[5] Deng, J., Dong, W., Socher, R., Li, L.J., Li, K., Fei-Fei, L.: ImageNet: A Large-Scale"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "ed850ded537aa0ac53c62e095a412dc4",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            431.23055555555555,
+            1666.7974488888888
+          ],
+          [
+            431.23055555555555,
+            1691.7041155555555
+          ],
+          [
+            987.1971688888888,
+            1691.7041155555555
+          ],
+          [
+            987.1971688888888,
+            1666.7974488888888
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "Hierarchical Image Database. In: CVPR09 (2009)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "b000578a41ffcc554faac04609d2f4e1",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.375,
+            1698.4252266666667
+          ],
+          [
+            390.375,
+            1784.2152266666667
+          ],
+          [
+            1339.9551705955555,
+            1784.2152266666667
+          ],
+          [
+            1339.9551705955555,
+            1698.4252266666667
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "[6] Deng, Y., Kanervisto, A., Ling, J., Rush, A.M.: Image-to-markup generation with coarse-to-ﬁne attention. In: International Conference on Machine Learning. pp. 980–989. PMLR (2017)"
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "c6e835fe03323406543926cc0f5a94de",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.375,
+            1790.467464428593
+          ],
+          [
+            390.375,
+            1848.3419077407912
+          ],
+          [
+            1339.9467521422218,
+            1848.3419077407912
+          ],
+          [
+            1339.9467521422218,
+            1790.467464428593
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 14
+    },
+    "text": "[7] Ganin, Y., Lempitsky, V.: Unsupervised domain adaptation by backpropagation. In: International conference on machine learning. pp. 1180–1189. PMLR (2015)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4c2478cf439baab6ace34761eda527d9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            658.7111111111111,
+            257.4113377777776
+          ],
+          [
+            658.7111111111111,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            283.01539111111094
+          ],
+          [
+            1243.1598124444442,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "238903180cc104ec2c5d8b3f20c5bc61",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            1309.386639111111,
+            257.4113377777776
+          ],
+          [
+            1309.386639111111,
+            282.31800444444434
+          ],
+          [
+            1334.985711111111,
+            282.31800444444434
+          ],
+          [
+            1334.985711111111,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "15"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "a24a28ea9e86cd280c8f7887ad2d0d99",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.375,
+            329.36411555555543
+          ],
+          [
+            390.375,
+            506.5068933333331
+          ],
+          [
+            1339.2489171555553,
+            506.5068933333331
+          ],
+          [
+            1339.2489171555553,
+            329.36411555555543
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[8] Gardner, M., Grus, J., Neumann, M., Tafjord, O., Dasigi, P., Liu, N., Peters, M., Schmitz, M., Zettlemoyer, L.: Allennlp: A deep semantic natural language processing platform. arXiv preprint arXiv:1803.07640 (2018) (cid:32)Lukasz Garncarek, Powalski, R., Stanis(cid:32)lawek, T., Topolski, B., Halama, P., Grali´nski, F.: Lambert: Layout-aware (language) modeling using bert for in- formation extraction (2020)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "ca3e69faa45c756ca454e118ff12f597",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            390.375,
+            420.71689333333336
+          ],
+          [
+            390.375,
+            445.62356000000005
+          ],
+          [
+            417.39624266666664,
+            445.62356000000005
+          ],
+          [
+            417.39624266666664,
+            420.71689333333336
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[9]"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "c8f5863d94cc9b9d77f153c6d1b0015a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            512.0668933333329
+          ],
+          [
+            377.575,
+            628.2985599999998
+          ],
+          [
+            1339.9500896355553,
+            628.2985599999998
+          ],
+          [
+            1339.9500896355553,
+            512.0668933333329
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[10] Graves, A., Fern´andez, S., Gomez, F., Schmidhuber, J.: Connectionist temporal classiﬁcation: labelling unsegmented sequence data with recurrent neural networks. In: Proceedings of the 23rd international conference on Machine learning. pp. 369–376 (2006)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "91c801cdf5af0b4fccd7f65d711d447a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            633.8613377777777
+          ],
+          [
+            377.575,
+            750.1180044444443
+          ],
+          [
+            1335.4910491022217,
+            750.1180044444443
+          ],
+          [
+            1335.4910491022217,
+            633.8613377777777
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[11] Harley, A.W., Ufkes, A., Derpanis, K.G.: Evaluation of deep convolutional nets for document image classiﬁcation and retrieval. In: 2015 13th International Conference on Document Analysis and Recognition (ICDAR). pp. 991–995. IEEE (2015) [12] He, K., Gkioxari, G., Doll´ar, P., Girshick, R.: Mask r-cnn. In: Proceedings of the"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "ecabb9a495995008845e44ab44bbda42",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            431.23055555555555,
+            755.6530044444442
+          ],
+          [
+            431.23055555555555,
+            780.5596711111109
+          ],
+          [
+            1246.0994782222217,
+            780.5596711111109
+          ],
+          [
+            1246.0994782222217,
+            755.6530044444442
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "IEEE international conference on computer vision. pp. 2961–2969 (2017)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "7ceaba2290e3f9c5f3754032ce4d5663",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            786.1224488888887
+          ],
+          [
+            377.575,
+            871.9124488888888
+          ],
+          [
+            1339.952371086222,
+            871.9124488888888
+          ],
+          [
+            1339.952371086222,
+            786.1224488888887
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[13] He, K., Zhang, X., Ren, S., Sun, J.: Deep residual learning for image recognition. In: Proceedings of the IEEE conference on computer vision and pattern recognition. pp. 770–778 (2016)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "901e0c80da6bc4ab586f53c474e71426",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            877.4752266666667
+          ],
+          [
+            377.575,
+            902.3818933333332
+          ],
+          [
+            1339.9449140302218,
+            902.3818933333332
+          ],
+          [
+            1339.9449140302218,
+            877.4752266666667
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[14] Kay, A.: Tesseract: An open-source optical character recognition engine. Linux J."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "2785f642a6abf514e88b8560ac84509f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            430.49444444444447,
+            907.9141155555557
+          ],
+          [
+            430.49444444444447,
+            932.8207822222222
+          ],
+          [
+            707.3747128888889,
+            932.8207822222222
+          ],
+          [
+            707.3747128888889,
+            907.9141155555557
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "2007(159), 2 (Jul 2007)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "1f1a0fac1bae95f076ea34c955551632",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.57500000000005,
+            938.38356
+          ],
+          [
+            377.57500000000005,
+            1024.17356
+          ],
+          [
+            1334.9688858168888,
+            1024.17356
+          ],
+          [
+            1334.9688858168888,
+            938.38356
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[15] Lamiroy, B., Lopresti, D.: An open architecture for end-to-end document analysis benchmarking. In: 2011 International Conference on Document Analysis and Recognition. pp. 42–47. IEEE (2011)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "0aabfb2a8e358618179ec2e1d322e519",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1029.7363377777779
+          ],
+          [
+            377.575,
+            1207.5459466666666
+          ],
+          [
+            1344.1208666666666,
+            1207.5459466666666
+          ],
+          [
+            1344.1208666666666,
+            1029.7363377777779
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[16] Lee, B.C., Weld, D.S.: Newspaper navigator: Open faceted search for 1.5 million images. In: Adjunct Publication of the 33rd Annual ACM Sym- posium on User Interface Software and Technology. p. 120–122. UIST ’20 Adjunct, Association for Computing Machinery, New York, NY, USA (2020). https://doi.org/10.1145/3379350.3416143, https://doi-org.offcampus. lib.washington.edu/10.1145/3379350.3416143"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "df18427a8013b4df36e8ac4e2ee5da3a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.57500000000005,
+            1212.4113377777778
+          ],
+          [
+            377.57500000000005,
+            1359.7820577777777
+          ],
+          [
+            1338.5299613155553,
+            1359.7820577777777
+          ],
+          [
+            1338.5299613155553,
+            1212.4113377777778
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[17] Lee, B.C.G., Mears, J., Jakeway, E., Ferriter, M., Adams, C., Yarasavage, N., Thomas, D., Zwaard, K., Weld, D.S.: The Newspaper Navigator Dataset: Extracting Headlines and Visual Content from 16 Million Historic Newspaper Pages in Chronicling America, p. 3055–3062. Association for Computing Machinery, New York, NY, USA (2020), https://doi.org/10.1145/3340531.3412767"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "257e7b8aef89c41e03bf837ea517885e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.5749999999999,
+            1364.6446711111112
+          ],
+          [
+            377.5749999999999,
+            1450.4346711111111
+          ],
+          [
+            1335.6497045688889,
+            1450.4346711111111
+          ],
+          [
+            1335.6497045688889,
+            1364.6446711111112
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[18] Li, M., Cui, L., Huang, S., Wei, F., Zhou, M., Li, Z.: Tablebank: Table benchmark for image-based table detection and recognition. arXiv preprint arXiv:1903.01949 (2019)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "00c7abdd98fedd1746994d16ca44d45f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1455.997448888889
+          ],
+          [
+            377.575,
+            1541.7874488888888
+          ],
+          [
+            1338.5234955448889,
+            1541.7874488888888
+          ],
+          [
+            1338.5234955448889,
+            1455.997448888889
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[19] Lin, T.Y., Maire, M., Belongie, S., Hays, J., Perona, P., Ramanan, D., Doll´ar, P., Zitnick, C.L.: Microsoft coco: Common objects in context. In: European conference on computer vision. pp. 740–755. Springer (2014)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "7a0afd734c99f6b076dc58b2e57cfec6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1547.347448888889
+          ],
+          [
+            377.575,
+            1633.137448888889
+          ],
+          [
+            1334.9783702755553,
+            1633.137448888889
+          ],
+          [
+            1334.9783702755553,
+            1547.347448888889
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[20] Long, J., Shelhamer, E., Darrell, T.: Fully convolutional networks for semantic segmentation. In: Proceedings of the IEEE conference on computer vision and pattern recognition. pp. 3431–3440 (2015)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "00d6ff1b3fb21f8a608f3b6269df56be",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1638.7002266666664
+          ],
+          [
+            377.575,
+            1754.9318933333334
+          ],
+          [
+            1339.2499632355552,
+            1754.9318933333334
+          ],
+          [
+            1339.2499632355552,
+            1638.7002266666664
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[21] Neudecker, C., Schlarb, S., Dogan, Z.M., Missier, P., Suﬁ, S., Williams, A., Wolsten- croft, K.: An experimental workﬂow development platform for historical document digitisation and analysis. In: Proceedings of the 2011 workshop on historical document imaging and processing. pp. 161–168 (2011)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "deecdfacbce71dd1425fd54010b2fad1",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1760.4946711111108
+          ],
+          [
+            377.575,
+            1846.2818933333333
+          ],
+          [
+            1334.9833516088884,
+            1846.2818933333333
+          ],
+          [
+            1334.9833516088884,
+            1760.4946711111108
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 15
+    },
+    "text": "[22] Oliveira, S.A., Seguin, B., Kaplan, F.: dhsegment: A generic deep-learning approach for document segmentation. In: 2018 16th International Conference on Frontiers in Handwriting Recognition (ICFHR). pp. 7–12. IEEE (2018)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "e6c21e8d260fe71882debdb339d2402a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            374.3472222222222,
+            257.4113377777776
+          ],
+          [
+            374.3472222222222,
+            282.31800444444434
+          ],
+          [
+            399.94629422222215,
+            282.31800444444434
+          ],
+          [
+            399.94629422222215,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "16"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            466.1482142222221,
+            257.4113377777776
+          ],
+          [
+            466.1482142222221,
+            282.31800444444434
+          ],
+          [
+            616.9232115555554,
+            282.31800444444434
+          ],
+          [
+            616.9232115555554,
+            257.4113377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "Z. Shen et al."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "9131e10ef09f98999ec5325db7034879",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            329.36411555555543
+          ],
+          [
+            377.575,
+            567.3624488888887
+          ],
+          [
+            1338.5452041955555,
+            567.3624488888887
+          ],
+          [
+            1338.5452041955555,
+            329.36411555555543
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[23] Paszke, A., Gross, S., Chintala, S., Chanan, G., Yang, E., DeVito, Z., Lin, Z., Desmaison, A., Antiga, L., Lerer, A.: Automatic diﬀerentiation in pytorch (2017) [24] Paszke, A., Gross, S., Massa, F., Lerer, A., Bradbury, J., Chanan, G., Killeen, T., Lin, Z., Gimelshein, N., Antiga, L., et al.: Pytorch: An imperative style, high-performance deep learning library. arXiv preprint arXiv:1912.01703 (2019) [25] Pletschacher, S., Antonacopoulos, A.: The page (page analysis and ground-truth elements) format framework. In: 2010 20th International Conference on Pattern Recognition. pp. 257–260. IEEE (2010)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "21d151e4c182a1f441c3486d2f79afc0",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            572.8946711111108
+          ],
+          [
+            377.575,
+            689.1263377777777
+          ],
+          [
+            1339.2598793066663,
+            689.1263377777777
+          ],
+          [
+            1339.2598793066663,
+            572.8946711111108
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[26] Prasad, D., Gadpal, A., Kapadni, K., Visave, M., Sultanpure, K.: Cascadetabnet: An approach for end to end table detection and structure recognition from image- based documents. In: Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition Workshops. pp. 572–573 (2020)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "c9d8f6434425015c72f94fb212bba28f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            694.6613377777775
+          ],
+          [
+            377.575,
+            780.4513377777776
+          ],
+          [
+            1334.9736678968882,
+            780.4513377777776
+          ],
+          [
+            1334.9736678968882,
+            694.6613377777775
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[27] Qasim, S.R., Mahmood, H., Shafait, F.: Rethinking table recognition using graph neural networks. In: 2019 International Conference on Document Analysis and Recognition (ICDAR). pp. 142–147. IEEE (2019)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "9c3e13a0e9738b846289bff06952da3b",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            785.9863377777776
+          ],
+          [
+            377.575,
+            871.7763377777777
+          ],
+          [
+            1335.6642998755558,
+            871.7763377777777
+          ],
+          [
+            1335.6642998755558,
+            785.9863377777776
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[28] Ren, S., He, K., Girshick, R., Sun, J.: Faster r-cnn: Towards real-time object detection with region proposal networks. In: Advances in neural information processing systems. pp. 91–99 (2015)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "3a0690c47686e01ff8feec37cccf1a90",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            877.3113377777779
+          ],
+          [
+            377.575,
+            1054.42356
+          ],
+          [
+            1339.9373324408884,
+            1054.42356
+          ],
+          [
+            1339.9373324408884,
+            877.3113377777779
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[29] Scarselli, F., Gori, M., Tsoi, A.C., Hagenbuchner, M., Monfardini, G.: The graph neural network model. IEEE transactions on neural networks 20(1), 61–80 (2008) [30] Schreiber, S., Agne, S., Wolf, I., Dengel, A., Ahmed, S.: Deepdesrt: Deep learning for detection and structure recognition of tables in document images. In: 2017 14th IAPR international conference on document analysis and recognition (ICDAR). vol. 1, pp. 1162–1167. IEEE (2017)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "bd680d8baa57cc15337de2e0c299d121",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1059.95856
+          ],
+          [
+            377.575,
+            1145.74856
+          ],
+          [
+            1335.4942472177777,
+            1145.74856
+          ],
+          [
+            1335.4942472177777,
+            1059.95856
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[31] Shen, Z., Zhang, K., Dell, M.: A large dataset of historical japanese documents with complex layouts. In: Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition Workshops. pp. 548–549 (2020)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "37bb128a8a87ef034991efa0574ee4a4",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1151.28356
+          ],
+          [
+            377.575,
+            1176.1902266666666
+          ],
+          [
+            1334.9834512355555,
+            1176.1902266666666
+          ],
+          [
+            1334.9834512355555,
+            1151.28356
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[32] Shen, Z., Zhao, J., Dell, M., Yu, Y., Li, W.: Olala: Object-level active learning"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "53dd155fea5e56f1dc9715fab422339a",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            431.23055555555555,
+            1181.7252266666667
+          ],
+          [
+            431.23055555555555,
+            1206.6318933333332
+          ],
+          [
+            1158.3159315555552,
+            1206.6318933333332
+          ],
+          [
+            1158.3159315555552,
+            1181.7252266666667
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "based layout annotation. arXiv preprint arXiv:2010.01762 (2020)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "4c8ddc159ec208bb7f454603fcd7c4bd",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1212.1641155555556
+          ],
+          [
+            377.575,
+            1328.3957822222221
+          ],
+          [
+            1338.5375827555556,
+            1328.3957822222221
+          ],
+          [
+            1338.5375827555556,
+            1212.1641155555556
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[33] Studer, L., Alberti, M., Pondenkandath, V., Goktepe, P., Kolonko, T., Fischer, A., Liwicki, M., Ingold, R.: A comprehensive study of imagenet pre-training for historical document image analysis. In: 2019 International Conference on Document Analysis and Recognition (ICDAR). pp. 720–725. IEEE (2019)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "1cd3d88315a8510c5fd1cbc7784db861",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1333.9307822222222
+          ],
+          [
+            377.575,
+            1450.8598355555555
+          ],
+          [
+            1339.2489171555555,
+            1450.8598355555555
+          ],
+          [
+            1339.2489171555555,
+            1333.9307822222222
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[34] Wolf, T., Debut, L., Sanh, V., Chaumond, J., Delangue, C., Moi, A., Cistac, P., Rault, T., Louf, R., Funtowicz, M., et al.: Huggingface’s transformers: State-of- the-art natural language processing. arXiv preprint arXiv:1910.03771 (2019) [35] Wu, Y., Kirillov, A., Massa, F., Lo, W.Y., Girshick, R.: Detectron2. https://"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "0626b5a309a35467b0f463c7e36114ce",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            431.23055555555567,
+            1455.697448888889
+          ],
+          [
+            431.23055555555567,
+            1481.301502222222
+          ],
+          [
+            1007.7529777777779,
+            1481.301502222222
+          ],
+          [
+            1007.7529777777779,
+            1455.697448888889
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "github.com/facebookresearch/detectron2 (2019)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "6c94dd219ce339c358163833e20d099e",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.5750000000002,
+            1486.1391155555552
+          ],
+          [
+            377.5750000000002,
+            1571.9263377777777
+          ],
+          [
+            1338.5299115022221,
+            1571.9263377777777
+          ],
+          [
+            1338.5299115022221,
+            1486.1391155555552
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[36] Xu, Y., Xu, Y., Lv, T., Cui, L., Wei, F., Wang, G., Lu, Y., Florencio, D., Zhang, C., Che, W., et al.: Layoutlmv2: Multi-modal pre-training for visually-rich document understanding. arXiv preprint arXiv:2012.14740 (2020)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "13767118077be05d9be07792d1785ecb",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1577.4613377777778
+          ],
+          [
+            377.575,
+            1602.3680044444445
+          ],
+          [
+            1334.9742556942222,
+            1602.3680044444445
+          ],
+          [
+            1334.9742556942222,
+            1577.4613377777778
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[37] Xu, Y., Li, M., Cui, L., Huang, S., Wei, F., Zhou, M.: Layoutlm: Pre-training of"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "df2e0c46ac32660311c5e8b2bee4c16d",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            431.23055555555555,
+            1607.9030044444444
+          ],
+          [
+            431.23055555555555,
+            1632.809671111111
+          ],
+          [
+            1082.1637982222219,
+            1632.809671111111
+          ],
+          [
+            1082.1637982222219,
+            1607.9030044444444
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "text and layout for document image understanding (2019)"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "24e0da607349c44bf53c752dd897fc58",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            377.575,
+            1638.3446711111112
+          ],
+          [
+            377.575,
+            1663.2513377777777
+          ],
+          [
+            978.7979933155555,
+            1663.2513377777777
+          ],
+          [
+            978.7979933155555,
+            1638.3446711111112
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "[38] Zhong, X., Tang, J., Yepes, A.J.: Publaynet:"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "0b7709205c824159e1f921b3e01431b6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            731.5991273955555,
+            1638.3446711111112
+          ],
+          [
+            731.5991273955555,
+            1724.1346711111112
+          ],
+          [
+            1339.9530069333332,
+            1724.1346711111112
+          ],
+          [
+            1339.9530069333332,
+            1638.3446711111112
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "largest dataset ever for doc- In: 2019 International Conference on Document IEEE (Sep 2019)."
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "869d8bf2a40ba100a2d83b864d9a654f",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            430.2833333333333,
+            1668.786337777778
+          ],
+          [
+            430.2833333333333,
+            1754.5763377777778
+          ],
+          [
+            1089.9723154133333,
+            1754.5763377777778
+          ],
+          [
+            1089.9723154133333,
+            1668.786337777778
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "ument Analysis and Recognition (ICDAR). pp. 1015–1022. https://doi.org/10.1109/ICDAR.2019.00166"
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "5ad8687ffef71730e40fbc829ea0d8b6",
+    "metadata": {
+      "coordinates": {
+        "points": [
+          [
+            523.5363558755555,
+            1668.786337777778
+          ],
+          [
+            523.5363558755555,
+            1693.6930044444443
+          ],
+          [
+            711.1482633955554,
+            1693.6930044444443
+          ],
+          [
+            711.1482633955554,
+            1668.786337777778
+          ]
+        ],
+        "system": "PixelSpace",
+        "layout_width": 1700,
+        "layout_height": 2200
+      },
+      "data_source": {},
+      "filetype": "application/pdf",
+      "page_number": 16
+    },
+    "text": "layout analysis."
+  }
+]

--- a/test_unstructured_ingest/expected-structured-output/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.json
+++ b/test_unstructured_ingest/expected-structured-output/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.json
@@ -3,29 +3,6 @@
     "type": "Title",
     "element_id": "2f7cc75f6467bba468022c4c2875335e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            437.83888888888885,
-            314.99337164100245
-          ],
-          [
-            437.83888888888885,
-            413.1229949803744
-          ],
-          [
-            1275.7076416015625,
-            413.1229949803744
-          ],
-          [
-            1275.7076416015625,
-            314.99337164100245
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -36,29 +13,6 @@
     "type": "NarrativeText",
     "element_id": "7d5d472da16528a310bc18c9682ed62d",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.46944444444443,
-            468.4452761333334
-          ],
-          [
-            374.46944444444443,
-            534.0326233333333
-          ],
-          [
-            1334.8511664111113,
-            534.0326233333333
-          ],
-          [
-            1334.8511664111113,
-            468.4452761333334
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -69,29 +23,6 @@
     "type": "ListItem",
     "element_id": "d598892f792aa3f81bde483737ac163e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            575.6388888888889,
-            556.8422415175876
-          ],
-          [
-            575.6388888888889,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            556.8422415175876
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -102,29 +33,6 @@
     "type": "ListItem",
     "element_id": "c44dd169d4120fc474358e959bc32f27",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            575.6388888888889,
-            556.8422415175876
-          ],
-          [
-            575.6388888888889,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            556.8422415175876
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -135,29 +43,6 @@
     "type": "ListItem",
     "element_id": "69ce85202ad89819bf6a6687c34c04a0",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            575.6388888888889,
-            556.8422415175876
-          ],
-          [
-            575.6388888888889,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            556.8422415175876
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -168,29 +53,6 @@
     "type": "ListItem",
     "element_id": "ee43ace21caffc7f3e421e0d25282863",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            575.6388888888889,
-            556.8422415175876
-          ],
-          [
-            575.6388888888889,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            556.8422415175876
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -201,29 +63,6 @@
     "type": "ListItem",
     "element_id": "91e84c77f84bea17e45f12fe8d612afa",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            575.6388888888889,
-            556.8422415175876
-          ],
-          [
-            575.6388888888889,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            556.8422415175876
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -234,29 +73,6 @@
     "type": "ListItem",
     "element_id": "a02bbc7d83b04c67fcac3ae66b21b824",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            575.6388888888889,
-            556.8422415175876
-          ],
-          [
-            575.6388888888889,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            874.4119218466939
-          ],
-          [
-            1133.6854444444443,
-            556.8422415175876
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -267,29 +83,6 @@
     "type": "UncategorizedText",
     "element_id": "7dce5432959ba3ffb1edad16bc3f458c",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            45.388888888888886,
-            592.6666666666666
-          ],
-          [
-            45.388888888888886,
-            703.7777777777778
-          ],
-          [
-            100.94444444444446,
-            703.7777777777778
-          ],
-          [
-            100.94444444444446,
-            592.6666666666666
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -300,29 +93,6 @@
     "type": "UncategorizedText",
     "element_id": "c8d21c806367081195dd372b58005d48",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            45.388888888888886,
-            717.6666666666666
-          ],
-          [
-            45.388888888888886,
-            794.8333333333333
-          ],
-          [
-            100.94444444444446,
-            794.8333333333333
-          ],
-          [
-            100.94444444444446,
-            717.6666666666666
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -333,29 +103,6 @@
     "type": "UncategorizedText",
     "element_id": "a6e2b7a040683432de03a18fd8a1939a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            45.388888888888886,
-            808.7222222222222
-          ],
-          [
-            45.388888888888886,
-            864.2777777777777
-          ],
-          [
-            100.94444444444446,
-            864.2777777777777
-          ],
-          [
-            100.94444444444446,
-            808.7222222222222
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -366,29 +113,6 @@
     "type": "UncategorizedText",
     "element_id": "f9416e09f78ba316c032568213b855ee",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            45.388888888888886,
-            892.0555555555554
-          ],
-          [
-            45.388888888888886,
-            910.5555555555555
-          ],
-          [
-            100.94444444444446,
-            910.5555555555555
-          ],
-          [
-            100.94444444444446,
-            892.0555555555554
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -399,29 +123,6 @@
     "type": "UncategorizedText",
     "element_id": "20f7b3c9b9ca29dbbf5c1975fb8894a9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            45.388888888888886,
-            910.5555555555555
-          ],
-          [
-            45.388888888888886,
-            1066.3888888888887
-          ],
-          [
-            100.94444444444446,
-            1066.3888888888887
-          ],
-          [
-            100.94444444444446,
-            910.5555555555555
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -432,29 +133,6 @@
     "type": "NarrativeText",
     "element_id": "be90d2640470e975e3402d19ba2c66cf",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            444.49250411987305,
-            940.1391155555556
-          ],
-          [
-            444.49250411987305,
-            1584.0870791817633
-          ],
-          [
-            1261.2144504231107,
-            1584.0870791817633
-          ],
-          [
-            1261.2144504231107,
-            940.1391155555556
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -465,29 +143,6 @@
     "type": "UncategorizedText",
     "element_id": "12529cdcfd90d0bf95ff502804e61a16",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            45.388888888888886,
-            1094.1666666666665
-          ],
-          [
-            45.388888888888886,
-            1555.5555555555554
-          ],
-          [
-            100.94444444444446,
-            1555.5555555555554
-          ],
-          [
-            100.94444444444446,
-            1094.1666666666665
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -498,29 +153,6 @@
     "type": "NarrativeText",
     "element_id": "e66a3d2b6c9a872c53e226d8e0cc0a0e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            444.8290100097656,
-            1603.7655555555555
-          ],
-          [
-            444.8290100097656,
-            1665.2347052385267
-          ],
-          [
-            1257.1887283325195,
-            1665.2347052385267
-          ],
-          [
-            1257.1887283325195,
-            1603.7655555555555
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -531,29 +163,6 @@
     "type": "Title",
     "element_id": "3fa53fc0dab8ef96d05d8fd4c7e41b49",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            413.9729633331299,
-            1718.8177224864132
-          ],
-          [
-            413.9729633331299,
-            1755.218948143116
-          ],
-          [
-            635.9834533333334,
-            1755.218948143116
-          ],
-          [
-            635.9834533333334,
-            1718.8177224864132
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -564,29 +173,6 @@
     "type": "UncategorizedText",
     "element_id": "4355a46b19d348dc2f57c046f8ef63d4",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.34722222222223,
-            1720.066968888889
-          ],
-          [
-            374.34722222222223,
-            1753.2758577777777
-          ],
-          [
-            393.02722222222224,
-            1753.2758577777777
-          ],
-          [
-            393.02722222222224,
-            1720.066968888889
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -597,29 +183,6 @@
     "type": "NarrativeText",
     "element_id": "bca638b88125eed8a8003e46a6055618",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.5987243652344,
-            1785.9365122222223
-          ],
-          [
-            372.5987243652344,
-            1848.6797417534724
-          ],
-          [
-            1338.8229390955555,
-            1848.6797417534724
-          ],
-          [
-            1338.8229390955555,
-            1785.9365122222223
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 1
@@ -630,29 +193,6 @@
     "type": "UncategorizedText",
     "element_id": "53c234e5e8472b6ac51c1ae1cab3fe06",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            257.4113377777776
-          ],
-          [
-            374.3472222222222,
-            282.31800444444434
-          ],
-          [
-            387.14675822222216,
-            282.31800444444434
-          ],
-          [
-            387.14675822222216,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -663,29 +203,6 @@
     "type": "Title",
     "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            464.5448570251465,
-            257.4113377777776
-          ],
-          [
-            464.5448570251465,
-            285.674692052574
-          ],
-          [
-            616.9257022222222,
-            285.674692052574
-          ],
-          [
-            616.9257022222222,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -696,29 +213,6 @@
     "type": "NarrativeText",
     "element_id": "82d5520be5fd847464727f56151d316c",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            369.18904876708984,
-            320.6916285712938
-          ],
-          [
-            369.18904876708984,
-            491.92897335918633
-          ],
-          [
-            1340.3470138088887,
-            491.92897335918633
-          ],
-          [
-            1340.3470138088887,
-            320.6916285712938
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -729,29 +223,6 @@
     "type": "NarrativeText",
     "element_id": "c1f1ba1630bc19bd24c1dfbc1548f2d8",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.225,
-            493.1781788888887
-          ],
-          [
-            372.225,
-            1085.4020677777778
-          ],
-          [
-            1339.607430018889,
-            1085.4020677777778
-          ],
-          [
-            1339.607430018889,
-            493.1781788888887
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -762,29 +233,6 @@
     "type": "NarrativeText",
     "element_id": "836e6ef5cecc9a73356c0d5bee181829",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.5436668395996,
-            1090.936512222222
-          ],
-          [
-            372.5436668395996,
-            1187.2160538383152
-          ],
-          [
-            1340.7606048583984,
-            1187.2160538383152
-          ],
-          [
-            1340.7606048583984,
-            1090.936512222222
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -795,29 +243,6 @@
     "type": "UncategorizedText",
     "element_id": "71c0c5ffbb8105ccb9f3bd1543f59007",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            386.03055555555545,
-            1207.097623333333
-          ],
-          [
-            386.03055555555545,
-            1234.771512222222
-          ],
-          [
-            1335.5285158244444,
-            1234.771512222222
-          ],
-          [
-            1335.5285158244444,
-            1207.097623333333
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -828,29 +253,6 @@
     "type": "UncategorizedText",
     "element_id": "798b60ffa3907be6de6b739de4b6ae6b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            421.39166666666665,
-            1240.3059566666666
-          ],
-          [
-            421.39166666666665,
-            1267.9798455555556
-          ],
-          [
-            961.884855777778,
-            1267.9798455555556
-          ],
-          [
-            961.884855777778,
-            1240.3059566666666
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -861,29 +263,6 @@
     "type": "UncategorizedText",
     "element_id": "5e547c7cebdde2107f00c9d51402dbe6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            386.03055555555557,
-            1272.3920677777778
-          ],
-          [
-            386.03055555555557,
-            1300.0659566666666
-          ],
-          [
-            1335.7155913133333,
-            1300.0659566666666
-          ],
-          [
-            1335.7155913133333,
-            1272.3920677777778
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -894,29 +273,6 @@
     "type": "UncategorizedText",
     "element_id": "a755646a34c86b2fb223ed3040821c4b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            421.39166666666665,
-            1305.600401111111
-          ],
-          [
-            421.39166666666665,
-            1333.2742899999998
-          ],
-          [
-            803.2138464444444,
-            1333.2742899999998
-          ],
-          [
-            803.2138464444444,
-            1305.600401111111
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -927,29 +283,6 @@
     "type": "UncategorizedText",
     "element_id": "beba83994ae4b4055cfc52903455a858",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            386.03055555555557,
-            1337.68929
-          ],
-          [
-            386.03055555555557,
-            1365.3631788888888
-          ],
-          [
-            1334.9671233144445,
-            1365.3631788888888
-          ],
-          [
-            1334.9671233144445,
-            1337.68929
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -960,29 +293,6 @@
     "type": "UncategorizedText",
     "element_id": "3ecbd234f3fb48c8974ca103ce412060",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            421.39166666666665,
-            1370.8976233333333
-          ],
-          [
-            421.39166666666665,
-            1398.571512222222
-          ],
-          [
-            1027.7597808888893,
-            1398.571512222222
-          ],
-          [
-            1027.7597808888893,
-            1370.8976233333333
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -993,29 +303,6 @@
     "type": "UncategorizedText",
     "element_id": "18b1855acfb386ae6e6a253da566e93b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            386.03055555555557,
-            1402.9865122222222
-          ],
-          [
-            386.03055555555557,
-            1497.0770677777775
-          ],
-          [
-            1339.5996769666667,
-            1497.0770677777775
-          ],
-          [
-            1339.5996769666667,
-            1402.9865122222222
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -1026,29 +313,6 @@
     "type": "NarrativeText",
     "element_id": "1f0f5df7c23d4f8e8de4de3085abd7d8",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            370.3133182525635,
-            1519.5807621905194
-          ],
-          [
-            370.3133182525635,
-            1714.7136360205316
-          ],
-          [
-            1335.7142673300004,
-            1714.7136360205316
-          ],
-          [
-            1335.7142673300004,
-            1519.5807621905194
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -1059,29 +323,6 @@
     "type": "NarrativeText",
     "element_id": "aebca7fedab12541cd5af93183b619e9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            368.1235980987549,
-            1719.5198455555555
-          ],
-          [
-            368.1235980987549,
-            1848.6279768644324
-          ],
-          [
-            1339.5998601505555,
-            1848.6279768644324
-          ],
-          [
-            1339.5998601505555,
-            1719.5198455555555
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 2
@@ -1092,29 +333,6 @@
     "type": "UncategorizedText",
     "element_id": "4c2478cf439baab6ace34761eda527d9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            658.7111111111111,
-            257.4113377777776
-          ],
-          [
-            658.7111111111111,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1125,29 +343,6 @@
     "type": "UncategorizedText",
     "element_id": "1121cfccd5913f0a63fec40a6ffd44ea",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            1322.1886657777777,
-            257.4113377777776
-          ],
-          [
-            1322.1886657777777,
-            282.31800444444434
-          ],
-          [
-            1334.9882017777777,
-            282.31800444444434
-          ],
-          [
-            1334.9882017777777,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1158,29 +353,6 @@
     "type": "NarrativeText",
     "element_id": "74a7758f83612467af8eea9d20e4a6f7",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            373.35,
-            327.13373444444437
-          ],
-          [
-            373.35,
-            493.4703410420441
-          ],
-          [
-            1340.341159733667,
-            493.4703410420441
-          ],
-          [
-            1340.341159733667,
-            327.13373444444437
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1191,29 +363,6 @@
     "type": "NarrativeText",
     "element_id": "9b8fc4816306f4f1b31874d53134979b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.87650871276855,
-            493.3290579238376
-          ],
-          [
-            372.87650871276855,
-            658.1393830672555
-          ],
-          [
-            1339.5969360802223,
-            658.1393830672555
-          ],
-          [
-            1339.5969360802223,
-            493.3290579238376
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1224,29 +373,6 @@
     "type": "Title",
     "element_id": "1513104c7bf6cd40223a7cc23798378f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            706.4619069859601
-          ],
-          [
-            374.3472222222222,
-            749.1161755548007
-          ],
-          [
-            662.1954727172852,
-            749.1161755548007
-          ],
-          [
-            662.1954727172852,
-            706.4619069859601
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1257,29 +383,6 @@
     "type": "NarrativeText",
     "element_id": "181670e0d50864954486b337b1d19118",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            368.8820171356201,
-            784.4587344444444
-          ],
-          [
-            368.8820171356201,
-            1011.385401111111
-          ],
-          [
-            1339.5917217947222,
-            1011.385401111111
-          ],
-          [
-            1339.5917217947222,
-            784.4587344444444
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1290,29 +393,6 @@
     "type": "NarrativeText",
     "element_id": "0ebd432f2495d0bfc8303eca930cc9e5",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.79019355773926,
-            1005.2570199275362
-          ],
-          [
-            372.79019355773926,
-            1543.0409566666665
-          ],
-          [
-            1340.3434336982218,
-            1543.0409566666665
-          ],
-          [
-            1340.3434336982218,
-            1005.2570199275362
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1323,29 +403,6 @@
     "type": "NarrativeText",
     "element_id": "19c6112edbf782bfc4f5cf04829f57ad",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            362.7286739349365,
-            1548.8920677777778
-          ],
-          [
-            362.7286739349365,
-            1613.4519125528382
-          ],
-          [
-            1340.2214431762695,
-            1613.4519125528382
-          ],
-          [
-            1340.2214431762695,
-            1548.8920677777778
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1356,29 +413,6 @@
     "type": "ListItem",
     "element_id": "27494431886c5be0e1b0dbeb2831a1e6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1389,29 +423,6 @@
     "type": "ListItem",
     "element_id": "193e03893373b61e7354231571171b6f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1422,29 +433,6 @@
     "type": "ListItem",
     "element_id": "a180bff913a0059538fe3609d9db6832",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1455,29 +443,6 @@
     "type": "ListItem",
     "element_id": "3be8a9f080762eb3b89459c83b9dc0cc",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1488,29 +453,6 @@
     "type": "ListItem",
     "element_id": "c84915bf4d12c1d1794529a2197c8f7e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1521,29 +463,6 @@
     "type": "ListItem",
     "element_id": "96811996068f19e87f4fc6944d2534c0",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1554,29 +473,6 @@
     "type": "ListItem",
     "element_id": "9b41ceaccf9f13d73692f2e1f5ec87ca",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1587,29 +483,6 @@
     "type": "ListItem",
     "element_id": "fcec4cb3f8a40c9c97f67564ef7b01cf",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1620,29 +493,6 @@
     "type": "ListItem",
     "element_id": "85932d11fa05437c5aca785378fe8b88",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1653,29 +503,6 @@
     "type": "ListItem",
     "element_id": "0c4475e4ef576fc3ba91edb83ac90529",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1686,29 +513,6 @@
     "type": "ListItem",
     "element_id": "f12bcd1c4c95f968487ef1d92f721777",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1719,29 +523,6 @@
     "type": "ListItem",
     "element_id": "c9a7576974bf76f87205a547952012b9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1752,29 +533,6 @@
     "type": "ListItem",
     "element_id": "c13539d1568999137c4e0354795cd37b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1785,29 +543,6 @@
     "type": "ListItem",
     "element_id": "f6adbb1b29c00a0317d87307ea7349c0",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1818,29 +553,6 @@
     "type": "ListItem",
     "element_id": "a52d4e55ffcecbb2b7e10950d6e3d2ff",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1851,29 +563,6 @@
     "type": "ListItem",
     "element_id": "c13539d1568999137c4e0354795cd37b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.80833333333334,
-            1634.8390399999998
-          ],
-          [
-            371.80833333333334,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1849.8120824841487
-          ],
-          [
-            1193.6330124444444,
-            1634.8390399999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 3
@@ -1884,29 +573,6 @@
     "type": "UncategorizedText",
     "element_id": "7de1555df0c2700329e815b93b32c571",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            257.4113377777776
-          ],
-          [
-            374.3472222222222,
-            282.31800444444434
-          ],
-          [
-            387.14675822222216,
-            282.31800444444434
-          ],
-          [
-            387.14675822222216,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 4
@@ -1917,29 +583,6 @@
     "type": "UncategorizedText",
     "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            466.1507048888888,
-            257.4113377777776
-          ],
-          [
-            466.1507048888888,
-            282.31800444444434
-          ],
-          [
-            616.9257022222222,
-            282.31800444444434
-          ],
-          [
-            616.9257022222222,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 4
@@ -1950,29 +593,6 @@
     "type": "FigureCaption",
     "element_id": "00401461c83b8b07511a4864781d8f8d",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            470.40833333333336,
-            312.29459163647346
-          ],
-          [
-            470.40833333333336,
-            700.0444444444444
-          ],
-          [
-            1238.9138333333335,
-            700.0444444444444
-          ],
-          [
-            1238.9138333333335,
-            312.29459163647346
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 4
@@ -1983,29 +603,6 @@
     "type": "NarrativeText",
     "element_id": "3fd5be2cdc473424f58b9da0192dec01",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            373.2944444444444,
-            728.6587344444443
-          ],
-          [
-            373.2944444444444,
-            1022.7797144444444
-          ],
-          [
-            1344.4991989135742,
-            1022.7797144444444
-          ],
-          [
-            1344.4991989135742,
-            728.6587344444443
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 4
@@ -2016,29 +613,6 @@
     "type": "NarrativeText",
     "element_id": "cd924e18fd419111b4ead552fb7cc36b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            373.2944444444444,
-            1095.6754011111111
-          ],
-          [
-            373.2944444444444,
-            1323.638332201087
-          ],
-          [
-            1341.1008071899414,
-            1323.638332201087
-          ],
-          [
-            1341.1008071899414,
-            1095.6754011111111
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 4
@@ -2049,29 +623,6 @@
     "type": "NarrativeText",
     "element_id": "de9b76ca2c36f4a1cc39c9bc69b75a45",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            370.2226905822754,
-            1327.8977133340882
-          ],
-          [
-            370.2226905822754,
-            1555.42429
-          ],
-          [
-            1341.0319366455078,
-            1555.42429
-          ],
-          [
-            1341.0319366455078,
-            1327.8977133340882
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 4
@@ -2082,29 +633,6 @@
     "type": "Title",
     "element_id": "740238ba10202556c962840e5c882446",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            1612.7707955917874
-          ],
-          [
-            374.3472222222222,
-            1650.5428177838164
-          ],
-          [
-            938.0814056396484,
-            1650.5428177838164
-          ],
-          [
-            938.0814056396484,
-            1612.7707955917874
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 4
@@ -2115,29 +643,6 @@
     "type": "NarrativeText",
     "element_id": "1f4bc06117d2be9d9e297dbe07aa05cd",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            365.80923652648926,
-            1685.8329795063407
-          ],
-          [
-            365.80923652648926,
-            1848.3114196482488
-          ],
-          [
-            1339.8717727661133,
-            1848.3114196482488
-          ],
-          [
-            1339.8717727661133,
-            1685.8329795063407
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 4
@@ -2148,29 +653,6 @@
     "type": "NarrativeText",
     "element_id": "4c2478cf439baab6ace34761eda527d9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            650.706672668457,
-            255.94129332021816
-          ],
-          [
-            650.706672668457,
-            284.3267940207956
-          ],
-          [
-            1247.0069122314453,
-            284.3267940207956
-          ],
-          [
-            1247.0069122314453,
-            255.94129332021816
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2181,29 +663,6 @@
     "type": "UncategorizedText",
     "element_id": "f0b5c2c2211c8d67ed15e75e656c7862",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            1322.1886657777777,
-            257.4113377777776
-          ],
-          [
-            1322.1886657777777,
-            282.31800444444434
-          ],
-          [
-            1334.9882017777777,
-            282.31800444444434
-          ],
-          [
-            1334.9882017777777,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2214,29 +673,6 @@
     "type": "NarrativeText",
     "element_id": "b51f99cb953082a922ba43c09d4492b3",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            401.9820957183838,
-            350.3809566666667
-          ],
-          [
-            401.9820957183838,
-            378.8297144444445
-          ],
-          [
-            1309.883644104004,
-            378.8297144444445
-          ],
-          [
-            1309.883644104004,
-            350.3809566666667
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2247,29 +683,6 @@
     "type": "Table",
     "element_id": "71e289a268220c21575bb55a73980b83",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            355.1971092224121,
-            368.17813007152023
-          ],
-          [
-            355.1971092224121,
-            569.5523380887681
-          ],
-          [
-            1330.2684173583984,
-            569.5523380887681
-          ],
-          [
-            1330.2684173583984,
-            368.17813007152023
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5,
@@ -2281,29 +694,6 @@
     "type": "UncategorizedText",
     "element_id": "654021138cc8eb1409b192c9c6bc9cad",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            541.4931199722222,
-            391.3053386788448
-          ],
-          [
-            541.4931199722222,
-            412.8620360849333
-          ],
-          [
-            871.8039053105956,
-            412.8620360849333
-          ],
-          [
-            871.8039053105956,
-            391.3053386788448
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2314,29 +704,6 @@
     "type": "UncategorizedText",
     "element_id": "396f3bb3ac3873b5455050e2beb7c68d",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            419.1515307222222,
-            394.21665635159997
-          ],
-          [
-            419.1515307222222,
-            412.8620360849333
-          ],
-          [
-            493.49438879496887,
-            412.8620360849333
-          ],
-          [
-            493.49438879496887,
-            394.21665635159997
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2347,29 +714,6 @@
     "type": "UncategorizedText",
     "element_id": "d994f2b2f63ea8768ac77b181d3621f6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.3154894166666,
-            431.9653156016001
-          ],
-          [
-            390.3154894166666,
-            559.9971726404887
-          ],
-          [
-            522.3322360805599,
-            559.9971726404887
-          ],
-          [
-            522.3322360805599,
-            431.9653156016001
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2380,29 +724,6 @@
     "type": "UncategorizedText",
     "element_id": "7c22bd490699f4fe4b4e3f22088ec82e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            572.1050305555555,
-            431.9653156016001
-          ],
-          [
-            572.1050305555555,
-            559.9971726404887
-          ],
-          [
-            624.5302447517689,
-            559.9971726404887
-          ],
-          [
-            624.5302447517689,
-            431.9653156016001
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2413,29 +734,6 @@
     "type": "UncategorizedText",
     "element_id": "3497cc19ecfddb5f0e0453223d71c3c5",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            726.855194388889,
-            431.9653156016001
-          ],
-          [
-            726.855194388889,
-            559.9971726404887
-          ],
-          [
-            744.4191420976889,
-            559.9971726404887
-          ],
-          [
-            744.4191420976889,
-            431.9653156016001
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2446,29 +744,6 @@
     "type": "UncategorizedText",
     "element_id": "3556a4a4ab68c8f8ffb7c40de795b758",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            816.1269368888888,
-            431.9653156016001
-          ],
-          [
-            816.1269368888888,
-            559.9971726404887
-          ],
-          [
-            1319.0580871259556,
-            559.9971726404887
-          ],
-          [
-            1319.0580871259556,
-            431.9653156016001
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2479,29 +754,6 @@
     "type": "NarrativeText",
     "element_id": "c24bcb2cf98d6226bd805b6f99d3b61a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            380.2362875555556,
-            574.6586429288442
-          ],
-          [
-            380.2362875555556,
-            711.3043242376208
-          ],
-          [
-            1330.5515779047234,
-            711.3043242376208
-          ],
-          [
-            1330.5515779047234,
-            574.6586429288442
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2512,29 +764,6 @@
     "type": "NarrativeText",
     "element_id": "9fb9573af5bf767f81cdaf2cf1a72cd9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.225,
-            774.672267747962
-          ],
-          [
-            372.225,
-            1002.0131788888888
-          ],
-          [
-            1339.891616821289,
-            1002.0131788888888
-          ],
-          [
-            1339.891616821289,
-            774.672267747962
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2545,29 +774,6 @@
     "type": "Title",
     "element_id": "9f26ca353a2c130a2e32f457d71c1350",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            1051.4504370942784
-          ],
-          [
-            374.3472222222222,
-            1083.4622855808425
-          ],
-          [
-            801.6733703613281,
-            1083.4622855808425
-          ],
-          [
-            801.6733703613281,
-            1051.4504370942784
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2578,29 +784,6 @@
     "type": "NarrativeText",
     "element_id": "11dff8778699e76422be6b86c9eaa62a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            357.58715057373047,
-            1105.8309566666667
-          ],
-          [
-            357.58715057373047,
-            1401.395293157458
-          ],
-          [
-            1340.338518815556,
-            1401.395293157458
-          ],
-          [
-            1340.338518815556,
-            1105.8309566666667
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2611,29 +794,6 @@
     "type": "UncategorizedText",
     "element_id": "f0c7e55ad98b18409dc6885d710fb288",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            351.09166666666664,
-            1419.7531688888887
-          ],
-          [
-            351.09166666666664,
-            1505.5431688888887
-          ],
-          [
-            1093.8868133333328,
-            1505.5431688888887
-          ],
-          [
-            1093.8868133333328,
-            1419.7531688888887
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2644,29 +804,6 @@
     "type": "UncategorizedText",
     "element_id": "4b27636ffb1723123a6cfbf67a2aa183",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            438.4194444444444,
-            1511.0781688888887
-          ],
-          [
-            438.4194444444444,
-            1535.9848355555555
-          ],
-          [
-            1188.9818444444438,
-            1535.9848355555555
-          ],
-          [
-            1188.9818444444438,
-            1511.0781688888887
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2677,29 +814,6 @@
     "type": "UncategorizedText",
     "element_id": "ac9c43a46f1221e9cc7611e910c88b58",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            351.09166666666664,
-            1519.3029783333334
-          ],
-          [
-            351.09166666666664,
-            1566.426502222222
-          ],
-          [
-            812.3808355555553,
-            1566.426502222222
-          ],
-          [
-            812.3808355555553,
-            1519.3029783333334
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2710,29 +824,6 @@
     "type": "NarrativeText",
     "element_id": "3aff40c86aa58c0362102802f4ef172f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.4021472930908,
-            1586.6837344444443
-          ],
-          [
-            371.4021472930908,
-            1847.9433570161534
-          ],
-          [
-            1341.3696746826172,
-            1847.9433570161534
-          ],
-          [
-            1341.3696746826172,
-            1586.6837344444443
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 5
@@ -2743,29 +834,6 @@
     "type": "UncategorizedText",
     "element_id": "06e9d52c1720fca412803e3b07c4b228",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            257.4113377777776
-          ],
-          [
-            374.3472222222222,
-            282.31800444444434
-          ],
-          [
-            387.14675822222216,
-            282.31800444444434
-          ],
-          [
-            387.14675822222216,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 6
@@ -2776,29 +844,6 @@
     "type": "UncategorizedText",
     "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            466.1507048888888,
-            257.4113377777776
-          ],
-          [
-            466.1507048888888,
-            282.31800444444434
-          ],
-          [
-            616.9257022222222,
-            282.31800444444434
-          ],
-          [
-            616.9257022222222,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 6
@@ -2809,29 +854,6 @@
     "type": "FigureCaption",
     "element_id": "2f498bdd91739a7083490999507420a5",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            542.4583333333333,
-            313.84669502000304
-          ],
-          [
-            542.4583333333333,
-            826.1194444444445
-          ],
-          [
-            1166.8136666666664,
-            826.1194444444445
-          ],
-          [
-            1166.8136666666664,
-            313.84669502000304
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 6
@@ -2842,29 +864,6 @@
     "type": "NarrativeText",
     "element_id": "cafae07120d714f0822e89865adf62da",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.78160095214844,
-            854.6140573105375
-          ],
-          [
-            372.78160095214844,
-            1048.4520677777778
-          ],
-          [
-            1340.3582779722226,
-            1048.4520677777778
-          ],
-          [
-            1340.3582779722226,
-            854.6140573105375
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 6
@@ -2875,29 +874,6 @@
     "type": "NarrativeText",
     "element_id": "7461d30ee7c51c91bca8003792d43bfe",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.0301856994629,
-            1126.0781788888887
-          ],
-          [
-            372.0301856994629,
-            1327.0712914213466
-          ],
-          [
-            1338.8324310627222,
-            1327.0712914213466
-          ],
-          [
-            1338.8324310627222,
-            1126.0781788888887
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 6
@@ -2908,29 +884,6 @@
     "type": "Title",
     "element_id": "acd4f4584a990134d927e19b6d7e5f88",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.82355880737305,
-            1385.1623947954408
-          ],
-          [
-            372.82355880737305,
-            1418.93360082654
-          ],
-          [
-            782.437931060791,
-            1418.93360082654
-          ],
-          [
-            782.437931060791,
-            1385.1623947954408
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 6
@@ -2941,29 +894,6 @@
     "type": "NarrativeText",
     "element_id": "fb271c99cdcfca1001a1a7d56425c5b4",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.66898918151855,
-            1452.4335277022947
-          ],
-          [
-            372.66898918151855,
-            1852.6438424667876
-          ],
-          [
-            1339.812370300293,
-            1852.6438424667876
-          ],
-          [
-            1339.812370300293,
-            1452.4335277022947
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 6
@@ -2974,29 +904,6 @@
     "type": "UncategorizedText",
     "element_id": "4c2478cf439baab6ace34761eda527d9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            658.7111111111111,
-            257.4113377777776
-          ],
-          [
-            658.7111111111111,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3007,29 +914,6 @@
     "type": "UncategorizedText",
     "element_id": "10159baf262b43a92d95db59dae1f72c",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            1322.1886657777777,
-            257.4113377777776
-          ],
-          [
-            1322.1886657777777,
-            282.31800444444434
-          ],
-          [
-            1334.9882017777777,
-            282.31800444444434
-          ],
-          [
-            1334.9882017777777,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3040,29 +924,6 @@
     "type": "NarrativeText",
     "element_id": "f2a3e5fbb983d9132dddecc381ed6e0b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            373.35,
-            327.13373444444437
-          ],
-          [
-            373.35,
-            824.8397104751662
-          ],
-          [
-            1338.822654916667,
-            824.8397104751662
-          ],
-          [
-            1338.822654916667,
-            327.13373444444437
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3073,29 +934,6 @@
     "type": "NarrativeText",
     "element_id": "eec800eef6e395c21feacd729868dd18",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            369.50525665283203,
-            825.2670677777776
-          ],
-          [
-            369.50525665283203,
-            1052.9686033333335
-          ],
-          [
-            1336.0764999389648,
-            1052.9686033333335
-          ],
-          [
-            1336.0764999389648,
-            825.2670677777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3106,29 +944,6 @@
     "type": "Title",
     "element_id": "89c6cd1d893f782ea68d75737e3393fd",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.09101486206055,
-            1098.9602911760267
-          ],
-          [
-            372.09101486206055,
-            1131.8007670969203
-          ],
-          [
-            517.5983406666666,
-            1131.8007670969203
-          ],
-          [
-            517.5983406666666,
-            1098.9602911760267
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3139,29 +954,6 @@
     "type": "NarrativeText",
     "element_id": "e284bd66511cfa064681253e7ac57a9a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            358.57750511169434,
-            1152.600401111111
-          ],
-          [
-            358.57750511169434,
-            1445.9437344444445
-          ],
-          [
-            1338.0908660888672,
-            1445.9437344444445
-          ],
-          [
-            1338.0908660888672,
-            1152.600401111111
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3172,29 +964,6 @@
     "type": "Image",
     "element_id": "65ac0f9ae348b12ed9484b8af7296617",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            1463.7416666666666
-          ],
-          [
-            374.3472222222222,
-            1494.1833333333332
-          ],
-          [
-            1334.9777777777776,
-            1494.1833333333332
-          ],
-          [
-            1334.9777777777776,
-            1463.7416666666666
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3205,29 +974,6 @@
     "type": "ListItem",
     "element_id": "bebbb4e94f1f97edeb5b96e252720a93",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            351.09166666666664,
-            1465.6726133333332
-          ],
-          [
-            351.09166666666664,
-            1555.0638888888889
-          ],
-          [
-            1334.9777777777776,
-            1555.0638888888889
-          ],
-          [
-            1334.9777777777776,
-            1465.6726133333332
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3238,29 +984,6 @@
     "type": "ListItem",
     "element_id": "38ad08d5b34f8a5030d33d6e23aaf335",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            351.09166666666664,
-            1465.6726133333332
-          ],
-          [
-            351.09166666666664,
-            1555.0638888888889
-          ],
-          [
-            1334.9777777777776,
-            1555.0638888888889
-          ],
-          [
-            1334.9777777777776,
-            1465.6726133333332
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3271,29 +994,6 @@
     "type": "ListItem",
     "element_id": "3277e23329a3e4d08d021cac5d0609c7",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            351.09166666666664,
-            1465.6726133333332
-          ],
-          [
-            351.09166666666664,
-            1555.0638888888889
-          ],
-          [
-            1334.9777777777776,
-            1555.0638888888889
-          ],
-          [
-            1334.9777777777776,
-            1465.6726133333332
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3304,29 +1004,6 @@
     "type": "ListItem",
     "element_id": "33c490deb7d22ca00a760f2d0c1a30e6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            351.09166666666664,
-            1465.6726133333332
-          ],
-          [
-            351.09166666666664,
-            1555.0638888888889
-          ],
-          [
-            1334.9777777777776,
-            1555.0638888888889
-          ],
-          [
-            1334.9777777777776,
-            1465.6726133333332
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3337,29 +1014,6 @@
     "type": "NarrativeText",
     "element_id": "7a151dbbe8b26ccdcb264ab005be5a36",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.4558753967285,
-            1570.6919086843297
-          ],
-          [
-            371.4558753967285,
-            1701.2823987583033
-          ],
-          [
-            1340.3498097622223,
-            1701.2823987583033
-          ],
-          [
-            1340.3498097622223,
-            1570.6919086843297
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3370,29 +1024,6 @@
     "type": "NarrativeText",
     "element_id": "77ccbf022ce60ecfc6bac26bc6306a1d",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.0273971557617,
-            1703.703178888889
-          ],
-          [
-            372.0273971557617,
-            1803.840320237017
-          ],
-          [
-            1334.9857759125555,
-            1803.840320237017
-          ],
-          [
-            1334.9857759125555,
-            1703.703178888889
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3403,29 +1034,6 @@
     "type": "NarrativeText",
     "element_id": "8bcb4c948fda07d2fdbf7d582983b93e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.81111111111113,
-            1817.4862622222222
-          ],
-          [
-            371.81111111111113,
-            1848.0536330955617
-          ],
-          [
-            1127.412109375,
-            1848.0536330955617
-          ],
-          [
-            1127.412109375,
-            1817.4862622222222
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 7
@@ -3436,29 +1044,6 @@
     "type": "UncategorizedText",
     "element_id": "aa67a169b0bba217aa0aa88a65346920",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            257.4113377777776
-          ],
-          [
-            374.3472222222222,
-            282.31800444444434
-          ],
-          [
-            387.14675822222216,
-            282.31800444444434
-          ],
-          [
-            387.14675822222216,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3469,29 +1054,6 @@
     "type": "UncategorizedText",
     "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            466.1507048888888,
-            257.4113377777776
-          ],
-          [
-            466.1507048888888,
-            282.31800444444434
-          ],
-          [
-            616.9257022222222,
-            282.31800444444434
-          ],
-          [
-            616.9257022222222,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3502,29 +1064,6 @@
     "type": "NarrativeText",
     "element_id": "6727ba436ddf5e47087d005ded6c049f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.7822322845459,
-            349.4496840324955
-          ],
-          [
-            371.7822322845459,
-            445.2463811111111
-          ],
-          [
-            1338.8222740077777,
-            445.2463811111111
-          ],
-          [
-            1338.8222740077777,
-            349.4496840324955
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3535,29 +1074,6 @@
     "type": "Table",
     "element_id": "548c38f86edc295baf869abe37a0d1cf",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.5897750854492,
-            447.425569543516
-          ],
-          [
-            372.5897750854492,
-            1042.987526419082
-          ],
-          [
-            1326.7686004638672,
-            1042.987526419082
-          ],
-          [
-            1326.7686004638672,
-            447.425569543516
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8,
@@ -3569,29 +1085,6 @@
     "type": "UncategorizedText",
     "element_id": "88f06b9b69e717a8a691e10387779bcf",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            462.0395871290665
-          ],
-          [
-            392.25507683333325,
-            482.94973006239996
-          ],
-          [
-            573.0504456778133,
-            482.94973006239996
-          ],
-          [
-            573.0504456778133,
-            462.0395871290665
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3602,29 +1095,6 @@
     "type": "UncategorizedText",
     "element_id": "c43500c63a83847bc5dd317182f0eaeb",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            797.9651138888887,
-            462.0395871290665
-          ],
-          [
-            797.9651138888887,
-            482.94973006239996
-          ],
-          [
-            922.474559985422,
-            482.94973006239996
-          ],
-          [
-            922.474559985422,
-            462.0395871290665
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3635,29 +1105,6 @@
     "type": "UncategorizedText",
     "element_id": "4606a3cb33e7e6857f77dda2c1daf535",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            504.37339162906636
-          ],
-          [
-            392.25507683333325,
-            525.869018564533
-          ],
-          [
-            1255.7634192141152,
-            525.869018564533
-          ],
-          [
-            1255.7634192141152,
-            504.37339162906636
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3668,29 +1115,6 @@
     "type": "UncategorizedText",
     "element_id": "97f87287f36dbf6c636a3017ae0879fb",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            797.9651138888887,
-            546.7048640735113
-          ],
-          [
-            797.9651138888887,
-            598.2838696179556
-          ],
-          [
-            1158.717354846222,
-            598.2838696179556
-          ],
-          [
-            1158.717354846222,
-            546.7048640735113
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3701,29 +1125,6 @@
     "type": "UncategorizedText",
     "element_id": "7cd6132d1ae515ab6d484f1b74e1c7e6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            561.7187757978668
-          ],
-          [
-            392.25507683333325,
-            582.6289187312
-          ],
-          [
-            600.8337525933332,
-            582.6289187312
-          ],
-          [
-            600.8337525933332,
-            561.7187757978668
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3734,29 +1135,6 @@
     "type": "UncategorizedText",
     "element_id": "25dc86fe689dee9f82609342e44e5ce3",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            797.9651138888887,
-            619.7075311846223
-          ],
-          [
-            797.9651138888887,
-            671.2842046735112
-          ],
-          [
-            1151.026604275342,
-            671.2842046735112
-          ],
-          [
-            1151.026604275342,
-            619.7075311846223
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3767,29 +1145,6 @@
     "type": "UncategorizedText",
     "element_id": "06c072cc8c8ed04ca343b16beb144048",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            634.721442908978
-          ],
-          [
-            392.25507683333325,
-            655.6315858423112
-          ],
-          [
-            600.8337525933332,
-            655.6315858423112
-          ],
-          [
-            600.8337525933332,
-            634.721442908978
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3800,29 +1155,6 @@
     "type": "UncategorizedText",
     "element_id": "4e5821785ee2be3e8c853010a6ad0b76",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            797.9651138888887,
-            692.7078662401776
-          ],
-          [
-            797.9651138888887,
-            713.6180091735112
-          ],
-          [
-            1121.8360447404086,
-            713.6180091735112
-          ],
-          [
-            1121.8360447404086,
-            692.7078662401776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3833,29 +1165,6 @@
     "type": "UncategorizedText",
     "element_id": "9281c2571853bd5e586a12067782746d",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            693.2933502423111
-          ],
-          [
-            392.25507683333325,
-            714.2034931756443
-          ],
-          [
-            608.7365291777778,
-            714.2034931756443
-          ],
-          [
-            608.7365291777778,
-            693.2933502423111
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3866,29 +1175,6 @@
     "type": "UncategorizedText",
     "element_id": "6afa487379762db34fc58d243c408566",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            797.9651138888887,
-            735.0416707401776
-          ],
-          [
-            797.9651138888887,
-            786.6183442290666
-          ],
-          [
-            1317.1263246662752,
-            786.6183442290666
-          ],
-          [
-            1317.1263246662752,
-            735.0416707401776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3899,29 +1185,6 @@
     "type": "UncategorizedText",
     "element_id": "517de49526055a51ab0e815fe66a5c73",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            750.0555824645334
-          ],
-          [
-            392.25507683333325,
-            770.9657253978665
-          ],
-          [
-            655.7228777933332,
-            770.9657253978665
-          ],
-          [
-            655.7228777933332,
-            750.0555824645334
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3932,29 +1195,6 @@
     "type": "UncategorizedText",
     "element_id": "8bdb5b868be61ec346e052b25ed4022a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            797.9651138888887,
-            808.0420057957332
-          ],
-          [
-            797.9651138888887,
-            859.6210113401778
-          ],
-          [
-            1317.1263246662752,
-            859.6210113401778
-          ],
-          [
-            1317.1263246662752,
-            808.0420057957332
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3965,29 +1205,6 @@
     "type": "UncategorizedText",
     "element_id": "fdbeffff8c43aaf3bbeb4791175c4e43",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            823.0559175200889
-          ],
-          [
-            392.25507683333325,
-            843.9660604534222
-          ],
-          [
-            611.8115776333332,
-            843.9660604534222
-          ],
-          [
-            611.8115776333332,
-            823.0559175200889
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -3998,29 +1215,6 @@
     "type": "UncategorizedText",
     "element_id": "46e8fb35b2888c35a00033faaa4851d9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            797.9651138888887,
-            881.0423408512887
-          ],
-          [
-            797.9651138888887,
-            932.6213463957333
-          ],
-          [
-            1226.9638793520353,
-            932.6213463957333
-          ],
-          [
-            1226.9638793520353,
-            881.0423408512887
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4031,29 +1225,6 @@
     "type": "UncategorizedText",
     "element_id": "1e09f3ee1bda1e38a11dbc80108923f1",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            896.0562525756445
-          ],
-          [
-            392.25507683333325,
-            916.9663955089778
-          ],
-          [
-            674.603106288889,
-            916.9663955089778
-          ],
-          [
-            674.603106288889,
-            896.0562525756445
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4064,29 +1235,6 @@
     "type": "UncategorizedText",
     "element_id": "b8a944f0af3a0a8cfc854d5c9b186900",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            797.9651138888887,
-            954.0450079623998
-          ],
-          [
-            797.9651138888887,
-            1005.6216814512887
-          ],
-          [
-            1270.4925238963551,
-            1005.6216814512887
-          ],
-          [
-            1270.4925238963551,
-            954.0450079623998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4097,29 +1245,6 @@
     "type": "UncategorizedText",
     "element_id": "bc47d0cd9d800d84cd9aefa2d9ec63ec",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            969.0565876312
-          ],
-          [
-            392.25507683333325,
-            989.9667305645333
-          ],
-          [
-            685.5800917888889,
-            989.9667305645333
-          ],
-          [
-            685.5800917888889,
-            969.0565876312
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4130,29 +1255,6 @@
     "type": "UncategorizedText",
     "element_id": "9ba6cbc77549790313b84b62a781a1f9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            797.9651138888887,
-            1027.0453430179555
-          ],
-          [
-            797.9651138888887,
-            1047.9554859512887
-          ],
-          [
-            1237.6677815196085,
-            1047.9554859512887
-          ],
-          [
-            1237.6677815196085,
-            1027.0453430179555
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4163,29 +1265,6 @@
     "type": "UncategorizedText",
     "element_id": "e2d920d1b163490b690e3730fda41064",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            392.25507683333325,
-            1027.6308270200889
-          ],
-          [
-            392.25507683333325,
-            1048.5409699534223
-          ],
-          [
-            641.6691647577778,
-            1048.5409699534223
-          ],
-          [
-            641.6691647577778,
-            1027.6308270200889
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4196,29 +1275,6 @@
     "type": "Title",
     "element_id": "709c2d8cd3b15512f8452715fab45e4f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            1126.438754906401
-          ],
-          [
-            374.3472222222222,
-            1158.6261369640702
-          ],
-          [
-            798.060131072998,
-            1158.6261369640702
-          ],
-          [
-            798.060131072998,
-            1126.438754906401
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4229,29 +1285,6 @@
     "type": "UncategorizedText",
     "element_id": "ef65f87405f1fd8a11b79bdde8aa10d1",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            373.35,
-            1187.3754011111112
-          ],
-          [
-            373.35,
-            1547.810401111111
-          ],
-          [
-            1335.8427039055555,
-            1547.810401111111
-          ],
-          [
-            1335.8427039055555,
-            1187.3754011111112
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4262,29 +1295,6 @@
     "type": "Title",
     "element_id": "d57c26aad19349fc98ee8822f24f19d9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            1602.8955078125
-          ],
-          [
-            374.3472222222222,
-            1636.3631302838164
-          ],
-          [
-            842.0438957214355,
-            1636.3631302838164
-          ],
-          [
-            842.0438957214355,
-            1602.8955078125
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4295,29 +1305,6 @@
     "type": "NarrativeText",
     "element_id": "e07a3053a112880cf693f019d010cc19",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            369.1406059265137,
-            1665.2337344444443
-          ],
-          [
-            369.1406059265137,
-            1803.490939670139
-          ],
-          [
-            1339.596139072222,
-            1803.490939670139
-          ],
-          [
-            1339.596139072222,
-            1665.2337344444443
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4328,29 +1315,6 @@
     "type": "NarrativeText",
     "element_id": "1ef9621705354b738772d2108d0fb6ab",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            370.98292541503906,
-            1817.4862622222222
-          ],
-          [
-            370.98292541503906,
-            1848.7453884548613
-          ],
-          [
-            682.7208404541016,
-            1848.7453884548613
-          ],
-          [
-            682.7208404541016,
-            1817.4862622222222
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 8
@@ -4361,29 +1325,6 @@
     "type": "NarrativeText",
     "element_id": "4c2478cf439baab6ace34761eda527d9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            652.2080764770508,
-            254.59611975628397
-          ],
-          [
-            652.2080764770508,
-            283.4609970608771
-          ],
-          [
-            1244.548843383789,
-            283.4609970608771
-          ],
-          [
-            1244.548843383789,
-            254.59611975628397
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 9
@@ -4394,29 +1335,6 @@
     "type": "UncategorizedText",
     "element_id": "2e6d31a5983a91251bfae5aefa1c0a19",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            1322.1886657777777,
-            257.4113377777776
-          ],
-          [
-            1322.1886657777777,
-            282.31800444444434
-          ],
-          [
-            1334.9882017777777,
-            282.31800444444434
-          ],
-          [
-            1334.9882017777777,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 9
@@ -4427,29 +1345,6 @@
     "type": "FigureCaption",
     "element_id": "6df6057f894a166cf24fd34f64267f09",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            470.40833333333336,
-            321.77152329596925
-          ],
-          [
-            470.40833333333336,
-            853.9777777777778
-          ],
-          [
-            1238.8140833333332,
-            853.9777777777778
-          ],
-          [
-            1238.8140833333332,
-            321.77152329596925
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 9
@@ -4460,29 +1355,6 @@
     "type": "NarrativeText",
     "element_id": "cc8ad6e0f933633a37b82200e6724f9e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            369.6209487915039,
-            882.5920677777776
-          ],
-          [
-            369.6209487915039,
-            1077.2100210880888
-          ],
-          [
-            1348.1226196289062,
-            1077.2100210880888
-          ],
-          [
-            1348.1226196289062,
-            882.5920677777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 9
@@ -4493,29 +1365,6 @@
     "type": "NarrativeText",
     "element_id": "19cc210888c40b3403e1992b335bccf7",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.52964210510254,
-            1185.325401111111
-          ],
-          [
-            371.52964210510254,
-            1284.3024654664855
-          ],
-          [
-            1339.6642532348633,
-            1284.3024654664855
-          ],
-          [
-            1339.6642532348633,
-            1185.325401111111
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 9
@@ -4526,29 +1375,6 @@
     "type": "NarrativeText",
     "element_id": "60c0620e0e68ad30f5cff23dd0ef53c5",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.4169006347656,
-            1302.9837344444443
-          ],
-          [
-            371.4169006347656,
-            1533.1710564802236
-          ],
-          [
-            1339.5860188733889,
-            1533.1710564802236
-          ],
-          [
-            1339.5860188733889,
-            1302.9837344444443
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 9
@@ -4559,29 +1385,6 @@
     "type": "NarrativeText",
     "element_id": "7cc706ff50f3746845f312c011318d84",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.5060691833496,
-            1553.475401111111
-          ],
-          [
-            371.5060691833496,
-            1846.8187344444443
-          ],
-          [
-            1338.8221180155556,
-            1846.8187344444443
-          ],
-          [
-            1338.8221180155556,
-            1553.475401111111
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 9
@@ -4592,29 +1395,6 @@
     "type": "UncategorizedText",
     "element_id": "917df3320d778ddbaa5c5c7742bc4046",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            257.4113377777776
-          ],
-          [
-            374.3472222222222,
-            282.31800444444434
-          ],
-          [
-            399.94629422222215,
-            282.31800444444434
-          ],
-          [
-            399.94629422222215,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 10
@@ -4625,29 +1405,6 @@
     "type": "UncategorizedText",
     "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            466.1482142222221,
-            257.4113377777776
-          ],
-          [
-            466.1482142222221,
-            282.31800444444434
-          ],
-          [
-            616.9232115555554,
-            282.31800444444434
-          ],
-          [
-            616.9232115555554,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 10
@@ -4658,29 +1415,6 @@
     "type": "FigureCaption",
     "element_id": "42aa5660e30073a0282c086fe4f29fce",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            336.74460220336914,
-            269.01225214419156
-          ],
-          [
-            336.74460220336914,
-            760.8166666666666
-          ],
-          [
-            1346.8375549316406,
-            760.8166666666666
-          ],
-          [
-            1346.8375549316406,
-            269.01225214419156
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 10
@@ -4691,29 +1425,6 @@
     "type": "NarrativeText",
     "element_id": "f6d1c03644c4866a2dd06f8e432f6286",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.62012481689453,
-            789.4309566666667
-          ],
-          [
-            372.62012481689453,
-            949.9409566666666
-          ],
-          [
-            1338.0015029907227,
-            949.9409566666666
-          ],
-          [
-            1338.0015029907227,
-            789.4309566666667
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 10
@@ -4724,29 +1435,6 @@
     "type": "Title",
     "element_id": "a84f27645308850514566b3bb9d3efa0",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            1012.7086355555556
-          ],
-          [
-            374.3472222222222,
-            1049.631465598581
-          ],
-          [
-            1002.1017646789551,
-            1049.631465598581
-          ],
-          [
-            1002.1017646789551,
-            1012.7086355555556
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 10
@@ -4757,29 +1445,6 @@
     "type": "NarrativeText",
     "element_id": "ea475aba47ae4b4db2eeb1a96bc30797",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            370.64836502075195,
-            1077.8642899999998
-          ],
-          [
-            370.64836502075195,
-            1306.2935914855072
-          ],
-          [
-            1342.7489013671875,
-            1306.2935914855072
-          ],
-          [
-            1342.7489013671875,
-            1077.8642899999998
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 10
@@ -4790,29 +1455,6 @@
     "type": "NarrativeText",
     "element_id": "966440df8a08ef481c35486bdb301d6a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            359.5111484527588,
-            1310.325401111111
-          ],
-          [
-            359.5111484527588,
-            1670.0854011111112
-          ],
-          [
-            1340.3437215066665,
-            1670.0854011111112
-          ],
-          [
-            1340.3437215066665,
-            1310.325401111111
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 10
@@ -4823,29 +1465,6 @@
     "type": "Title",
     "element_id": "0e654d0b0bc44cbd58f1cb7c7b02c3c5",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            1717.9037283929651
-          ],
-          [
-            374.3472222222222,
-            1756.6726463428442
-          ],
-          [
-            595.0036844444444,
-            1756.6726463428442
-          ],
-          [
-            595.0036844444444,
-            1717.9037283929651
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 10
@@ -4856,29 +1475,6 @@
     "type": "NarrativeText",
     "element_id": "9d4feeabd8c04d4b33897afb58e46f55",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            351.7041015625,
-            1785.9365122222223
-          ],
-          [
-            351.7041015625,
-            1847.5650451955014
-          ],
-          [
-            1343.1623840332031,
-            1847.5650451955014
-          ],
-          [
-            1343.1623840332031,
-            1785.9365122222223
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 10
@@ -4889,29 +1485,6 @@
     "type": "UncategorizedText",
     "element_id": "4c2478cf439baab6ace34761eda527d9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            658.7111111111111,
-            257.4113377777776
-          ],
-          [
-            658.7111111111111,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -4922,29 +1495,6 @@
     "type": "UncategorizedText",
     "element_id": "25d4f2a86deb5e2574bb3210b67bb24f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            1309.386639111111,
-            257.4113377777776
-          ],
-          [
-            1309.386639111111,
-            282.31800444444434
-          ],
-          [
-            1334.985711111111,
-            282.31800444444434
-          ],
-          [
-            1334.985711111111,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -4955,29 +1505,6 @@
     "type": "NarrativeText",
     "element_id": "5cdbcea58a81d8f7de9a4fa841107be1",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            361.9180507659912,
-            327.13373444444437
-          ],
-          [
-            361.9180507659912,
-            658.9452417346015
-          ],
-          [
-            1340.3336205372223,
-            658.9452417346015
-          ],
-          [
-            1340.3336205372223,
-            327.13373444444437
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -4988,29 +1515,6 @@
     "type": "Title",
     "element_id": "1fe1cb84a12b8216ea9d734262b3e4ec",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            720.5787371206975
-          ],
-          [
-            374.3472222222222,
-            754.6290065009813
-          ],
-          [
-            1297.6990051269531,
-            754.6290065009813
-          ],
-          [
-            1297.6990051269531,
-            720.5787371206975
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -5021,29 +1525,6 @@
     "type": "UncategorizedText",
     "element_id": "a5a6fe2f9e40a8e2b2fe290d51094b4d",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            373.35,
-            792.9698455555556
-          ],
-          [
-            373.35,
-            1318.77429
-          ],
-          [
-            1339.592486118889,
-            1318.77429
-          ],
-          [
-            1339.592486118889,
-            792.9698455555556
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -5054,29 +1535,6 @@
     "type": "FigureCaption",
     "element_id": "55f2474c66877608ca9b463a7076573e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            854.661111111111,
-            1040.4540956653834
-          ],
-          [
-            854.661111111111,
-            1562.3222222222223
-          ],
-          [
-            1334.9642777777776,
-            1562.3222222222223
-          ],
-          [
-            1334.9642777777776,
-            1040.4540956653834
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -5087,29 +1545,6 @@
     "type": "UncategorizedText",
     "element_id": "fa19ab2536cbbb48c09de29fdebd52bd",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.93611111111113,
-            1327.1670677777777
-          ],
-          [
-            372.93611111111113,
-            1753.3465122222221
-          ],
-          [
-            832.3503600722222,
-            1753.3465122222221
-          ],
-          [
-            832.3503600722222,
-            1327.1670677777777
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -5120,29 +1555,6 @@
     "type": "UncategorizedText",
     "element_id": "3cbd8234ac0c6d29feb24e6202144aa8",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            854.661111111111,
-            1618.6115122222222
-          ],
-          [
-            854.661111111111,
-            1712.7048455555555
-          ],
-          [
-            1339.5826849615555,
-            1712.7048455555555
-          ],
-          [
-            1339.5826849615555,
-            1618.6115122222222
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -5153,29 +1565,6 @@
     "type": "UncategorizedText",
     "element_id": "6382276306254e0b0d045fb230db668a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.81111111111113,
-            1787.0445955555554
-          ],
-          [
-            371.81111111111113,
-            1815.8402266666667
-          ],
-          [
-            1335.8948114844447,
-            1815.8402266666667
-          ],
-          [
-            1335.8948114844447,
-            1787.0445955555554
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -5186,29 +1575,6 @@
     "type": "UncategorizedText",
     "element_id": "30c13a2facbda6a7391ac1656e832db4",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            402.01944444444445,
-            1821.3752266666665
-          ],
-          [
-            402.01944444444445,
-            1846.2818933333333
-          ],
-          [
-            1258.6668097777776,
-            1846.2818933333333
-          ],
-          [
-            1258.6668097777776,
-            1821.3752266666665
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 11
@@ -5219,29 +1585,6 @@
     "type": "Title",
     "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            464.2409381866455,
-            256.27799213796425
-          ],
-          [
-            464.2409381866455,
-            285.17215747188254
-          ],
-          [
-            616.9232115555554,
-            285.17215747188254
-          ],
-          [
-            616.9232115555554,
-            256.27799213796425
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5252,29 +1595,6 @@
     "type": "UncategorizedText",
     "element_id": "a1fb50e6c86fae1679ef3351296fd671",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            257.4113377777776
-          ],
-          [
-            374.3472222222222,
-            282.31800444444434
-          ],
-          [
-            399.94629422222215,
-            282.31800444444434
-          ],
-          [
-            399.94629422222215,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5285,29 +1605,6 @@
     "type": "UncategorizedText",
     "element_id": "7174760d4c8d9b7b13da3918015312dc",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            415.85833333333335,
-            327.13373444444437
-          ],
-          [
-            415.85833333333335,
-            354.8076233333335
-          ],
-          [
-            827.7333048366664,
-            354.8076233333335
-          ],
-          [
-            827.7333048366664,
-            327.13373444444437
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5318,29 +1615,6 @@
     "type": "NarrativeText",
     "element_id": "9b51c55d2dd4ffd289138fc4f66e11e6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            373.37777777777774,
-            348.63957649267815
-          ],
-          [
-            373.37777777777774,
-            755.7774345655948
-          ],
-          [
-            1343.92138671875,
-            755.7774345655948
-          ],
-          [
-            1343.92138671875,
-            348.63957649267815
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5351,29 +1625,6 @@
     "type": "NarrativeText",
     "element_id": "888b9c9ec4431146d744bc6f39e16fd0",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            370.57433891296387,
-            766.3677654174215
-          ],
-          [
-            370.57433891296387,
-            1093.1076233333333
-          ],
-          [
-            1347.6912384033203,
-            1093.1076233333333
-          ],
-          [
-            1347.6912384033203,
-            766.3677654174215
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5384,29 +1635,6 @@
     "type": "NarrativeText",
     "element_id": "07be9fda679b805e67cf5e563eada033",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.0198097229004,
-            1103.1441656287743
-          ],
-          [
-            372.0198097229004,
-            1503.410526588919
-          ],
-          [
-            1341.46435546875,
-            1503.410526588919
-          ],
-          [
-            1341.46435546875,
-            1103.1441656287743
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5417,29 +1645,6 @@
     "type": "NarrativeText",
     "element_id": "069379b2abcf2bed44f13bdaea90ec2d",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            359.488094329834,
-            1509.9235615753323
-          ],
-          [
-            359.488094329834,
-            1673.071512222222
-          ],
-          [
-            1335.0079040527344,
-            1673.071512222222
-          ],
-          [
-            1335.0079040527344,
-            1509.9235615753323
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5450,29 +1655,6 @@
     "type": "UncategorizedText",
     "element_id": "0575dcbfd82c79a56a8028d0af3cbe07",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.81111111111113,
-            1726.16404
-          ],
-          [
-            371.81111111111113,
-            1754.9596711111112
-          ],
-          [
-            1334.9801016977776,
-            1754.9596711111112
-          ],
-          [
-            1334.9801016977776,
-            1726.16404
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5483,29 +1665,6 @@
     "type": "UncategorizedText",
     "element_id": "59ad9914d41efc63dfb974146f279fa6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            402.01944444444445,
-            1760.491893333333
-          ],
-          [
-            402.01944444444445,
-            1785.3985599999999
-          ],
-          [
-            611.222991111111,
-            1785.3985599999999
-          ],
-          [
-            611.222991111111,
-            1760.491893333333
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5516,29 +1675,6 @@
     "type": "UncategorizedText",
     "element_id": "3b2feff30ba56d2407ebe555afc5858a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            371.81111111111113,
-            1787.0445955555554
-          ],
-          [
-            371.81111111111113,
-            1815.8402266666667
-          ],
-          [
-            1338.5435906524442,
-            1815.8402266666667
-          ],
-          [
-            1338.5435906524442,
-            1787.0445955555554
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5549,29 +1685,6 @@
     "type": "UncategorizedText",
     "element_id": "72bbddd6bb0b167876e1be851d281caf",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            402.01944444444445,
-            1821.3752266666665
-          ],
-          [
-            402.01944444444445,
-            1846.2818933333333
-          ],
-          [
-            619.1806711111111,
-            1846.2818933333333
-          ],
-          [
-            619.1806711111111,
-            1821.3752266666665
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 12
@@ -5582,29 +1695,6 @@
     "type": "UncategorizedText",
     "element_id": "4c2478cf439baab6ace34761eda527d9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            658.7111111111111,
-            257.4113377777776
-          ],
-          [
-            658.7111111111111,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 13
@@ -5615,29 +1705,6 @@
     "type": "UncategorizedText",
     "element_id": "1a252402972f6057fa53cc172b52b9ff",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            1309.386639111111,
-            257.4113377777776
-          ],
-          [
-            1309.386639111111,
-            282.31800444444434
-          ],
-          [
-            1334.985711111111,
-            282.31800444444434
-          ],
-          [
-            1334.985711111111,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 13
@@ -5648,29 +1715,6 @@
     "type": "FigureCaption",
     "element_id": "f58d47bde7ebddd81c4a678c918a8f1b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            364.207088470459,
-            286.4425703408062
-          ],
-          [
-            364.207088470459,
-            659.1314785722374
-          ],
-          [
-            1347.2821655273438,
-            659.1314785722374
-          ],
-          [
-            1347.2821655273438,
-            286.4425703408062
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 13
@@ -5681,29 +1725,6 @@
     "type": "NarrativeText",
     "element_id": "1a2b9e59d53ac38ee6affb3ffcda6b8c",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            675.5019625603865
-          ],
-          [
-            374.3472222222222,
-            806.0270677777778
-          ],
-          [
-            1336.2064590454102,
-            806.0270677777778
-          ],
-          [
-            1336.2064590454102,
-            675.5019625603865
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 13
@@ -5714,29 +1735,6 @@
     "type": "UncategorizedText",
     "element_id": "76c98240da7b06b4b3fcf8109edbbaba",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            901.6198455555555
-          ],
-          [
-            374.3472222222222,
-            929.2937344444443
-          ],
-          [
-            975.0228175,
-            929.2937344444443
-          ],
-          [
-            975.0228175,
-            901.6198455555555
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 13
@@ -5747,29 +1745,6 @@
     "type": "NarrativeText",
     "element_id": "0f6c572efe499db5f3a396c3f898b39a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            367.0137252807617,
-            1013.5670677777777
-          ],
-          [
-            367.0137252807617,
-            1246.013572803442
-          ],
-          [
-            1347.2739944458008,
-            1246.013572803442
-          ],
-          [
-            1347.2739944458008,
-            1013.5670677777777
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 13
@@ -5780,29 +1755,6 @@
     "type": "NarrativeText",
     "element_id": "d423e43627591688a7a55d37adbf14e7",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            372.09555435180664,
-            1253.305546120169
-          ],
-          [
-            372.09555435180664,
-            1755.742045969203
-          ],
-          [
-            1339.50537109375,
-            1755.742045969203
-          ],
-          [
-            1339.50537109375,
-            1253.305546120169
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 13
@@ -5813,29 +1765,6 @@
     "type": "NarrativeText",
     "element_id": "8ff0f0a5b4e520b95b6d74614366af1e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            370.06954765319824,
-            1817.4862622222222
-          ],
-          [
-            370.06954765319824,
-            1849.237868451842
-          ],
-          [
-            1257.1753692626953,
-            1849.237868451842
-          ],
-          [
-            1257.1753692626953,
-            1817.4862622222222
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 13
@@ -5846,29 +1775,6 @@
     "type": "UncategorizedText",
     "element_id": "9a92adbc0cee38ef658c71ce1b1bf8c6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            257.4113377777776
-          ],
-          [
-            374.3472222222222,
-            282.31800444444434
-          ],
-          [
-            399.94629422222215,
-            282.31800444444434
-          ],
-          [
-            399.94629422222215,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -5879,29 +1785,6 @@
     "type": "UncategorizedText",
     "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            466.1482142222221,
-            257.4113377777776
-          ],
-          [
-            466.1482142222221,
-            282.31800444444434
-          ],
-          [
-            616.9232115555554,
-            282.31800444444434
-          ],
-          [
-            616.9232115555554,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -5912,29 +1795,6 @@
     "type": "UncategorizedText",
     "element_id": "a2a71736439cbc5e1445bddd40712b9b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            322.6725244444446
-          ],
-          [
-            374.3472222222222,
-            355.88141333333346
-          ],
-          [
-            609.094216,
-            355.88141333333346
-          ],
-          [
-            609.094216,
-            322.6725244444446
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -5945,29 +1805,6 @@
     "type": "NarrativeText",
     "element_id": "ad29b99d522a90b8084b53f55ca78e02",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            365.2317810058594,
-            399.22159241017516
-          ],
-          [
-            365.2317810058594,
-            737.0763629415761
-          ],
-          [
-            1335.72186516,
-            737.0763629415761
-          ],
-          [
-            1335.72186516,
-            399.22159241017516
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -5978,29 +1815,6 @@
     "type": "NarrativeText",
     "element_id": "f85505b114cf50b99bc0ae7c3805774d",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            367.7756462097168,
-            787.3087344444442
-          ],
-          [
-            367.7756462097168,
-            914.6076233333333
-          ],
-          [
-            1340.3328733422225,
-            914.6076233333333
-          ],
-          [
-            1340.3328733422225,
-            787.3087344444442
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6011,29 +1825,6 @@
     "type": "Title",
     "element_id": "e56261e0bd30965b8e68ed2abb15b141",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            975.375575558575
-          ],
-          [
-            374.3472222222222,
-            1010.3268653759059
-          ],
-          [
-            549.1687759999999,
-            1010.3268653759059
-          ],
-          [
-            549.1687759999999,
-            975.375575558575
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6044,29 +1835,6 @@
     "type": "UncategorizedText",
     "element_id": "f7e8d95a8f2b84a4461e037b0a7b9704",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.375,
-            1053.2280044444444
-          ],
-          [
-            390.375,
-            1291.9209466666666
-          ],
-          [
-            1338.5426637155554,
-            1291.9209466666666
-          ],
-          [
-            1338.5426637155554,
-            1053.2280044444444
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6077,29 +1845,6 @@
     "type": "UncategorizedText",
     "element_id": "24862433f743a0910da62ec3fb4f537c",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.3749999999999,
-            1297.9446711111111
-          ],
-          [
-            390.3749999999999,
-            1414.1763377777777
-          ],
-          [
-            1339.9368193635553,
-            1414.1763377777777
-          ],
-          [
-            1339.9368193635553,
-            1297.9446711111111
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6110,29 +1855,6 @@
     "type": "UncategorizedText",
     "element_id": "79a1f55a3945eb6304697ec72847ed35",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.375,
-            1420.894671111111
-          ],
-          [
-            390.375,
-            1537.126337777778
-          ],
-          [
-            1339.9424681955552,
-            1537.126337777778
-          ],
-          [
-            1339.9424681955552,
-            1420.894671111111
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6143,29 +1865,6 @@
     "type": "UncategorizedText",
     "element_id": "cafb24e03d3f74ce81ba82312af7bfc2",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.375,
-            1543.847448888889
-          ],
-          [
-            390.375,
-            1629.637448888889
-          ],
-          [
-            1335.6571068302223,
-            1629.637448888889
-          ],
-          [
-            1335.6571068302223,
-            1543.847448888889
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6176,29 +1875,6 @@
     "type": "UncategorizedText",
     "element_id": "117fc6b27c81b420f6e0fa2c6e3f6b92",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.375,
-            1636.3557822222222
-          ],
-          [
-            390.375,
-            1661.262448888889
-          ],
-          [
-            1334.976029048889,
-            1661.262448888889
-          ],
-          [
-            1334.976029048889,
-            1636.3557822222222
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6209,29 +1885,6 @@
     "type": "UncategorizedText",
     "element_id": "ed850ded537aa0ac53c62e095a412dc4",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            431.23055555555555,
-            1666.7974488888888
-          ],
-          [
-            431.23055555555555,
-            1691.7041155555555
-          ],
-          [
-            987.1971688888888,
-            1691.7041155555555
-          ],
-          [
-            987.1971688888888,
-            1666.7974488888888
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6242,29 +1895,6 @@
     "type": "UncategorizedText",
     "element_id": "b000578a41ffcc554faac04609d2f4e1",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.375,
-            1698.4252266666667
-          ],
-          [
-            390.375,
-            1784.2152266666667
-          ],
-          [
-            1339.9551705955555,
-            1784.2152266666667
-          ],
-          [
-            1339.9551705955555,
-            1698.4252266666667
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6275,29 +1905,6 @@
     "type": "NarrativeText",
     "element_id": "c6e835fe03323406543926cc0f5a94de",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.375,
-            1790.467464428593
-          ],
-          [
-            390.375,
-            1848.3419077407912
-          ],
-          [
-            1339.9467521422218,
-            1848.3419077407912
-          ],
-          [
-            1339.9467521422218,
-            1790.467464428593
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 14
@@ -6308,29 +1915,6 @@
     "type": "UncategorizedText",
     "element_id": "4c2478cf439baab6ace34761eda527d9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            658.7111111111111,
-            257.4113377777776
-          ],
-          [
-            658.7111111111111,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            283.01539111111094
-          ],
-          [
-            1243.1598124444442,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6341,29 +1925,6 @@
     "type": "UncategorizedText",
     "element_id": "238903180cc104ec2c5d8b3f20c5bc61",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            1309.386639111111,
-            257.4113377777776
-          ],
-          [
-            1309.386639111111,
-            282.31800444444434
-          ],
-          [
-            1334.985711111111,
-            282.31800444444434
-          ],
-          [
-            1334.985711111111,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6374,29 +1935,6 @@
     "type": "UncategorizedText",
     "element_id": "a24a28ea9e86cd280c8f7887ad2d0d99",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.375,
-            329.36411555555543
-          ],
-          [
-            390.375,
-            506.5068933333331
-          ],
-          [
-            1339.2489171555553,
-            506.5068933333331
-          ],
-          [
-            1339.2489171555553,
-            329.36411555555543
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6407,29 +1945,6 @@
     "type": "UncategorizedText",
     "element_id": "ca3e69faa45c756ca454e118ff12f597",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            390.375,
-            420.71689333333336
-          ],
-          [
-            390.375,
-            445.62356000000005
-          ],
-          [
-            417.39624266666664,
-            445.62356000000005
-          ],
-          [
-            417.39624266666664,
-            420.71689333333336
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6440,29 +1955,6 @@
     "type": "UncategorizedText",
     "element_id": "c8f5863d94cc9b9d77f153c6d1b0015a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            512.0668933333329
-          ],
-          [
-            377.575,
-            628.2985599999998
-          ],
-          [
-            1339.9500896355553,
-            628.2985599999998
-          ],
-          [
-            1339.9500896355553,
-            512.0668933333329
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6473,29 +1965,6 @@
     "type": "UncategorizedText",
     "element_id": "91c801cdf5af0b4fccd7f65d711d447a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            633.8613377777777
-          ],
-          [
-            377.575,
-            750.1180044444443
-          ],
-          [
-            1335.4910491022217,
-            750.1180044444443
-          ],
-          [
-            1335.4910491022217,
-            633.8613377777777
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6506,29 +1975,6 @@
     "type": "UncategorizedText",
     "element_id": "ecabb9a495995008845e44ab44bbda42",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            431.23055555555555,
-            755.6530044444442
-          ],
-          [
-            431.23055555555555,
-            780.5596711111109
-          ],
-          [
-            1246.0994782222217,
-            780.5596711111109
-          ],
-          [
-            1246.0994782222217,
-            755.6530044444442
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6539,29 +1985,6 @@
     "type": "UncategorizedText",
     "element_id": "7ceaba2290e3f9c5f3754032ce4d5663",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            786.1224488888887
-          ],
-          [
-            377.575,
-            871.9124488888888
-          ],
-          [
-            1339.952371086222,
-            871.9124488888888
-          ],
-          [
-            1339.952371086222,
-            786.1224488888887
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6572,29 +1995,6 @@
     "type": "UncategorizedText",
     "element_id": "901e0c80da6bc4ab586f53c474e71426",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            877.4752266666667
-          ],
-          [
-            377.575,
-            902.3818933333332
-          ],
-          [
-            1339.9449140302218,
-            902.3818933333332
-          ],
-          [
-            1339.9449140302218,
-            877.4752266666667
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6605,29 +2005,6 @@
     "type": "UncategorizedText",
     "element_id": "2785f642a6abf514e88b8560ac84509f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            430.49444444444447,
-            907.9141155555557
-          ],
-          [
-            430.49444444444447,
-            932.8207822222222
-          ],
-          [
-            707.3747128888889,
-            932.8207822222222
-          ],
-          [
-            707.3747128888889,
-            907.9141155555557
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6638,29 +2015,6 @@
     "type": "UncategorizedText",
     "element_id": "1f1a0fac1bae95f076ea34c955551632",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.57500000000005,
-            938.38356
-          ],
-          [
-            377.57500000000005,
-            1024.17356
-          ],
-          [
-            1334.9688858168888,
-            1024.17356
-          ],
-          [
-            1334.9688858168888,
-            938.38356
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6671,29 +2025,6 @@
     "type": "UncategorizedText",
     "element_id": "0aabfb2a8e358618179ec2e1d322e519",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1029.7363377777779
-          ],
-          [
-            377.575,
-            1207.5459466666666
-          ],
-          [
-            1344.1208666666666,
-            1207.5459466666666
-          ],
-          [
-            1344.1208666666666,
-            1029.7363377777779
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6704,29 +2035,6 @@
     "type": "UncategorizedText",
     "element_id": "df18427a8013b4df36e8ac4e2ee5da3a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.57500000000005,
-            1212.4113377777778
-          ],
-          [
-            377.57500000000005,
-            1359.7820577777777
-          ],
-          [
-            1338.5299613155553,
-            1359.7820577777777
-          ],
-          [
-            1338.5299613155553,
-            1212.4113377777778
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6737,29 +2045,6 @@
     "type": "UncategorizedText",
     "element_id": "257e7b8aef89c41e03bf837ea517885e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.5749999999999,
-            1364.6446711111112
-          ],
-          [
-            377.5749999999999,
-            1450.4346711111111
-          ],
-          [
-            1335.6497045688889,
-            1450.4346711111111
-          ],
-          [
-            1335.6497045688889,
-            1364.6446711111112
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6770,29 +2055,6 @@
     "type": "UncategorizedText",
     "element_id": "00c7abdd98fedd1746994d16ca44d45f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1455.997448888889
-          ],
-          [
-            377.575,
-            1541.7874488888888
-          ],
-          [
-            1338.5234955448889,
-            1541.7874488888888
-          ],
-          [
-            1338.5234955448889,
-            1455.997448888889
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6803,29 +2065,6 @@
     "type": "UncategorizedText",
     "element_id": "7a0afd734c99f6b076dc58b2e57cfec6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1547.347448888889
-          ],
-          [
-            377.575,
-            1633.137448888889
-          ],
-          [
-            1334.9783702755553,
-            1633.137448888889
-          ],
-          [
-            1334.9783702755553,
-            1547.347448888889
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6836,29 +2075,6 @@
     "type": "UncategorizedText",
     "element_id": "00d6ff1b3fb21f8a608f3b6269df56be",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1638.7002266666664
-          ],
-          [
-            377.575,
-            1754.9318933333334
-          ],
-          [
-            1339.2499632355552,
-            1754.9318933333334
-          ],
-          [
-            1339.2499632355552,
-            1638.7002266666664
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6869,29 +2085,6 @@
     "type": "UncategorizedText",
     "element_id": "deecdfacbce71dd1425fd54010b2fad1",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1760.4946711111108
-          ],
-          [
-            377.575,
-            1846.2818933333333
-          ],
-          [
-            1334.9833516088884,
-            1846.2818933333333
-          ],
-          [
-            1334.9833516088884,
-            1760.4946711111108
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 15
@@ -6902,29 +2095,6 @@
     "type": "UncategorizedText",
     "element_id": "e6c21e8d260fe71882debdb339d2402a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            374.3472222222222,
-            257.4113377777776
-          ],
-          [
-            374.3472222222222,
-            282.31800444444434
-          ],
-          [
-            399.94629422222215,
-            282.31800444444434
-          ],
-          [
-            399.94629422222215,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -6935,29 +2105,6 @@
     "type": "UncategorizedText",
     "element_id": "22364b7a1d2b35282b360d61ae08e2b9",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            466.1482142222221,
-            257.4113377777776
-          ],
-          [
-            466.1482142222221,
-            282.31800444444434
-          ],
-          [
-            616.9232115555554,
-            282.31800444444434
-          ],
-          [
-            616.9232115555554,
-            257.4113377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -6968,29 +2115,6 @@
     "type": "UncategorizedText",
     "element_id": "9131e10ef09f98999ec5325db7034879",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            329.36411555555543
-          ],
-          [
-            377.575,
-            567.3624488888887
-          ],
-          [
-            1338.5452041955555,
-            567.3624488888887
-          ],
-          [
-            1338.5452041955555,
-            329.36411555555543
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7001,29 +2125,6 @@
     "type": "UncategorizedText",
     "element_id": "21d151e4c182a1f441c3486d2f79afc0",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            572.8946711111108
-          ],
-          [
-            377.575,
-            689.1263377777777
-          ],
-          [
-            1339.2598793066663,
-            689.1263377777777
-          ],
-          [
-            1339.2598793066663,
-            572.8946711111108
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7034,29 +2135,6 @@
     "type": "UncategorizedText",
     "element_id": "c9d8f6434425015c72f94fb212bba28f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            694.6613377777775
-          ],
-          [
-            377.575,
-            780.4513377777776
-          ],
-          [
-            1334.9736678968882,
-            780.4513377777776
-          ],
-          [
-            1334.9736678968882,
-            694.6613377777775
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7067,29 +2145,6 @@
     "type": "UncategorizedText",
     "element_id": "9c3e13a0e9738b846289bff06952da3b",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            785.9863377777776
-          ],
-          [
-            377.575,
-            871.7763377777777
-          ],
-          [
-            1335.6642998755558,
-            871.7763377777777
-          ],
-          [
-            1335.6642998755558,
-            785.9863377777776
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7100,29 +2155,6 @@
     "type": "UncategorizedText",
     "element_id": "3a0690c47686e01ff8feec37cccf1a90",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            877.3113377777779
-          ],
-          [
-            377.575,
-            1054.42356
-          ],
-          [
-            1339.9373324408884,
-            1054.42356
-          ],
-          [
-            1339.9373324408884,
-            877.3113377777779
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7133,29 +2165,6 @@
     "type": "UncategorizedText",
     "element_id": "bd680d8baa57cc15337de2e0c299d121",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1059.95856
-          ],
-          [
-            377.575,
-            1145.74856
-          ],
-          [
-            1335.4942472177777,
-            1145.74856
-          ],
-          [
-            1335.4942472177777,
-            1059.95856
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7166,29 +2175,6 @@
     "type": "UncategorizedText",
     "element_id": "37bb128a8a87ef034991efa0574ee4a4",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1151.28356
-          ],
-          [
-            377.575,
-            1176.1902266666666
-          ],
-          [
-            1334.9834512355555,
-            1176.1902266666666
-          ],
-          [
-            1334.9834512355555,
-            1151.28356
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7199,29 +2185,6 @@
     "type": "UncategorizedText",
     "element_id": "53dd155fea5e56f1dc9715fab422339a",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            431.23055555555555,
-            1181.7252266666667
-          ],
-          [
-            431.23055555555555,
-            1206.6318933333332
-          ],
-          [
-            1158.3159315555552,
-            1206.6318933333332
-          ],
-          [
-            1158.3159315555552,
-            1181.7252266666667
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7232,29 +2195,6 @@
     "type": "UncategorizedText",
     "element_id": "4c8ddc159ec208bb7f454603fcd7c4bd",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1212.1641155555556
-          ],
-          [
-            377.575,
-            1328.3957822222221
-          ],
-          [
-            1338.5375827555556,
-            1328.3957822222221
-          ],
-          [
-            1338.5375827555556,
-            1212.1641155555556
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7265,29 +2205,6 @@
     "type": "UncategorizedText",
     "element_id": "1cd3d88315a8510c5fd1cbc7784db861",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1333.9307822222222
-          ],
-          [
-            377.575,
-            1450.8598355555555
-          ],
-          [
-            1339.2489171555555,
-            1450.8598355555555
-          ],
-          [
-            1339.2489171555555,
-            1333.9307822222222
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7298,29 +2215,6 @@
     "type": "UncategorizedText",
     "element_id": "0626b5a309a35467b0f463c7e36114ce",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            431.23055555555567,
-            1455.697448888889
-          ],
-          [
-            431.23055555555567,
-            1481.301502222222
-          ],
-          [
-            1007.7529777777779,
-            1481.301502222222
-          ],
-          [
-            1007.7529777777779,
-            1455.697448888889
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7331,29 +2225,6 @@
     "type": "UncategorizedText",
     "element_id": "6c94dd219ce339c358163833e20d099e",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.5750000000002,
-            1486.1391155555552
-          ],
-          [
-            377.5750000000002,
-            1571.9263377777777
-          ],
-          [
-            1338.5299115022221,
-            1571.9263377777777
-          ],
-          [
-            1338.5299115022221,
-            1486.1391155555552
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7364,29 +2235,6 @@
     "type": "UncategorizedText",
     "element_id": "13767118077be05d9be07792d1785ecb",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1577.4613377777778
-          ],
-          [
-            377.575,
-            1602.3680044444445
-          ],
-          [
-            1334.9742556942222,
-            1602.3680044444445
-          ],
-          [
-            1334.9742556942222,
-            1577.4613377777778
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7397,29 +2245,6 @@
     "type": "UncategorizedText",
     "element_id": "df2e0c46ac32660311c5e8b2bee4c16d",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            431.23055555555555,
-            1607.9030044444444
-          ],
-          [
-            431.23055555555555,
-            1632.809671111111
-          ],
-          [
-            1082.1637982222219,
-            1632.809671111111
-          ],
-          [
-            1082.1637982222219,
-            1607.9030044444444
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7430,29 +2255,6 @@
     "type": "UncategorizedText",
     "element_id": "24e0da607349c44bf53c752dd897fc58",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            377.575,
-            1638.3446711111112
-          ],
-          [
-            377.575,
-            1663.2513377777777
-          ],
-          [
-            978.7979933155555,
-            1663.2513377777777
-          ],
-          [
-            978.7979933155555,
-            1638.3446711111112
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7463,29 +2265,6 @@
     "type": "UncategorizedText",
     "element_id": "0b7709205c824159e1f921b3e01431b6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            731.5991273955555,
-            1638.3446711111112
-          ],
-          [
-            731.5991273955555,
-            1724.1346711111112
-          ],
-          [
-            1339.9530069333332,
-            1724.1346711111112
-          ],
-          [
-            1339.9530069333332,
-            1638.3446711111112
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7496,29 +2275,6 @@
     "type": "UncategorizedText",
     "element_id": "869d8bf2a40ba100a2d83b864d9a654f",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            430.2833333333333,
-            1668.786337777778
-          ],
-          [
-            430.2833333333333,
-            1754.5763377777778
-          ],
-          [
-            1089.9723154133333,
-            1754.5763377777778
-          ],
-          [
-            1089.9723154133333,
-            1668.786337777778
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16
@@ -7529,29 +2285,6 @@
     "type": "UncategorizedText",
     "element_id": "5ad8687ffef71730e40fbc829ea0d8b6",
     "metadata": {
-      "coordinates": {
-        "points": [
-          [
-            523.5363558755555,
-            1668.786337777778
-          ],
-          [
-            523.5363558755555,
-            1693.6930044444443
-          ],
-          [
-            711.1482633955554,
-            1693.6930044444443
-          ],
-          [
-            711.1482633955554,
-            1668.786337777778
-          ]
-        ],
-        "system": "PixelSpace",
-        "layout_width": 1700,
-        "layout_height": 2200
-      },
       "data_source": {},
       "filetype": "application/pdf",
       "page_number": 16

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-encoding.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-encoding.sh
@@ -11,7 +11,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     local \
     --metadata-exclude filename,file_directory,metadata.data_source.date_processed,metadata.last_modified \
     --structured-output-dir "$OUTPUT_DIR" \
-    --encoding cp1252 \
+    --partition-encoding cp1252 \
     --verbose \
     --reprocess \
     --input-path example-docs/fake-html-cp1252.html

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
@@ -10,6 +10,7 @@ OUTPUT_DIR=$SCRIPT_DIR/structured-output/$OUTPUT_FOLDER_NAME
 PYTHONPATH=. ./unstructured/ingest/main.py \
     local \
     --metadata-exclude filename,file_directory,metadata.data_source.date_processed,metadata.last_modified \
+    --partition-by-api \
     --structured-output-dir "$OUTPUT_DIR" \
     --partition-pdf-infer-table-structure True \
     -partition-strategy hi_res \

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
@@ -10,10 +10,8 @@ OUTPUT_DIR=$SCRIPT_DIR/structured-output/$OUTPUT_FOLDER_NAME
 PYTHONPATH=. ./unstructured/ingest/main.py \
     local \
     --metadata-exclude filename,file_directory,metadata.data_source.date_processed,metadata.last_modified \
-    --api-key "$UNS_API_KEY" \
-    --partition-by-api \
     --structured-output-dir "$OUTPUT_DIR" \
-    --partition-pdf-infer-table-structure True \
+    --partition-pdf-infer-table-structure true \
     --partition-strategy hi_res \
     --verbose \
     --reprocess \

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR=$SCRIPT_DIR/structured-output/$OUTPUT_FOLDER_NAME
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
     local \
-    --metadata-exclude coordinates, filename,file_directory,metadata.data_source.date_processed,metadata.last_modified \
+    --metadata-exclude coordinates,filename,file_directory,metadata.data_source.date_processed,metadata.last_modified \
     --structured-output-dir "$OUTPUT_DIR" \
     --partition-pdf-infer-table-structure true \
     --partition-strategy hi_res \

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+cd "$SCRIPT_DIR"/.. || exit 1
+OUTPUT_FOLDER_NAME=local-single-file-with-pdf-infer-table-structure
+OUTPUT_DIR=$SCRIPT_DIR/structured-output/$OUTPUT_FOLDER_NAME
+
+PYTHONPATH=. ./unstructured/ingest/main.py \
+    local \
+    --metadata-exclude filename,file_directory,metadata.data_source.date_processed,metadata.last_modified \
+    --structured-output-dir "$OUTPUT_DIR" \
+    --partition-pdf-infer-table-structure True \
+    -partition-strategy hi_res \
+    --verbose \
+    --reprocess \
+    --input-path example-docs/layout-parser-paper.pdf
+
+set +e
+
+sh "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
@@ -13,7 +13,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --partition-by-api \
     --structured-output-dir "$OUTPUT_DIR" \
     --partition-pdf-infer-table-structure True \
-    -partition-strategy hi_res \
+    --partition-strategy hi_res \
     --verbose \
     --reprocess \
     --input-path example-docs/layout-parser-paper.pdf

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
@@ -10,6 +10,7 @@ OUTPUT_DIR=$SCRIPT_DIR/structured-output/$OUTPUT_FOLDER_NAME
 PYTHONPATH=. ./unstructured/ingest/main.py \
     local \
     --metadata-exclude filename,file_directory,metadata.data_source.date_processed,metadata.last_modified \
+    --api-key "$UNS_API_KEY" \
     --partition-by-api \
     --structured-output-dir "$OUTPUT_DIR" \
     --partition-pdf-infer-table-structure True \

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR=$SCRIPT_DIR/structured-output/$OUTPUT_FOLDER_NAME
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
     local \
-    --metadata-exclude filename,file_directory,metadata.data_source.date_processed,metadata.last_modified \
+    --metadata-exclude coordinates, filename,file_directory,metadata.data_source.date_processed,metadata.last_modified \
     --structured-output-dir "$OUTPUT_DIR" \
     --partition-pdf-infer-table-structure true \
     --partition-strategy hi_res \

--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -30,5 +30,6 @@ export OMP_THREAD_LIMIT=1
 ./test_unstructured_ingest/test-ingest-confluence-large.sh
 ./test_unstructured_ingest/test-ingest-local-single-file.sh
 ./test_unstructured_ingest/test-ingest-local-single-file-with-encoding.sh
+./test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
 # NOTE(yuming): The following test should be put after any tests with --preserve-downloads option
 ./test_unstructured_ingest/test-ingest-pdf-fast-reprocess.sh

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.1-dev10"  # pragma: no cover
+__version__ = "0.9.1-dev11"  # pragma: no cover

--- a/unstructured/ingest/cli/common.py
+++ b/unstructured/ingest/cli/common.py
@@ -104,6 +104,7 @@ def map_to_processor_config(options: dict) -> ProcessorConfigs:
     return ProcessorConfigs(
         partition_strategy=options["partition_strategy"],
         partition_ocr_languages=options["partition_ocr_languages"],
+        partition_pdf_infer_table_structure=options["partition_pdf_infer_table_structure"],
         encoding=options["encoding"],
         num_processes=options["num_processes"],
         reprocess=options["reprocess"],

--- a/unstructured/ingest/cli/common.py
+++ b/unstructured/ingest/cli/common.py
@@ -105,7 +105,7 @@ def map_to_processor_config(options: dict) -> ProcessorConfigs:
         partition_strategy=options["partition_strategy"],
         partition_ocr_languages=options["partition_ocr_languages"],
         partition_pdf_infer_table_structure=options["partition_pdf_infer_table_structure"],
-        encoding=options["encoding"],
+        partition_encoding=options["partition_encoding"],
         num_processes=options["num_processes"],
         reprocess=options["reprocess"],
         max_docs=options["max_docs"],
@@ -203,14 +203,11 @@ def add_shared_options(cmd: Command):
         Option(
             ["--partition-pdf-infer-table-structure"],
             default=False,
-            help="A list of language packs to specify which languages to use for OCR, "
-            "separated by '+' e.g. 'eng+deu' to use the English and German language packs. "
-            "The appropriate Tesseract "
-            "language pack needs to be installed."
-            "Default: eng",
+            help="If set to True, partition will includ the table's text content in the response."
+            "Default: False",
         ),
         Option(
-            ["--encoding"],
+            ["--partition-encoding"],
             default=None,
             help="Text encoding to use when reading documents. By default the encoding is "
             "detected automatically.",

--- a/unstructured/ingest/cli/common.py
+++ b/unstructured/ingest/cli/common.py
@@ -201,6 +201,15 @@ def add_shared_options(cmd: Command):
             "Default: eng",
         ),
         Option(
+            ["--partition-pdf-infer-table-structure"],
+            default=False,
+            help="A list of language packs to specify which languages to use for OCR, "
+            "separated by '+' e.g. 'eng+deu' to use the English and German language packs. "
+            "The appropriate Tesseract "
+            "language pack needs to be installed."
+            "Default: eng",
+        ),
+        Option(
             ["--encoding"],
             default=None,
             help="Text encoding to use when reading documents. By default the encoding is "

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -24,6 +24,7 @@ class ProcessorConfigs:
 
     partition_strategy: str
     partition_ocr_languages: str
+    partition_pdf_infer_table_structure: str
     encoding: str
     num_processes: int
     reprocess: bool

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -24,7 +24,7 @@ class ProcessorConfigs:
 
     partition_strategy: str
     partition_ocr_languages: str
-    partition_pdf_infer_table_structure: str
+    partition_pdf_infer_table_structure: bool
     encoding: str
     num_processes: int
     reprocess: bool

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -25,7 +25,7 @@ class ProcessorConfigs:
     partition_strategy: str
     partition_ocr_languages: str
     partition_pdf_infer_table_structure: bool
-    encoding: str
+    partition_encoding: str
     num_processes: int
     reprocess: bool
     max_docs: int

--- a/unstructured/ingest/processor.py
+++ b/unstructured/ingest/processor.py
@@ -97,7 +97,7 @@ def process_documents(
         process_document,
         strategy=processor_config.partition_strategy,
         ocr_languages=processor_config.partition_ocr_languages,
-        encoding=processor_config.encoding,
+        encoding=processor_config.partition_encoding,
         pdf_infer_table_structure=processor_config.partition_pdf_infer_table_structure,
     )
 

--- a/unstructured/ingest/processor.py
+++ b/unstructured/ingest/processor.py
@@ -98,6 +98,7 @@ def process_documents(
         strategy=processor_config.partition_strategy,
         ocr_languages=processor_config.partition_ocr_languages,
         encoding=processor_config.encoding,
+        pdf_infer_table_structure=processor_config.partition_pdf_infer_table_structure,
     )
 
     Processor(

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -330,8 +330,8 @@ def decide_table_extraction(
     if doc_type == "pdf":
         if doc_type in skip_infer_table_types and pdf_infer_table_structure:
             logger.warning(
-                f"Conflict between variables skip_infer_table_types: {skip_infer_table_types}"
-                f"and pdf_infer_table_structure: {pdf_infer_table_structure},"
+                f"Conflict between variables skip_infer_table_types: {skip_infer_table_types} "
+                f"and pdf_infer_table_structure: {pdf_infer_table_structure}, "
                 "please reset skip_infer_table_types to turn on table extraction for PDFs.",
             )
         return not (doc_type in skip_infer_table_types) or pdf_infer_table_structure


### PR DESCRIPTION
### Summary

* adding --partition-pdf-infer-table-structure to unstructured-ingest

### Test

* check there are field `"text_as_html"` for extracted tables in output json file

### Note

all partition parameters are not passing into request correctly when use together with `partition-by-api`, so currently we have to stick with local partition (will be fixed soon).