### PR TITLE
chore: changelog repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
-## 0.10.3
+## 0.10.4-dev0
+
+### Enhancements
+* Adds ability to reuse connections per process in unstructured-ingest
+
+### Features
+
+### Fixes
+
+## 0.10.2
 
 ### Enhancements
 * Bump unstructured-inference==0.5.13:
   - Fix extracted image elements being included in layout merge, addresses the issue
     where an entire-page image in a PDF was not passed to the layout model when using hi_res.
-* Adds ability to reuse connections per process in unstructured-ingest
 
 ### Features
 
@@ -35,9 +43,6 @@
 ### Features
 
 ### Fixes
-
-* fix pdf partition of list items being detected as titles in OCR only mode
-
 
 ## 0.9.3
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.3"  # pragma: no cover
+__version__ = "0.10.4-dev0"  # pragma: no cover


### PR DESCRIPTION
0.10.2 had been released, but  prior commit co-mingled 0.10.2 and 0.10.3. This corrects the changelog and intentionally skips over 0.10.3.

Bonus: remove accidental dupe line in 0.10.0.