### PR TITLE
Roman/fsspec compression support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.10.17-dev2
+## 0.10.17-dev3
 
 ### Enhancements
 
 * **Adds data source properties to SharePoint, Outlook, Onedrive, Reddit, and Slack connectors** These properties (date_created, date_modified, version, source_url, record_locator) are written to element metadata during ingest, mapping elements to information about the document source from which they derive. This functionality enables downstream applications to reveal source document applications, e.g. a link to a GDrive doc, Salesforce record, etc.
+* **Fsspec source connector compression support** All fsspec-based source connectors used by `unstructured-ingest` now support un-compressing tar and zip files locally before processing via a CLI flag.
 
 ### Features
 

--- a/examples/ingest/s3-small-batch-compression/ingest.sh
+++ b/examples/ingest/s3-small-batch-compression/ingest.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Processes 3 PDF's from s3://utic-dev-tech-fixtures/small-pdf-set/
+# through Unstructured's library in 2 processes.
+
+# Structured outputs are stored in s3-small-batch-output/
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR"/../../.. || exit 1
+
+PYTHONPATH=. ./unstructured/ingest/main.py \
+        s3 \
+         --remote-url s3://utic-dev-tech-fixtures/small-pdf-set-w-compression/ \
+         --anonymous \
+         --output-dir small-pdf-set-w-compression-output \
+         --download-dir small-pdf-set-w-compression-download \
+         --num-processes 2 \
+         --recursive \
+         --uncompress \
+         --reprocess \
+         --verbose

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.17-dev2"  # pragma: no cover
+__version__ = "0.10.17-dev3"  # pragma: no cover

