### PR TITLE
feat: chunk elements based on titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.10.8-dev0
+
+### Enhancements
+
+### Features
+
+* Adds `chunk_by_title` to break a document into sections based on the presence of `Title`
+  elements.
+
+### Fixes
+
 ## 0.10.7
 
 ### Enhancements
@@ -19,7 +30,7 @@
 * Add functionality to sort elements using `xy-cut` sorting approach in `partition_pdf` for `hi_res` and `fast` strategies
 * Bump unstructured-inference
   * Set OMP_THREAD_LIMIT to 1 if not set for better tesseract perf (0.5.17)
-  
+
 ### Features
 
 * Extract coordinates from PDFs and images when using OCR only strategy and add to metadata

--- a/docs/source/bricks.rst
+++ b/docs/source/bricks.rst
@@ -9,6 +9,7 @@ After reading this section, you should understand the following:
 * How to remove unwanted content from document elements using cleaning bricks.
 * How to extract content from a document using the extraction bricks.
 * How to prepare data for downstream use cases using staging bricks
+* How to chunk partitioned documents for use cases such as Retrieval Augmented Generation (RAG).
 
 .. toctree::
    :maxdepth: 1
@@ -17,3 +18,4 @@ After reading this section, you should understand the following:
    bricks/cleaning
    bricks/extracting
    bricks/staging
+   bricks/chunking

--- a/docs/source/bricks/chunking.rst
+++ b/docs/source/bricks/chunking.rst
@@ -1,6 +1,51 @@
-
 ########
 Chunking
 ########
 
-This needs to be written
+Chunking functions in ``unstructured`` use metadata and document elements
+detected with ``partition`` functions to split a document into subsections
+for uses cases such as Retrieval Augmented Generation (RAG).
+
+
+``chunk_by_title``
+------------------
+
+The ``chunk_by_title`` function combines elements into sections by looking
+for the presence of titles. When a title is detected, a new section is created.
+Tables and non-text elements (such as page breaks or images) are always their
+own section.
+
+New sections are also created if changes in metadata occure. Examples of when
+this occurs include when the section of the document or the page number changes
+or when an element comes from an attachment instead of from the main document.
+If you set ``multipage_sections=True``, ``chunk_by_title`` will allow for sections
+that span between pages. This kwarg is ``True`` by default.
+
+``chunk_by_title`` will start a new section if the length of a section exceed
+``new_after_n_chars``. The default value is ``1500``. ``chunk_by_title`` does
+not split elements, it is possible for a section to exceed that lenght, for
+example if a ``NarrativeText`` elements exceeds ``1500`` characters on its on.
+
+Similarly, sections under ``combine_under_n_chars`` will be combined if they
+do not exceed the specified threshold, which defaults to ``500``. This will combine
+a series of ``Title`` elements that occur one after another, which sometimes
+happens in lists that are not detected as ``ListItem`` elements. Set
+``combine_under_n_chars=0`` to turn off this behavior.
+
+The following shows an example of how to use ``chunk_by_title``. You will
+see the document chunked into sections instead of elements.
+
+
+.. code:: python
+
+  from unstructured.partition.html import partition_html
+  from unstructured.chunking.title import chunk_by_title
+
+  url = "https://understandingwar.org/backgrounder/russian-offensive-campaign-assessment-august-27-2023-0"
+  elements = partition_html(url=url)
+  chunks = chunk_by_title(elements)
+
+  for chunk in chunks:
+      print(chunk)
+      print("\n\n" + "-"*80)
+      input()

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -55,24 +55,35 @@ def test_split_elements_by_title_and_table():
 
 def test_chunk_by_title():
     elements = [
-        Title("A Great Day"),
-        Text("Today is a great day."),
+        Title("A Great Day", metadata=ElementMetadata(emphasized_text_contents=["Day"])),
+        Text("Today is a great day.", metadata=ElementMetadata(emphasized_text_contents=["day"])),
         Text("It is sunny outside."),
         Table("<table></table>"),
         Title("An Okay Day"),
         Text("Today is an okay day."),
         Text("It is rainy outside."),
         Title("A Bad Day"),
-        Text("Today is a bad day."),
+        Text(
+            "Today is a bad day.",
+            metadata=ElementMetadata(regex_metadata=[{"text": "A", "start": 0, "end": 1}]),
+        ),
         Text("It is storming outside."),
         CheckBox(),
     ]
