### PR TITLE
Move all dependency requirement check to cli code rather than connectors

### DIFF
--- a/unstructured/ingest/cli/cmds/airtable.py
+++ b/unstructured/ingest/cli/cmds/airtable.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import airtable as airtable_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -55,6 +56,7 @@ from unstructured.ingest.runner import airtable as airtable_fn
         base1/view1     → has to mention table to be valid
     """,
 )
+@requires_dependencies(["pyairtable", "pandas"])
 def airtable(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/azure.py
+++ b/unstructured/ingest/cli/cmds/azure.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import azure as azure_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -32,6 +33,7 @@ from unstructured.ingest.runner import azure as azure_fn
     default=None,
     help="Azure Blob Storage or DataLake connection string.",
 )
+@requires_dependencies(["adlfs", "fsspec"], extras="azure")
 def azure(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/box.py
+++ b/unstructured/ingest/cli/cmds/box.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import box as box_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -21,6 +22,7 @@ from unstructured.ingest.runner import box as box_fn
     default=None,
     help="Path to Box app credentials as json file.",
 )
+@requires_dependencies(["boxfs", "fsspec"], extras="box")
 def box(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/confluence.py
+++ b/unstructured/ingest/cli/cmds/confluence.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import confluence as confluence_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -52,6 +53,7 @@ from unstructured.ingest.runner import confluence as confluence_fn
     required=True,
     help="Email to authenticate into Confluence Cloud",
 )
+@requires_dependencies(["atlassian"], extras="confluence")
 def confluence(
     **options,
 ):

--- a/unstructured/ingest/cli/cmds/delta_table.py
+++ b/unstructured/ingest/cli/cmds/delta_table.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import delta_table as delta_table_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -38,6 +39,7 @@ from unstructured.ingest.runner import delta_table as delta_table_fn
     default=False,
     help="If set, will load table without tracking files.",
 )
+@requires_dependencies(["deltalake", "fsspec"], extras="delta-table")
 def delta_table(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/discord.py
+++ b/unstructured/ingest/cli/cmds/discord.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import discord as discord_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -30,6 +31,7 @@ from unstructured.ingest.runner import discord as discord_fn
     help="Bot token used to access Discord API, must have "
     "READ_MESSAGE_HISTORY scope for the bot user",
 )
+@requires_dependencies(dependencies=["discord"], extras="discord")
 def discord(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/dropbox.py
+++ b/unstructured/ingest/cli/cmds/dropbox.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import dropbox as dropbox_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -21,6 +22,7 @@ from unstructured.ingest.runner import dropbox as dropbox_fn
     required=True,
     help="Dropbox access token.",
 )
+@requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
 def dropbox(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/elasticsearch.py
+++ b/unstructured/ingest/cli/cmds/elasticsearch.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import elasticsearch as elasticsearch_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -32,6 +33,7 @@ from unstructured.ingest.runner import elasticsearch as elasticsearch_fn
     required=True,
     help='URL to the Elasticsearch cluster, e.g. "http://localhost:9200"',
 )
+@requires_dependencies(["elasticsearch"], extras="elasticsearch")
 def elasticsearch(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/gcs.py
+++ b/unstructured/ingest/cli/cmds/gcs.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import gcs as gcs_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -22,6 +23,7 @@ from unstructured.ingest.runner import gcs as gcs_fn
     help="Token used to access Google Cloud. GCSFS will attempt to use your default gcloud creds"
     "or get creds from the google metadata service or fall back to anonymous access.",
 )
+@requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
 def gcs(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/github.py
+++ b/unstructured/ingest/cli/cmds/github.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import github as github_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -38,6 +39,7 @@ from unstructured.ingest.runner import github as github_fn
     help='URL to GitHub repository, e.g. "https://github.com/Unstructured-IO/unstructured",'
     ' or a repository owner/name pair, e.g. "Unstructured-IO/unstructured"',
 )
+@requires_dependencies(["github"], extras="github")
 def github(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/gitlab.py
+++ b/unstructured/ingest/cli/cmds/gitlab.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import gitlab as gitlab_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -38,6 +39,7 @@ from unstructured.ingest.runner import gitlab as gitlab_fn
     help='URL to GitLab repository, e.g. "https://gitlab.com/gitlab-com/content-sites/docsy-gitlab"'
     ', or a repository path, e.g. "gitlab-com/content-sites/docsy-gitlab"',
 )
+@requires_dependencies(["gitlab"], extras="gitlab")
 def gitlab(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/google_drive.py
+++ b/unstructured/ingest/cli/cmds/google_drive.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import gdrive as gdrive_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -30,6 +31,7 @@ from unstructured.ingest.runner import gdrive as gdrive_fn
     required=True,
     help="Path to the Google Drive service account json file.",
 )
+@requires_dependencies(["googleapiclient"], extras="google-drive")
 def gdrive(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/notion.py
+++ b/unstructured/ingest/cli/cmds/notion.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import notion as notion_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -30,6 +31,7 @@ from unstructured.ingest.runner import notion as notion_fn
     required=True,
     help="API key for Notion api",
 )
+@requires_dependencies(dependencies=["notion_client"], extras="notion")
 def notion(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/onedrive.py
+++ b/unstructured/ingest/cli/cmds/onedrive.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import onedrive as onedrive_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -46,6 +47,7 @@ from unstructured.ingest.runner import onedrive as onedrive_fn
     required=True,
     help="User principal name, usually is your Azure AD email.",
 )
+@requires_dependencies(["office365", "msal"], extras="onedrive")
 def onedrive(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/outlook.py
+++ b/unstructured/ingest/cli/cmds/outlook.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import outlook as outlook_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -47,6 +48,7 @@ from unstructured.ingest.runner import outlook as outlook_fn
     required=True,
     help="Outlook email to download messages from.",
 )
+@requires_dependencies(["msal", "office365"], extras="outlook")
 def outlook(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/reddit.py
+++ b/unstructured/ingest/cli/cmds/reddit.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import reddit as reddit_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -47,6 +48,7 @@ from unstructured.ingest.runner import reddit as reddit_fn
     "https://praw.readthedocs.io/en/stable/getting_started/quick_start.html#prerequisites"
     " for more information.",
 )
+@requires_dependencies(["praw"], extras="reddit")
 def reddit(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/s3.py
+++ b/unstructured/ingest/cli/cmds/s3.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import s3 as s3_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -22,6 +23,7 @@ from unstructured.ingest.runner import s3 as s3_fn
     default=False,
     help="Connect to s3 without local AWS credentials.",
 )
+@requires_dependencies(["s3fs", "fsspec"], extras="s3")
 def s3(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/sharepoint.py
+++ b/unstructured/ingest/cli/cmds/sharepoint.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import sharepoint as sharepoint_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -47,6 +48,7 @@ from unstructured.ingest.runner import sharepoint as sharepoint_fn
     default=False,
     help="Process only files.",
 )
+@requires_dependencies(["office365"], extras="sharepoint")
 def sharepoint(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/slack.py
+++ b/unstructured/ingest/cli/cmds/slack.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import slack as slack_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -37,6 +38,7 @@ from unstructured.ingest.runner import slack as slack_fn
     required=True,
     help="Bot token used to access Slack API, must have channels:history " "scope for the bot user",
 )
+@requires_dependencies(dependencies=["slack_sdk"], extras="slack")
 def slack(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/cli/cmds/wikipedia.py
+++ b/unstructured/ingest/cli/cmds/wikipedia.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.common import (
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import wikipedia as wikipedia_fn
+from unstructured.utils import requires_dependencies
 
 
 @click.command()
@@ -25,6 +26,7 @@ from unstructured.ingest.runner import wikipedia as wikipedia_fn
     required=True,
     help='Title of a Wikipedia page, e.g. "Open source software".',
 )
+@requires_dependencies(dependencies=["wikipedia"], extras="wikipedia")
 def wikipedia(**options):
     verbose = options.get("verbose", False)
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)

--- a/unstructured/ingest/connector/azure.py
+++ b/unstructured/ingest/connector/azure.py
@@ -7,7 +7,6 @@ from unstructured.ingest.connector.fsspec import (
     SimpleFsspecConfig,
 )
 from unstructured.ingest.interfaces import StandardConnectorConfig
-from unstructured.utils import requires_dependencies
 
 
 @dataclass
@@ -16,12 +15,10 @@ class SimpleAzureBlobStorageConfig(SimpleFsspecConfig):
 
 
 class AzureBlobStorageIngestDoc(FsspecIngestDoc):
-    @requires_dependencies(["adlfs", "fsspec"], extras="azure")
     def get_file(self):
         super().get_file()
 
 
-@requires_dependencies(["adlfs", "fsspec"], extras="azure")
 class AzureBlobStorageConnector(FsspecConnector):
     ingest_doc_cls: Type[AzureBlobStorageIngestDoc] = AzureBlobStorageIngestDoc
 

--- a/unstructured/ingest/connector/box.py
+++ b/unstructured/ingest/connector/box.py
@@ -11,13 +11,14 @@ REAUTHORIZE app after making any of the above changes
 from dataclasses import dataclass
 from typing import Type
 
+from boxsdk import JWTAuth
+
 from unstructured.ingest.connector.fsspec import (
     FsspecConnector,
     FsspecIngestDoc,
     SimpleFsspecConfig,
 )
 from unstructured.ingest.interfaces import StandardConnectorConfig
-from unstructured.utils import requires_dependencies
 
 
 class AccessTokenError(Exception):
@@ -26,10 +27,7 @@ class AccessTokenError(Exception):
 
 @dataclass
 class SimpleBoxConfig(SimpleFsspecConfig):
-    @requires_dependencies(["boxfs"], extras="box")
     def __post_init__(self):
-        from boxsdk import JWTAuth
-
         super().__post_init__()
         # We are passing in a json file path via the envt. variable.
         # Need to convert that to an Oauth2 object.
@@ -57,12 +55,10 @@ class SimpleBoxConfig(SimpleFsspecConfig):
 
 
 class BoxIngestDoc(FsspecIngestDoc):
-    @requires_dependencies(["boxfs", "fsspec"], extras="box")
     def get_file(self):
         super().get_file()
 
 
-@requires_dependencies(["boxfs", "fsspec"], extras="box")
 class BoxConnector(FsspecConnector):
     ingest_doc_cls: Type[BoxIngestDoc] = BoxIngestDoc
 

--- a/unstructured/ingest/connector/confluence.py
+++ b/unstructured/ingest/connector/confluence.py
@@ -15,7 +15,6 @@ from unstructured.ingest.interfaces import (
     StandardConnectorConfig,
 )
 from unstructured.ingest.logger import logger
-from unstructured.utils import requires_dependencies
 
 
 @dataclass
@@ -101,7 +100,6 @@ class ConfluenceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         output_file = f"{self.file_meta.document_id}.json"
         return Path(self.standard_config.output_dir) / self.file_meta.space_id / output_file
 
-    @requires_dependencies(["atlassian"])
     @BaseIngestDoc.skip_if_file_exists
     def get_file(self):
         logger.debug(f"Fetching {self} - PID: {os.getpid()}")
@@ -121,7 +119,6 @@ class ConfluenceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             f.write(self.document)
 
 
-@requires_dependencies(["atlassian"])
 @dataclass
 class ConfluenceConnector(ConnectorCleanupMixin, BaseConnector):
     """Fetches body fields from all documents within all spaces in a Confluence Cloud instance."""
@@ -135,7 +132,6 @@ class ConfluenceConnector(ConnectorCleanupMixin, BaseConnector):
     ):
         super().__init__(standard_config, config)
 
-    @requires_dependencies(["atlassian"])
     def initialize(self):
         self.confluence = Confluence(
             url=self.config.url,
@@ -153,7 +149,6 @@ class ConfluenceConnector(ConnectorCleanupMixin, BaseConnector):
                     --confluence-list-of-spaces that you've provided.""",
                 )
 
