### PR TITLE
Roman/ingest exit on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.17-dev6
+## 0.10.17-dev7
 
 ### Enhancements
 
@@ -17,7 +17,7 @@
 * **Fixes SharePoint connector failures if any document has an unsupported filetype** Problem: Currently the entire connector ingest run fails if a single IngestDoc has an unsupported filetype. This is because a ValueError is raised in the IngestDoc's `__post_init__`. Fix: Adds a try/catch when the IngestConnector runs get_ingest_docs such that the error is logged but all processable documents->IngestDocs are still instantiated and returned. Importance: Allows users to ingest SharePoint content even when some files with unsupported filetypes exist there.
 
 * **Fix badly initialized Formula** Problem: YoloX contain new types of elements, when loading a document that contain formulas a new element of that class
-should be generated, however the Formula class inherits from Element instead of Text. After this change the element is correctly created with the correct class 
+should be generated, however the Formula class inherits from Element instead of Text. After this change the element is correctly created with the correct class
 allowing the document to be loaded. Fix: Change parent class for Formula to Text. Importance: Crucial to be able to load documents that contain formulas.
 
 ## 0.10.16

--- a/test_unstructured_ingest/test-ingest-against-api.sh
+++ b/test_unstructured_ingest/test-ingest-against-api.sh
@@ -26,6 +26,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     --num-processes 1 \
     --file-glob "*1p.txt" \
-    --input-path example-docs
+    --input-path example-docs \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-num-files-output.sh 1 $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-airtable-diff.sh
+++ b/test_unstructured_ingest/test-ingest-airtable-diff.sh
@@ -32,6 +32,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --num-processes 2 \
     --preserve-downloads \
     --reprocess \
-    --output-dir "$OUTPUT_DIR"
+    --output-dir "$OUTPUT_DIR" \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-airtable-large.sh
+++ b/test_unstructured_ingest/test-ingest-airtable-large.sh
@@ -35,7 +35,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --num-processes 2 \
     --preserve-downloads \
     --reprocess \
-    --output-dir "$OUTPUT_DIR"
+    --output-dir "$OUTPUT_DIR" \
+    --exit-on-error
 
 
 # We are expecting fifteen directories: fourteen bases and the parent directory

--- a/test_unstructured_ingest/test-ingest-azure.sh
+++ b/test_unstructured_ingest/test-ingest-azure.sh
@@ -23,6 +23,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --output-dir "$OUTPUT_DIR" \
     --verbose \
     --account-name azureunstructured1 \
-    --remote-url abfs://container1/
+    --remote-url abfs://container1/ \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-biomed-api.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-api.sh
@@ -31,5 +31,6 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --decay .3 \
     --max-request-time 30 \
     --max-retries 5 \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-biomed-path.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-path.sh
@@ -29,5 +29,6 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --max-request-time 30 \
     --max-retries 5 \
     --path "oa_pdf/07/07/sbaa031.073.PMC7234218.pdf" \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-box.sh
+++ b/test_unstructured_ingest/test-ingest-box.sh
@@ -37,6 +37,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --preserve-downloads \
     --recursive \
     --reprocess \
-    --verbose
+    --verbose \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-confluence-diff.sh
+++ b/test_unstructured_ingest/test-ingest-confluence-diff.sh
@@ -31,6 +31,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --url https://unstructured-ingest-test.atlassian.net \
     --user-email "$CONFLUENCE_USER_EMAIL" \
     --api-token "$CONFLUENCE_API_TOKEN" \
-    --spaces testteamsp,MFS
+    --spaces testteamsp,MFS \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-confluence-large.sh
+++ b/test_unstructured_ingest/test-ingest-confluence-large.sh
@@ -40,6 +40,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --max-num-of-spaces 10 \
     --spaces testteamsp1 \
     --max-num-of-docs-from-each-space 250 \
+    --exit-on-error
 
 OUTPUT_SUBFOLDER_NAME=testteamsp1
 

--- a/test_unstructured_ingest/test-ingest-delta-table.sh
+++ b/test_unstructured_ingest/test-ingest-delta-table.sh
@@ -35,7 +35,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     delta-table \
     --write-column json_data \
-    --table-uri "$DESTINATION_TABLE"
+    --table-uri "$DESTINATION_TABLE" \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME
 

--- a/test_unstructured_ingest/test-ingest-discord.sh
+++ b/test_unstructured_ingest/test-ingest-discord.sh
@@ -27,5 +27,6 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     --channels 1099442333440802930,1099601456321003600 \
     --token "$DISCORD_TOKEN" \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-dropbox.sh
