### PR TITLE
chore: refactor languages parameter for image partition functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.15-dev6
+## 0.10.15-dev7
 
 ### Enhancements
 
@@ -7,6 +7,7 @@
 * Create and add `add_chunking_strategy` decorator to partition functions
 * Adds `languages` as an input parameter and marks `ocr_languages` kwarg for deprecation in pdf partitioning functions
 * Adds `xlsx` and `xls` to `skip_infer_table_types` default list in `partition`
+* Adds `languages` as an input parameter and marks `ocr_languages` kwarg for deprecation in image partitioning functions
 
 ### Features
 

--- a/test_unstructured/partition/pdf-image/test_image.py
+++ b/test_unstructured/partition/pdf-image/test_image.py
@@ -412,6 +412,12 @@ def test_partition_image_with_ocr_has_coordinates_from_file(
     assert int_coordinates == [(14, 36), (14, 16), (381, 16), (381, 36)]
 
 
+def test_partition_image_warns_with_ocr_languages(caplog):
+    filename = "example-docs/layout-parser-paper-fast.jpg"
+    image.partition_image(filename=filename, strategy="hi_res", ocr_languages="eng")
+    assert "The ocr_languages kwarg will be deprecated" in caplog.text
+
+
 def test_add_chunking_strategy_on_partition_image(
     filename="example-docs/layout-parser-paper-fast.jpg",
 ):

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.15-dev6"  # pragma: no cover
+__version__ = "0.10.15-dev7"  # pragma: no cover

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -13,7 +13,8 @@ def partition_image(
     file: Optional[bytes] = None,
     include_page_breaks: bool = False,
     infer_table_structure: bool = False,
-    ocr_languages: str = "eng",
+    ocr_languages: Optional[str] = None,
+    languages: List[str] = ["eng"],
     strategy: str = "hi_res",
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,
@@ -36,9 +37,9 @@ def partition_image(
         I.e., rows and cells are preserved.
         Whether True or False, the "text" field is always present in any Table element
         and is the text content of the table (no structure).
-    ocr_languages
-        The languages to use for the Tesseract agent. To use a language, you'll first need
-        to install the appropriate Tesseract language pack.
+    languages
+        The languages present in the document, for use in partitioning and/or OCR. To use a language
+        with Tesseract, you'll first need to install the appropriate Tesseract language pack.
     strategy
         The strategy to use for partitioning the image. Valid strategies are "hi_res" and
         "ocr_only". When using the "hi_res" strategy, the function uses a layout detection
@@ -50,13 +51,30 @@ def partition_image(
     """
     exactly_one(filename=filename, file=file)
 
+    if not isinstance(languages, list):
+        raise TypeError("The language parameter must be a list of language codes as strings.")
+
+    if ocr_languages is not None:
+        if languages != ["eng"]:
+            raise ValueError(
+                "Only one of languages and ocr_languages should be specified. "
+                "languages is preferred. ocr_languages is marked for deprecation.",
+            )
+
+        else:
+            languages = convert_old_ocr_languages_to_languages(ocr_languages)
+            logger.warning(
+                "The ocr_languages kwarg will be deprecated in a future version of unstructured. "
+                "Please use languages instead.",
+            )
+
     return partition_pdf_or_image(
         filename=filename,
         file=file,
         is_image=True,
         include_page_breaks=include_page_breaks,
         infer_table_structure=infer_table_structure,
-        ocr_languages=ocr_languages,
+        languages=languages,
         strategy=strategy,
         metadata_last_modified=metadata_last_modified,
     )

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -2,7 +2,11 @@ from typing import List, Optional
 
 from unstructured.chunking.title import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
+from unstructured.logger import logger
 from unstructured.partition.common import exactly_one
+from unstructured.partition.lang import (
+    convert_old_ocr_languages_to_languages,
+)
 from unstructured.partition.pdf import partition_pdf_or_image
 
 


### PR DESCRIPTION
### Summary
In order to support language functionality other than Tesseract OCR, we want to represent languages provided for either partitioning accuracy or OCR as a standard list of langcodes as strings.

### Details
Follows the pattern established with PDFs in #1334. Adds languages (a list of strings) as a parameter to `partition_image`. Marks ocr_languages for deprecation. 

### Test
Call partition_image or partition_pdf_or_image with a variety of strategies, languages, or ocr_languages.
- inclusion of ocr_languages as a parameter should display a deprecation warning and may proceed with partitioning if no other conflicts
- the other valid call outputs should be no different from the current outputs.

ex:
```
from unstructured.partition.image import partition_image

elements = partition_image(filename="example-docs/layout-parser-paper-10p.jpg", strategy="hi_res", ocr_languages="eng")
print("\n\n".join([str(el) for el in elements]))
```
should display a deprecation warning, but will convert the information from `ocr_languages` to `languages` and proceed.