### PR TITLE
feat: get connector session by config map

### DIFF
--- a/test_unstructured_ingest/unit/doc_processor/test_generalized.py
+++ b/test_unstructured_ingest/unit/doc_processor/test_generalized.py
@@ -8,30 +8,27 @@ from unstructured.ingest.doc_processor.generalized import (
 from unstructured.ingest.interfaces import BaseIngestDoc, IngestDocSessionHandleMixin
 
 
-@dataclass
-class IngestDocWithSessionHandle(IngestDocSessionHandleMixin, BaseIngestDoc):
-    pass
-
 def test_process_document_with_session_handle(mocker):
     """Test that the process_document function calls the doc_processor_fn with the correct
     arguments, assigns the session handle, and returns the correct results."""
+    mock_doc = mocker.MagicMock()
+    mock_doc.session_handle = None
+    mock_doc.__class__ = IngestDocSessionHandleMixin
     mock_session_handle = mocker.MagicMock()
-    mocker.patch("unstructured.ingest.doc_processor.generalized.session_handle", mock_session_handle)
-    mock_doc = mocker.MagicMock(spec=(IngestDocWithSessionHandle))
+    mocker.patch("unstructured.ingest.doc_processor.generalized.session_handles_map", {hash(mock_doc.config): mock_session_handle})
 
     result = process_document(mock_doc)
     
     mock_doc.get_file.assert_called_once_with()
     mock_doc.write_result.assert_called_with()
     mock_doc.cleanup_file.assert_called_once_with()
-    assert result == mock_doc.process_file.return_value 
+    assert result == mock_doc.process_file.return_value
     assert mock_doc.session_handle == mock_session_handle
 
 
 def test_process_document_no_session_handle(mocker):
     """Test that the process_document function calls does not assign session handle the IngestDoc
     does not have the session handle mixin."""
-    mocker.patch("unstructured.ingest.doc_processor.generalized.session_handle", mocker.MagicMock())
     mock_doc = mocker.MagicMock(spec=(BaseIngestDoc))
 
     process_document(mock_doc)

--- a/test_unstructured_ingest/unit/test_interfaces.py
+++ b/test_unstructured_ingest/unit/test_interfaces.py
@@ -23,7 +23,7 @@ TEST_ID = "test"
 TEST_FILE_PATH = os.path.join(EXAMPLE_DOCS_DIRECTORY, "book-war-and-peace-1p.txt")
 
 
-@dataclass
+@dataclass(frozen=True)
 class TestConfig(BaseConnectorConfig):
     id: str
     path: str

--- a/unstructured/ingest/cli/cmds/discord.py
+++ b/unstructured/ingest/cli/cmds/discord.py
@@ -22,6 +22,7 @@ from unstructured.ingest.runner import discord as discord_fn
 @click.option(
     "--period",
     default=None,
+    type=int,
     help="Number of days to go back in the history of discord channels, must be a number",
 )
 @click.option(

--- a/unstructured/ingest/connector/airtable.py
+++ b/unstructured/ingest/connector/airtable.py
@@ -64,7 +64,7 @@ class AirtableIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         output_file = f"{self.file_meta.table_id}.json"
         return Path(self.standard_config.output_dir) / self.file_meta.base_id / output_file
 
-    @requires_dependencies(["pyairtable", "pandas"])
+    @requires_dependencies(["pyairtable", "pandas"], extras="airtable")
     @BaseIngestDoc.skip_if_file_exists
     def get_file(self):
         logger.debug(f"Fetching {self} - PID: {os.getpid()}")
@@ -142,7 +142,7 @@ class AirtableConnector(ConnectorCleanupMixin, BaseConnector):
     ):
         super().__init__(standard_config, config)
 
-    @requires_dependencies(["pyairtable"])
+    @requires_dependencies(["pyairtable"], extras="airtable")
     def initialize(self):
         from pyairtable import Api
 
@@ -152,7 +152,7 @@ class AirtableConnector(ConnectorCleanupMixin, BaseConnector):
 
         self.api = Api(self.config.personal_access_token)
 
-    @requires_dependencies(["pyairtable"])
+    @requires_dependencies(["pyairtable"], extras="airtable")
     def use_all_bases(self):
         from pyairtable.metadata import get_api_bases
 
@@ -160,7 +160,7 @@ class AirtableConnector(ConnectorCleanupMixin, BaseConnector):
             base["id"] for base in get_api_bases(self.api)["bases"]
         ]
 