-    sections = chunk_by_title(elements)
+    chunks = chunk_by_title(elements)
+    import ipdb; ipdb.set_trace()
 
-    assert sections == [
-        Section("A Great Day\n\nToday is a great day.\n\nIt is sunny outside."),
+    assert chunks == [
+        Section(
+            "A Great Day\n\nToday is a great day.\n\nIt is sunny outside.",
+        ),
         Table("<table></table>"),
         Section("An Okay Day\n\nToday is an okay day.\n\nIt is rainy outside."),
-        Section("A Bad Day\n\nToday is a bad day.\n\nIt is storming outside."),
+        Section(
+            "A Bad Day\n\nToday is a bad day.\n\nIt is storming outside.",
+        ),
         CheckBox(),
     ]
+
+    assert chunks[0].metadata == ElementMetadata(emphasized_text_contents=["Day", "day"])
+    assert chunks[2].metadata == ElementMetadata(regex_metadata=[{"text": "A", "start": 11, "end": 12}])

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -2,7 +2,14 @@ from unstructured.chunking.title import (
     _split_elements_by_title_and_table,
     chunk_by_title,
 )
-from unstructured.documents.elements import CheckBox, Section, Table, Text, Title
+from unstructured.documents.elements import (
+    CheckBox,
+    ElementMetadata,
+    Section,
+    Table,
+    Text,
+    Title,
+)
 
 
 def test_split_elements_by_title_and_table():

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -123,3 +123,70 @@ def test_chunk_by_title_respects_section_change():
         ),
         CheckBox(),
     ]
+
+
+def test_chunk_by_title_separates_by_page_number():
+    elements = [
+        Title("A Great Day", metadata=ElementMetadata(page_number=1)),
+        Text("Today is a great day.", metadata=ElementMetadata(page_number=2)),
+        Text("It is sunny outside.", metadata=ElementMetadata(page_number=2)),
+        Table("<table></table>"),
+        Title("An Okay Day"),
+        Text("Today is an okay day."),
+        Text("It is rainy outside."),
+        Title("A Bad Day"),
+        Text(
+            "Today is a bad day.",
+            metadata=ElementMetadata(regex_metadata=[{"text": "A", "start": 0, "end": 1}]),
+        ),
+        Text("It is storming outside."),
+        CheckBox(),
+    ]
+    chunks = chunk_by_title(elements, multipage_sections=False)
+
+    assert chunks == [
+        Section(
+            "A Great Day",
+        ),
+        Section(
+            "Today is a great day.\n\nIt is sunny outside.",
+        ),
+        Table("<table></table>"),
+        Section("An Okay Day\n\nToday is an okay day.\n\nIt is rainy outside."),
+        Section(
+            "A Bad Day\n\nToday is a bad day.\n\nIt is storming outside.",
+        ),
+        CheckBox(),
+    ]
+
+
+def test_chunk_by_title_groups_across_pages():
+    elements = [
+        Title("A Great Day", metadata=ElementMetadata(page_number=1)),
+        Text("Today is a great day.", metadata=ElementMetadata(page_number=2)),
+        Text("It is sunny outside.", metadata=ElementMetadata(page_number=2)),
+        Table("<table></table>"),
+        Title("An Okay Day"),
+        Text("Today is an okay day."),
+        Text("It is rainy outside."),
+        Title("A Bad Day"),
+        Text(
+            "Today is a bad day.",
+            metadata=ElementMetadata(regex_metadata=[{"text": "A", "start": 0, "end": 1}]),
+        ),
+        Text("It is storming outside."),
+        CheckBox(),
+    ]
+    chunks = chunk_by_title(elements, multipage_sections=True)
+
+    assert chunks == [
+        Section(
+            "A Great Day\n\nToday is a great day.\n\nIt is sunny outside.",
+        ),
+        Table("<table></table>"),
+        Section("An Okay Day\n\nToday is an okay day.\n\nIt is rainy outside."),
+        Section(
+            "A Bad Day\n\nToday is a bad day.\n\nIt is storming outside.",
+        ),
+        CheckBox(),
+    ]

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -88,3 +88,38 @@ def test_chunk_by_title():
     assert chunks[3].metadata == ElementMetadata(
         regex_metadata=[{"text": "A", "start": 11, "end": 12}],
     )