+++ b/test_unstructured_ingest/test-ingest-dropbox.sh
@@ -32,7 +32,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     --token  "$DROPBOX_ACCESS_TOKEN" \
     --recursive \
-    --remote-url "dropbox:// /"
+    --remote-url "dropbox:// /" \
+    --exit-on-error
 
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-elasticsearch.sh
+++ b/test_unstructured_ingest/test-ingest-elasticsearch.sh
@@ -39,6 +39,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     --index-name movies \
     --url http://localhost:9200 \
-    --jq-query '{ethnicity, director, plot}'
+    --jq-query '{ethnicity, director, plot}' \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-gcs.sh
+++ b/test_unstructured_ingest/test-ingest-gcs.sh
@@ -31,7 +31,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     --token "$GCP_INGEST_SERVICE_KEY_FILE" \
     --recursive \
-    --remote-url gs://utic-test-ingest-fixtures/
+    --remote-url gs://utic-test-ingest-fixtures/ \
+    --exit-on-error
 
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-github.sh
+++ b/test_unstructured_ingest/test-ingest-github.sh
@@ -37,6 +37,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     --url dcneiner/Downloadify \
     --git-file-glob '*.html,*.txt' \
-    $ACCESS_TOKEN_FLAGS
+    $ACCESS_TOKEN_FLAGS \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-gitlab.sh
+++ b/test_unstructured_ingest/test-ingest-gitlab.sh
@@ -23,6 +23,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     --git-branch 'v0.0.7' \
     --git-file-glob '*.md,*.txt' \
-    --url https://gitlab.com/gitlab-com/content-sites/docsy-gitlab
+    --url https://gitlab.com/gitlab-com/content-sites/docsy-gitlab \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-num-files-output.sh 2 $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-google-drive.sh
+++ b/test_unstructured_ingest/test-ingest-google-drive.sh
@@ -33,7 +33,8 @@ PYTHONPATH=. unstructured/ingest/main.py \
     --output-dir "$OUTPUT_DIR" \
     --verbose \
     --drive-id 1OQZ66OHBE30rNsNa7dweGLfRmXvkT_jr \
-    --service-account-key "$GCP_INGEST_SERVICE_KEY_FILE"
+    --service-account-key "$GCP_INGEST_SERVICE_KEY_FILE" \
+    --exit-on-error
 
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-jira.sh
+++ b/test_unstructured_ingest/test-ingest-jira.sh
@@ -52,7 +52,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
         --api-token "$JIRA_INGEST_API_TOKEN" \
         --projects "JCTP3" \
         --boards "1" \
-        --issues "JCTP2-4,JCTP2-7,JCTP2-8,10012,JCTP2-11"
+        --issues "JCTP2-4,JCTP2-7,JCTP2-8,10012,JCTP2-11" \
+        --exit-on-error
 
 
 

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-encoding.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-encoding.sh
@@ -18,7 +18,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --encoding cp1252 \
     --verbose \
     --reprocess \
-    --input-path example-docs/fake-html-cp1252.html
+    --input-path example-docs/fake-html-cp1252.html \
+    --exit-on-error
 
 set +e
 

--- a/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file-with-pdf-infer-table-structure.sh
@@ -19,7 +19,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --strategy hi_res \
     --verbose \
     --reprocess \
-    --input-path example-docs/layout-parser-paper.pdf
+    --input-path example-docs/layout-parser-paper.pdf \
+    --exit-on-error
 
 set +e
 

--- a/test_unstructured_ingest/test-ingest-local-single-file.sh
+++ b/test_unstructured_ingest/test-ingest-local-single-file.sh
@@ -19,7 +19,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --strategy ocr_only \
     --verbose \
     --reprocess \
-    --input-path example-docs/english-and-korean.png
+    --input-path example-docs/english-and-korean.png \
+    --exit-on-error
 
 set +e
 

--- a/test_unstructured_ingest/test-ingest-local.sh
+++ b/test_unstructured_ingest/test-ingest-local.sh
@@ -19,6 +19,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --output-dir "$OUTPUT_DIR" \
     --verbose \
     --file-glob "*.html" \
-    --input-path example-docs
+    --input-path example-docs \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-num-files-output.sh 12 $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-notion.sh
+++ b/test_unstructured_ingest/test-ingest-notion.sh
@@ -26,7 +26,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --database-ids "122b2c22996b435b9de2ee0e9d2b04bc" \
     --num-processes 2 \
     --recursive \