--- a/unstructured/ingest/cli/cmds/azure.py
+++ b/unstructured/ingest/cli/cmds/azure.py
@@ -9,11 +9,11 @@ from unstructured.ingest.cli.common import (
     log_options,
 )
 from unstructured.ingest.cli.interfaces import (
+    CliFsspecConfig,
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
-    CliRemoteUrlConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -74,7 +74,7 @@ def azure_source(ctx: click.Context, **options):
 def get_source_cmd() -> click.Group:
     cmd = azure_source
     AzureCliConfig.add_cli_options(cmd)
-    CliRemoteUrlConfig.add_cli_options(cmd)
+    CliFsspecConfig.add_cli_options(cmd)
     CliRecursiveConfig.add_cli_options(cmd)
 
     # Common CLI configs

--- a/unstructured/ingest/cli/cmds/box.py
+++ b/unstructured/ingest/cli/cmds/box.py
@@ -9,11 +9,11 @@ from unstructured.ingest.cli.common import (
     log_options,
 )
 from unstructured.ingest.cli.interfaces import (
+    CliFsspecConfig,
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
-    CliRemoteUrlConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -61,7 +61,7 @@ def box_source(ctx: click.Context, **options):
 def get_source_cmd() -> click.Group:
     cmd = box_source
     BoxCliConfig.add_cli_options(cmd)
-    CliRemoteUrlConfig.add_cli_options(cmd)
+    CliFsspecConfig.add_cli_options(cmd)
     CliRecursiveConfig.add_cli_options(cmd)
 
     # Common CLI configs

--- a/unstructured/ingest/cli/cmds/dropbox.py
+++ b/unstructured/ingest/cli/cmds/dropbox.py
@@ -8,11 +8,11 @@ from unstructured.ingest.cli.common import (
     log_options,
 )
 from unstructured.ingest.cli.interfaces import (
+    CliFsspecConfig,
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
-    CliRemoteUrlConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -60,7 +60,7 @@ def dropbox_source(ctx: click.Context, **options):
 def get_source_cmd() -> click.Group:
     cmd = dropbox_source
     DropboxCliConfig.add_cli_options(cmd)
-    CliRemoteUrlConfig.add_cli_options(cmd)
+    CliFsspecConfig.add_cli_options(cmd)
     CliRecursiveConfig.add_cli_options(cmd)
 
     # Common CLI configs

--- a/unstructured/ingest/cli/cmds/fsspec.py
+++ b/unstructured/ingest/cli/cmds/fsspec.py
@@ -7,10 +7,10 @@ from unstructured.ingest.cli.common import (
     log_options,
 )
 from unstructured.ingest.cli.interfaces import (
+    CliFsspecConfig,
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
-    CliRemoteUrlConfig,
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import fsspec as fsspec_fn
@@ -38,7 +38,7 @@ def fsspec_source(ctx: click.Context, **options):
 
 def get_source_cmd() -> click.Group:
     cmd = fsspec_source
-    CliRemoteUrlConfig.add_cli_options(cmd)
+    CliFsspecConfig.add_cli_options(cmd)
     CliRecursiveConfig.add_cli_options(cmd)
 
     # Common CLI configs

--- a/unstructured/ingest/cli/cmds/gcs.py
+++ b/unstructured/ingest/cli/cmds/gcs.py
@@ -9,11 +9,11 @@ from unstructured.ingest.cli.common import (
     log_options,
 )
 from unstructured.ingest.cli.interfaces import (
+    CliFsspecConfig,
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
-    CliRemoteUrlConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -63,7 +63,7 @@ def gcs_source(ctx: click.Context, **options):
 def get_source_cmd() -> click.Group:
     cmd = gcs_source
     GcsCliConfig.add_cli_options(cmd)
-    CliRemoteUrlConfig.add_cli_options(cmd)
+    CliFsspecConfig.add_cli_options(cmd)
     CliRecursiveConfig.add_cli_options(cmd)
 
     # Common CLI configs

--- a/unstructured/ingest/cli/cmds/s3.py
+++ b/unstructured/ingest/cli/cmds/s3.py
@@ -8,11 +8,11 @@ from unstructured.ingest.cli.common import (
     log_options,
 )
 from unstructured.ingest.cli.interfaces import (
+    CliFsspecConfig,
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
-    CliRemoteUrlConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -97,14 +97,14 @@ def s3_dest(ctx: click.Context, **options):
 def get_dest_cmd() -> click.Command:
     cmd = s3_dest
     S3CliConfig.add_cli_options(cmd)
-    CliRemoteUrlConfig.add_cli_options(cmd)
+    CliFsspecConfig.add_cli_options(cmd)
     return cmd
 
 
 def get_source_cmd() -> click.Group:
     cmd = s3_source
     S3CliConfig.add_cli_options(cmd)
-    CliRemoteUrlConfig.add_cli_options(cmd)
+    CliFsspecConfig.add_cli_options(cmd)
     CliRecursiveConfig.add_cli_options(cmd)
 
     # Common CLI configs

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -171,8 +171,9 @@ class CliRecursiveConfig(BaseConfig, CliMixin):
         cmd.params.extend(options)
 
 
-class CliRemoteUrlConfig(BaseConfig, CliMixin):
+class CliFsspecConfig(BaseConfig, CliMixin):
     remote_url: str
+    uncompress: bool
 
     @staticmethod
     def add_cli_options(cmd: click.Command) -> None:
@@ -181,6 +182,12 @@ class CliRemoteUrlConfig(BaseConfig, CliMixin):
                 ["--remote-url"],
                 required=True,
                 help="Remote fsspec URL formatted as `protocol://dir/path`",
+            ),
+            click.Option(
+                ["--uncompress"],
+                type=bool,
+                default=False,
+                is_flag=True,
             ),
         ]
         cmd.params.extend(options)

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -188,6 +188,8 @@ class CliFsspecConfig(BaseConfig, CliMixin):
                 type=bool,
                 default=False,
                 is_flag=True,
+                help="Uncompress any archived files. Currently supporting zip and tar "
+                "files based on file extension.",
             ),
         ]
         cmd.params.extend(options)

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -47,8 +47,7 @@ class SimpleFsspecConfig(BaseConnectorConfig):
     # fsspec specific options
     path: str
     recursive: bool = False
-    # TODO revert to False as default
-    uncompress: bool = True
+    uncompress: bool = False
     access_kwargs: dict = field(default_factory=dict)
     protocol: str = field(init=False)
     path_without_protocol: str = field(init=False)

--- a/unstructured/ingest/runner/azure.py
+++ b/unstructured/ingest/runner/azure.py
@@ -16,6 +16,7 @@ def azure(
     account_key: t.Optional[str],
     connection_string: t.Optional[str],
     remote_url: str,
+    uncompress: bool,
     recursive: bool,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
@@ -54,6 +55,7 @@ def azure(
         connector_config=SimpleAzureBlobStorageConfig(
             path=remote_url,
             recursive=recursive,
+            uncompress=uncompress,
             access_kwargs=access_kwargs,
         ),
         read_config=read_config,

--- a/unstructured/ingest/runner/box.py
+++ b/unstructured/ingest/runner/box.py
@@ -14,6 +14,7 @@ def box(
     partition_config: PartitionConfig,
     remote_url: str,
     recursive: bool,
+    uncompress: bool,
     box_app_config: t.Optional[str],
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
@@ -36,6 +37,7 @@ def box(
         connector_config=SimpleBoxConfig(
             path=remote_url,
             recursive=recursive,
+            uncompress=uncompress,
             access_kwargs={"box_app_config": box_app_config},
         ),
         partition_config=partition_config,

--- a/unstructured/ingest/runner/dropbox.py
+++ b/unstructured/ingest/runner/dropbox.py
@@ -14,6 +14,7 @@ def dropbox(
     partition_config: PartitionConfig,
     remote_url: str,
     recursive: bool,
+    uncompress: bool,
     token: t.Optional[str],
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
@@ -39,6 +40,7 @@ def dropbox(
         connector_config=SimpleDropboxConfig(
             path=remote_url,
             recursive=recursive,
+            uncompress=uncompress,
             access_kwargs={"token": token},
         ),
         partition_config=partition_config,

--- a/unstructured/ingest/runner/fsspec.py
+++ b/unstructured/ingest/runner/fsspec.py
@@ -16,6 +16,7 @@ def fsspec(
     partition_config: PartitionConfig,
     remote_url: str,
     recursive: bool,
+    uncompress: bool,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -47,6 +48,7 @@ def fsspec(
         connector_config=SimpleFsspecConfig(
             path=remote_url,
             recursive=recursive,
+            uncompress=uncompress,
         ),
         read_config=read_config,
         partition_config=partition_config,

--- a/unstructured/ingest/runner/gcs.py
+++ b/unstructured/ingest/runner/gcs.py
@@ -14,6 +14,7 @@ def gcs(
     partition_config: PartitionConfig,
     remote_url: str,
     recursive: bool,
+    uncompress: bool,
     token: t.Optional[str],
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
@@ -35,6 +36,7 @@ def gcs(
         connector_config=SimpleGcsConfig(
             path=remote_url,
             recursive=recursive,
+            uncompress=uncompress,
             access_kwargs={"token": token},
         ),
         read_config=read_config,

--- a/unstructured/ingest/runner/s3.py
+++ b/unstructured/ingest/runner/s3.py
@@ -14,6 +14,7 @@ def s3(
     partition_config: PartitionConfig,
     remote_url: str,
     recursive: bool,
+    uncompress: bool,
     anonymous: bool,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
@@ -35,6 +36,7 @@ def s3(
         connector_config=SimpleS3Config(
             path=remote_url,
             recursive=recursive,
+            uncompress=uncompress,
             access_kwargs={"anon": anonymous},
         ),
         read_config=read_config,


### PR DESCRIPTION
### Description
As part of the `get_ingest_docs` method of the `FsspecSourceConnector`, any file that ends in an extension that is recognized as either a zip or tar file will be first pulled down, decompressed and those files will be added to the list of docs as `LocalIngestDoc` to be processed alongside all of the original `FsspecIngestDoc`. This adds a bit of overhead to the creation of the Fsspec connector but then all docs can be parallelized using multiprocessing Pool. 

Closes out https://github.com/Unstructured-IO/unstructured/issues/1317