### PR TITLE
Roman/expand fsspec downstream connectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,10 +300,9 @@ jobs:
         sudo apt-get install -y tesseract-ocr-kor
         sudo apt-get install -y diffstat
         sudo apt-get install -y unzip
-        sudo curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        sudo unzip awscliv2.zip
-        sudo ./aws/install
         tesseract --version
+        which aws
+        aws --version
         make install-ingest-s3
         make install-ingest-airtable
         make install-ingest-azure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,11 +298,8 @@ jobs:
         sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
         sudo apt-get install -y tesseract-ocr
         sudo apt-get install -y tesseract-ocr-kor
-        sudo apt-get install -y diffstat
-        sudo apt-get install -y unzip
+        sudo apt-get install diffstat
         tesseract --version
-        which aws
-        aws --version
         make install-ingest-s3
         make install-ingest-airtable
         make install-ingest-azure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,11 @@ jobs:
         sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
         sudo apt-get install -y tesseract-ocr
         sudo apt-get install -y tesseract-ocr-kor
-        sudo apt-get install diffstat
+        sudo apt-get install -y diffstat
+        sudo apt-get install -y unzip
+        sudo curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        sudo unzip awscliv2.zip
+        sudo ./aws/install
         tesseract --version
         make install-ingest-s3
         make install-ingest-airtable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-## 0.10.17-dev2
+## 0.10.17-dev3
 
 ### Enhancements
 
 * **Adds data source properties to SharePoint, Outlook, Onedrive, Reddit, and Slack connectors** These properties (date_created, date_modified, version, source_url, record_locator) are written to element metadata during ingest, mapping elements to information about the document source from which they derive. This functionality enables downstream applications to reveal source document applications, e.g. a link to a GDrive doc, Salesforce record, etc.
+* **Fsspec downstream connectors** New destination connector added to ingest CLI, users may now use `unstructured-ingest` to write to any of the following:
+  * Azure
+  * Box
+  * Dropbox
+  * Google Cloud Service
 
 ### Features
 

--- a/docs/source/downstream_connectors.rst
+++ b/docs/source/downstream_connectors.rst
@@ -9,3 +9,4 @@ in our community `Slack. <https://join.slack.com/t/unstructuredw-kbe4326/shared_
    :maxdepth: 1
 
    downstream_connectors/delta_table
+   downstream_connectors/s3

--- a/docs/source/downstream_connectors/s3.rst
+++ b/docs/source/downstream_connectors/s3.rst
@@ -1,0 +1,65 @@
+S3
+==========
+Batch process all your records using ``unstructured-ingest`` to store structured outputs locally on your filesystem and upload those local files to S3.
+
+First you'll need to install the delta table dependencies as shown here.
+
+.. code:: shell
+
+  pip install "unstructured[delta-table]"
+
+Run Locally
+-----------
+The upstream connector can be any of the ones supported, but for convenience here, showing a sample command using the
+upstream s3 connector.
+
+.. tabs::
+
+   .. tab:: Shell
+
+      .. code:: shell
+
+        unstructured-ingest \
+            s3 \
+            --remote-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
+            --anonymous \
+            --output-dir s3-small-batch-output \
+            --num-processes 2
+            s3 \
+            --anonymous \
+            --remote-url s3://utic-dev-tech-fixtures/small-pdf-set-output
+
+   .. tab:: Python
+
+      .. code:: python
+
+        import subprocess
+
+        command = [
+            "unstructured-ingest",
+            "s3",
+            "--remote-url", "s3://utic-dev-tech-fixtures/small-pdf-set/",
+            "--anonymous",
+            "--output-dir", "s3-small-batch-output",
+            "--num-processes", "2",
+            "s3",
+            "--remote-url", "s3://utic-dev-tech-fixtures/small-pdf-set-output/",
+            "--anonymous",
+        ]
+
+        # Run the command
+        process = subprocess.Popen(command, stdout=subprocess.PIPE)
+        output, error = process.communicate()
+
+        # Print output
+        if process.returncode == 0:
+            print('Command executed successfully. Output:')
+            print(output.decode())
+        else:
+            print('Command failed. Error:')
+            print(error.decode())
+
+
+For a full list of the options the CLI accepts check ``unstructured-ingest <upstream connector> s3 --help``.
+
+NOTE: Keep in mind that you will need to have all the appropriate extras and dependencies for the file types of the documents contained in your data storage platform if you're running this locally. You can find more information about this in the `installation guide <https://unstructured-io.github.io/unstructured/installing.html>`_.

