### PR TITLE
roman/define json schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.10.17-dev1
+## 0.10.17-dev2
 
 ### Enhancements
 
 * **Adds data source properties to SharePoint, Outlook, Onedrive, Reddit, and Slack connectors** These properties (date_created, date_modified, version, source_url, record_locator) are written to element metadata during ingest, mapping elements to information about the document source from which they derive. This functionality enables downstream applications to reveal source document applications, e.g. a link to a GDrive doc, Salesforce record, etc.
+* **JSON Schema** Schema added to validate the output of all element types. This helps keep the generated json output consistent and allows users to map the output to any desired destination.
 
 ### Features
 
@@ -87,7 +88,7 @@
 * Update all connectors to use new downstream architecture
   * New click type added to parse comma-delimited string inputs
   * Some CLI options renamed
- 
+
 ### Features
 
 ### Fixes

--- a/test_unstructured/documents/test_schema.py
+++ b/test_unstructured/documents/test_schema.py
@@ -1,0 +1,107 @@
+import uuid
+
+import pytest
+from jsonschema import validate
+
+from unstructured.documents import elements
+from unstructured.documents.schema import _element_schema
+
+element_id = uuid.uuid4()
+coordinates = ((1.1, 2.2), (3.3, 4.4))
+coordinate_system = elements.CoordinateSystem(width=87, height=78)
+data_source = elements.DataSourceMetadata(
+    url="some_url",
+    version="some_version",
+    record_locator={"random": "text", "list": [1, 2, 3]},
+    date_created="date_created",
+    date_modified="date_modified",
+    date_processed="date_processed",
+)
+coordinates_metadata = elements.CoordinatesMetadata(
+    points=coordinates,
+    system=coordinate_system,
+)
+metadata = elements.ElementMetadata(
+    coordinates=coordinates_metadata,
+    data_source=data_source,
+    filename="some_filename",
+    file_directory="some_file_directory",
+    last_modified="some_last_modified",
+    filetype="some_filetype",
+    attached_to_filename="some_attached_to_filename",
+    parent_id=uuid.uuid4(),
+    category_depth=234,
+    page_number=777,
+    page_name="some_page_name",
+    url="some_url",
+    link_urls=["some", "link", "urls"],
+    link_texts=["some", "link", "texts"],
+    sent_from=["some", "sent", "from"],
+    sent_to=["some", "sent", "to"],
+    subject="some_subject",
+    section="some_section",
+    header_footer_type="some_header_footer_type",
+    emphasized_text_contents=["some", "emphasized", "text", "contents"],
+    emphasized_text_tags=["some", "emphasized", "text", "tags"],
+    text_as_html="<some_html>",
+    regex_metadata={
+        "some_regex_metadata": [
+            elements.RegexMetadata(text="some text", start=3, end=5),
+            elements.RegexMetadata(text="some more text", start=33, end=55),
+        ],
+    },
+    detection_class_prob=0.222,
+)
+
+
+def test_checkbox_element():
+    element = elements.CheckBox(
+        element_id=element_id,
+        coordinates=coordinates,
+        coordinate_system=coordinate_system,
+        checked=True,
+        metadata=metadata,
+    )
+
+    validate(element.to_dict(), schema=_element_schema)
+
+
+def test_formula_element():
+    element = elements.Formula(
+        element_id=element_id,
+        coordinates=coordinates,
+        coordinate_system=coordinate_system,
+        metadata=metadata,
+    )
+
+    validate(element.to_dict(), schema=_element_schema)
+
+
+@pytest.mark.parametrize(
+    "element_type",
+    [
+        elements.Text,
+        elements.CompositeElement,
+        elements.FigureCaption,
+        elements.NarrativeText,
+        elements.ListItem,
+        elements.Title,
+        elements.Address,
+        elements.EmailAddress,
+        elements.Image,
+        elements.PageBreak,
+        elements.Table,
+        elements.Header,
+        elements.Footer,
+    ],
+)
+def test_text_elements(element_type):
+    element = element_type(
+        text="some_text",
+        element_id=element_id,
+        coordinates=coordinates,
+        coordinate_system=coordinate_system,
+        metadata=metadata,
+    )
+
+    validate(element.to_dict(), schema=_element_schema)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.17-dev1"  # pragma: no cover
+__version__ = "0.10.17-dev2"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -77,7 +77,7 @@ class CoordinatesMetadata:
 
     def to_dict(self):
         return {
-            "points": self.points,
+            "points": [[p[0], p[1]] for p in self.points],
             "system": None if self.system is None else str(self.system.__class__.__name__),
             "layout_width": None if self.system is None else self.system.width,
             "layout_height": None if self.system is None else self.system.height,
@@ -191,6 +191,8 @@ class ElementMetadata:
             _dict["data_source"] = cast(DataSourceMetadata, self.data_source).to_dict()
         if self.coordinates:
             _dict["coordinates"] = cast(CoordinatesMetadata, self.coordinates).to_dict()
+        if self.parent_id:
+            _dict["parent_id"] = str(self.parent_id)
         return _dict
 
     @classmethod
@@ -328,7 +330,7 @@ class Element(abc.ABC):
     def to_dict(self) -> dict:
         return {
             "type": None,
-            "element_id": self.id,
+            "element_id": str(self.id),
             "metadata": self.metadata.to_dict(),
         }
 
@@ -385,7 +387,7 @@ class CheckBox(Element):
         out = super().to_dict()
         out["type"] = "CheckBox"
         out["checked"] = self.checked
-        out["element_id"] = self.id
+        out["element_id"] = str(self.id)
         return out
 
 
@@ -441,7 +443,7 @@ class Text(Element):
 
     def to_dict(self) -> dict:
         out = super().to_dict()
-        out["element_id"] = self.id
+        out["element_id"] = str(self.id)
         out["type"] = self.category
         out["text"] = self.text
         return out

--- a/unstructured/documents/schema.py
+++ b/unstructured/documents/schema.py
@@ -1,0 +1,124 @@
+import jsonschema
+
+_coordinates_schema = {
+    "type": "object",
+    "properties": {
+        "system": {"type": "string"},
+        "layout_width": {"type": "number"},
+        "layout_height": {"type": "number"},
+        "points": {
+            "type": "array",
+            "items": {
+                "type": "array",
+                "maxItems": 2,
+                "minItems": 2,
+                "items": {
+                    "type": "number",
+                },
+            },
+        },
+    },
+}
+
+_data_source_schema = {
+    "type": "object",
+    "properties": {
+        "url": {"type": "string"},
+        "version": {"type": "string"},
+        "record_locator": {"type": "object"},
+        "date_created": {"type": "string"},
+        "date_modified": {"type": "string"},
+        "date_processed": {"type": "string"},
+    },
+}
+
+_metadata_schema = {
+    "type": "object",
+    "properties": {
+        "coordinates": _coordinates_schema,
+        "data_source": _data_source_schema,
+        "filename": {"type": "string"},
+        "file_directory": {"type": "string"},
+        "last_modified": {"type": "string"},
+        "filetype": {"type": "string"},
+        "attached_to_filename": {"type": "string"},
+        "parent_id": {"type": "string"},
+        "category_depth": {"type": "integer"},
+        "page_numbed": {"type": "integer"},
+        "page_name": {"type": "string"},
+        "url": {"type": "string"},
+        "link_urls": {
+            "type": "array",
+            "items": {
+                "type": "string",
+            },
+        },
+        "link_texts": {
+            "type": "array",
+            "items": {
+                "type": "string",
+            },
+        },
+        "sent_from": {
+            "type": "array",
+            "items": {
+                "type": "string",
+            },
+        },
+        "sent_to": {
+            "type": "array",
+            "items": {
+                "type": "string",
+            },
+        },
+        "subject": {"type": "string"},
+        "section": {"type": "string"},
+        "header_footer_type": {"type": "string"},
+        "emphasized_text_contents": {
+            "type": "array",
+            "items": {
+                "type": "string",
+            },
+        },
+        "emphasized_text_tags": {
+            "type": "array",
+            "items": {
+                "type": "string",
+            },
+        },
+        "text_as_html": {"type": "string"},
+        "regex_metadata": {"type": "object"},
+        "detection_class_prob": {"type": "number"},
+    },
+}
+
+_element_schema = {
+    "type": "object",
+    "properties": {
+        "text": {
+            "type": "string",
+        },
+        "element_id": {
+            "type": "string",
+        },
+        "type": {
+            "type": "string",
+        },
+        "metadata": _metadata_schema,
+    },
+    "required": ["type", "text", "metadata", "element_id"],
+}
+
+_schema = {
+    "type": "array",
+    "items": _element_schema,
+}
+
+
+def get_schema() -> dict:
+    try:
+        jsonschema.validate({}, schema=_schema)
+    except jsonschema.SchemaError as error:
+        raise ValueError(f"json schema is invalid: {error}") from error
+
+    return _schema

--- a/unstructured/documents/schema.py
+++ b/unstructured/documents/schema.py
@@ -102,11 +102,11 @@ _element_schema = {
             "type": "string",
         },
         "type": {
-            "type": "string",
+            "type": ["string", "null"],
         },
         "metadata": _metadata_schema,
     },
-    "required": ["type", "text", "metadata", "element_id"],
+    "required": ["metadata", "element_id"],
 }
 
 _schema = {

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -138,10 +138,10 @@ class FsspecIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         with suppress(NotImplementedError):
             date_modified = fs.modified(self.remote_file_path).isoformat()
 
-        version = (
+        version = str(
             fs.checksum(self.remote_file_path)
             if self.connector_config.protocol != "gs"
-            else fs.info(self.remote_file_path).get("etag", "")
+            else fs.info(self.remote_file_path).get("etag", ""),
         )
         file_exists = fs.exists(self.remote_file_path)
         self.source_metadata = SourceMetadata(


### PR DESCRIPTION
### Description
Add schema that can be used for validation of the json output produced via partition.

### Testing
* Unit test added that validate the element schema across each of the element types we support. 

### Open conversation:
* When, if ever, should this schema be enforced to make sure any breaking changes to it are caught? 
* Should this be published in our docs/README? And if so, have a reference to it rather than a copy-paste of the python. 