-    @requires_dependencies(["pyairtable"])
+    @requires_dependencies(["pyairtable"], extras="airtable")
     def fetch_table_ids(self):
         from pyairtable.metadata import get_base_schema
 

--- a/unstructured/ingest/connector/airtable.py
+++ b/unstructured/ingest/connector/airtable.py
@@ -15,7 +15,7 @@ from unstructured.ingest.logger import logger
 from unstructured.utils import requires_dependencies
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleAirtableConfig(BaseConnectorConfig):
     """Connector config where:
     auth_token is the authentication token to authenticate into Airtable.

--- a/unstructured/ingest/connector/azure.py
+++ b/unstructured/ingest/connector/azure.py
@@ -10,7 +10,7 @@ from unstructured.ingest.interfaces import StandardConnectorConfig
 from unstructured.utils import requires_dependencies
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleAzureBlobStorageConfig(SimpleFsspecConfig):
     pass
 

--- a/unstructured/ingest/connector/biomed.py
+++ b/unstructured/ingest/connector/biomed.py
@@ -61,11 +61,11 @@ class SimpleBiomedConfig(BaseConnectorConfig):
             valid = validate_date_args(self.until)
 
         return valid
-    
+
     def is_api(self):
         return not self.path
-    
-    @functools.lru_cache(maxsize=1) 
+
+    @functools.lru_cache(maxsize=1)
     def is_file(self):
         if not self.is_api():
             is_valid = self.formatted_path.lower().startswith(PDF_DIR)
@@ -91,15 +91,14 @@ class SimpleBiomedConfig(BaseConnectorConfig):
                         "Something went wrong when validating the path: {path}.",
                     )
         return False
-    
+
     def is_dir(self):
         return not self.is_api() and not self.is_file()
-    
+
     @property
     def formatted_path(self):
         if self.path:
             return self.path.strip("/")
-            
 
     def __post_init__(self):
         if not self.path:
@@ -109,7 +108,6 @@ class SimpleBiomedConfig(BaseConnectorConfig):
                     "Path argument or at least one of the "
                     "OA Web Service arguments MUST be provided.",
                 )
-            
 
 
 @dataclass

--- a/unstructured/ingest/connector/box.py
+++ b/unstructured/ingest/connector/box.py
@@ -24,7 +24,7 @@ class AccessTokenError(Exception):
     """There is a problem with the Access Token."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleBoxConfig(SimpleFsspecConfig):
     @requires_dependencies(["boxfs"], extras="box")
     def __post_init__(self):

--- a/unstructured/ingest/connector/confluence.py
+++ b/unstructured/ingest/connector/confluence.py
@@ -103,6 +103,7 @@ class ConfluenceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
     @BaseIngestDoc.skip_if_file_exists
     def get_file(self):
         from atlassian import Confluence
+
         logger.debug(f"Fetching {self} - PID: {os.getpid()}")
 
         # TODO: instead of having a separate connection object for each doc,
@@ -136,6 +137,7 @@ class ConfluenceConnector(ConnectorCleanupMixin, BaseConnector):
 
     def initialize(self):
         from atlassian import Confluence