--- a/examples/ingest/azure/ingest.sh
+++ b/examples/ingest/azure/ingest.sh
@@ -14,6 +14,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
         --account-name azureunstructured1 \
         --output-dir azure-ingest-output \
         --num-processes 2 \
+        --verbose \
         azure \
         --remote-url abfs://utic-ingest-test-fixtures-output/ \
-        --account-name azureunstructured1 \
+        --connection-string  <provide connection string> \
+        --overwrite

--- a/examples/ingest/azure/ingest.sh
+++ b/examples/ingest/azure/ingest.sh
@@ -13,4 +13,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
         --remote-url abfs://container1/ \
         --account-name azureunstructured1 \
         --output-dir azure-ingest-output \
-        --num-processes 2
+        --num-processes 2 \
+        azure \
+        --remote-url abfs://utic-ingest-test-fixtures-output/ \
+        --account-name azureunstructured1 \

--- a/examples/ingest/box/ingest.sh
+++ b/examples/ingest/box/ingest.sh
@@ -29,4 +29,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
    --output-dir box-output \
    --num-processes 2 \
    --recursive \
-   --verbose
+   --verbose \
+   box \
+   --remote-url box://utic-test-ingest-fixtures-output \
+   --box-app-config "$BOX_APP_CONFIG_PATH"

--- a/examples/ingest/dropbox/ingest.sh
+++ b/examples/ingest/dropbox/ingest.sh
@@ -22,4 +22,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
    --token  "$DROPBOX_TOKEN" \
    --num-processes 2 \
    --recursive \
-   --verbose
+   --verbose \
+   dropbox \
+   --remote-url "dropbox://utic-ingest-test-fixtures-output/" \
+   --token "$DROPBOX_TOKEN"

