### PR TITLE
fix: version-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 0.10.12-dev0
+## 0.10.12-dev1
 
 ### Enhancements
 
 ### Features
 
 ### Fixes
+
+* Update version-sync to prevent duplicate release versions
 
 ## 0.10.11
 

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -eux
+
 function usage {
     echo "Usage: $(basename "$0") [-c] -f FILE_TO_CHANGE REPLACEMENT_FORMAT [-f FILE_TO_CHANGE REPLACEMENT_FORMAT ...]" 2>&1
     echo 'Synchronize files to latest version in source file'
@@ -103,7 +106,8 @@ fi
 # Search files in FILES_TO_CHECK and change (or get diffs)
 declare FAILED_CHECK=0
 
-MAIN_VERSION=$(git show main:unstructured/__version__.py | grep -o -m 1 -E "${RE_SEMVER_FULL}")
+git fetch origin main
+MAIN_VERSION=$(git show origin/main:unstructured/__version__.py | grep -o -m 1 -E "${RE_SEMVER_FULL}")
 MAIN_IS_RELEASE=false
 [[ $MAIN_VERSION != *"-dev"* ]] && MAIN_IS_RELEASE=true
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.12-dev0"  # pragma: no cover
+__version__ = "0.10.12-dev1"  # pragma: no cover


### PR DESCRIPTION
The check to verify version changes has recently permitted commits with the same release version to merge; the intention is that this should be prevented.

The issue is that the version-sync script's call to get the version on `main` attempts to look at the local main branch. When this doesn't exist the variable MAIN_VERSION is assigned to an empty value rather than a semantic version string. This means that later comparisons are meaningless. [Here](https://github.com/ryannikolaidis/unstructured/actions/runs/6045554705/job/16405814607#step:6:77) is an example of the script "succeeding" with this condition.

Instead, this PR adds logic to fetch origin main and compare against the version value there. It also adds `set -eux` at the top of the script so we can debug issues if they come up in the future and also force this to fail and exit if values are unset (which would have prevented the bug from resulting in success).