### PR TITLE
feat: improved salesforce partitioning

### DIFF
--- a/unstructured/ingest/connector/salesforce.py
+++ b/unstructured/ingest/connector/salesforce.py
@@ -8,13 +8,13 @@ https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_de
 https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_connected_app.htm
 """
 import os
+from collections import OrderedDict
 from dataclasses import dataclass
 from email.utils import formatdate
 from pathlib import Path
 from string import Template
 from textwrap import dedent
 from typing import Any, Dict, List, Type
-from collections import OrderedDict
 
 from dateutil import parser  # type: ignore
 
@@ -180,13 +180,13 @@ class SalesforceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
                 if isinstance(value, OrderedDict):
                     flatten_dict(value, parent, prefix=f"{prefix}{key}.")
                 else:
-                    item = ET.Element('item')
+                    item = ET.Element("item")
                     item.text = f"{prefix}{key}: {value}"
                     parent.append(item)
 
-        root = ET.Element('root')
+        root = ET.Element("root")
         flatten_dict(record, root)
-        xml_string = ET.tostring(root, encoding='utf-8', xml_declaration=True).decode()
+        xml_string = ET.tostring(root, encoding="utf-8", xml_declaration=True).decode()
         return xml_string
 
     def _eml_for_record(self, email_json: Dict[str, Any]) -> str:

--- a/unstructured/ingest/connector/salesforce.py
+++ b/unstructured/ingest/connector/salesforce.py
@@ -14,9 +14,11 @@ from pathlib import Path
 from string import Template
 from textwrap import dedent
 from typing import Any, Dict, List, Type
+from collections import OrderedDict
 
 from dateutil import parser  # type: ignore
 
+from unstructured.ingest.error import SourceConnectionError
 from unstructured.ingest.interfaces import (
     BaseConnector,
     BaseConnectorConfig,
@@ -49,7 +51,7 @@ Content-Type: text/plain; charset="UTF-8"
 $textbody
 --00000000000095c9b205eff92630
 Content-Type: text/html; charset="UTF-8"
-$textbody
+$htmlbody
 --00000000000095c9b205eff92630--
 """,
 )
@@ -154,7 +156,7 @@ class SalesforceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         if self.record_type == "EmailMessage":
             record_file = self.record_id + ".eml"
         elif self.record_type in ["Account", "Lead", "Case", "Campaign"]:
-            record_file = self.record_id + ".txt"
+            record_file = self.record_id + ".xml"
         else:
             raise MissingCategoryError(
                 f"There are no categories with the name: {self.record_type}",
@@ -169,77 +171,25 @@ class SalesforceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
     def _create_full_tmp_dir_path(self):
         self._tmp_download_file().parent.mkdir(parents=True, exist_ok=True)
 
-    def create_account(self, account_json: Dict[str, Any]) -> str:
-        """Creates partitionable account file"""
-        account = ACCOUNT_TEMPLATE.substitute(
-            id=account_json.get("Id"),
-            name=account_json.get("Name"),
-            account_type=account_json.get("Type"),
-            phone=account_json.get("Phone"),
-            account_number=account_json.get("AccountNumber"),
-            website=account_json.get("Website"),
-            industry=account_json.get("Industry"),
-            annual_revenue=account_json.get("AnnualRevenue"),
-            number_employees=account_json.get("NumberOfEmployees"),
-            ownership=account_json.get("Ownership"),
-            ticker_symbol=account_json.get("TickerSymbol"),
-            description=account_json.get("Description"),
-            rating=account_json.get("Rating"),
-            dnb_id=account_json.get("DandbCompanyId"),
-        )
-        return dedent(account)
+    def _xml_for_record(self, record: OrderedDict) -> str:
+        """Creates partitionable xml file from a record"""
+        import xml.etree.ElementTree as ET
 
-    def create_lead(self, lead_json: Dict[str, Any]) -> str:
-        """Creates partitionable lead file"""
-        lead = LEAD_TEMPLATE.substitute(
-            id=lead_json.get("Id"),
-            name=lead_json.get("Name"),
-            title=lead_json.get("Title"),
-            company=lead_json.get("Company"),
-            phone=lead_json.get("Phone"),
-            email=lead_json.get("Email"),
-            website=lead_json.get("Website"),
-            description=lead_json.get("Description"),
-            lead_source=lead_json.get("LeadSource"),
-            rating=lead_json.get("Rating"),
-            status=lead_json.get("Status"),
-            industry=lead_json.get("Industry"),
-        )
-        return dedent(lead)
+        def flatten_dict(data, parent, prefix=""):
+            for key, value in data.items():
+                if isinstance(value, OrderedDict):
+                    flatten_dict(value, parent, prefix=f"{prefix}{key}.")
+                else:
+                    item = ET.Element('item')
+                    item.text = f"{prefix}{key}: {value}"
+                    parent.append(item)
 
-    def create_case(self, case_json: Dict[str, Any]) -> str:
-        """Creates partitionable case file"""
-        case = CASE_TEMPLATE.substitute(
-            id=case_json.get("Id"),
-            type=case_json.get("Type"),
-            status=case_json.get("Status"),
-            reason=case_json.get("Reason"),
-            origin=case_json.get("Origin"),
-            subject=case_json.get("Subject"),
-            priority=case_json.get("Priority"),
-            description=case_json.get("Description"),
-            comments=case_json.get("Comments"),
-        )
-        return dedent(case)
+        root = ET.Element('root')
+        flatten_dict(record, root)
+        xml_string = ET.tostring(root, encoding='utf-8', xml_declaration=True).decode()
+        return xml_string
 
-    def create_campaign(self, campaign_json: Dict[str, Any]) -> str:
-        """Creates partitionable campaign file"""
-        campaign = CAMPAIGN_TEMPLATE.substitute(
-            id=campaign_json.get("Id"),
-            name=campaign_json.get("Name"),
-            type=campaign_json.get("Type"),
-            status=campaign_json.get("Status"),
-            start_date=campaign_json.get("StartDate"),
-            end_date=campaign_json.get("EndDate"),
-            budgeted_cost=campaign_json.get("BudgetedCost"),
-            actual_cost=campaign_json.get("ActualCost"),
-            description=campaign_json.get("Description"),
-            number_of_leads=campaign_json.get("NumberOfLeads"),
-            number_of_converted_leads=campaign_json.get("NumberOfConvertedLeads"),
-        )
-        return dedent(campaign)
-
-    def create_eml(self, email_json: Dict[str, Any]) -> str:
+    def _eml_for_record(self, email_json: Dict[str, Any]) -> str:
         """Recreates standard expected .eml format using template."""
         eml = EMAIL_TEMPLATE.substitute(
             date=formatdate(parser.parse(email_json.get("MessageDate")).timestamp()),
@@ -248,9 +198,11 @@ class SalesforceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             from_email=email_json.get("FromAddress"),
             to_email=email_json.get("ToAddress"),
             textbody=email_json.get("TextBody"),
+            htmlbody=email_json.get("HtmlBody"),
         )
         return dedent(eml)
 
+    @SourceConnectionError.wrap
     @BaseIngestDoc.skip_if_file_exists
     def get_file(self):
         """Saves individual json records locally."""
@@ -266,18 +218,12 @@ class SalesforceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
 
         try:
             if self.record_type == "EmailMessage":
-                formatted_record = self.create_eml(record)
-            elif self.record_type == "Account":
-                formatted_record = self.create_account(record)
-            elif self.record_type == "Lead":
-                formatted_record = self.create_lead(record)
-            elif self.record_type == "Case":
-                formatted_record = self.create_case(record)
-            elif self.record_type == "Campaign":
-                formatted_record = self.create_campaign(record)
+                document = self._eml_for_record(record)
+            else:
+                document = self._xml_for_record(record)
 
             with open(self._tmp_download_file(), "w") as page_file:
-                page_file.write(formatted_record)
+                page_file.write(document)
 
         except Exception as e:
             logger.error(


### PR DESCRIPTION
Currently email bodies are created with only the body text. Instead we should leverage the html body such that partitioning will better structure the content.

Additionally, the Salesforce connector currently partitions all non-email records, which are (sometimes nested) dictionaries of structured data, by writing them to a templated, raw text. The result is that the key value pairs are limited to only keys that we specify in the template and that the partitioning may sometimes incorrectly group content. Instead by using xml as the intermediary format we can guarantee the element content will adhere to the key-value pairs.

* leverage html content for email files
* use xml as intermediary format for well better structured key-values
* bonus: wraps get_file with @SourceConnectionError.wrap