### PR TITLE
stop printing all commands in version-sync script

### DIFF
--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
 
 function usage {
     echo "Usage: $(basename "$0") [-c] -f FILE_TO_CHANGE REPLACEMENT_FORMAT [-f FILE_TO_CHANGE REPLACEMENT_FORMAT ...]" 2>&1


### PR DESCRIPTION
### Summary

Remove -x in version-sync script to stop printing all commands and arguments and improve readability.

### Test

`make check` and `make check-version` no longer print all the commands and arguments.

```
(unstructured) shreyanid@Shreyas-MBP-2 unstructured % make check-version 
scripts/version-sync.sh -c \
                -f "unstructured/__version__.py" semver
From github.com:Unstructured-IO/unstructured
 * branch              main       -> FETCH_HEAD
version sync would make no changes to unstructured/__version__.py.
```