### PR TITLE
Update docker download url to use scarf gateway

### DIFF
--- a/docs/source/installation/docker.rst
+++ b/docs/source/installation/docker.rst
@@ -18,7 +18,7 @@ We create Docker images for every push to the main branch. These images are tagg
 
 .. code-block:: bash
 
-   docker pull quay.io/unstructured-io/unstructured:latest
+   docker pull downloads.unstructured.io/unstructured-io/unstructured:latest
 
 Using the Docker Image
 ----------------------
@@ -28,7 +28,7 @@ After pulling the image, you can create and start a container from it:
 .. code-block:: bash
 
    # create the container
-   docker run -dt --name unstructured quay.io/unstructured-io/unstructured:latest
+   docker run -dt --name unstructured downloads.unstructured.io/unstructured-io/unstructured:latest
 
    # start a bash shell inside the running Docker container
    docker exec -it unstructured bash


### PR DESCRIPTION
This updates the docker image download url to pass through the scarf gateway, this allows anonymous tracking of downloads

Related to: https://github.com/Unstructured-IO/unstructured#chart_with_upwards_trend-analytics

Testing:
docker pull downloads.unstructured.io/unstructured-io/unstructured:latest

Result:
Image should download