### PR TITLE
fix: ARM build with constraint for safetensors <=0.3.2

### DIFF
--- a/requirements/constraints.in
+++ b/requirements/constraints.in
@@ -30,4 +30,5 @@ unstructured-inference==0.5.14
 # NOTE(klaijan) - Moved pin from test.in
 # pinning to avoid error in argilla library
 pydantic<2
+safetensors<=0.3.2
 

--- a/requirements/constraints.in
+++ b/requirements/constraints.in
@@ -30,5 +30,6 @@ unstructured-inference==0.5.14
 # NOTE(klaijan) - Moved pin from test.in
 # pinning to avoid error in argilla library
 pydantic<2
+# unable to build wheel for arm on 0.3.3+
 safetensors<=0.3.2
 

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -56,7 +56,7 @@ iopath==0.1.10
     # via layoutparser
 jinja2==3.1.2
     # via torch
-kiwisolver==1.4.4
+kiwisolver==1.4.5
     # via matplotlib
 layoutparser[layoutmodels,tesseract]==0.3.4
     # via unstructured-inference
@@ -161,8 +161,9 @@ requests==2.31.0
     #   huggingface-hub
     #   torchvision
     #   transformers
-safetensors==0.3.3
+safetensors==0.3.2
     # via
+    #   -c requirements/constraints.in
     #   timm
     #   transformers
 scipy==1.10.1

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -68,8 +68,10 @@ requests==2.31.0
     #   transformers
 sacremoses==0.0.53
     # via -r requirements/huggingface.in
-safetensors==0.3.3
-    # via transformers
+safetensors==0.3.2
+    # via
+    #   -c requirements/constraints.in
+    #   transformers
 sentencepiece==0.1.99
     # via -r requirements/huggingface.in
 six==1.16.0


### PR DESCRIPTION
The build for ARM fails when attempting to build safetensors 0.3.3. This PR rolls it back to 0.3.2 by adding a constraint and building dependencies

* adds constraint for safetensors
* bumps dependencies