### PR TITLE
WIP: update notion to use subcommands

### DIFF
--- a/unstructured/ingest/cli/cmds/notion_2.py
+++ b/unstructured/ingest/cli/cmds/notion_2.py
@@ -1,0 +1,170 @@
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import List, Tuple, Type
+
+import click
+import jsonschema
+
+from unstructured.ingest.cli.common import (
+    RecursiveOption,
+    log_options,
+)
+from unstructured.ingest.interfaces import BaseConfig, ReadConfigs
+from unstructured.ingest.logger import ingest_log_streaming_init, logger
+from unstructured.ingest.runner.notion import read as notion_fn_read
+
+
+@dataclass
+class NotionReadConfig(BaseConfig):
+    api_key: str
+    page_ids: List[str] = field(default_factory=list)
+    database_ids: List[str] = field(default_factory=list)
+
+    @classmethod
+    def get_sample_dict(cls) -> dict:
+        config = cls(api_key="to populate")
+        return config.__dict__
+
+    @staticmethod
+    def get_schema() -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "api_key": {"type": ["string", "null"], "default": None},
+                "page_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                    },
+                },
+                "database_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                    },
+                },
+            },
+        }
+
+    @staticmethod
+    def add_cli_options(cmd: click.Command) -> None:
+        options = [
+            click.Option(
+                ["--page-ids"],
+                default=None,
+                multiple=True,
+                help="List of Notion page IDs to pull text from",
+            ),
+            click.Option(
+                ["--database-ids"],
+                default=None,
+                multiple=True,
+                help="List of Notion database IDs to pull text from",
+            ),
+            click.Option(
+                ["--api-key"],
+                # required=True,
+                help="API key for Notion api",
+            ),
+        ]
+        cmd.params.extend(options)
+
+
+@click.group
+def notion():
+    pass
+
+
+@click.command
+def read(**options):
+    # Click sets all multiple fields as tuple, this needs to be updated to list
+    for k, v in options.items():
+        if isinstance(v, tuple):
+            options[k] = list(v)
+    verbose = options.get("verbose", False)
+    ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)
+    log_options(options)
+
+    cli_input_json = options.pop("cli_input_json", None)
+    if cli_input_json:
+        data: dict = json.load(cli_input_json)
+        _, configs = get_read_cmd()
+        base = configs.pop(0)
+        jsonschema.validate(data, schema=base.merge_schemas(configs=configs))
+        for k, v in data.items():
+            if not options.get(k, None):
+                options[k] = v
+
+    logger.info(f"updated values: {options}")
+    read_configs = ReadConfigs.from_dict(options)
+    notion_configs = NotionReadConfig.from_dict(options)
+    for k in read_configs.__dict__:
+        options.pop(k, None)
+    for k in notion_configs.__dict__:
+        options.pop(k, None)
+    try:
+        notion_fn_read(read_configs=read_configs, **notion_configs.__dict__, **options)
+    except Exception as e:
+        logger.error(e, exc_info=True)
+        raise click.ClickException(str(e)) from e
+
+
+@click.command()
+@click.option("--schema", is_flag=True, help="show expected schema of input json for read command")
+@click.option(
+    "--generate-cli-skeleton",
+    is_flag=True,
+    help="generate sample json skeleton for read input",
+)
+@click.option(
+    "--validate-json",
+    type=click.File("rb"),
+    help="given a json file, validate it against expected schema",
+)
+def read_spec(schema: bool, generate_cli_skeleton: bool, validate_json):
+    _, configs = get_read_cmd()
+    if len(configs) == 0:
+        return
+    base = configs.pop(0)
+
+    if schema:
+        click.echo(json.dumps(base.merge_schemas(configs=configs), indent=3))
+        exit()
+    if generate_cli_skeleton:
+        click.echo(json.dumps(base.merge_sample_jsons(configs=configs), indent=3))
+        exit()
+    if validate_json:
+        try:
+            data = json.load(validate_json)
+        except json.decoder.JSONDecodeError:
+            raise click.ClickException("input file not valid json")
+        try:
+            jsonschema.validate(data, schema=base.merge_schemas(configs=configs))
+        except jsonschema.ValidationError as error:
+            raise click.ClickException(f"input json not valid: {error}")
+
+
+def get_read_cmd() -> Tuple[click.Command, List[Type[BaseConfig]]]:
+    cmd = read
+    ReadConfigs.add_cli_options(cmd)
+    NotionReadConfig.add_cli_options(cmd)
+    RecursiveOption.add_cli_options(cmd)
+    cmd.params.append(
+        click.Option(
+            ["--cli-input-json"],
+            type=click.File("rb"),
+            help="optional json to pass in to populate expected cli params",
+        ),
+    )
+    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    return cmd, [ReadConfigs, NotionReadConfig, RecursiveOption]
+
+
+def get_group() -> click.Group:
+    parent = notion
+    parent.add_command(read_spec)
+    read_cmd, _ = get_read_cmd()
+    parent.add_command(read_cmd)
+
+    return parent