+
+
+def test_chunk_by_title_respects_section_change():
+    elements = [
+        Title("A Great Day", metadata=ElementMetadata(section="first")),
+        Text("Today is a great day.", metadata=ElementMetadata(section="second")),
+        Text("It is sunny outside.", metadata=ElementMetadata(section="second")),
+        Table("<table></table>"),
+        Title("An Okay Day"),
+        Text("Today is an okay day."),
+        Text("It is rainy outside."),
+        Title("A Bad Day"),
+        Text(
+            "Today is a bad day.",
+            metadata=ElementMetadata(regex_metadata=[{"text": "A", "start": 0, "end": 1}]),
+        ),
+        Text("It is storming outside."),
+        CheckBox(),
+    ]
+    chunks = chunk_by_title(elements)
+
+    assert chunks == [
+        Section(
+            "A Great Day",
+        ),
+        Section(
+            "Today is a great day.\n\nIt is sunny outside.",
+        ),
+        Table("<table></table>"),
+        Section("An Okay Day\n\nToday is an okay day.\n\nIt is rainy outside."),
+        Section(
+            "A Bad Day\n\nToday is a bad day.\n\nIt is storming outside.",
+        ),
+        CheckBox(),
+    ]

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -1,0 +1,43 @@
+from unstructured.chunking.title import _split_elements_by_title_and_table
+from unstructured.documents.elements import CheckBox, Table, Text, Title
+
+
+def test_split_elements_by_title_and_table():
+    elements = [
+        Title("A Great Day"),
+        Text("Today is a great day."),
+        Text("It is sunny outside."),
+        Table("<table></table>"),
+        Title("An Okay Day"),
+        Text("Today is an okay day."),
+        Text("It is rainy outside."),
+        Title("A Bad Day"),
+        Text("Today is a bad day."),
+        Text("It is storming outside."),
+        CheckBox(),
+    ]
+    sections = _split_elements_by_title_and_table(elements)
+
+    assert sections == [
+        [
+            Title("A Great Day"),
+            Text("Today is a great day."),
+            Text("It is sunny outside."),
+        ],
+        [
+            Table("<table></table>"),
+        ],
+        [
+            Title("An Okay Day"),
+            Text("Today is an okay day."),
+            Text("It is rainy outside."),
+        ],
+        [
+            Title("A Bad Day"),
+            Text("Today is a bad day."),
+            Text("It is storming outside."),
+        ],
+        [
+            CheckBox(),
+        ],
+    ]

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -1,5 +1,8 @@
-from unstructured.chunking.title import _split_elements_by_title_and_table
-from unstructured.documents.elements import CheckBox, Table, Text, Title
+from unstructured.chunking.title import (
+    _split_elements_by_title_and_table,
+    chunk_by_title,
+)
+from unstructured.documents.elements import CheckBox, Section, Table, Text, Title
 
 
 def test_split_elements_by_title_and_table():
@@ -40,4 +43,29 @@ def test_split_elements_by_title_and_table():
         [
             CheckBox(),
         ],
+    ]
+
+
+def test_chunk_by_title():
+    elements = [
+        Title("A Great Day"),
+        Text("Today is a great day."),
+        Text("It is sunny outside."),
+        Table("<table></table>"),
+        Title("An Okay Day"),
+        Text("Today is an okay day."),
+        Text("It is rainy outside."),
+        Title("A Bad Day"),
+        Text("Today is a bad day."),
+        Text("It is storming outside."),
+        CheckBox(),
+    ]
+    sections = chunk_by_title(elements)
+
+    assert sections == [
+        Section("A Great Day\n\nToday is a great day.\n\nIt is sunny outside."),
+        Table("<table></table>"),
+        Section("An Okay Day\n\nToday is an okay day.\n\nIt is rainy outside."),
+        Section("A Bad Day\n\nToday is a bad day.\n\nIt is storming outside."),
+        CheckBox(),
     ]

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -86,5 +86,5 @@ def test_chunk_by_title():
 
     assert chunks[0].metadata == ElementMetadata(emphasized_text_contents=["Day", "day"])
     assert chunks[3].metadata == ElementMetadata(
-        regex_metadata=[{"text": "A", "start": 11, "end": 12}]
+        regex_metadata=[{"text": "A", "start": 11, "end": 12}],
     )

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -71,7 +71,6 @@ def test_chunk_by_title():
         CheckBox(),
     ]
     chunks = chunk_by_title(elements)
