### PR TITLE
fix: remove duplicate target in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ test-extra-pptx:
 		test_${PACKAGE_NAME}/partition/pptx
 
 .PHONY: test-extra-epub
-test-extra-pypandoc:
+test-extra-epub:
 	PYTHONPATH=. CI=$(CI) pytest \
 		test_${PACKAGE_NAME}/partition/epub
 


### PR DESCRIPTION
Removed a duplicate make target in the `Makefile`.