### PR TITLE
Chore: Libmagic detection for "application/octet-stream" when  it is not a zip file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Updated documentation: Added back support doc types for partitioning, more Python codes in the API page,  RAG definition, and use case.
 * Updated Hi-Res Metadata: PDFs and Images using Hi-Res strategy now have layout model class probabilities added ot metadata.
-
+* Updated the `_detect_filetype_from_octet_stream()` function to use libmagic to infer the content type of file when it is not a zip file.
 ### Features
 
 * Add Jira Connector to be able to pull issues from a Jira organization

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -8,6 +8,7 @@ import pytest
 from unstructured.file_utils import filetype
 from unstructured.file_utils.filetype import (
     FileType,
+    _detect_filetype_from_octet_stream,
     _is_code_mime_type,
     _is_text_file_a_csv,
     _is_text_file_a_json,
@@ -439,3 +440,8 @@ def test_detect_filetype_skips_escape_commas_for_csv(tmpdir):
 
     with open(filename, "rb") as f:
         assert detect_filetype(file=f) == FileType.CSV
+
+
+def test_detect_filetype_from_octet_stream(filename="example-docs/emoji.xlsx"):
+    with open(filename, "rb") as f:
+        assert _detect_filetype_from_octet_stream(file=f) == FileType.XLSX

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -397,6 +397,10 @@ def _detect_filetype_from_octet_stream(file: IO) -> FileType:
         elif all(f in archive_filenames for f in EXPECTED_PPTX_FILES):
             return FileType.PPTX
 
+    if LIBMAGIC_AVAILABLE:
+        # Infer mime type using magic if octet-stream is not zip file
+        mime_type = magic.from_buffer(file.read(4096), mime=True)
+        return STR_TO_FILETYPE.get(mime_type, FileType.UNK)
     logger.warning(
         "Could not detect the filetype from application/octet-stream MIME type.",
     )


### PR DESCRIPTION
Addressed the issue #494 .
Updated the `_detect_filetype_from_octet_stream()` function to use libmagic to infer the content type of file when it is not a zip file.