-    @requires_dependencies(["atlassian"])
     def _get_space_ids(self):
         """Fetches spaces in a confluence domain."""
 
@@ -166,7 +161,6 @@ class ConfluenceConnector(ConnectorCleanupMixin, BaseConnector):
         space_ids = [space["key"] for space in all_results]
         return space_ids
 
-    @requires_dependencies(["atlassian"])
     def _get_docs_ids_within_one_space(
         self,
         space_id: str,
@@ -182,7 +176,6 @@ class ConfluenceConnector(ConnectorCleanupMixin, BaseConnector):
         doc_ids = [(space_id, doc["id"]) for doc in results]
         return doc_ids
 
-    @requires_dependencies(["atlassian"])
     def _get_doc_ids_within_spaces(self):
         space_ids = self._get_space_ids() if not self.list_of_spaces else self.list_of_spaces
 

--- a/unstructured/ingest/connector/discord.py
+++ b/unstructured/ingest/connector/discord.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
+import discord
+from discord.ext import commands
+
 from unstructured.ingest.interfaces import (
     BaseConnector,
     BaseConnectorConfig,
@@ -13,9 +16,6 @@ from unstructured.ingest.interfaces import (
     StandardConnectorConfig,
 )
 from unstructured.ingest.logger import logger
-from unstructured.utils import (
-    requires_dependencies,
-)
 
 
 @dataclass
@@ -74,12 +74,8 @@ class DiscordIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         self._tmp_download_file().parent.mkdir(parents=True, exist_ok=True)
 
     @BaseIngestDoc.skip_if_file_exists
-    @requires_dependencies(dependencies=["discord"], extras="discord")
     def get_file(self):
         """Actually fetches the data from discord and stores it locally."""
-
-        import discord
-        from discord.ext import commands
 
         self._create_full_tmp_dir_path()
         if self.config.verbose:

--- a/unstructured/ingest/connector/dropbox.py
+++ b/unstructured/ingest/connector/dropbox.py
@@ -19,7 +19,6 @@ from unstructured.ingest.connector.fsspec import (
     SimpleFsspecConfig,
 )
 from unstructured.ingest.interfaces import StandardConnectorConfig
-from unstructured.utils import requires_dependencies
 
 
 class MissingFolderError(Exception):
@@ -32,7 +31,6 @@ class SimpleDropboxConfig(SimpleFsspecConfig):
 
 
 class DropboxIngestDoc(FsspecIngestDoc):
-    @requires_dependencies(["dropboxdrivefs", "fsspec"])
     def get_file(self):
         super().get_file()
 
@@ -70,7 +68,6 @@ class DropboxIngestDoc(FsspecIngestDoc):
             )
 
 
-@requires_dependencies(["dropboxdrivefs", "fsspec"])
 class DropboxConnector(FsspecConnector):
     ingest_doc_cls: Type[DropboxIngestDoc] = DropboxIngestDoc
 

--- a/unstructured/ingest/connector/elasticsearch.py
+++ b/unstructured/ingest/connector/elasticsearch.py
@@ -18,7 +18,6 @@ from unstructured.ingest.interfaces import (
     StandardConnectorConfig,
 )
 from unstructured.ingest.logger import logger
-from unstructured.utils import requires_dependencies
 
 
 @dataclass
@@ -105,7 +104,6 @@ class ElasticsearchIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         concatenated_values = seperator.join(values)
         return concatenated_values
 
-    @requires_dependencies(["elasticsearch"])
     @BaseIngestDoc.skip_if_file_exists
     def get_file(self):
         logger.debug(f"Fetching {self} - PID: {os.getpid()}")
@@ -124,7 +122,6 @@ class ElasticsearchIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             f.write(self.document)
 
 
-@requires_dependencies(["elasticsearch"])
 @dataclass
 class ElasticsearchConnector(ConnectorCleanupMixin, BaseConnector):
     """Fetches particular fields from all documents in a given elasticsearch cluster and index"""
@@ -144,7 +141,6 @@ class ElasticsearchConnector(ConnectorCleanupMixin, BaseConnector):
         self.search_query: dict = {"match_all": {}}
         self.es.search(index=self.config.index_name, query=self.search_query, size=1)
 
-    @requires_dependencies(["elasticsearch"])
     def _get_doc_ids(self):
         """Fetches all document ids in an index"""
         hits = scan(

--- a/unstructured/ingest/connector/gcs.py
+++ b/unstructured/ingest/connector/gcs.py
@@ -7,7 +7,6 @@ from unstructured.ingest.connector.fsspec import (
     SimpleFsspecConfig,
 )
 from unstructured.ingest.interfaces import StandardConnectorConfig
-from unstructured.utils import requires_dependencies
 
 
 @dataclass
@@ -16,12 +15,10 @@ class SimpleGcsConfig(SimpleFsspecConfig):
 
 
 class GcsIngestDoc(FsspecIngestDoc):
-    @requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
     def get_file(self):
         super().get_file()
 
 
-@requires_dependencies(["gcsfs", "fsspec"], extras="gcs")
 class GcsConnector(FsspecConnector):
     ingest_doc_cls: Type[GcsIngestDoc] = GcsIngestDoc
 

--- a/unstructured/ingest/connector/github.py
+++ b/unstructured/ingest/connector/github.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import requests
+from github import Github
+from github.Repository import Repository
 
 from unstructured.ingest.connector.git import (
     GitConnector,
@@ -10,10 +11,6 @@ from unstructured.ingest.connector.git import (
     SimpleGitConfig,
 )
 from unstructured.ingest.logger import logger
-from unstructured.utils import requires_dependencies
-
-if TYPE_CHECKING:
-    from github.Repository import Repository
 
 
 @dataclass
@@ -40,7 +37,7 @@ class SimpleGitHubConfig(SimpleGitConfig):
 
 @dataclass
 class GitHubIngestDoc(GitIngestDoc):
-    repo: "Repository"
+    repo: Repository
 
     def _fetch_and_write(self) -> None:
         content_file = self.repo.get_contents(self.path)
@@ -63,12 +60,9 @@ class GitHubIngestDoc(GitIngestDoc):
             f.write(contents)
 
 
-@requires_dependencies(["github"], extras="github")
 @dataclass
 class GitHubConnector(GitConnector):
     def __post_init__(self) -> None:
-        from github import Github
-
         self.github = Github(self.config.access_token)
 
     def get_ingest_docs(self):

--- a/unstructured/ingest/connector/gitlab.py
+++ b/unstructured/ingest/connector/gitlab.py
@@ -1,16 +1,14 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
+
+from gitlab import Gitlab
+from gitlab.v4.objects.projects import Project
 
 from unstructured.ingest.connector.git import (
     GitConnector,
     GitIngestDoc,
     SimpleGitConfig,
 )
-from unstructured.utils import requires_dependencies
-
-if TYPE_CHECKING:
-    from gitlab.v4.objects.projects import Project
 
 
 @dataclass
@@ -30,7 +28,7 @@ class SimpleGitLabConfig(SimpleGitConfig):
 
 @dataclass
 class GitLabIngestDoc(GitIngestDoc):
-    project: "Project"
+    project: Project
 
     def _fetch_and_write(self) -> None:
         content_file = self.project.files.get(
@@ -43,12 +41,9 @@ class GitLabIngestDoc(GitIngestDoc):
             f.write(contents)
 
 
-@requires_dependencies(["gitlab"], extras="gitlab")
 @dataclass
 class GitLabConnector(GitConnector):
     def __post_init__(self) -> None:
-        from gitlab import Gitlab
-
         self.gitlab = Gitlab(self.config.url, private_token=self.config.access_token)
 
     def get_ingest_docs(self):

--- a/unstructured/ingest/connector/notion/connector.py
+++ b/unstructured/ingest/connector/notion/connector.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import List, Optional
 from uuid import UUID
 
+from notion_client import APIErrorCode, APIResponseError
+
 from unstructured.ingest.connector.notion.types.database import Database
 from unstructured.ingest.connector.notion.types.page import Page
 from unstructured.ingest.interfaces import (
@@ -16,9 +18,6 @@ from unstructured.ingest.interfaces import (
     StandardConnectorConfig,
 )
 from unstructured.ingest.logger import make_default_logger
-from unstructured.utils import (
-    requires_dependencies,
-)
 
 
 @dataclass
@@ -72,10 +71,7 @@ class NotionPageIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         self._tmp_download_file().parent.mkdir(parents=True, exist_ok=True)
 
     @BaseIngestDoc.skip_if_file_exists
-    @requires_dependencies(dependencies=["notion_client"])
     def get_file(self):
-        from notion_client import APIErrorCode, APIResponseError
-
         from unstructured.ingest.connector.notion.client import Client as NotionClient
         from unstructured.ingest.connector.notion.helpers import extract_page_html
 
@@ -104,10 +100,7 @@ class NotionPageIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             else:
                 self.config.get_logger().error(f"Error: {error}")
 
-    @requires_dependencies(dependencies=["notion_client"])
     def get_file_metadata(self):
-        from notion_client import APIErrorCode, APIResponseError
-
         from unstructured.ingest.connector.notion.client import Client as NotionClient
 
         client = NotionClient(auth=self.api_key, logger=self.config.get_logger())
@@ -186,10 +179,7 @@ class NotionDatabaseIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         self._tmp_download_file().parent.mkdir(parents=True, exist_ok=True)
 
     @BaseIngestDoc.skip_if_file_exists
-    @requires_dependencies(dependencies=["notion_client"])
     def get_file(self):
-        from notion_client import APIErrorCode, APIResponseError
-
         from unstructured.ingest.connector.notion.client import Client as NotionClient
         from unstructured.ingest.connector.notion.helpers import extract_database_html
 
@@ -218,10 +208,7 @@ class NotionDatabaseIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             else:
                 self.config.get_logger().error(f"Error: {error}")
 
-    @requires_dependencies(dependencies=["notion_client"])
     def get_file_metadata(self):
-        from notion_client import APIErrorCode, APIResponseError
-
         from unstructured.ingest.connector.notion.client import Client as NotionClient
 
         client = NotionClient(auth=self.api_key, logger=self.config.get_logger())
@@ -273,7 +260,6 @@ class NotionDatabaseIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         return self._tmp_download_file()
 
 
-@requires_dependencies(dependencies=["notion_client"])
 class NotionConnector(ConnectorCleanupMixin, BaseConnector):
     """Objects of this class support fetching document(s) from"""
 
@@ -289,12 +275,10 @@ class NotionConnector(ConnectorCleanupMixin, BaseConnector):
             config=config,
         )
 
-    @requires_dependencies(dependencies=["notion_client"])
     def initialize(self):
         """Verify that can get metadata for an object, validates connections info."""
         pass
 
-    @requires_dependencies(dependencies=["notion_client"])
     def get_child_page_content(self, page_id: str):
         from unstructured.ingest.connector.notion.client import Client as NotionClient
         from unstructured.ingest.connector.notion.helpers import (
@@ -332,7 +316,6 @@ class NotionConnector(ConnectorCleanupMixin, BaseConnector):
         )
         return child_content
 
-    @requires_dependencies(dependencies=["notion_client"])
     def get_child_database_content(self, database_id: str):
         from unstructured.ingest.connector.notion.client import Client as NotionClient
         from unstructured.ingest.connector.notion.helpers import (

--- a/unstructured/ingest/connector/outlook.py
+++ b/unstructured/ingest/connector/outlook.py
@@ -6,6 +6,7 @@ from itertools import chain
 from pathlib import Path
 from typing import List, Optional
 
+from msal import ConfidentialClientApplication
 from office365.onedrive.driveitems.driveItem import DriveItem
 
 from unstructured.ingest.interfaces import (
@@ -17,7 +18,6 @@ from unstructured.ingest.interfaces import (
     StandardConnectorConfig,
 )
 from unstructured.ingest.logger import logger
-from unstructured.utils import requires_dependencies
 
 MAX_NUM_EMAILS = 1000000  # Maximum number of emails per folder
 
@@ -46,10 +46,7 @@ class SimpleOutlookConfig(BaseConnectorConfig):
             )
         self.token_factory = self._acquire_token
 
-    @requires_dependencies(["msal"])
     def _acquire_token(self):
-        from msal import ConfidentialClientApplication
-
         try:
             app = ConfidentialClientApplication(
                 authority=f"{self.authority_url}/{self.tenant}",
@@ -104,7 +101,6 @@ class OutlookIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         return Path(self.output_filepath).resolve()
 
     @BaseIngestDoc.skip_if_file_exists
-    @requires_dependencies(["office365"])
     def get_file(self):
         """Relies on Office365 python sdk message object to do the download."""
         try:
@@ -145,7 +141,6 @@ class OutlookConnector(ConnectorCleanupMixin, BaseConnector):
         self._set_client()
         self.get_folder_ids()
 
-    @requires_dependencies(["office365"])
     def _set_client(self):
         from office365.graph_client import GraphClient
 

--- a/unstructured/ingest/connector/reddit.py
+++ b/unstructured/ingest/connector/reddit.py
@@ -1,7 +1,10 @@
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
+
+from praw import Reddit
+from praw.models import Submission
 
 from unstructured.ingest.interfaces import (
     BaseConnector,
@@ -12,10 +15,6 @@ from unstructured.ingest.interfaces import (
     StandardConnectorConfig,
 )
 from unstructured.ingest.logger import logger
-from unstructured.utils import requires_dependencies
-
-if TYPE_CHECKING:
-    from praw.models import Submission
 
 
 @dataclass
@@ -35,7 +34,7 @@ class SimpleRedditConfig(BaseConnectorConfig):
 @dataclass
 class RedditIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
     config: SimpleRedditConfig = field(repr=False)
-    post: "Submission"
+    post: Submission
 
     @property
     def filename(self) -> Path:
@@ -59,13 +58,10 @@ class RedditIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             f.write(text_to_write)
 
 
-@requires_dependencies(["praw"], extras="reddit")
 class RedditConnector(ConnectorCleanupMixin, BaseConnector):
     config: SimpleRedditConfig
 
     def __init__(self, standard_config: StandardConnectorConfig, config: SimpleRedditConfig):
-        from praw import Reddit
-
         super().__init__(standard_config, config)
         self.reddit = Reddit(
             client_id=config.client_id,

--- a/unstructured/ingest/connector/s3.py
+++ b/unstructured/ingest/connector/s3.py
@@ -7,7 +7,6 @@ from unstructured.ingest.connector.fsspec import (
     SimpleFsspecConfig,
 )
 from unstructured.ingest.interfaces import StandardConnectorConfig
-from unstructured.utils import requires_dependencies
 
 
 @dataclass
@@ -16,12 +15,10 @@ class SimpleS3Config(SimpleFsspecConfig):
 
 
 class S3IngestDoc(FsspecIngestDoc):
-    @requires_dependencies(["s3fs", "fsspec"], extras="s3")
     def get_file(self):
         super().get_file()
 
 
-@requires_dependencies(["s3fs", "fsspec"], extras="s3")
 class S3Connector(FsspecConnector):
     ingest_doc_cls: Type[S3IngestDoc] = S3IngestDoc
 

--- a/unstructured/ingest/connector/slack.py
+++ b/unstructured/ingest/connector/slack.py
@@ -4,6 +4,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
 from unstructured.ingest.interfaces import (
     BaseConnector,
     BaseConnectorConfig,
@@ -13,10 +16,7 @@ from unstructured.ingest.interfaces import (
     StandardConnectorConfig,
 )
 from unstructured.ingest.logger import logger
-from unstructured.utils import (
-    requires_dependencies,
-    validate_date_args,
-)
+from unstructured.utils import validate_date_args
 
 DATE_FORMATS = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%S%z")
 
@@ -87,11 +87,7 @@ class SlackIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         self._tmp_download_file().parent.mkdir(parents=True, exist_ok=True)
 
     @BaseIngestDoc.skip_if_file_exists
-    @requires_dependencies(dependencies=["slack_sdk"], extras="slack")
     def get_file(self):
-        from slack_sdk import WebClient
-        from slack_sdk.errors import SlackApiError
-
         """Fetches the data from a slack channel and stores it locally."""
 
         self._create_full_tmp_dir_path()
@@ -145,7 +141,6 @@ class SlackIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         return self._tmp_download_file()
 
 
-@requires_dependencies(dependencies=["slack_sdk"], extras="slack")
 class SlackConnector(ConnectorCleanupMixin, BaseConnector):
     """Objects of this class support fetching document(s) from"""
 

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -1,7 +1,8 @@
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+
+from wikipedia import WikipediaPage
 
 from unstructured.ingest.interfaces import (
     BaseConnector,
@@ -13,9 +14,6 @@ from unstructured.ingest.interfaces import (
 )
 from unstructured.ingest.logger import logger
 
-if TYPE_CHECKING:
-    from wikipedia import WikipediaPage
-
 
 @dataclass
 class SimpleWikipediaConfig(BaseConnectorConfig):
@@ -26,7 +24,7 @@ class SimpleWikipediaConfig(BaseConnectorConfig):
 @dataclass
 class WikipediaIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
     config: SimpleWikipediaConfig = field(repr=False)
-    page: "WikipediaPage"
+    page: WikipediaPage
 
     @property
     def filename(self) -> Path:


### PR DESCRIPTION
### Description
This refactor is happening for a couple reasons:
* The formatted error for a missing response makes sense in the context of a user running the cli (`s3fs` for example):
```
Following dependencies are missing: s3fs. Please install them using `pip install "unstructured[s3]"`
``` 
If a user wanted to import the connector code itself to use, this might not apply so having functions wrapped in that codebase doesn't make sense
* The code is meant to only wrap a function but was being used to also wrap classes which can break the inheritance of classes already wrapped by `@dataclass`.
* This also helps consolidate what needs to be wrapped with the `@requires_dependencies` decorator to a single method, being the CLI entrypoint for each connector.