+
         self.confluence = Confluence(
             url=self.config.url,
             username=self.config.user_email,

--- a/unstructured/ingest/connector/confluence.py
+++ b/unstructured/ingest/connector/confluence.py
@@ -18,7 +18,7 @@ from unstructured.ingest.logger import logger
 from unstructured.utils import requires_dependencies
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleConfluenceConfig(BaseConnectorConfig):
     """Connector config where:
     user_email is the email to authenticate into Confluence Cloud,

--- a/unstructured/ingest/connector/discord.py
+++ b/unstructured/ingest/connector/discord.py
@@ -98,7 +98,8 @@ class DiscordIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
 
         bot.run(self.token)
 
-        with open(self._tmp_download_file(), "w") as f:
+        self.filename.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.filename, "w") as f:
             for m in messages:
                 f.write(m.content + "\n")
 
@@ -121,8 +122,7 @@ class DiscordConnector(ConnectorCleanupMixin, BaseConnector):
         super().__init__(standard_config, config)
 
     def initialize(self):
-        """Verify that can get metadata for an object, validates connections info."""
-        os.mkdir(self.standard_config.download_dir)
+        pass
 
     def get_ingest_docs(self):
         return [

--- a/unstructured/ingest/connector/discord.py
+++ b/unstructured/ingest/connector/discord.py
@@ -18,7 +18,7 @@ from unstructured.utils import (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleDiscordConfig(BaseConnectorConfig):
     """Connector config where channels is a comma separated list of
     Discord channels to pull messages from.
@@ -29,15 +29,6 @@ class SimpleDiscordConfig(BaseConnectorConfig):
     token: str
     days: Optional[int]
     verbose: bool = False
-
-    def __post_init__(self):
-        if self.days:
-            try:
-                self.days = int(self.days)
-            except ValueError:
-                raise ValueError("--discord-period must be an integer")
-
-        pass
 
     @staticmethod
     def parse_channels(channel_str: str) -> List[str]:

--- a/unstructured/ingest/connector/dropbox.py
+++ b/unstructured/ingest/connector/dropbox.py
@@ -26,13 +26,13 @@ class MissingFolderError(Exception):
     """There is no folder by that name. For root try `dropbox:// /`"""
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleDropboxConfig(SimpleFsspecConfig):
     pass
 
 
 class DropboxIngestDoc(FsspecIngestDoc):
-    @requires_dependencies(["dropboxdrivefs", "fsspec"])
+    @requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
     def get_file(self):
         super().get_file()
 
@@ -70,7 +70,7 @@ class DropboxIngestDoc(FsspecIngestDoc):
             )
 
 
-@requires_dependencies(["dropboxdrivefs", "fsspec"])
+@requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
 class DropboxConnector(FsspecConnector):
     ingest_doc_cls: Type[DropboxIngestDoc] = DropboxIngestDoc
 

