### PR TITLE
build(test): disable airtable-large ingest test

### DIFF
--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -30,7 +30,8 @@ scripts=(
 'test-ingest-confluence-diff.sh'
 'test-ingest-confluence-large.sh'
 'test-ingest-airtable-diff.sh'
-'test-ingest-airtable-large.sh'
+# NOTE(ryan): This test is disabled because it is triggering too many requests to the API
+# 'test-ingest-airtable-large.sh'
 'test-ingest-local-single-file.sh'
 'test-ingest-local-single-file-with-encoding.sh'
 'test-ingest-local-single-file-with-pdf-infer-table-structure.sh'


### PR DESCRIPTION
We test the Airtable source connector through a detailed diff test and a "large" test that pulls a lot of content over the course of a lot of requests (for 246 docs). This is triggering `HTTP 429 Too Many Requests` errors when several tests are running in parallel in CI. In the meantime it's probably okay for us to skip that particular test in CI while keeping coverage in the diff test.