### PR TITLE
Fix: Replace list with iterator in fsspec and sharepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.5-dev1
+## 0.10.5-dev2
 
 ### Enhancements
 * Create new CI Pipelines

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.5-dev1"  # pragma: no cover
+__version__ = "0.10.5-dev2"  # pragma: no cover

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -147,29 +147,23 @@ class FsspecConnector(ConnectorCleanupMixin, BaseConnector):
             # fs.ls does not walk directories
             # directories that are listed in cloud storage can cause problems
             # because they are seen as 0 byte files
-            return [
-                x.get("name")
-                for x in self.fs.ls(self.config.path_without_protocol, detail=True)
-                if x.get("size") > 0
-            ]
+            for x in self.fs.ls(self.config.path_without_protocol, detail=True):
+                if x.get("size") > 0:
+                    yield x.get("name")
         else:
             # fs.find will recursively walk directories
             # "size" is a common key for all the cloud protocols with fs
-            return [
-                k
-                for k, v in self.fs.find(
-                    self.config.path_without_protocol,
-                    detail=True,
-                ).items()
-                if v.get("size") > 0
-            ]
+            for k, v in self.fs.find(
+                self.config.path_without_protocol,
+                detail=True,
+            ).items():
+                if v.get("size") > 0:
+                    yield k
 
     def get_ingest_docs(self):
-        return [
-            self.ingest_doc_cls(
+        for file in self._list_files():
+            yield self.ingest_doc_cls(
                 standard_config=self.standard_config,
                 config=self.config,
                 remote_file_path=file,
             )
-            for file in self._list_files()
-        ]

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Iterable
+from typing import Any, Dict, Iterable, List, Optional
 
 import requests
 
@@ -69,7 +69,9 @@ class BaseConnector(ABC):
     config: BaseConnectorConfig
 
     def __init__(
-        self, standard_config: StandardConnectorConfig, config: BaseConnectorConfig
+        self,
+        standard_config: StandardConnectorConfig,
+        config: BaseConnectorConfig,
     ):
         """Expects a standard_config object that implements StandardConnectorConfig
         and config object that implements BaseConnectorConfig."""
@@ -208,7 +210,10 @@ class BaseIngestDoc(ABC):
         self._output_filename.parent.mkdir(parents=True, exist_ok=True)
         with open(self._output_filename, "w", encoding="utf8") as output_f:
             json.dump(
-                self.isd_elems_no_filename, output_f, ensure_ascii=False, indent=2
+                self.isd_elems_no_filename,
+                output_f,
+                ensure_ascii=False,
+                indent=2,
             )
         logger.info(f"Wrote {self._output_filename}")
 
@@ -248,7 +253,7 @@ class BaseIngestDoc(ABC):
 
             if response.status_code != 200:
                 raise RuntimeError(
-                    f"Caught {response.status_code} from API: {response.text}"
+                    f"Caught {response.status_code} from API: {response.text}",
                 )
 
             return response.json()
@@ -310,10 +315,7 @@ class ConnectorCleanupMixin:
 
     def cleanup(self, cur_dir=None):
         """Recursively clean up downloaded files and directories."""
-        if (
-            self.standard_config.preserve_downloads
-            or self.standard_config.download_only
-        ):
+        if self.standard_config.preserve_downloads or self.standard_config.download_only:
             return
         if cur_dir is None:
             cur_dir = self.standard_config.download_dir

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Iterable
 
 import requests
 
@@ -68,7 +68,9 @@ class BaseConnector(ABC):
     standard_config: StandardConnectorConfig
     config: BaseConnectorConfig
 
-    def __init__(self, standard_config: StandardConnectorConfig, config: BaseConnectorConfig):
+    def __init__(
+        self, standard_config: StandardConnectorConfig, config: BaseConnectorConfig
+    ):
         """Expects a standard_config object that implements StandardConnectorConfig
         and config object that implements BaseConnectorConfig."""
         self.standard_config = standard_config
@@ -89,7 +91,7 @@ class BaseConnector(ABC):
         pass
 
     @abstractmethod
-    def get_ingest_docs(self):
+    def get_ingest_docs(self) -> Iterable["BaseIngestDoc"]:
         """Returns all ingest docs (derived from BaseIngestDoc).
         This does not imply downloading all the raw documents themselves,
         rather each IngestDoc is capable of fetching its content (in another process)
@@ -146,7 +148,9 @@ class BaseIngestDoc(ABC):
         """Filename of the structured output for this doc."""
 
     @property
-    def record_locator(self) -> Optional[Dict[str, Any]]:  # Values must be JSON-serializable
+    def record_locator(
+        self,
+    ) -> Optional[Dict[str, Any]]:  # Values must be JSON-serializable
         """A dictionary with any data necessary to uniquely identify the document on
         the source system."""
         return None
@@ -203,7 +207,9 @@ class BaseIngestDoc(ABC):
             return
         self._output_filename.parent.mkdir(parents=True, exist_ok=True)
         with open(self._output_filename, "w", encoding="utf8") as output_f:
-            json.dump(self.isd_elems_no_filename, output_f, ensure_ascii=False, indent=2)
+            json.dump(
+                self.isd_elems_no_filename, output_f, ensure_ascii=False, indent=2
+            )
         logger.info(f"Wrote {self._output_filename}")
 
     def partition_file(self, **partition_kwargs) -> List[Dict[str, Any]]:
@@ -241,7 +247,9 @@ class BaseIngestDoc(ABC):
                 )
 
             if response.status_code != 200:
-                raise RuntimeError(f"Caught {response.status_code} from API: {response.text}")
+                raise RuntimeError(
+                    f"Caught {response.status_code} from API: {response.text}"
+                )
 
             return response.json()
 
@@ -302,7 +310,10 @@ class ConnectorCleanupMixin:
 
     def cleanup(self, cur_dir=None):
         """Recursively clean up downloaded files and directories."""
-        if self.standard_config.preserve_downloads or self.standard_config.download_only:
+        if (
+            self.standard_config.preserve_downloads
+            or self.standard_config.download_only
+        ):
             return
         if cur_dir is None:
             cur_dir = self.standard_config.download_dir
@@ -342,7 +353,8 @@ class ConfigSessionHandleMixin:
     @abstractmethod
     def create_session_handle(self) -> BaseSessionHandle:
         """Creates a session handle that will be assigned on each IngestDoc to share
-        session related resources across all document handling for a given subprocess."""
+        session related resources across all document handling for a given subprocess.
+        """
 
 
 class IngestDocSessionHandleMixin:


### PR DESCRIPTION
This change is fairly minor, but will allow ingest steps to start more quickly as it will not require all files to be accounted for before starting the partition step.