--- a/unstructured/ingest/connector/elasticsearch.py
+++ b/unstructured/ingest/connector/elasticsearch.py
@@ -5,10 +5,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-import jq
-from elasticsearch import Elasticsearch
-from elasticsearch.helpers import scan
-
 from unstructured.ingest.interfaces import (
     BaseConnector,
     BaseConnectorConfig,
@@ -21,7 +17,7 @@ from unstructured.ingest.logger import logger
 from unstructured.utils import requires_dependencies
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleElasticsearchConfig(BaseConnectorConfig):
     """Connector config where:
     url is the url to access the elasticsearch server,
@@ -105,9 +101,11 @@ class ElasticsearchIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         concatenated_values = seperator.join(values)
         return concatenated_values
 
-    @requires_dependencies(["elasticsearch"])
+    @requires_dependencies(["elasticsearch", "jq"], extras="elasticsearch")
     @BaseIngestDoc.skip_if_file_exists
     def get_file(self):
+        import jq
+        from elasticsearch import Elasticsearch
         logger.debug(f"Fetching {self} - PID: {os.getpid()}")
         # TODO: instead of having a separate client for each doc,
         # have a separate client for each process
@@ -124,7 +122,7 @@ class ElasticsearchIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             f.write(self.document)
 
 
-@requires_dependencies(["elasticsearch"])
+@requires_dependencies(["elasticsearch"], extras="elasticsearch")
 @dataclass
 class ElasticsearchConnector(ConnectorCleanupMixin, BaseConnector):
     """Fetches particular fields from all documents in a given elasticsearch cluster and index"""
@@ -138,15 +136,18 @@ class ElasticsearchConnector(ConnectorCleanupMixin, BaseConnector):
     ):
         super().__init__(standard_config, config)
 
+    @requires_dependencies(["elasticsearch"], extras="elasticsearch")
     def initialize(self):
+        from elasticsearch import Elasticsearch
         self.es = Elasticsearch(self.config.url)
         self.scan_query: dict = {"query": {"match_all": {}}}
         self.search_query: dict = {"match_all": {}}
         self.es.search(index=self.config.index_name, query=self.search_query, size=1)
 
-    @requires_dependencies(["elasticsearch"])
+    @requires_dependencies(["elasticsearch"], extras="elasticsearch")
     def _get_doc_ids(self):
         """Fetches all document ids in an index"""
+        from elasticsearch.helpers import scan
         hits = scan(
             self.es,
             query=self.scan_query,

--- a/unstructured/ingest/connector/elasticsearch.py
+++ b/unstructured/ingest/connector/elasticsearch.py
@@ -106,6 +106,7 @@ class ElasticsearchIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
     def get_file(self):
         import jq
         from elasticsearch import Elasticsearch
+
         logger.debug(f"Fetching {self} - PID: {os.getpid()}")
         # TODO: instead of having a separate client for each doc,
         # have a separate client for each process
@@ -139,6 +140,7 @@ class ElasticsearchConnector(ConnectorCleanupMixin, BaseConnector):
     @requires_dependencies(["elasticsearch"], extras="elasticsearch")
     def initialize(self):
         from elasticsearch import Elasticsearch
+
         self.es = Elasticsearch(self.config.url)
         self.scan_query: dict = {"query": {"match_all": {}}}
         self.search_query: dict = {"match_all": {}}
@@ -148,6 +150,7 @@ class ElasticsearchConnector(ConnectorCleanupMixin, BaseConnector):
     def _get_doc_ids(self):
         """Fetches all document ids in an index"""
         from elasticsearch.helpers import scan
+
         hits = scan(
             self.es,
             query=self.scan_query,

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -36,18 +36,18 @@ class SimpleFsspecConfig(BaseConnectorConfig):
     @property
     def protocol(self):
         return self.path.split("://")[0]
-    
+
     @property
     def path_without_protocol(self):
         return self.path.split("://")[1]
-   
+
     @property
     def dir_path(self):
         if self.protocol == "dropbox":
             return " "
         match = re.match(rf"{self.protocol}://([^/\s]+?)(/*)$", self.path)
         if match:
-            return match.group(1)        
+            return match.group(1)
         match = re.match(rf"{self.protocol}://([^/\s]+?)/([^\s]*)", self.path)
         if not match:
             raise ValueError(f"Invalid path {self.path}.")
@@ -64,13 +64,14 @@ class SimpleFsspecConfig(BaseConnectorConfig):
         if not match:
             raise ValueError(f"Invalid path {self.path}.")
         return match.group(2) or ""
-        
+
     def __post_init__(self):
         if self.protocol not in SUPPORTED_REMOTE_FSSPEC_PROTOCOLS:
             raise ValueError(
                 f"Protocol {self.protocol} not supported yet, only "
                 f"{SUPPORTED_REMOTE_FSSPEC_PROTOCOLS} are supported.",
             )
+
 
 @dataclass
 class FsspecIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):

--- a/unstructured/ingest/connector/gcs.py
+++ b/unstructured/ingest/connector/gcs.py
@@ -10,7 +10,7 @@ from unstructured.ingest.interfaces import StandardConnectorConfig
 from unstructured.utils import requires_dependencies
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleGcsConfig(SimpleFsspecConfig):
     pass
 

--- a/unstructured/ingest/connector/git.py
+++ b/unstructured/ingest/connector/git.py
@@ -14,7 +14,7 @@ from unstructured.ingest.interfaces import (
 from unstructured.ingest.logger import logger
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleGitConfig(BaseConnectorConfig):
     url: str
     access_token: Optional[str]

--- a/unstructured/ingest/connector/git.py
+++ b/unstructured/ingest/connector/git.py
@@ -1,5 +1,6 @@
 import fnmatch
 import os
+from abc import abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -20,7 +21,11 @@ class SimpleGitConfig(BaseConnectorConfig):
     access_token: Optional[str]
     branch: Optional[str]
     file_glob: Optional[str]
-    repo_path: str = field(init=False, repr=False)
+
+    @property
+    @abstractmethod
+    def repo_path(self):
+        pass
 
 
 @dataclass

--- a/unstructured/ingest/connector/github.py
+++ b/unstructured/ingest/connector/github.py
@@ -16,26 +16,33 @@ if TYPE_CHECKING:
     from github.Repository import Repository
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleGitHubConfig(SimpleGitConfig):
-    def __post_init__(self):
-        parsed_gh_url = urlparse(self.url)
-        path_fragments = [fragment for fragment in parsed_gh_url.path.split("/") if fragment]
 
+    @property
+    def parsed_gh_url(self):
+        return urlparse(self.url)
+
+    @property
+    def path_fragments(self):
+        return [fragment for fragment in self.parsed_gh_url.path.split("/") if fragment]
+    
+    @property
+    def repo_path(self):
+        return self.parsed_gh_url.path
+
+    def __post_init__(self):
         # If a scheme and netloc are provided, ensure they are correct
         # Additionally, ensure that the path contains two fragments
         if (
-            (parsed_gh_url.scheme and parsed_gh_url.scheme != "https")
-            or (parsed_gh_url.netloc and parsed_gh_url.netloc != "github.com")
-            or len(path_fragments) != 2
+            (self.parsed_gh_url.scheme and self.parsed_gh_url.scheme != "https")
+            or (self.parsed_gh_url.netloc and self.parsed_gh_url.netloc != "github.com")
+            or len(self.path_fragments) != 2
         ):
             raise ValueError(
                 'Please provide a valid URL, e.g. "https://github.com/Unstructured-IO/unstructured"'
                 ' or a repository owner/name pair, e.g. "Unstructured-IO/unstructured".',
             )
-
-        # If there's no issues, store the core repository info
-        self.repo_path = parsed_gh_url.path
 
 
 @dataclass

--- a/unstructured/ingest/connector/github.py
+++ b/unstructured/ingest/connector/github.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class SimpleGitHubConfig(SimpleGitConfig):
-
     @property
     def parsed_gh_url(self):
         return urlparse(self.url)
@@ -26,7 +25,7 @@ class SimpleGitHubConfig(SimpleGitConfig):
     @property
     def path_fragments(self):
         return [fragment for fragment in self.parsed_gh_url.path.split("/") if fragment]
-    
+
     @property
     def repo_path(self):
         return self.parsed_gh_url.path

--- a/unstructured/ingest/connector/gitlab.py
+++ b/unstructured/ingest/connector/gitlab.py
@@ -15,18 +15,17 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class SimpleGitLabConfig(SimpleGitConfig):
-
     @property
     def parsed_gh_url(self):
         return urlparse(self.url)
-    
+
     @property
     def repo_path(self):
         repo_path = self.parsed_gh_url.path
         while repo_path.startswith("/"):
             repo_path = repo_path[1:]
         return repo_path
-    
+
     @property
     def url_with_scheme(self):
         # If no scheme or netloc are provided, use the default gitlab.com
@@ -34,6 +33,7 @@ class SimpleGitLabConfig(SimpleGitConfig):
             return "https://gitlab.com"
         else:
             return f"{self.parsed_gh_url.scheme}://{self.parsed_gh_url.netloc}"
+
 
 @dataclass
 class GitLabIngestDoc(GitIngestDoc):
@@ -53,6 +53,8 @@ class GitLabIngestDoc(GitIngestDoc):
 @requires_dependencies(["gitlab"], extras="gitlab")
 @dataclass
 class GitLabConnector(GitConnector):
+    config: SimpleGitLabConfig
+
     def __post_init__(self) -> None:
         from gitlab import Gitlab
 

--- a/unstructured/ingest/connector/google_drive.py
+++ b/unstructured/ingest/connector/google_drive.py
@@ -75,7 +75,7 @@ def create_service_account_object(key_path, id=None):
     return service
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleGoogleDriveConfig(ConfigSessionHandleMixin, BaseConnectorConfig):
     """Connector config where drive_id is the id of the document to process or
     the folder to process all documents from."""

--- a/unstructured/ingest/connector/local.py
+++ b/unstructured/ingest/connector/local.py
@@ -14,18 +14,15 @@ from unstructured.ingest.interfaces import (
 from unstructured.ingest.logger import logger
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleLocalConfig(BaseConnectorConfig):
     # Local specific options
     input_path: str
     recursive: bool = False
     file_glob: Optional[str] = None
 
-    def __post_init__(self):
-        if os.path.isfile(self.input_path):
-            self.input_path_is_file = True
-        else:
-            self.input_path_is_file = False
+    def input_path_is_file(self):
+        return os.path.isfile(self.input_path)
 
 
 @dataclass
@@ -87,7 +84,7 @@ class LocalConnector(BaseConnector):
         pass
 
     def _list_files(self):
-        if self.config.input_path_is_file:
+        if self.config.input_path_is_file():
             return glob.glob(f"{self.config.input_path}")
         elif self.config.recursive:
             return glob.glob(f"{self.config.input_path}/**", recursive=self.config.recursive)

--- a/unstructured/ingest/connector/notion/connector.py
+++ b/unstructured/ingest/connector/notion/connector.py
@@ -21,7 +21,7 @@ from unstructured.utils import (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleNotionConfig(BaseConnectorConfig):
     """Connector config to process all messages by channel id's."""
 

--- a/unstructured/ingest/connector/onedrive.py
+++ b/unstructured/ingest/connector/onedrive.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 MAX_MB_SIZE = 512_000_000
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleOneDriveConfig(BaseConnectorConfig):
     client_id: str
     client_credential: str = field(repr=False)

--- a/unstructured/ingest/connector/onedrive.py
+++ b/unstructured/ingest/connector/onedrive.py
@@ -36,10 +36,9 @@ class SimpleOneDriveConfig(BaseConnectorConfig):
                 "Please provide all the following mandatory values:"
                 "\n-ms-client_id\n-ms-client_cred\n-ms-user-pname",
             )