-    import ipdb; ipdb.set_trace()
 
     assert chunks == [
         Section(
@@ -86,4 +85,6 @@ def test_chunk_by_title():
     ]
 
     assert chunks[0].metadata == ElementMetadata(emphasized_text_contents=["Day", "day"])
-    assert chunks[2].metadata == ElementMetadata(regex_metadata=[{"text": "A", "start": 11, "end": 12}])
+    assert chunks[3].metadata == ElementMetadata(
+        regex_metadata=[{"text": "A", "start": 11, "end": 12}]
+    )

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -26,7 +26,7 @@ def test_split_elements_by_title_and_table():
         Text("It is storming outside."),
         CheckBox(),
     ]
-    sections = _split_elements_by_title_and_table(elements)
+    sections = _split_elements_by_title_and_table(elements, combine_under_n_chars=0)
 
     assert sections == [
         [
@@ -70,7 +70,7 @@ def test_chunk_by_title():
         Text("It is storming outside."),
         CheckBox(),
     ]
-    chunks = chunk_by_title(elements)
+    chunks = chunk_by_title(elements, combine_under_n_chars=0)
 
     assert chunks == [
         Section(
@@ -107,7 +107,7 @@ def test_chunk_by_title_respects_section_change():
         Text("It is storming outside."),
         CheckBox(),
     ]
-    chunks = chunk_by_title(elements)
+    chunks = chunk_by_title(elements, combine_under_n_chars=0)
 
     assert chunks == [
         Section(
@@ -142,7 +142,7 @@ def test_chunk_by_title_separates_by_page_number():
         Text("It is storming outside."),
         CheckBox(),
     ]
-    chunks = chunk_by_title(elements, multipage_sections=False)
+    chunks = chunk_by_title(elements, multipage_sections=False, combine_under_n_chars=0)
 
     assert chunks == [
         Section(
@@ -177,7 +177,7 @@ def test_chunk_by_title_groups_across_pages():
         Text("It is storming outside."),
         CheckBox(),
     ]
-    chunks = chunk_by_title(elements, multipage_sections=True)
+    chunks = chunk_by_title(elements, multipage_sections=True, combine_under_n_chars=0)
 
     assert chunks == [
         Section(

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.7"  # pragma: no cover
+__version__ = "0.10.8-dev0"  # pragma: no cover

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -18,11 +18,16 @@ def chunk_by_title(
             for element in section:
                 if text:
                     text += "\n\n"
+                start_char = len(text)
                 text += element.text
 
                 for attr, value in vars(element.metadata).items():
                     if isinstance(value, list):
                         _value = metadata.get(attr, [])
+                        if attr == "regex_metadata":
+                            value["start"] += start_char
+                            value["end"] += end_char
+
                         _value.extend(value)
                         metadata.set(attr, _value)
 

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -19,7 +19,10 @@ def chunk_by_title(
     sections = _split_elements_by_title_and_table(elements)
 
     for section in sections:
-        if isinstance(section[0], Title):
+        if not isinstance(section[0], Text) or isinstance(section[0], Table):
+            chunked_elements.extend(section)
+
+        elif isinstance(section[0], Text):
             text = ""
             metadata = section[0].metadata
 
@@ -46,9 +49,6 @@ def chunk_by_title(
                             setattr(metadata, attr, _value)
 
             chunked_elements.append(Section(text=text, metadata=metadata))
-
-        else:
-            chunked_elements.extend(section)
 
     return chunked_elements
 
@@ -114,6 +114,7 @@ def _drop_extra_metadata(
             keys_to_drop.append(key)
 
     for key in keys_to_drop:
-        del metadata_dict[key]
+        if key in metadata_dict:
+            del metadata_dict[key]
 
     return metadata_dict

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -1,10 +1,18 @@
 from typing import List
 
-from unstructured.documents.elements import Element, Section, Table, Text, Title
+from unstructured.documents.elements import (
+    Element,
+    ElementMetadata,
+    Section,
+    Table,
+    Text,
+    Title,
+)
 
 
 def chunk_by_title(
     elements: List[Element],
+    multipage_sections: bool = True,
 ) -> List[Element]:
     """Uses title elements to identify sections within the document for chunking."""
     chunked_elements: List[Element] = []
@@ -16,10 +24,11 @@ def chunk_by_title(
             metadata = section[0].metadata
 
             for i, element in enumerate(section):
-                if text:
-                    text += "\n\n"
-                start_char = len(text)
-                text += element.text
+                if isinstance(element, Text):
+                    if text:
+                        text += "\n\n"
+                    start_char = len(text)
+                    text += element.text
 
                 for attr, value in vars(element.metadata).items():
                     if isinstance(value, list):
@@ -44,15 +53,28 @@ def chunk_by_title(
     return chunked_elements
 
 
-def _split_elements_by_title_and_table(elements: List[Element]) -> List[List[Element]]:
+def _split_elements_by_title_and_table(
+    elements: List[Element],
+    multipage_sections: bool = True,
+) -> List[List[Element]]:
     sections: List[List[Element]] = []
     section: List[Element] = []
-    for element in elements:
+
+    for i, element in enumerate(elements):
+        metadata_matches = True
+        if i > 0:
+            last_element = elements[i - 1]
+            metadata_matches = _metadata_matches(
+                element.metadata,
+                last_element.metadata,
+                include_pages=not multipage_sections,
+            )
+
         if isinstance(element, Table) or not isinstance(element, Text):
             sections.append(section)
             sections.append([element])
             section = []
-        elif isinstance(element, Title):
+        elif isinstance(element, Title) or not metadata_matches:
             if len(section) > 0:
                 sections.append(section)
             section = [element]
@@ -63,3 +85,35 @@ def _split_elements_by_title_and_table(elements: List[Element]) -> List[List[Ele
         sections.append(section)
 
     return sections
+
+
+def _metadata_matches(
+    metadata1: ElementMetadata,
+    metadata2: ElementMetadata,
+    include_pages: bool = True,
+) -> bool:
+    metadata_dict1 = metadata1.to_dict()
+    metadata_dict1 = _drop_extra_metadata(metadata_dict1, include_pages=include_pages)
+
+    metadata_dict2 = metadata2.to_dict()
+    metadata_dict2 = _drop_extra_metadata(metadata_dict2, include_pages=include_pages)
+
+    return metadata_dict1 == metadata_dict2
+
+
+def _drop_extra_metadata(
+    metadata_dict: dict,
+    include_pages: bool = True,
+) -> dict:
+    keys_to_drop = ["element_id", "type"]
+    if include_pages and "page_number" in metadata_dict:
+        keys_to_drop.append("page_number")
+
+    for key, value in metadata_dict.items():
+        if isinstance(value, list):
+            keys_to_drop.append(key)
+
+    for key in keys_to_drop:
+        del metadata_dict[key]
+
+    return metadata_dict

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -16,7 +16,23 @@ def chunk_by_title(
     combine_under_n_chars: int = 500,
     new_after_n_chars: int = 1500,
 ) -> List[Element]:
-    """Uses title elements to identify sections within the document for chunking."""
+    """Uses title elements to identify sections within the document for chunking. Splits
+    off into a new section when a title is detection or if metadata changes, which happens
+    when page numbers or sections change. Cuts off sections once they have exceeded
+    a character length of new_after_n_chars.
+
+    Parameters
+    ----------
+    elements
+        A list of unstructured elements. Usually the ouput of a partition functions.
+    multipage_sections
+        If True, sections can span multiple pages. Defaults to True.
+    combine_under_n_chars
+        Combines elements (for example a series of titles) until a section reaches
+        a length of n characters.
+    new_after_n_chars
+        Cuts off new sections once they reach a length of n characters
+    """
     chunked_elements: List[Element] = []
     sections = _split_elements_by_title_and_table(
         elements,

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -1,0 +1,31 @@
+from typing import List
+
+from unstructured.documents.elements import Element, Table, Text, Title
+
+
+def chunk_by_title(
+    elements: List[Element],
+) -> List[Element]:
+    """Uses title elements to identify sections within the document for chunking."""
+    return []
+
+
+def _split_elements_by_title_and_table(elements: List[Element]) -> List[List[Element]]:
+    sections: List[List[Element]] = []
+    section: List[Element] = []
+    for element in elements:
+        if isinstance(element, Table) or not isinstance(element, Text):
+            sections.append(section)
+            sections.append([element])
+            section = []
+        elif isinstance(element, Title):
+            if len(section) > 0:
+                sections.append(section)
+            section = [element]
+        else:
+            section.append(element)
+
+    if len(section) > 0:
+        sections.append(section)
+
+    return sections

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -15,7 +15,7 @@ def chunk_by_title(
             text = ""
             metadata = section[0].metadata
 
-            for element in section:
+            for i, element in enumerate(section):
                 if text:
                     text += "\n\n"
                 start_char = len(text)
@@ -23,13 +23,18 @@ def chunk_by_title(
 
                 for attr, value in vars(element.metadata).items():
                     if isinstance(value, list):
-                        _value = metadata.get(attr, [])
-                        if attr == "regex_metadata":
-                            value["start"] += start_char
-                            value["end"] += end_char
+                        _value = getattr(metadata, attr, [])
+                        if _value is None:
+                            _value = []
 
-                        _value.extend(value)
-                        metadata.set(attr, _value)
+                        if attr == "regex_metadata":
+                            for item in value:
+                                item["start"] += start_char
+                                item["end"] += start_char
+
+                        if i > 0:
+                            _value.extend(value)
+                            setattr(metadata, attr, _value)
 
             chunked_elements.append(Section(text=text, metadata=metadata))
 

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -16,7 +16,7 @@ def chunk_by_title(
 ) -> List[Element]:
     """Uses title elements to identify sections within the document for chunking."""
     chunked_elements: List[Element] = []
-    sections = _split_elements_by_title_and_table(elements)
+    sections = _split_elements_by_title_and_table(elements, multipage_sections)
 
     for section in sections:
         if not isinstance(section[0], Text) or isinstance(section[0], Table):
@@ -106,7 +106,7 @@ def _drop_extra_metadata(
     include_pages: bool = True,
 ) -> dict:
     keys_to_drop = ["element_id", "type"]
-    if include_pages and "page_number" in metadata_dict:
+    if not include_pages and "page_number" in metadata_dict:
         keys_to_drop.append("page_number")
 
     for key, value in metadata_dict.items():

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -1,13 +1,37 @@
 from typing import List
 
-from unstructured.documents.elements import Element, Table, Text, Title
+from unstructured.documents.elements import Element, Section, Table, Text, Title
 
 
 def chunk_by_title(
     elements: List[Element],
 ) -> List[Element]:
     """Uses title elements to identify sections within the document for chunking."""
-    return []
+    chunked_elements: List[Element] = []
+    sections = _split_elements_by_title_and_table(elements)
+
+    for section in sections:
+        if isinstance(section[0], Title):
+            text = ""
+            metadata = section[0].metadata
+
+            for element in section:
+                if text:
+                    text += "\n\n"
+                text += element.text
+
+                for attr, value in vars(element.metadata).items():
+                    if isinstance(value, list):
+                        _value = metadata.get(attr, [])
+                        _value.extend(value)
+                        metadata.set(attr, _value)
+
+            chunked_elements.append(Section(text=text, metadata=metadata))
+
+        else:
+            chunked_elements.extend(section)
+
+    return chunked_elements
 
 
 def _split_elements_by_title_and_table(elements: List[Element]) -> List[List[Element]]:

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -443,6 +443,14 @@ class Text(Element):
         self.text = cleaned_text
 
 
+class Section(Text):
+    """A section of text consisting of a combination of elements."""
+
+    category = "Section"
+
+    pass
+
+
 class FigureCaption(Text):
     """An element for capturing text associated with figure captions."""
 


### PR DESCRIPTION
### Summary

An initial pass on smart chunking for RAG applications. Breaks a document into sections based on the presence of `Title` elements. Also starts a new section under the following conditions:

- If metadata changes, indicating a change in section or page or a switch to processing attachments. If `multipage_sections=True`, sections can span pages. `multipage_sections` defaults to True.
- If the length of the section exceeds `new_after_n_chars` characters. The default is `1500`. The chunking function does not split individual elements, so it's possible for a section to exceed that threshold if an individual element if over `new_after_n_chars` characters, which could occur with a long `NarrativeText` element.
- Section under `combine_under_n_chars` characters are combined. The default is `500`. 

### Testing

```python
from unstructured.partition.html import partition_html
from unstructured.chunking.title import chunk_by_title

url = "https://understandingwar.org/backgrounder/russian-offensive-campaign-assessment-august-27-2023-0"
elements = partition_html(url=url)
chunks = chunk_by_title(elements)

for chunk in chunks:
    print(chunk)
    print("\n\n" + "-"*80)
    input()
```