-    --verbose
+    --verbose \
+    --exit-on-error
 
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-onedrive.sh
+++ b/test_unstructured_ingest/test-ingest-onedrive.sh
@@ -33,5 +33,6 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --user-pname "$MS_USER_PNAME" \
     --path '/utic-test-ingest-fixtures' \
     --recursive \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-outlook.sh
+++ b/test_unstructured_ingest/test-ingest-outlook.sh
@@ -31,7 +31,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --tenant "$MS_TENANT_ID" \
     --user-email "$MS_USER_EMAIL" \
     --outlook-folders IntegrationTest \
-    --recursive
+    --recursive \
+    --exit-on-error
 
 
 

--- a/test_unstructured_ingest/test-ingest-pdf-fast-reprocess.sh
+++ b/test_unstructured_ingest/test-ingest-pdf-fast-reprocess.sh
@@ -26,7 +26,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     --file-glob "*.pdf" \
     --input-path "$INPUT_PATH" \
-    --recursive
+    --recursive \
+    --exit-on-error
 
 
 

--- a/test_unstructured_ingest/test-ingest-s3.sh
+++ b/test_unstructured_ingest/test-ingest-s3.sh
@@ -25,7 +25,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --output-dir "$OUTPUT_DIR" \
     --verbose \
     --remote-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
-    --anonymous
+    --anonymous\
+    --exit-on-error
 
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-salesforce.sh
+++ b/test_unstructured_ingest/test-ingest-salesforce.sh
@@ -39,6 +39,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --recursive \
     --reprocess \
     --output-dir "$OUTPUT_DIR" \
-    --verbose
+    --verbose \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-sharepoint.sh
+++ b/test_unstructured_ingest/test-ingest-sharepoint.sh
@@ -32,5 +32,6 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --site "$SHAREPOINT_SITE" \
     --path "Shared Documents" \
     --recursive \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-slack.sh
+++ b/test_unstructured_ingest/test-ingest-slack.sh
@@ -29,6 +29,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
    --channels C052BGT7718 \
    --token "${SLACK_TOKEN}" \
    --start-date 2023-04-01 \
-   --end-date 2023-04-08T12:00:00-08:00
+   --end-date 2023-04-08T12:00:00-08:00 \
+   --exit-on-error
 
 "$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME

--- a/test_unstructured_ingest/test-ingest-wikipedia.sh
+++ b/test_unstructured_ingest/test-ingest-wikipedia.sh
@@ -21,6 +21,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --preserve-downloads \
     --output-dir "$OUTPUT_DIR" \
     --verbose \
-    --page-title "Open Source Software"
+    --page-title "Open Source Software" \
+    --exit-on-error
 
 "$SCRIPT_DIR"/check-num-files-output.sh 3 $OUTPUT_FOLDER_NAME

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.17-dev6"  # pragma: no cover
+__version__ = "0.10.17-dev7"  # pragma: no cover