-        self.token_factory = self._acquire_token
 
     @requires_dependencies(["msal"])
-    def _acquire_token(self):
+    def acquire_token(self):
         from msal import ConfidentialClientApplication
 
         try:
@@ -133,7 +132,7 @@ class OneDriveConnector(ConnectorCleanupMixin, BaseConnector):
     def _set_client(self):
         from office365.graph_client import GraphClient
 
-        self.client = GraphClient(self.config.token_factory)
+        self.client = GraphClient(self.config.acquire_token)
 
     def _list_objects(self, folder, recursive) -> List["DriveItem"]:
         drive_items = folder.children.get().execute_query()

--- a/unstructured/ingest/connector/outlook.py
+++ b/unstructured/ingest/connector/outlook.py
@@ -26,7 +26,7 @@ class MissingFolderError(Exception):
     """There are no root folders with those names."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleOutlookConfig(BaseConnectorConfig):
     """This class is getting the token."""
 

--- a/unstructured/ingest/connector/outlook.py
+++ b/unstructured/ingest/connector/outlook.py
@@ -44,10 +44,9 @@ class SimpleOutlookConfig(BaseConnectorConfig):
                 "Please provide one of the following mandatory values:"
                 "\n--client_id\n--client_cred\n--user-email",
             )
-        self.token_factory = self._acquire_token
 
     @requires_dependencies(["msal"])
-    def _acquire_token(self):
+    def acquire_token(self):
         from msal import ConfidentialClientApplication
 
         try:
@@ -149,7 +148,7 @@ class OutlookConnector(ConnectorCleanupMixin, BaseConnector):
     def _set_client(self):
         from office365.graph_client import GraphClient
 
-        self.client = GraphClient(self.config.token_factory)
+        self.client = GraphClient(self.config.acquire_token)
 
     def initialize(self):
         pass

--- a/unstructured/ingest/connector/reddit.py
+++ b/unstructured/ingest/connector/reddit.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from praw.models import Submission
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleRedditConfig(BaseConnectorConfig):
     subreddit_name: str
     client_id: Optional[str]

--- a/unstructured/ingest/connector/s3.py
+++ b/unstructured/ingest/connector/s3.py
@@ -10,7 +10,7 @@ from unstructured.ingest.interfaces import StandardConnectorConfig
 from unstructured.utils import requires_dependencies
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleS3Config(SimpleFsspecConfig):
     pass
 

--- a/unstructured/ingest/connector/sharepoint.py
+++ b/unstructured/ingest/connector/sharepoint.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 MAX_MB_SIZE = 512_000_000
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleSharepointConfig(BaseConnectorConfig):
     client_id: str
     client_credential: str = field(repr=False)

--- a/unstructured/ingest/connector/slack.py
+++ b/unstructured/ingest/connector/slack.py
@@ -21,7 +21,7 @@ from unstructured.utils import (
 DATE_FORMATS = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%S%z")
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleSlackConfig(BaseConnectorConfig):
     """Connector config to process all messages by channel id's."""
 

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from wikipedia import WikipediaPage
 
 
-@dataclass
+@dataclass(frozen=True)
 class SimpleWikipediaConfig(BaseConnectorConfig):
     title: str
     auto_suggest: bool

