### PR TITLE
 build(deps): bump unstructured-inference to 0.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.10.1-dev2
+## 0.10.1-dev3
 
 ### Enhancements
+* Bump unstructured-inference==0.5.12:
+  - fix to avoid trace for certain PDF's
 * Bump unstructured-inference==0.5.11:
   - better defaults for DPI for hi_res and  Chipper
 * Bump unstructured-inference==0.5.10:

--- a/requirements/constraints.in
+++ b/requirements/constraints.in
@@ -26,4 +26,4 @@ Pillow<10.0.0
 # AttributeError: 'ResourcePath' object has no attribute 'collection'
 Office365-REST-Python-Client<2.4.3
 # NOTE(christine) Pinned to set the `unstructured-inference` version
-unstructured-inference==0.5.11
+unstructured-inference==0.5.12

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -205,7 +205,7 @@ typing-extensions==4.7.1
     #   torch
 tzdata==2023.3
     # via pandas
-unstructured-inference==0.5.11
+unstructured-inference==0.5.12
     # via
     #   -c requirements/constraints.in
     #   -r requirements/extra-pdf-image.in

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.1-dev2"  # pragma: no cover
+__version__ = "0.10.1-dev3"  # pragma: no cover


### PR DESCRIPTION
Pulls in @awalker4 's fix:

https://github.com/Unstructured-IO/unstructured-inference/pull/178

> When a pdf page doesn't have much data, it may get buffered in the write to a tempfile. If this happens, we'll hit an error reading the file back. Open to suggestions for a way to unit test this - I was creating some test files with pypdf but I couldn't trigger the error.