### PR TITLE
Handle inline and lacking filename

### DIFF
--- a/example-docs/eml/email-inline-content-disposition.eml
+++ b/example-docs/eml/email-inline-content-disposition.eml
@@ -1,0 +1,23 @@
+From: Test User <testuser@example.com>
+To: recipient@example.com
+Subject: Testing Inline
+Message-ID: <CAPgCCDEzLVJ-d1OCX_TjFgJU7ugtQrjFybPtAMmmYZzphxNFYg@mail.example.com>
+X-Mailer: Claws Mail 4.1.1 (GTK 3.24.34; x86_64-pc-linux-gnu)
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="MP_/pqqQE0ldE7RYQcFW3Kd0aQV"
+
+--MP_/pqqQE0ldE7RYQcFW3Kd0aQV
+Content-Type: text/plain; charset=US-ASCII
+Content-Transfer-Encoding: 7bit
+Content-Disposition: inline
+
+This is a test of inline
+
+--MP_/pqqQE0ldE7RYQcFW3Kd0aQV
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename=t.txt
+
+test
+
+--MP_/pqqQE0ldE7RYQcFW3Kd0aQV--

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -11,6 +11,7 @@ from unstructured.documents.elements import (
     ListItem,
     NarrativeText,
     Title,
+    Text,
 )
 from unstructured.documents.email_elements import (
     MetaData,
@@ -491,3 +492,17 @@ def test_partition_email_custom_metadata_date(
     )
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+def test_partition_email_inline_content_disposition(
+    filename="example-docs/eml/email-inline-content-disposition.eml",
+):
+    elements = partition_email(
+        filename=filename,
+        process_attachments=True,
+        attachment_partitioner=partition_text,
+    )
+
+    assert isinstance(elements[0], Text)
+    assert elements[0].text == "test"
+    assert isinstance(elements[1], Text)
+    assert elements[1].text == "This is a test of inline"

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -5,7 +5,7 @@ import re
 import sys
 from email.message import Message
 from functools import partial
-from tempfile import SpooledTemporaryFile, TemporaryDirectory
+from tempfile import SpooledTemporaryFile, TemporaryDirectory, NamedTemporaryFile
 from typing import IO, Callable, Dict, List, Optional, Tuple, Union
 
 from unstructured.file_utils.encoding import (
@@ -163,10 +163,10 @@ def extract_attachment_info(
             cdisp = part["content-disposition"].split(";")
             cdisp = [clean_extra_whitespace(item) for item in cdisp]
 
+            attachment_info = {}
             for item in cdisp:
-                attachment_info = {}
 
-                if item.lower() == "attachment":
+                if item.lower() == "attachment" or item.lower() == "inline":
                     continue
                 key, value = item.split("=")
                 key = clean_extra_whitespace(key.replace('"', ""))
@@ -177,13 +177,23 @@ def extract_attachment_info(
             attachment_info["payload"] = part.get_payload(decode=True)
             list_attachments.append(attachment_info)
 
-            for attachment in list_attachments:
+            for idx, attachment in enumerate(list_attachments):
                 if output_dir:
-                    filename = output_dir + "/" + attachment["filename"]
-                    with open(filename, "wb") as f:
-                        # Note(harrell) mypy wants to just us `w` when opening the file but this
-                        # causes an error since the payloads are bytes not str
-                        f.write(attachment["payload"])  # type: ignore
+                    if "filename" in attachment:
+                        filename = output_dir + "/" + attachment["filename"]
+                        with open(filename, "wb") as f:
+                            # Note(harrell) mypy wants to just us `w` when opening the file but this
+                            # causes an error since the payloads are bytes not str
+                            f.write(attachment["payload"])  # type: ignore
+                    else:
+                        with NamedTemporaryFile(
+                            mode="wb",
+                            dir=output_dir,
+                            delete=False,
+                        ) as f:
+                            list_attachments[idx]["filename"] = os.path.basename(f.name)
+                            f.write(attachment["payload"])
+
     return list_attachments
 
 


### PR DESCRIPTION
Handle `Content-Disposition: inline` and attachment without filename

* Add new email test example and test with `Content-Disposition: inline`.
* Move `attachment_info` above for loop so it is always defined
* Check if `item` is inline as well as attachment as these both lack an `=` character to split on
* Create filename if filename is not specified and write file.
* Update `list_attachments` with new filename