--- a/unstructured/ingest/doc_processor/generalized.py
+++ b/unstructured/ingest/doc_processor/generalized.py
@@ -12,9 +12,8 @@ from unstructured.ingest.interfaces import (
 )
 from unstructured.ingest.logger import logger
 
-# module-level variable to store session handle
-session_handle: Optional[BaseSessionHandle] = None
-
+# Dictionary to store session handles by config hash
+session_handles_map: Dict[int, BaseSessionHandle] = {}
 
 def initialize():
     """Download default model or model specified by UNSTRUCTURED_HI_RES_MODEL_NAME environment
@@ -37,16 +36,16 @@ def process_document(doc: "IngestDoc", **partition_kwargs) -> Optional[List[Dict
     partition_kwargs
         ultimately the parameters passed to partition()
     """
-    global session_handle
     isd_elems_no_filename = None
     try:
+        # assign session handle to doc if it supports it
         if isinstance(doc, IngestDocSessionHandleMixin):
-            if session_handle is None:
+            if hash(doc.config) not in session_handles_map:
                 # create via doc.session_handle, which is a property that creates a
                 # session handle if one is not already defined
-                session_handle = doc.session_handle
+                session_handles_map[hash(doc.config)] = doc.session_handle
             else:
-                doc.session_handle = session_handle
+                doc.session_handle = session_handles_map[hash(doc.config)]
         # does the work necessary to load file into filesystem
         # in the future, get_file_handle() could also be supported
         doc.get_file()

