### PR TITLE
build(deps): Remove pillow pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.10.12-dev1
+## 0.10.12-dev2
 
 ### Enhancements
+
+* Removed PIL pin as issue has been resolved upstream
 
 ### Features
 

--- a/Makefile
+++ b/Makefile
@@ -204,10 +204,13 @@ install-pandoc:
 ## pip-compile:             compiles all base/dev/test requirements
 .PHONY: pip-compile
 pip-compile:
-	@for file in $(shell ls requirements/*.in); \
-		do echo "running: pip-compile --upgrade $${file}" && \
+	@for file in $(shell ls requirements/*.in); do \
+		if [[ "$${file}" =~ "constraints" ]]; then \
+			continue; \
+		fi; \
+		echo "running: pip-compile --upgrade $${file}"; \
 		pip-compile --upgrade $${file}; \
-	 done
+	done
 	cp requirements/build.txt docs/requirements.txt
 
 

--- a/requirements/constraints.in
+++ b/requirements/constraints.in
@@ -19,9 +19,6 @@ pyparsing<3.1.0
 numpy<1.25.0
 scipy<1.11.0
 IPython<8.13
-# NOTE(robinson) - See this issue here
-# https://github.com/facebookresearch/detectron2/issues/5010
-Pillow<10.0.0
 # NOTE(alan) Pinned to avoid error that occurs with 2.4.3:
 # AttributeError: 'ResourcePath' object has no attribute 'collection'
 Office365-REST-Python-Client<2.4.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -294,7 +294,7 @@ pyzmq==25.1.1
     #   jupyter-console
     #   jupyter-server
     #   qtconsole
-qtconsole==5.4.3
+qtconsole==5.4.4
     # via jupyter
 qtpy==2.4.0
     # via qtconsole

--- a/requirements/extra-pdf-image.in
+++ b/requirements/extra-pdf-image.in
@@ -3,7 +3,4 @@
 
 pdf2image
 pdfminer.six
-# NOTE(robinson) - See this issue here
-# https://github.com/facebookresearch/detectron2/issues/5010
-Pillow<10
 unstructured-inference

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -109,10 +109,8 @@ pdfminer-six==20221105
     #   pdfplumber
 pdfplumber==0.10.2
     # via layoutparser
-pillow==9.5.0
+pillow==10.0.0
     # via
-    #   -c requirements/constraints.in
-    #   -r requirements/extra-pdf-image.in
     #   layoutparser
     #   matplotlib
     #   pdf2image

--- a/requirements/extra-pptx.in
+++ b/requirements/extra-pptx.in
@@ -1,3 +1,5 @@
 -c "constraints.in"
 
-python-pptx
+# NOTE(alan): Pinned due to python-pptx 0.6.22 pinning Pillow to <= 0.9.5, and it seems more
+# important to use the new version of Pillow
+python-pptx<=0.6.21

--- a/requirements/extra-pptx.txt
+++ b/requirements/extra-pptx.txt
@@ -6,11 +6,9 @@
 #
 lxml==4.9.3
     # via python-pptx
-pillow==9.5.0
-    # via
-    #   -c requirements/constraints.in
-    #   python-pptx
-python-pptx==0.6.22
+pillow==10.0.0
+    # via python-pptx
+python-pptx==0.6.21
     # via -r requirements/extra-pptx.in
 xlsxwriter==3.1.2
     # via python-pptx

--- a/requirements/ingest-gcs.txt
+++ b/requirements/ingest-gcs.txt
@@ -80,7 +80,6 @@ protobuf==4.23.4
     # via
     #   -c requirements/constraints.in
     #   google-api-core
-    #   googleapis-common-protos
 pyasn1==0.5.0
     # via
     #   pyasn1-modules

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -97,7 +97,7 @@ requests==2.31.0
     # via
     #   -c requirements/base.txt
     #   label-studio-sdk
-ruff==0.0.286
+ruff==0.0.287
     # via -r requirements/test.in
 six==1.16.0
     # via python-dateutil

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.12-dev1"  # pragma: no cover
+__version__ = "0.10.12-dev2"  # pragma: no cover


### PR DESCRIPTION
Removed pin for `PIL` as `detectron2` repo has been updated, and so has `unstructured-inference` (see [154](https://github.com/Unstructured-IO/unstructured-inference/pull/154)).

#### Tests:

Any problems should have shown up as a unit test failure in `unstructured-inference` (that tests with `PIL==10.0.0`) so we should be good to go.