### PR TITLE
fix: fix benchmark script when DOCKER_TEST=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.17-dev6
+## 0.10.17-dev7
 
 ### Enhancements
 

--- a/scripts/performance/benchmark.sh
+++ b/scripts/performance/benchmark.sh
@@ -44,9 +44,9 @@ if [[ "$DOCKER_TEST" == "true" ]]; then
     -e GIT_HASH="$GIT_HASH" \
     -e SLOW_FILES="${SLOW_FILES[*]}" \
     -e HI_RES_STRATEGY_FILES="${HI_RES_STRATEGY_FILES[*]}" \
-    -v "${SCRIPT_DIR}":/home/scripts/performance \
+    -v "${SCRIPT_DIR}":/home/notebook-user/scripts/performance \
     unstructured:perf-test \
-    bash /home/scripts/performance/benchmark-local.sh 2>&1 | tee >(while IFS= read -r line; do
+    bash /home/notebook-user/scripts/performance/benchmark-local.sh 2>&1 | tee >(while IFS= read -r line; do
         read_benchmark_logs_for_results
     done)
 else


### PR DESCRIPTION
The home directory for our dockerfile changed and broke this script. To verify, try running the benchmark script:

```
export DOCKER_TEST=true
./scripts/performance/benchmark.sh
```