--- a/unstructured/ingest/doc_processor/generalized.py
+++ b/unstructured/ingest/doc_processor/generalized.py
@@ -15,6 +15,7 @@ from unstructured.ingest.logger import logger
 # Dictionary to store session handles by config hash
 session_handles_map: Dict[int, BaseSessionHandle] = {}
 
+
 def initialize():
     """Download default model or model specified by UNSTRUCTURED_HI_RES_MODEL_NAME environment
     variable (avoids subprocesses all doing the same)"""

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -57,6 +57,7 @@ class StandardConnectorConfig:
     re_download: bool = False
 
 
+@dataclass(frozen=True)
 class BaseConnectorConfig(ABC):
     """Abstract definition on which to define connector-specific attributes."""
 


### PR DESCRIPTION
Updates the [process_document](https://github.com/Unstructured-IO/unstructured/blob/main/unstructured/ingest/doc_processor/generalized.py#L32C1-L65) function in `generalized.py` to store and lookup an IngestDocument's SessionHandle as mapped to its ConnectorConfig (or rather, a hash of its ConnectorConfig). This accounts for scenarios where `process_document` may be called within a context of mixed connector IngestDocuments (meaning they don't all share the same config and session handle).

* updates `process_document` to use a session_handles_map rather than directly storing a single session_handle
* updates all BaseConnectorConfig classes/subclasses to be frozen (i.e. `dataclass(frozen=True)`) so that these are all forced predictable and hashable
* bonus: updates connectors where import flow would not properly trigger the required_dependencies decorator or not trigger it with a specified extra (easier for developer to know how to resolve)
