### PR TITLE
fix: unstructured-ingest entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.1-dev11
+## 0.9.1
 
 ### Enhancements
 
@@ -27,6 +27,7 @@
 * Simplifies `min_partition` logic; makes partitions falling below the `min_partition`
   less likely.
 * Fix bug where ingest test check for number of files fails in smoke test
+* Fix unstructured-ingest entrypoint failure
 
 ## 0.9.0
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.1-dev11"  # pragma: no cover
+__version__ = "0.9.1"  # pragma: no cover

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 from unstructured.ingest.cli.cli import get_cmd
 
+
 def main():
     ingest_cmd = get_cmd()
     ingest_cmd()
+
 
 if __name__ == "__main__":
     main()

--- a/unstructured/ingest/main.py
+++ b/unstructured/ingest/main.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 from unstructured.ingest.cli.cli import get_cmd
 
-if __name__ == "__main__":
+def main():
     ingest_cmd = get_cmd()
     ingest_cmd()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The library entrypoint for ingest `unstructured-ingest` was broken with the recent refactor. This is because the main function which is accessed here: https://github.com/Unstructured-IO/unstructured/blob/7f9340ce00a23f71f9348d9f8e542ba86a79753f/setup.py#L105 was removed from `unstructured/ingest/main.py`

## Changes

* add main function back to `unstructured/ingest/main.py`

## Test

On the main branch, run `pip install -e .` to install the latest local version of the unstructured library. Then validate the broken state by running `PYTHONPATH=. unstructured-ingest --help` which results in: 
```
Traceback (most recent call last):
  File "~/.pyenv/versions/unstructured/bin/unstructured-ingest", line 5, in <module>
    from unstructured.ingest.main import main
ImportError: cannot import name 'main' from 'unstructured.ingest.main' (~/.pyenv/versions/unstructured/lib/python3.10/site-packages/unstructured/ingest/main.py)
```

Change to this branch and run both commands again. Note that this time it succeeds, giving the expected help options.
```
Usage: unstructured-ingest [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  azure
  biomed
  box
  confluence
  discord
  dropbox
  elasticsearch
  fsspec
  gcs
  gdrive
  github
  gitlab
  local
  notion
  onedrive
  outlook
  reddit
  s3
  slack
  wikipedia
  ```