### PR TITLE
build: docker image fix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,6 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,7 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -38,7 +38,7 @@ trap stop_container EXIT
 await_container
 
 # Run the tests
-docker cp test_unstructured_ingest $CONTAINER_NAME:/home
+docker cp test_unstructured_ingest $CONTAINER_NAME:/home/notebook_user
 docker exec "$CONTAINER_NAME" /bin/bash -c "/home/notebook_user/test_unstructured_ingest/test-ingest-wikipedia.sh"
 
 result=$?

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -39,6 +39,7 @@ await_container
 
 # Run the tests
 docker cp test_unstructured_ingest $CONTAINER_NAME:/home/notebook-user
+docker exec "$CONTAINER_NAME" /bin/bash -c "chown -R 1000:1000 /home/notebook-user/test_unstructured_ingest"
 docker exec "$CONTAINER_NAME" /bin/bash -c "/home/notebook-user/test_unstructured_ingest/test-ingest-wikipedia.sh"
 
 result=$?

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -39,7 +39,7 @@ await_container
 
 # Run the tests
 docker cp test_unstructured_ingest $CONTAINER_NAME:/home/notebook-user
-docker exec "$CONTAINER_NAME" /bin/bash -c "chown -R 1000:1000 /home/notebook-user/test_unstructured_ingest"
+docker exec -u root "$CONTAINER_NAME" /bin/bash -c "chown -R 1000:1000 /home/notebook-user/test_unstructured_ingest"
 docker exec "$CONTAINER_NAME" /bin/bash -c "/home/notebook-user/test_unstructured_ingest/test-ingest-wikipedia.sh"
 
 result=$?

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -38,8 +38,8 @@ trap stop_container EXIT
 await_container
 
 # Run the tests
-docker cp test_unstructured_ingest $CONTAINER_NAME:/home/notebook_user
-docker exec "$CONTAINER_NAME" /bin/bash -c "/home/notebook_user/test_unstructured_ingest/test-ingest-wikipedia.sh"
+docker cp test_unstructured_ingest $CONTAINER_NAME:/home/notebook-user
+docker exec "$CONTAINER_NAME" /bin/bash -c "/home/notebook-user/test_unstructured_ingest/test-ingest-wikipedia.sh"
 
 result=$?
 exit $result


### PR DESCRIPTION
Moving to a non-root user in the docker image caused a failure in the publication workflow.

This fix was used to publish the 0.10.9 unstructured image in this workflow:
https://github.com/Unstructured-IO/unstructured/actions/runs/6020624226/job/16332230987