### PR TITLE
docs: correct spelling of partition in docs

### DIFF
--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -207,7 +207,7 @@ saved in the ``.doc`` format. This partition brick uses a combination of the sty
 information in the document and the structure of the text to determine the type
 of a text element. The ``partition_doc`` can take a filename or file-like object
 as input.
-``partiton_doc`` uses ``libreoffice`` to convert the file to ``.docx`` and then
+``partition_doc`` uses ``libreoffice`` to convert the file to ``.docx`` and then
 calls ``partition_docx``. Ensure you have ``libreoffice`` installed
 before using ``partition_doc``.
 

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -26,7 +26,7 @@ def partition_epub(
     **kwargs,
 ) -> List[Element]:
     """Partitions an EPUB document. The document is first converted to HTML and then
-    partitoned using partiton_html. Book `section` info is included in metadata, but
+    partitioned using partition_html. Book `section` info is included in metadata, but
     does not perfectly align with sections in document because of ebooklib constraints.
 
     Parameters

--- a/unstructured/partition/rtf.py
+++ b/unstructured/partition/rtf.py
@@ -17,7 +17,7 @@ def partition_rtf(
     **kwargs,
 ) -> List[Element]:
     """Partitions an RTF document. The document is first converted to HTML and then
-    partitioned using partiton_html.
+    partitioned using partition_html.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes a typo in several places where the word `partition` is misspelled as `partiton`