### PR TITLE
chore: don't cleanup ingest test outputs (non-CI)

### DIFF
--- a/test_unstructured_ingest/cleanup.sh
+++ b/test_unstructured_ingest/cleanup.sh
@@ -2,6 +2,11 @@
 
 
 function cleanup_dir() {
+  # NOTE(crag): for developers that want to always clean up .json outputs, etc., set
+  # UNSTRUCTURED_CLEANUP_DEV_FIXTURES=1
+  if [ "$CI" != "true" ] && [ -z "$UNSTRUCTURED_CLEANUP_DEV_FIXTURES" ] ; then
+    return 0
+  fi
   local dir_to_cleanup="${1}"
   echo "--- Running cleanup of $dir_to_cleanup ---"
 


### PR DESCRIPTION
When running test-ingest test fixtures locally (but not in CI), keep output .json's and other workdir artifacts around for the convenience of debugging.

**Test Instructions**

Run 

    bash -x ./test_unstructured_ingest/test-ingest-azure.sh

and witness output .json's are visible. Yay! Now, to instead clean up output .json's and workdir, run:

    UNSTRUCTURED_CLEANUP_DEV_FIXTURES=1 bash -x ./test_unstructured_ingest/test-ingest-azure.sh
    
and witness the files have been cleaned up. Yay!