--- a/test_unstructured_ingest/test-ingest-s3.sh
+++ b/test_unstructured_ingest/test-ingest-s3.sh
@@ -23,7 +23,7 @@ function cleanup() {
 
   if aws s3 ls "$DESTINATION_S3"; then
     echo "deleting destination s3 location: $DESTINATION_S3"
-    aws s3 rm "$DESTINATION_S3" --recursive
+    aws s3 rm "$DESTINATION_S3" --recursive --region us-east-2
   fi
 
   if [ -d "$OUTPUT_DIR_DEST" ]; then
@@ -55,6 +55,6 @@ sh "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME
 
 # Check against content uploaded to s3
 
-aws s3 cp "$DESTINATION_S3" "$OUTPUT_DIR_DEST" --recursive --no-sign-request
+aws s3 cp "$DESTINATION_S3" "$OUTPUT_DIR_DEST" --recursive --no-sign-request --region us-east-2
 
 sh "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME_DEST

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.17-dev2"  # pragma: no cover
+__version__ = "0.10.17-dev3"  # pragma: no cover

--- a/unstructured/ingest/cli/cmds/__init__.py
+++ b/unstructured/ingest/cli/cmds/__init__.py
@@ -16,6 +16,7 @@ from .dropbox import get_dest_cmd as dropbox_dest
 from .dropbox import get_source_cmd as dropbox_src
 from .elasticsearch import get_source_cmd as elasticsearch_src
 from .fsspec import get_source_cmd as fsspec_src
+from .gcs import get_dest_cmd as gcs_dest
 from .gcs import get_source_cmd as gcs_src
 from .github import get_source_cmd as github_src
 from .gitlab import get_source_cmd as gitlab_src
@@ -67,7 +68,9 @@ dest: t.List[click.Command] = [
     dropbox_dest(),
     azure_dest(),
     box_dest(),
+    gcs_dest(),
 ]
+
 
 __all__ = [
     "src",

--- a/unstructured/ingest/cli/cmds/__init__.py
+++ b/unstructured/ingest/cli/cmds/__init__.py
@@ -6,6 +6,7 @@ from .airtable import get_source_cmd as airtable_src
 from .azure import get_dest_cmd as azure_dest
 from .azure import get_source_cmd as azure_src
 from .biomed import get_source_cmd as biomed_src
+from .box import get_dest_cmd as box_dest
 from .box import get_source_cmd as box_src
 from .confluence import get_source_cmd as confluence_src
 from .delta_table import get_dest_cmd as delta_table_dest
@@ -60,7 +61,13 @@ src: t.List[click.Group] = [
     wikipedia_src(),
 ]
 
-dest: t.List[click.Command] = [s3_dest(), delta_table_dest(), dropbox_dest(), azure_dest()]
+dest: t.List[click.Command] = [
+    s3_dest(),
+    delta_table_dest(),
+    dropbox_dest(),
+    azure_dest(),
+    box_dest(),
+]
 
 __all__ = [
     "src",

--- a/unstructured/ingest/cli/cmds/__init__.py
+++ b/unstructured/ingest/cli/cmds/__init__.py
@@ -10,6 +10,7 @@ from .confluence import get_source_cmd as confluence_src
 from .delta_table import get_dest_cmd as delta_table_dest
 from .delta_table import get_source_cmd as delta_table_src
 from .discord import get_source_cmd as discord_src
+from .dropbox import get_dest_cmd as dropbox_dest
 from .dropbox import get_source_cmd as dropbox_src
 from .elasticsearch import get_source_cmd as elasticsearch_src
 from .fsspec import get_source_cmd as fsspec_src
@@ -58,7 +59,7 @@ src: t.List[click.Group] = [
     wikipedia_src(),
 ]
 
-dest: t.List[click.Command] = [s3_dest(), delta_table_dest()]
+dest: t.List[click.Command] = [s3_dest(), delta_table_dest(), dropbox_dest()]
 
 __all__ = [
     "src",

--- a/unstructured/ingest/cli/cmds/__init__.py
+++ b/unstructured/ingest/cli/cmds/__init__.py
@@ -3,6 +3,7 @@ import typing as t
 import click
 
 from .airtable import get_source_cmd as airtable_src
+from .azure import get_dest_cmd as azure_dest
 from .azure import get_source_cmd as azure_src
 from .biomed import get_source_cmd as biomed_src
 from .box import get_source_cmd as box_src
@@ -59,7 +60,7 @@ src: t.List[click.Group] = [
     wikipedia_src(),
 ]
 
-dest: t.List[click.Command] = [s3_dest(), delta_table_dest(), dropbox_dest()]
+dest: t.List[click.Command] = [s3_dest(), delta_table_dest(), dropbox_dest(), azure_dest()]
 
 __all__ = [
     "src",

--- a/unstructured/ingest/cli/cmds/azure.py
+++ b/unstructured/ingest/cli/cmds/azure.py
@@ -71,6 +71,46 @@ def azure_source(ctx: click.Context, **options):
         raise click.ClickException(str(e)) from e
 
 
+@click.command(name="azure")
+@click.pass_context
+def azure_dest(ctx: click.Context, **options):
+    parent_options: dict = ctx.parent.params if ctx.parent else {}
+    # Click sets all multiple fields as tuple, this needs to be updated to list
+    for k, v in options.items():
+        if isinstance(v, tuple):
+            options[k] = list(v)
+    for k, v in parent_options.items():
+        if isinstance(v, tuple):
+            parent_options[k] = list(v)
+    verbose = parent_options.get("verbose", False)
+    ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)
+    log_options(parent_options, verbose=verbose)
+    log_options(options, verbose=verbose)
+    try:
+        # run_init_checks(**options)
+        read_config = CliReadConfig.from_dict(parent_options)
+        partition_config = CliPartitionConfig.from_dict(parent_options)
+        # Run for schema validation
+        AzureCliConfig.from_dict(options)
+        azure_fn(
+            read_config=read_config,
+            partition_config=partition_config,
+            writer_type="azure",
+            writer_kwargs=options,
+            **parent_options,
+        )
+    except Exception as e:
+        logger.error(e, exc_info=True)
+        raise click.ClickException(str(e)) from e
+
+
+def get_dest_cmd() -> click.Command:
+    cmd = azure_dest
+    AzureCliConfig.add_cli_options(cmd)
+    CliRemoteUrlConfig.add_cli_options(cmd)
+    return cmd
+
+
 def get_source_cmd() -> click.Group:
     cmd = azure_source
     AzureCliConfig.add_cli_options(cmd)

--- a/unstructured/ingest/cli/cmds/azure.py
+++ b/unstructured/ingest/cli/cmds/azure.py
@@ -49,6 +49,23 @@ class AzureCliConfig(BaseConfig, CliMixin):
         cmd.params.extend(options)
 
 
+@dataclass
+class AzureWriteConfig(BaseConfig, CliMixin):
+    overwrite: bool = False
+
+    @staticmethod
+    def add_cli_options(cmd: click.Command) -> None:
+        options = [
+            click.Option(
+                ["--overwrite"],
+                is_flag=True,
+                default=False,
+                help="If the content already exists, should new uploads overwrite.",
+            ),
+        ]
+        cmd.params.extend(options)
+
+
 @click.group(name="azure", invoke_without_command=True, cls=Group)
 @click.pass_context
 def azure_source(ctx: click.Context, **options):
@@ -107,6 +124,7 @@ def azure_dest(ctx: click.Context, **options):
 def get_dest_cmd() -> click.Command:
     cmd = azure_dest
     AzureCliConfig.add_cli_options(cmd)
+    AzureWriteConfig.add_cli_options(cmd)
     CliRemoteUrlConfig.add_cli_options(cmd)
     return cmd
 

--- a/unstructured/ingest/cli/cmds/box.py
+++ b/unstructured/ingest/cli/cmds/box.py
@@ -58,6 +58,46 @@ def box_source(ctx: click.Context, **options):
         raise click.ClickException(str(e)) from e
 
 
+@click.command(name="box")
+@click.pass_context
+def box_dest(ctx: click.Context, **options):
+    parent_options: dict = ctx.parent.params if ctx.parent else {}
+    # Click sets all multiple fields as tuple, this needs to be updated to list
+    for k, v in options.items():
+        if isinstance(v, tuple):
+            options[k] = list(v)
+    for k, v in parent_options.items():
+        if isinstance(v, tuple):
+            parent_options[k] = list(v)
+    verbose = parent_options.get("verbose", False)
+    ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)
+    log_options(parent_options, verbose=verbose)
+    log_options(options, verbose=verbose)
+    try:
+        # run_init_checks(**options)
+        read_config = CliReadConfig.from_dict(parent_options)
+        partition_config = CliPartitionConfig.from_dict(parent_options)
+        # Run for schema validation
+        BoxCliConfig.from_dict(options)
+        box_fn(
+            read_config=read_config,
+            partition_config=partition_config,
+            writer_type="box",
+            writer_kwargs=options,
+            **parent_options,
+        )
+    except Exception as e:
+        logger.error(e, exc_info=True)
+        raise click.ClickException(str(e)) from e
+
+
+def get_dest_cmd() -> click.Command:
+    cmd = box_dest
+    BoxCliConfig.add_cli_options(cmd)
+    CliRemoteUrlConfig.add_cli_options(cmd)
+    return cmd
+
+
 def get_source_cmd() -> click.Group:
     cmd = box_source
     BoxCliConfig.add_cli_options(cmd)

--- a/unstructured/ingest/cli/cmds/dropbox.py
+++ b/unstructured/ingest/cli/cmds/dropbox.py
@@ -57,6 +57,46 @@ def dropbox_source(ctx: click.Context, **options):
         raise click.ClickException(str(e)) from e
 
 
+@click.command(name="dropbox")
+@click.pass_context
+def dropbox_dest(ctx: click.Context, **options):
+    parent_options: dict = ctx.parent.params if ctx.parent else {}
+    # Click sets all multiple fields as tuple, this needs to be updated to list
+    for k, v in options.items():
+        if isinstance(v, tuple):
+            options[k] = list(v)
+    for k, v in parent_options.items():
+        if isinstance(v, tuple):
+            parent_options[k] = list(v)
+    verbose = parent_options.get("verbose", False)
+    ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)
+    log_options(parent_options, verbose=verbose)
+    log_options(options, verbose=verbose)
+    try:
+        # run_init_checks(**options)
+        read_config = CliReadConfig.from_dict(parent_options)
+        partition_config = CliPartitionConfig.from_dict(parent_options)
+        # Run for schema validation
+        DropboxCliConfig.from_dict(options)
+        dropbox_fn(
+            read_config=read_config,
+            partition_config=partition_config,
+            writer_type="dropbox",
+            writer_kwargs=options,
+            **parent_options,
+        )
+    except Exception as e:
+        logger.error(e, exc_info=True)
+        raise click.ClickException(str(e)) from e
+
+
+def get_dest_cmd() -> click.Command:
+    cmd = dropbox_dest
+    DropboxCliConfig.add_cli_options(cmd)
+    CliRemoteUrlConfig.add_cli_options(cmd)
+    return cmd
+
+
 def get_source_cmd() -> click.Group:
     cmd = dropbox_source
     DropboxCliConfig.add_cli_options(cmd)

--- a/unstructured/ingest/cli/cmds/gcs.py
+++ b/unstructured/ingest/cli/cmds/gcs.py
@@ -60,6 +60,46 @@ def gcs_source(ctx: click.Context, **options):
         raise click.ClickException(str(e)) from e
 
 
+@click.command(name="gcs")
+@click.pass_context
+def gcs_dest(ctx: click.Context, **options):
+    parent_options: dict = ctx.parent.params if ctx.parent else {}
+    # Click sets all multiple fields as tuple, this needs to be updated to list
+    for k, v in options.items():
+        if isinstance(v, tuple):
+            options[k] = list(v)
+    for k, v in parent_options.items():
+        if isinstance(v, tuple):
+            parent_options[k] = list(v)
+    verbose = parent_options.get("verbose", False)
+    ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)
+    log_options(parent_options, verbose=verbose)
+    log_options(options, verbose=verbose)
+    try:
+        # run_init_checks(**options)
+        read_config = CliReadConfig.from_dict(parent_options)
+        partition_config = CliPartitionConfig.from_dict(parent_options)
+        # Run for schema validation
+        GcsCliConfig.from_dict(options)
+        gcs_fn(
+            read_config=read_config,
+            partition_config=partition_config,
+            writer_type="gcs",
+            writer_kwargs=options,
+            **parent_options,
+        )
+    except Exception as e:
+        logger.error(e, exc_info=True)
+        raise click.ClickException(str(e)) from e
+
+
+def get_dest_cmd() -> click.Command:
+    cmd = gcs_dest
+    GcsCliConfig.add_cli_options(cmd)
+    CliRemoteUrlConfig.add_cli_options(cmd)
+    return cmd
+
+
 def get_source_cmd() -> click.Group:
     cmd = gcs_source
     GcsCliConfig.add_cli_options(cmd)

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -38,7 +38,7 @@ class SimpleFsspecConfig(BaseConnectorConfig):
     # fsspec specific options
     path: str
     recursive: bool = False
-    access_kwargs: dict = field(default_factory=dict)
+    access_kwargs: t.Dict[str, t.Any] = field(default_factory=dict)
     protocol: str = field(init=False)
     path_without_protocol: str = field(init=False)
     dir_path: str = field(init=False)

--- a/unstructured/ingest/runner/box.py
+++ b/unstructured/ingest/runner/box.py
@@ -23,7 +23,7 @@ def box(
     ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)
 
     read_config.download_dir = update_download_dir_remote_url(
-        connector_name="azure",
+        connector_name="box",
         read_config=read_config,
         remote_url=remote_url,
         logger=logger,

--- a/unstructured/ingest/runner/writers.py
+++ b/unstructured/ingest/runner/writers.py
@@ -70,6 +70,32 @@ def dropbox_writer(
     )
 
 
+@requires_dependencies(["boxfs", "fsspec"], extras="box")
+def box_writer(
+    remote_url: str,
+    box_app_config: t.Optional[str],
+    verbose: bool = False,
+) -> BaseDestinationConnector:
+    import boxsdk
+
+    from unstructured.ingest.connector.box import (
+        BoxDestinationConnector,
+        SimpleBoxConfig,
+    )
+    from unstructured.ingest.connector.fsspec import FsspecWriteConfig
+
+    access_kwargs: t.Dict[str, t.Any] = {"box_app_config": box_app_config}
+    if verbose:
+        access_kwargs["client_type"] = boxsdk.LoggingClient
+    return BoxDestinationConnector(
+        write_config=FsspecWriteConfig(),
+        connector_config=SimpleBoxConfig(
+            path=remote_url,
+            access_kwargs=access_kwargs,
+        ),
+    )
+
+
 @requires_dependencies(["adlfs", "fsspec"], extras="azure")
 def azure_writer(
     remote_url: str,
@@ -107,6 +133,7 @@ def azure_writer(
 writer_map: t.Dict[str, t.Callable] = {
     "s3": s3_writer,
     "delta_table": delta_table_writer,
+    "box": box_writer,
     "dropbox": dropbox_writer,
     "azure": azure_writer,
 }

--- a/unstructured/ingest/runner/writers.py
+++ b/unstructured/ingest/runner/writers.py
@@ -130,10 +130,31 @@ def azure_writer(
     )
 
 
+def gcs_writer(
+    remote_url: str,
+    token: t.Optional[str],
+    verbose: bool = False,
+):
+    from unstructured.ingest.connector.fsspec import FsspecWriteConfig
+    from unstructured.ingest.connector.gcs import (
+        GcsDestinationConnector,
+        SimpleGcsConfig,
+    )
+
+    return GcsDestinationConnector(
+        write_config=FsspecWriteConfig(),
+        connector_config=SimpleGcsConfig(
+            path=remote_url,
+            access_kwargs={"token": token},
+        ),
+    )
+
+
 writer_map: t.Dict[str, t.Callable] = {
     "s3": s3_writer,
     "delta_table": delta_table_writer,
     "box": box_writer,
     "dropbox": dropbox_writer,
     "azure": azure_writer,
+    "gcs": gcs_writer,
 }

--- a/unstructured/ingest/runner/writers.py
+++ b/unstructured/ingest/runner/writers.py
@@ -68,4 +68,41 @@ def dropbox_writer(
     )
 
 
-writer_map = {"s3": s3_writer, "delta_table": delta_table_writer, "dropbox": dropbox_writer}
+@requires_dependencies(["adlfs", "fsspec"], extras="azure")
+def azure_writer(
+    remote_url: str,
+    account_name: t.Optional[str],
+    account_key: t.Optional[str],
+    connection_string: t.Optional[str],
+    verbose: bool = False,
+):
+    from unstructured.ingest.connector.azure import (
+        AzureBlobStorageDestinationConnector,
+        SimpleAzureBlobStorageConfig,
+    )
+
+    if account_name:
+        access_kwargs = {
+            "account_name": account_name,
+            "account_key": account_key,
+        }
+    elif connection_string:
+        access_kwargs = {"connection_string": connection_string}
+    else:
+        access_kwargs = {}
+
+    return AzureBlobStorageDestinationConnector(
+        write_config=WriteConfig(),
+        connector_config=SimpleAzureBlobStorageConfig(
+            path=remote_url,
+            access_kwargs=access_kwargs,
+        ),
+    )
+
+
+writer_map = {
+    "s3": s3_writer,
+    "delta_table": delta_table_writer,
+    "dropbox": dropbox_writer,
+    "azure": azure_writer,
+}

--- a/unstructured/ingest/runner/writers.py
+++ b/unstructured/ingest/runner/writers.py
@@ -48,7 +48,24 @@ def delta_table_writer(
     )
 
 
-writer_map: t.Dict[str, t.Callable] = {
-    "s3": s3_writer,
-    "delta_table": delta_table_writer,
-}
+@requires_dependencies(["dropboxdrivefs", "fsspec"], extras="dropbox")
+def dropbox_writer(
+    remote_url: str,
+    token: t.Optional[str],
+    verbose: bool = False,
+):
+    from unstructured.ingest.connector.dropbox import (
+        DropboxDestinationConnector,
+        SimpleDropboxConfig,
+    )
+
+    return DropboxDestinationConnector(
+        write_config=WriteConfig(),
+        connector_config=SimpleDropboxConfig(
+            path=remote_url,
+            access_kwargs={"token": token},
+        ),
+    )
+
+
+writer_map = {"s3": s3_writer, "delta_table": delta_table_writer, "dropbox": dropbox_writer}

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -1,7 +1,6 @@
 import functools
 import importlib
 import json
-import types
 import typing as t
 from datetime import datetime
 from functools import wraps
@@ -155,19 +154,10 @@ def requires_dependencies(
             )
 
     def decorator(to_wrap):
-        if isinstance(to_wrap, types.FunctionType):
-
-            @wraps(to_wrap)
-            def wrapper(*args, **kwargs):
-                check_deps()
-                return to_wrap(*args, **kwargs)
-
-        else:
-
-            @wraps(to_wrap)
-            def wrapper():
-                check_deps()
-                return to_wrap
+        @wraps(to_wrap)
+        def wrapper(*args, **kwargs):
+            check_deps()
+            return to_wrap(*args, **kwargs)
 
         return wrapper
 


### PR DESCRIPTION
### Description
Because all of the fsspec connectors have their interactions with the various underlying file system libraries abstracted away by the parent `fsspec` library, adding the rest on top of the existing s3 downstream connector is fairly simple. This adds the following downstream connectors: 
 * azure
 * box
 * dropbox
 * gcs

Also updated docs/ingest tests for s3 since that falls in the fsspec category. 