### PR TITLE
roman/ingest-custom-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.5-dev2
+## 0.10.5-dev3
 
 ### Enhancements
 * Create new CI Pipelines
@@ -6,6 +6,8 @@
   - Checking each library extra against their respective tests
 * `partition` raises and error and tells the user to install the appropriate extra if a filetype
   is detected that is missing dependencies.
+* Add custom errors to ingest
+
 
 ## 0.10.3
 * Adds ability to reuse connections per process in unstructured-ingest

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.5-dev2"  # pragma: no cover
+__version__ = "0.10.5-dev3"  # pragma: no cover

--- a/unstructured/ingest/error.py
+++ b/unstructured/ingest/error.py
@@ -16,7 +16,7 @@ class CustomError(BaseException, ABC):
         @wraps(f)
         def wrapper(*args, **kwargs):
             try:
-                f(*args, **kwargs)
+                return f(*args, **kwargs)
             except BaseException as error:
                 if not isinstance(error, cls):
                     raise cls(cls.error_string.format(str(error)))

--- a/unstructured/ingest/error.py
+++ b/unstructured/ingest/error.py
@@ -1,0 +1,37 @@
+from abc import ABC
+from functools import wraps
+
+
+class CustomError(BaseException, ABC):
+    error_string: str
+
+    @classmethod
+    def wrap(cls, f):
+        """
+        Provides a wrapper for a function that catches any exception and
+        re-raises it as the customer error. If the exception itself is already an instance
+        of the custom error, re-raises original error.
+        """
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            try:
+                f(*args, **kwargs)
+            except BaseException as error:
+                if not isinstance(error, cls):
+                    raise cls(cls.error_string.format(str(error)))
+                raise error
+
+        return wrapper
+
+
+class SourceConnectionError(CustomError):
+    error_string = "Error in connecting to upstream data source: {}"
+
+
+class DestinationConnectionError(CustomError):
+    error_string = "Error in connecting to downstream data source: {}"
+
+
+class PartitionError(CustomError):
+    error_string = "Error in partitioning content: {}"

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from unstructured.documents.elements import DataSourceMetadata
+from unstructured.ingest.error import PartitionError, SourceConnectionError
 from unstructured.ingest.logger import logger
 from unstructured.partition.auto import partition
 from unstructured.staging.base import convert_to_dict
@@ -189,6 +190,7 @@ class BaseIngestDoc(ABC):
     # NOTE(crag): Future BaseIngestDoc classes could define get_file_object() methods
     # in addition to or instead of get_file()
     @abstractmethod
+    @SourceConnectionError.wrap
     def get_file(self):
         """Fetches the "remote" doc and stores it locally on the filesystem."""
         pass
@@ -206,6 +208,7 @@ class BaseIngestDoc(ABC):
             json.dump(self.isd_elems_no_filename, output_f, ensure_ascii=False, indent=2)
         logger.info(f"Wrote {self._output_filename}")
 
+    @PartitionError.wrap
     def partition_file(self, **partition_kwargs) -> List[Dict[str, Any]]:
         if not self.standard_config.partition_by_api:
             logger.debug("Using local partition")


### PR DESCRIPTION
### Description
Adds three custom errors to ingest:
* `SourceConnectionError`
* `DestinationConnectionError`
* `PartitionError`

Included is a base custom error class that adds a wrapper. This wrapper wraps any raised exception into the custom error. 