### PR TITLE
fix: coordinates metadata hinders chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.15-dev7
+## 0.10.15-dev8
 
 ### Enhancements
 
@@ -12,6 +12,8 @@
 ### Features
 
 ### Fixes
+
+* Fixes an issue where each element was being assigned to a separate chunk in chunk_by_title, by dropping the coordinates metadata field
 
 ## 0.10.14
 
@@ -66,7 +68,7 @@
 
 * Bump unstructured-inference
   * Avoid divide-by-zero errors swith `safe_division` (0.5.21)
-  
+
 ## 0.10.11
 
 ### Enhancements

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -2,9 +2,11 @@ from unstructured.chunking.title import (
     _split_elements_by_title_and_table,
     chunk_by_title,
 )
+from unstructured.documents.coordinates import CoordinateSystem
 from unstructured.documents.elements import (
     CheckBox,
     CompositeElement,
+    CoordinatesMetadata,
     ElementMetadata,
     Table,
     Text,
@@ -190,3 +192,86 @@ def test_chunk_by_title_groups_across_pages():
         ),
         CheckBox(),
     ]
+
+
+def test_chunk_by_title_drops_extra_metadata():
+    elements = [
+        Title(
+            "A Great Day",
+            metadata=ElementMetadata(
+                coordinates=CoordinatesMetadata(
+                    points=(
+                        (0.1, 0.1),
+                        (0.2, 0.1),
+                        (0.1, 0.2),
+                        (0.2, 0.2),
+                    ),
+                    system=CoordinateSystem(width=0.1, height=0.1),
+                ),
+            ),
+        ),
+        Text(
+            "Today is a great day.",
+            metadata=ElementMetadata(
+                coordinates=CoordinatesMetadata(
+                    points=(
+                        (0.2, 0.2),
+                        (0.3, 0.2),
+                        (0.2, 0.3),
+                        (0.3, 0.3),
+                    ),
+                    system=CoordinateSystem(width=0.2, height=0.2),
+                ),
+            ),
+        ),
+        Text(
+            "It is sunny outside.",
+            metadata=ElementMetadata(
+                coordinates=CoordinatesMetadata(
+                    points=(
+                        (0.3, 0.3),
+                        (0.4, 0.3),
+                        (0.3, 0.4),
+                        (0.4, 0.4),
+                    ),
+                    system=CoordinateSystem(width=0.3, height=0.3),
+                ),
+            ),
+        ),
+        Title(
+            "An Okay Day",
+            metadata=ElementMetadata(
+                coordinates=CoordinatesMetadata(
+                    points=(
+                        (0.3, 0.3),
+                        (0.4, 0.3),
+                        (0.3, 0.4),
+                        (0.4, 0.4),
+                    ),
+                    system=CoordinateSystem(width=0.3, height=0.3),
+                ),
+            ),
+        ),
+        Text(
+            "Today is an okay day.",
+            metadata=ElementMetadata(
+                coordinates=CoordinatesMetadata(
+                    points=(
+                        (0.4, 0.4),
+                        (0.5, 0.4),
+                        (0.4, 0.5),
+                        (0.5, 0.5),
+                    ),
+                    system=CoordinateSystem(width=0.4, height=0.4),
+                ),
+            ),
+        ),
+    ]
+
+    chunks = chunk_by_title(elements, combine_under_n_chars=0)
+
+    assert str(chunks[0]) == str(
+        CompositeElement("A Great Day\n\nToday is a great day.\n\nIt is sunny outside."),
+    )
+
+    assert str(chunks[1]) == str(CompositeElement("An Okay Day\n\nToday is an okay day."))

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.15-dev7"  # pragma: no cover
+__version__ = "0.10.15-dev8"  # pragma: no cover

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -135,7 +135,7 @@ def _drop_extra_metadata(
     metadata_dict: dict,
     include_pages: bool = True,
 ) -> dict:
-    keys_to_drop = ["element_id", "type"]
+    keys_to_drop = ["element_id", "type", "coordinates"]
     if not include_pages and "page_number" in metadata_dict:
         keys_to_drop.append("page_number")
 


### PR DESCRIPTION
Closes https://github.com/Unstructured-IO/unstructured/issues/1373

This PR: 
- drops the `coordinates`  metadata field in `chunk_by_title` to fix https://github.com/Unstructured-IO/unstructured/issues/1373 (read issue for the details)
- adds relevant test that checks the particular case