--- a/unstructured/ingest/cli/common.py
+++ b/unstructured/ingest/cli/common.py
@@ -1,9 +1,12 @@
 import logging
+from dataclasses import dataclass
 from typing import Optional
 
+import click
 from click import ClickException, Command, Option
 
 from unstructured.ingest.interfaces import (
+    BaseConfig,
     ProcessorConfigs,
     StandardConnectorConfig,
 )
@@ -133,6 +136,32 @@ def add_recursive_option(cmd: Command):
             "otherwise stop at the files in provided folder level.",
         ),
     )
+
+
+@dataclass
+class RecursiveOption(BaseConfig):
+    recursive: bool = False
+
+    @staticmethod
+    def get_schema() -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "recursive": {"type": "boolean"},
+            },
+        }
+
+    @staticmethod
+    def add_cli_options(cmd: click.Command) -> None:
+        cmd.params.append(
+            Option(
+                ["--recursive"],
+                is_flag=True,
+                default=False,
+                help="Recursively download files in their respective folders"
+                "otherwise stop at the files in provided folder level.",
+            ),
+        )
 
 
 def add_shared_options(cmd: Command):

--- a/unstructured/ingest/doc_processor/generalized.py
+++ b/unstructured/ingest/doc_processor/generalized.py
@@ -63,3 +63,28 @@ def process_document(doc: "IngestDoc", **partition_kwargs) -> Optional[List[Dict
     finally:
         doc.cleanup_file()
         return isd_elems_no_filename
+
+
+def download_document(doc: "IngestDoc", **partition_kwargs) -> None:
+    """Process any IngestDoc-like class of document with chosen Unstructured's partition logic.
+
+    Parameters
+    ----------
+    partition_kwargs
+        ultimately the parameters passed to partition()
+    """
+    global session_handle
+    try:
+        if isinstance(doc, IngestDocSessionHandleMixin):
+            if session_handle is None:
+                # create via doc.session_handle, which is a property that creates a
+                # session handle if one is not already defined
+                session_handle = doc.session_handle
+            else:
+                doc.session_handle = session_handle
+        # does the work necessary to load file into filesystem
+        # in the future, get_file_handle() could also be supported
+        doc.get_file()
+    except Exception:
+        # TODO(crag) save the exception instead of print?
+        logger.error(f"Failed to process {doc}", exc_info=True)

--- a/unstructured/ingest/runner/notion.py
+++ b/unstructured/ingest/runner/notion.py
@@ -1,8 +1,12 @@
 import hashlib
 import logging
-from typing import Optional
+from typing import List, Optional
 
-from unstructured.ingest.interfaces import ProcessorConfigs, StandardConnectorConfig
+from unstructured.ingest.interfaces import (
+    ProcessorConfigs,
+    ReadConfigs,
+    StandardConnectorConfig,
+)
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.processor import process_documents
 from unstructured.ingest.runner.utils import update_download_dir_hash
@@ -61,3 +65,58 @@ def notion(
     )
 
     process_documents(doc_connector=doc_connector, processor_config=processor_config)
+
+
+def read(
+    verbose: bool,
+    read_configs: ReadConfigs,
+    api_key: str,
+    recursive: bool,
+    page_ids: Optional[List[str]] = None,
+    database_ids: Optional[List[str]] = None,
+    **kwargs,
+):
+    ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)
+    if not page_ids and not database_ids:
+        raise ValueError("no page ids nor database ids provided")
+
+    if page_ids and database_ids:
+        hashed_dir_name = hashlib.sha256(
+            f"{page_ids},{database_ids}".encode("utf-8"),
+        )
+    elif page_ids:
+        hashed_dir_name = hashlib.sha256(
+            ",".join(page_ids).encode("utf-8"),
+        )
+    elif database_ids:
+        hashed_dir_name = hashlib.sha256(
+            ",".join(database_ids).encode("utf-8"),
+        )
+    else:
+        raise ValueError("could not create local cache directory name")
+    read_configs.download_dir = update_download_dir_hash(
+        connector_name="notion",
+        connector_config=read_configs,
+        hashed_dir_name=hashed_dir_name,
+        logger=logger,
+    )
+    # TODO refactor to only download content
+
+    # from unstructured.ingest.connector.notion.connector import (
+    #     NotionConnector,
+    #     SimpleNotionConfig,
+    # )
+
+    # doc_connector = NotionConnector(  # type: ignore
+    #     standard_config=connector_config,
+    #     config=SimpleNotionConfig(
+    #         page_ids=page_ids if page_ids else [],
+    #         database_ids=database_ids if database_ids else [],
+    #         api_key=api_key,
+    #         verbose=verbose,
+    #         recursive=recursive,
+    #         logger=logger,
+    #     ),
+    # )
+
+    # process_documents(doc_connector=doc_connector, processor_config=processor_config)

--- a/unstructured/ingest/runner/utils.py
+++ b/unstructured/ingest/runner/utils.py
@@ -36,11 +36,11 @@ def update_download_dir_hash(
         if not cache_path.exists():
             cache_path.mkdir(parents=True, exist_ok=True)
         download_dir = cache_path / connector_name / hashed_dir_name.hexdigest()[:10]
-        if connector_config.preserve_downloads:
-            logger.warning(
-                f"Preserving downloaded files but download_dir is not specified,"
-                f" using {download_dir}",
-            )
+        # if connector_config.preserve_downloads:
+        #     logger.warning(
+        #         f"Preserving downloaded files but download_dir is not specified,"
+        #         f" using {download_dir}",
+        #     )
         new_download_dir = str(download_dir)
         logger.debug(f"updating download directory to: {new_download_dir}")
     return new_download_dir


### PR DESCRIPTION
### Description
WIP PR to highlight an approach to split the responsibility of each connector cli into subcommands: `read`, `'validate`, `partition`, and in the future `write`. As we add functionality to the cli, the list of potential params keeps growing, not only will splitting it onto subcommands help with that, this PR also introduces an approach used in the aws cli to provide all params via a json file (`--generate-cli-skeleton` and `--cli-input-json`). 

Subcommands:
* `read`: download all files that will need to be processed via the partition function or api
* `validate`: functions around the input configs/parameters. Validates a given input json file without having to run `read`, generates a skeleton json that can be used. 
* `partition`: would run partition over the files that had been downloaded, which gets written to another location
* `write`: for downstream connections, would take the content that was written by `partition` and write it to whatever data store is configured on the connector

Things that need to be considered: 
* How does the data get mapped from the `read` cli invocation to the `partition` one to alleviate the used having to keep track of it if it's downloaded to the local cache location.
* How/when should cleanup of files take place that are downloaded during `read` if the user doesn't care to preserve them? 