--- a/unstructured/ingest/cli/cmds/airtable.py
+++ b/unstructured/ingest/cli/cmds/airtable.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -100,5 +101,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/azure.py
+++ b/unstructured/ingest/cli/cmds/azure.py
@@ -14,6 +14,7 @@ from unstructured.ingest.cli.interfaces import (
     CliReadConfig,
     CliRecursiveConfig,
     CliRemoteUrlConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -80,5 +81,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/biomed.py
+++ b/unstructured/ingest/cli/cmds/biomed.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -99,5 +100,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/box.py
+++ b/unstructured/ingest/cli/cmds/box.py
@@ -14,6 +14,7 @@ from unstructured.ingest.cli.interfaces import (
     CliReadConfig,
     CliRecursiveConfig,
     CliRemoteUrlConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -67,5 +68,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/confluence.py
+++ b/unstructured/ingest/cli/cmds/confluence.py
@@ -16,6 +16,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -108,5 +109,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/delta_table.py
+++ b/unstructured/ingest/cli/cmds/delta_table.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -155,5 +156,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/discord.py
+++ b/unstructured/ingest/cli/cmds/discord.py
@@ -16,6 +16,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -82,5 +83,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/dropbox.py
+++ b/unstructured/ingest/cli/cmds/dropbox.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.interfaces import (
     CliReadConfig,
     CliRecursiveConfig,
     CliRemoteUrlConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -66,5 +67,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/elasticsearch.py
+++ b/unstructured/ingest/cli/cmds/elasticsearch.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -81,5 +82,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/fsspec.py
+++ b/unstructured/ingest/cli/cmds/fsspec.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.interfaces import (
     CliReadConfig,
     CliRecursiveConfig,
     CliRemoteUrlConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner import fsspec as fsspec_fn
@@ -44,5 +45,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/gcs.py
+++ b/unstructured/ingest/cli/cmds/gcs.py
@@ -14,6 +14,7 @@ from unstructured.ingest.cli.interfaces import (
     CliReadConfig,
     CliRecursiveConfig,
     CliRemoteUrlConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -69,5 +70,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/github.py
+++ b/unstructured/ingest/cli/cmds/github.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -90,5 +91,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/gitlab.py
+++ b/unstructured/ingest/cli/cmds/gitlab.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -90,5 +91,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/google_drive.py
+++ b/unstructured/ingest/cli/cmds/google_drive.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.interfaces import (
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -80,5 +81,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/jira.py
+++ b/unstructured/ingest/cli/cmds/jira.py
@@ -16,6 +16,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -110,5 +111,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/local.py
+++ b/unstructured/ingest/cli/cmds/local.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.interfaces import (
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -74,5 +75,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/notion.py
+++ b/unstructured/ingest/cli/cmds/notion.py
@@ -17,6 +17,7 @@ from unstructured.ingest.cli.interfaces import (
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -84,5 +85,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/onedrive.py
+++ b/unstructured/ingest/cli/cmds/onedrive.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.interfaces import (
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -102,5 +103,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/outlook.py
+++ b/unstructured/ingest/cli/cmds/outlook.py
@@ -17,6 +17,7 @@ from unstructured.ingest.cli.interfaces import (
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -106,5 +107,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/reddit.py
+++ b/unstructured/ingest/cli/cmds/reddit.py
@@ -12,6 +12,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -90,5 +91,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/s3.py
+++ b/unstructured/ingest/cli/cmds/s3.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.interfaces import (
     CliReadConfig,
     CliRecursiveConfig,
     CliRemoteUrlConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -110,5 +111,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/salesforce.py
+++ b/unstructured/ingest/cli/cmds/salesforce.py
@@ -17,6 +17,7 @@ from unstructured.ingest.cli.interfaces import (
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -95,5 +96,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/sharepoint.py
+++ b/unstructured/ingest/cli/cmds/sharepoint.py
@@ -13,6 +13,7 @@ from unstructured.ingest.cli.interfaces import (
     CliPartitionConfig,
     CliReadConfig,
     CliRecursiveConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -101,5 +102,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/slack.py
+++ b/unstructured/ingest/cli/cmds/slack.py
@@ -16,6 +16,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -93,5 +94,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/cmds/wikipedia.py
+++ b/unstructured/ingest/cli/cmds/wikipedia.py
@@ -11,6 +11,7 @@ from unstructured.ingest.cli.interfaces import (
     CliMixin,
     CliPartitionConfig,
     CliReadConfig,
+    CommonSourceCliConfig,
 )
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
@@ -71,5 +72,5 @@ def get_source_cmd() -> click.Group:
     # Common CLI configs
     CliReadConfig.add_cli_options(cmd)
     CliPartitionConfig.add_cli_options(cmd)
-    cmd.params.append(click.Option(["-v", "--verbose"], is_flag=True, default=False))
+    CommonSourceCliConfig.add_cli_options(cmd)
     return cmd

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -13,6 +13,29 @@ class CliMixin:
         pass
 
 
+class CommonSourceCliConfig(BaseConfig, CliMixin):
+    verbose: bool
+    exit_on_error: bool
+
+    @staticmethod
+    def add_cli_options(cmd: click.Command) -> None:
+        options = [
+            click.Option(
+                ["-v", "--verbose"],
+                is_flag=True,
+                default=False,
+            ),
+            click.Option(
+                ["--exit-on-error"],
+                is_flag=True,
+                default=False,
+                help="If any of the docs being processed have an error, "
+                "exit with the appropriate exit code",
+            ),
+        ]
+        cmd.params.extend(options)
+
+
 class CliReadConfig(ReadConfig, CliMixin):
     @staticmethod
     def add_cli_options(cmd: click.Command) -> None:

--- a/unstructured/ingest/doc_processor/generalized.py
+++ b/unstructured/ingest/doc_processor/generalized.py
@@ -29,7 +29,11 @@ def initialize():
     get_model(os.environ.get("UNSTRUCTURED_HI_RES_MODEL_NAME"))
 
 
-def process_document(ingest_doc_json: str, **partition_kwargs) -> Optional[List[Dict[str, Any]]]:
+def process_document(
+    ingest_doc_json: str,
+    exit_on_error: bool = False,
+    **partition_kwargs,
+) -> Optional[List[Dict[str, Any]]]:
     """Process the serialized json for any IngestDoc-like class of document with chosen
     Unstructured partition logic.
 
@@ -62,8 +66,11 @@ def process_document(ingest_doc_json: str, **partition_kwargs) -> Optional[List[
         doc.write_result()
     except Exception:
         # TODO(crag) save the exception instead of print?
+        if exit_on_error:
+            logger.error(f"Failed to process {doc}")
+            raise Exception
         logger.error(f"Failed to process {doc}", exc_info=True)
     finally:
         if doc:
             doc.cleanup_file()
-        return isd_elems_no_filename
+    return isd_elems_no_filename

--- a/unstructured/ingest/processor.py
+++ b/unstructured/ingest/processor.py
@@ -105,9 +105,11 @@ def process_documents(
     partition_config: PartitionConfig,
     verbose: bool,
     dest_doc_connector: t.Optional[BaseDestinationConnector] = None,
+    exit_on_error: bool = False,
 ) -> None:
     process_document_with_partition_args = partial(
         process_document,
+        exit_on_error=exit_on_error,
         strategy=partition_config.strategy,
         ocr_languages=partition_config.ocr_languages,
         encoding=partition_config.encoding,

--- a/unstructured/ingest/runner/airtable.py
+++ b/unstructured/ingest/runner/airtable.py
@@ -15,6 +15,7 @@ def airtable(
     partition_config: PartitionConfig,
     personal_access_token: str,
     list_of_paths: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -57,4 +58,5 @@ def airtable(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/azure.py
+++ b/unstructured/ingest/runner/azure.py
@@ -17,6 +17,7 @@ def azure(
     connection_string: t.Optional[str],
     remote_url: str,
     recursive: bool,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -70,4 +71,5 @@ def azure(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/biomed.py
+++ b/unstructured/ingest/runner/biomed.py
@@ -20,6 +20,7 @@ def biomed(
     max_retries: int,
     max_request_time: int,
     decay: float,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -77,4 +78,5 @@ def biomed(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/box.py
+++ b/unstructured/ingest/runner/box.py
@@ -15,6 +15,7 @@ def box(
     remote_url: str,
     recursive: bool,
     box_app_config: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -51,4 +52,5 @@ def box(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/confluence.py
+++ b/unstructured/ingest/runner/confluence.py
@@ -19,6 +19,7 @@ def confluence(
     max_num_of_spaces: int,
     max_num_of_docs_from_each_space: int,
     spaces: t.Optional[t.List[str]] = None,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -67,4 +68,5 @@ def confluence(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/delta_table.py
+++ b/unstructured/ingest/runner/delta_table.py
@@ -19,6 +19,7 @@ def delta_table(
     storage_options: t.Optional[str] = None,
     without_files: bool = False,
     columns: t.Optional[t.List[str]] = None,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -67,4 +68,5 @@ def delta_table(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/discord.py
+++ b/unstructured/ingest/runner/discord.py
@@ -16,6 +16,7 @@ def discord(
     channels: t.List[str],
     token: str,
     period: t.Optional[int],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -61,4 +62,5 @@ def discord(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/dropbox.py
+++ b/unstructured/ingest/runner/dropbox.py
@@ -15,6 +15,7 @@ def dropbox(
     remote_url: str,
     recursive: bool,
     token: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -54,4 +55,5 @@ def dropbox(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/elasticsearch.py
+++ b/unstructured/ingest/runner/elasticsearch.py
@@ -16,6 +16,7 @@ def elasticsearch(
     url: str,
     index_name: str,
     jq_query: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -62,4 +63,5 @@ def elasticsearch(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/fsspec.py
+++ b/unstructured/ingest/runner/fsspec.py
@@ -16,6 +16,7 @@ def fsspec(
     partition_config: PartitionConfig,
     remote_url: str,
     recursive: bool,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -62,4 +63,5 @@ def fsspec(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/gcs.py
+++ b/unstructured/ingest/runner/gcs.py
@@ -15,6 +15,7 @@ def gcs(
     remote_url: str,
     recursive: bool,
     token: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -51,4 +52,5 @@ def gcs(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/github.py
+++ b/unstructured/ingest/runner/github.py
@@ -17,6 +17,7 @@ def github(
     git_branch: str,
     git_access_token: t.Optional[str],
     git_file_glob: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -64,4 +65,5 @@ def github(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/gitlab.py
+++ b/unstructured/ingest/runner/gitlab.py
@@ -17,6 +17,7 @@ def gitlab(
     git_branch: str,
     git_access_token: t.Optional[str],
     git_file_glob: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -64,4 +65,5 @@ def gitlab(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/google_drive.py
+++ b/unstructured/ingest/runner/google_drive.py
@@ -17,6 +17,7 @@ def gdrive(
     recursive: bool,
     drive_id: str,
     extension: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -62,4 +63,5 @@ def gdrive(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/jira.py
+++ b/unstructured/ingest/runner/jira.py
@@ -19,6 +19,7 @@ def jira(
     projects: t.Optional[t.List[str]],
     boards: t.Optional[t.List[str]],
     issues: t.Optional[t.List[str]],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -69,4 +70,5 @@ def jira(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/local.py
+++ b/unstructured/ingest/runner/local.py
@@ -14,6 +14,7 @@ def local(
     input_path: str,
     recursive: bool,
     file_glob: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -47,4 +48,5 @@ def local(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/notion.py
+++ b/unstructured/ingest/runner/notion.py
@@ -18,6 +18,7 @@ def notion(
     recursive: bool,
     page_ids: t.Optional[t.List[str]] = None,
     database_ids: t.Optional[t.List[str]] = None,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -79,4 +80,5 @@ def notion(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/onedrive.py
+++ b/unstructured/ingest/runner/onedrive.py
@@ -20,6 +20,7 @@ def onedrive(
     authority_url: t.Optional[str],
     path: t.Optional[str],
     recursive: bool,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -68,4 +69,5 @@ def onedrive(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/outlook.py
+++ b/unstructured/ingest/runner/outlook.py
@@ -20,6 +20,7 @@ def outlook(
     authority_url: t.Optional[str],
     recursive: bool,
     outlook_folders: t.Optional[t.List[str]] = None,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -66,4 +67,5 @@ def outlook(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/reddit.py
+++ b/unstructured/ingest/runner/reddit.py
@@ -19,6 +19,7 @@ def reddit(
     user_agent: str,
     search_query: t.Optional[str],
     num_posts: int,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -66,4 +67,5 @@ def reddit(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/s3.py
+++ b/unstructured/ingest/runner/s3.py
@@ -15,6 +15,7 @@ def s3(
     remote_url: str,
     recursive: bool,
     anonymous: bool,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -51,4 +52,5 @@ def s3(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/salesforce.py
+++ b/unstructured/ingest/runner/salesforce.py
@@ -18,6 +18,7 @@ def salesforce(
     consumer_key: str,
     private_key_path: str,
     categories: t.List[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -61,4 +62,5 @@ def salesforce(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/sharepoint.py
+++ b/unstructured/ingest/runner/sharepoint.py
@@ -19,6 +19,7 @@ def sharepoint(
     files_only: bool,
     path: str,
     recursive: bool,
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -66,4 +67,5 @@ def sharepoint(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/slack.py
+++ b/unstructured/ingest/runner/slack.py
@@ -17,6 +17,7 @@ def slack(
     token: str,
     start_date: t.Optional[str],
     end_date: t.Optional[str],
+    exit_on_error: bool = False,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
     **kwargs,
@@ -63,4 +64,5 @@ def slack(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )

--- a/unstructured/ingest/runner/wikipedia.py
+++ b/unstructured/ingest/runner/wikipedia.py
@@ -17,6 +17,7 @@ def wikipedia(
     auto_suggest: bool,
     writer_type: t.Optional[str] = None,
     writer_kwargs: t.Optional[dict] = None,
+    exit_on_error: bool = False,
     **kwargs,
 ):
     writer_kwargs = writer_kwargs if writer_kwargs else {}
@@ -58,4 +59,5 @@ def wikipedia(
         partition_config=partition_config,
         verbose=verbose,
         dest_doc_connector=dest_doc_connector,
+        exit_on_error=exit_on_error,
     )


### PR DESCRIPTION
### Description
Currently if an ingest doc fails, this is only logged and the ingest test script has no information from the exit code that anything went wrong. This then causes the scripts that check file diffs to run and break, making the logs look like it was those scripts that causes the ingest test to fail rather than the partitioning process. This adds an optional flag to cause the CLI to exit on error with the appropriate response code and avoid the subsequent checks to run in the ingest tests. 