### PR TITLE
feat: `partition_xml` infers element type on each leaf node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-## 0.10.10-dev0
+## 0.10.10-dev1
 
 ### Enhancements
+
+* If `xml_keep_tags=False`, `partition_xml` infers the element type for each leaf element
+  separately without delegating to `partition_text`. Note, `max_partition` and `min_partition`
+  no longer apply when `xml_keep_tags=True` since `partition_xml` no longer delegates
+  to `partition_text` in that case.
 * Bump `unstructured-inference==0.5.18`, change non-default detectron2 classification threshold
 
 ### Features
@@ -17,7 +22,7 @@
 
 * Adds `chunk_by_title` to break a document into sections based on the presence of `Title`
   elements.
-  
+
 ### Fixes
 
 * Make cv2 dependency optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * If `xml_keep_tags=False`, `partition_xml` infers the element type for each leaf element
   separately without delegating to `partition_text`. Note, `max_partition` and `min_partition`
-  no longer apply when `xml_keep_tags=True` since `partition_xml` no longer delegates
+  no longer apply when `xml_keep_tags=False` since `partition_xml` no longer delegates
   to `partition_text` in that case.
 * Bump `unstructured-inference==0.5.18`, change non-default detectron2 classification threshold
 

--- a/docs/source/bricks/partition.rst
+++ b/docs/source/bricks/partition.rst
@@ -881,5 +881,7 @@ If ``xml_keep_tags=True``, the function returns tag information in addition to t
 The default value is ``1500``, which roughly corresponds to
 the average character length for a paragraph.
 You can disable ``max_partition`` by setting it to ``None``.
+Currently, the ``max_partition`` and ``min_partition`` kwargs only apply if ``xml_keep_tags=True``.
+
 
 For more information about the ``partition_xml`` brick, you can check the `source code here <https://github.com/Unstructured-IO/unstructured/blob/a583d47b841bdd426b9058b7c34f6aa3ed8de152/unstructured/partition/xml.py>`_.

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.10-dev0"  # pragma: no cover
+__version__ = "0.10.10-dev1"  # pragma: no cover


### PR DESCRIPTION
### Summary

Closes #1229. Updates `partition_xml` so that the element type is inferred on each leaf node when `xml_keep_tags=False` instead of delegating splitting and partitioning to `partition_xml`. If `xml_keep_tags=True`, the file is treated like a text file still and partitioning is still delegated to `partition_text`.