### PR TITLE
chore: refactor languages parameter for auto partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.15-dev7
+## 0.10.15-dev8
 
 ### Enhancements
 
@@ -8,6 +8,7 @@
 * Adds `languages` as an input parameter and marks `ocr_languages` kwarg for deprecation in pdf partitioning functions
 * Adds `xlsx` and `xls` to `skip_infer_table_types` default list in `partition`
 * Adds `languages` as an input parameter and marks `ocr_languages` kwarg for deprecation in image partitioning functions
+* Adds `languages` as an input parameter and marks `ocr_languages` kwarg for deprecation in auto partition
 
 ### Features
 

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -339,7 +339,7 @@ def test_auto_partition_pdf_with_fast_strategy(monkeypatch):
         include_page_breaks=False,
         infer_table_structure=False,
         strategy="fast",
-        ocr_languages="eng",
+        languages=["eng"],
     )
 
 
@@ -367,6 +367,12 @@ def test_auto_partition_pdf_from_file(pass_metadata_filename, content_type, requ
 
     assert isinstance(elements[1], NarrativeText)
     assert elements[1].text.startswith("Zejiang Shen")
+
+
+def test_auto_partition_warns_with_ocr_languages(caplog):
+    filename = "example-docs/chevron-page.pdf"
+    partition(filename=filename, strategy="hi_res", ocr_languages="eng")
+    assert "The ocr_languages kwarg will be deprecated" in caplog.text
 
 
 def test_partition_pdf_doesnt_raise_warning():

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.15-dev7"  # pragma: no cover
+__version__ = "0.10.15-dev8"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -128,7 +128,8 @@ def partition(
     headers: Dict[str, str] = {},
     skip_infer_table_types: List[str] = ["pdf", "jpg", "png", "xls", "xlsx"],
     ssl_verify: bool = True,
-    ocr_languages: str = "eng",
+    ocr_languages: Optional[str] = None,  # changing to optional for deprecation
+    languages: List[str] = ["eng"],
     pdf_infer_table_structure: bool = False,
     xml_keep_tags: bool = False,
     data_source_metadata: Optional[DataSourceMetadata] = None,
@@ -168,9 +169,9 @@ def partition(
     ssl_verify
         If the URL parameter is set, determines whether or not partition uses SSL verification
         in the HTTP request.
-    ocr_languages
-        The languages to use for the Tesseract agent. To use a language, you'll first need
-        to isntall the appropriate Tesseract language pack.
+    languages
+        The languages present in the document, for use in partitioning and/or OCR. To use a language
+        with Tesseract, you'll first need to install the appropriate Tesseract language pack.
     pdf_infer_table_structure
         If True and strategy=hi_res, any Table Elements extracted from a PDF will include an
         additional metadata field, "text_as_html," where the value (string) is a just a
@@ -195,6 +196,25 @@ def partition(
             "Please use metadata_filename instead.",
         )
     kwargs.setdefault("metadata_filename", metadata_filename)
+
+    if not isinstance(languages, list):
+        raise TypeError("The language parameter must be a list of language codes as strings.")
+
+    if ocr_languages is not None:
+        # check if languages was set to anything not the default value
+        # languages and ocr_languages were therefore both provided - raise error
+        if languages != ["eng"]:
+            raise ValueError(
+                "Only one of languages and ocr_languages should be specified. "
+                "languages is preferred. ocr_languages is marked for deprecation.",
+            )
+
+        else:
+            languages = convert_old_ocr_languages_to_languages(ocr_languages)
+            logger.warning(
+                "The ocr_languages kwarg will be deprecated in a future version of unstructured. "
+                "Please use languages instead.",
+            )
 
     if url is not None:
         file, filetype = file_and_type_from_url(
@@ -297,7 +317,7 @@ def partition(
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             strategy=strategy,
-            ocr_languages=ocr_languages,
+            languages=languages,
             **kwargs,
         )
     elif (filetype == FileType.PNG) or (filetype == FileType.JPG) or (filetype == FileType.TIFF):
@@ -308,7 +328,7 @@ def partition(
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             strategy=strategy,
-            ocr_languages=ocr_languages,
+            languages=languages,
             **kwargs,
         )
     elif filetype == FileType.TXT:

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -16,6 +16,9 @@ from unstructured.partition.common import exactly_one
 from unstructured.partition.email import partition_email
 from unstructured.partition.html import partition_html
 from unstructured.partition.json import partition_json
+from unstructured.partition.lang import (
+    convert_old_ocr_languages_to_languages,
+)
 from unstructured.partition.text import partition_text
 from unstructured.partition.xml import partition_xml
 from unstructured.utils import dependency_exists


### PR DESCRIPTION
### Summary
In order to support language functionality other than Tesseract OCR, we want to represent languages provided for either partitioning accuracy or OCR as a standard list of langcodes as strings.

### Details
Follows the pattern established with PDFs in #1334. Adds languages (a list of strings) as a parameter to partition in auto.py. Marks ocr_languages for deprecation.

### Test
Call partition with a variety of filetypes (especially pdfs/images), strategies, languages, or ocr_languages.
- inclusion of ocr_languages as a parameter should display a deprecation warning and may proceed with partitioning if no other conflicts
- the other valid call outputs should be no different from the current outputs