### PR TITLE
Klaijan/return coordinates points for ocr strategy as tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+* Edit `add_pytesseract_bbox_to_elements`'s (`ocr_only` strategy) `metadata.coordinates.points` return type to `Tuple` for consistency.
+
 ## 0.10.7
 
 ### Enhancements

--- a/test_unstructured/partition/pdf-image/test_pdf.py
+++ b/test_unstructured/partition/pdf-image/test_pdf.py
@@ -774,12 +774,12 @@ def test_partition_pdf_with_ocr_has_coordinates_from_filename(
     filename="example-docs/chevron-page.pdf",
 ):
     elements = pdf.partition_pdf(filename=filename, strategy="ocr_only")
-    assert elements[0].metadata.coordinates.points == [
+    assert elements[0].metadata.coordinates.points == (
         (657.0, 2144.0),
         (657.0, 2106.0),
         (1043.0, 2106.0),
         (1043.0, 2144.0),
-    ]
+    )
 
 
 def test_partition_pdf_with_ocr_has_coordinates_from_file(
@@ -790,9 +790,9 @@ def test_partition_pdf_with_ocr_has_coordinates_from_file(
             file=f,
             strategy="ocr_only",
         )
-    assert elements[0].metadata.coordinates.points == [
+    assert elements[0].metadata.coordinates.points == (
         (657.0, 2144.0),
         (657.0, 2106.0),
         (1043.0, 2106.0),
         (1043.0, 2144.0),
-    ]
+    )

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -509,6 +509,7 @@ def add_pytesseract_bbox_to_elements(elements, bboxes, width, height):
             new_x, new_y = point_space.convert_coordinates_to_new_system(pixel_space, x, y)
             converted_points.append((new_x, new_y))
 
+        converted_points = tuple(converted_points)
         element.metadata.coordinates = CoordinatesMetadata(
             points=converted_points,
             system=pixel_space,

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -503,13 +503,12 @@ def add_pytesseract_bbox_to_elements(elements, bboxes, width, height):
             max_y = max(max_y, y2)
 
         points = ((min_x, min_y), (min_x, max_y), (max_x, max_y), (max_x, min_y))
-        converted_points = []
+        converted_points = tuple()
         for point in points:
             x, y = point
             new_x, new_y = point_space.convert_coordinates_to_new_system(pixel_space, x, y)
-            converted_points.append((new_x, new_y))
+            converted_points = (*converted_points, (new_x, new_y))
 
-        converted_points = tuple(converted_points)
         element.metadata.coordinates = CoordinatesMetadata(
             points=converted_points,
             system=pixel_space,

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -503,11 +503,12 @@ def add_pytesseract_bbox_to_elements(elements, bboxes, width, height):
             max_y = max(max_y, y2)
 
         points = ((min_x, min_y), (min_x, max_y), (max_x, max_y), (max_x, min_y))
-        converted_points = tuple()
-        for point in points:
-            x, y = point
-            new_x, new_y = point_space.convert_coordinates_to_new_system(pixel_space, x, y)
-            converted_points = (*converted_points, (new_x, new_y))
+        converted_points = tuple(
+            [
+                point_space.convert_coordinates_to_new_system(pixel_space, *point)
+                for point in points
+            ],
+        )
 
         element.metadata.coordinates = CoordinatesMetadata(
             points=converted_points,


### PR DESCRIPTION
The `add_pytesseract_bbox_to_elements` returned the `metadata.coordinates.points` as `Tuple` whereas other strategies returned as `List`. Make change accordingly for consistency.

Previously: 
```
element.metadata.coordinates.points = [
            (x1, y1),
            (x2, y2),
            (x3, y3),
            (x4, y4),
]
```
Currently:
```
element.metadata.coordinates.points = (
            (x1, y1),
            (x2, y2),
            (x3, y3),
            (x4, y4),
)
```