### PR TITLE
fix: update .gitignores to include text comparison files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,5 @@ unstructured-inference/
 
 example-docs/*_images
 examples/**/output/
+
+outputdiff.txt

--- a/test_unstructured_ingest/.gitignore
+++ b/test_unstructured_ingest/.gitignore
@@ -1,4 +1,4 @@
 structured-output
 download
-test_unstructured_ingest/expected-text-output/**
-test_unstructured_ingest/text-output/**
+expected-text-output/**
+text-output/**


### PR DESCRIPTION
We recently added plain-text comparison during the ingest testing. This generates files in `test_unstructured_ingest/expected-text-output/`. It looks like the intent was that these files are to be generated but ignored in git. However, the paths relative to the root of the repo were used instead of paths relative to the `.gitignore` file in which they were added. This updates those paths so that the `test_unstructured_ingest/expected-text-output/` and `test_unstructured_ingest/text-output` paths are ignored. Additionally a `outputdiff.txt` file is generated at the root of the repo. This will change with each test, so presumably we don't want that checked in either. This also adds that to the gitignore.

## Testing
I ran an ingest test which generated some of these text comparison files. I updated with the changes in this PR and validated that the generated files were in fact all ignored.