### PR TITLE
Chore: move scarf to setup.py

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,7 +11,4 @@ emoji
 dataclasses-json
 python-iso639
 langdetect
-# (Trevor): This is a simple hello world package that is used to track
-# download count for this package using scarf.
-https://packages.unstructured.io/scarf.tgz
 numpy

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,8 +50,6 @@ regex==2023.8.8
     # via nltk
 requests==2.31.0
     # via -r requirements/base.in
-scarf @ https://packages.unstructured.io/scarf.tgz
-    # via -r requirements/base.in
 six==1.16.0
     # via langdetect
 soupsieve==2.5

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,12 @@ setup(
     entry_points={
         "console_scripts": ["unstructured-ingest=unstructured.ingest.main:main"],
     },
-    install_requires=load_requirements(),
+    install_requires=[
+        # (Trevor): This is a simple hello world package that is used to track
+        # download count for this package using scarf.
+        'scarf @ https://packages.unstructured.io/scarf.tgz',
+        load_requirements()
+    ],
     extras_require={
         # Document specific extra requirements
         "all-docs": all_doc_reqs,


### PR DESCRIPTION
This also follows what I have seen as the recommend way to define a file package like this.

Also bumps minor versions from pip compile

Testing:
`pip install -e .`
Everything should build as normal

`❯ pip install -e .
Obtaining file:///Users/trevor/dev/unstructured
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Collecting scarf@ https://packages.unstructured.io/scarf.tgz (from unstructured==0.10.17.dev16)
  Using cached https://packages.unstructured.io/scarf.tgz (1.1 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done`

When new release goes out, I will test just plain pip install to verify that functionality still works
