### PR TITLE
build(test): skip full python matrix for most ingest tests

### DIFF
--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -15,7 +15,7 @@ jobs:
       (github.event_name == 'push' && contains(github.event.head_commit.message, 'ingest-test-fixtures-update'))
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
-      PYTHON_VERSION: "3.8"
+      PYTHON_VERSION: "3.10"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -72,6 +72,7 @@ for test in "${all_tests[@]}"; do
   CURRENT_TEST="$test"
   if [[ "$python_version" != "Python 3.10"* ]] && [[ ! "${full_python_matrix_tests[*]}" =~ $test ]] ; then
     echo "--------- SKIPPING SCRIPT $test ---------"
+    continue
   fi
   if [[ "$test" == "test-ingest-notion.sh" ]]; then
     echo "--------- RUNNING SCRIPT $test --- IGNORING FAILURES"

--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -52,7 +52,6 @@ full_python_matrix_tests=(
   'test-ingest-local-single-file-with-encoding.sh'
   'test-ingest-local-single-file-with-pdf-infer-table-structure.sh'
   'test-ingest-s3.sh'
-  'test-ingest-delta-table.sh'
   'test-ingest-google-drive.sh'
   'test-ingest-gcs.sh'
 )

--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -70,6 +70,8 @@ python_version=$(python --version 2>&1)
 
 for test in "${all_tests[@]}"; do
   CURRENT_TEST="$test"
+  # IF: python_version is not 3.10 (wildcarded to match any subminor version) AND the current test is not in full_python_matrix_tests
+  # Note: to test we expand the full_python_matrix_tests array to a string and then regex match the current test
   if [[ "$python_version" != "Python 3.10"* ]] && [[ ! "${full_python_matrix_tests[*]}" =~ $test ]] ; then
     echo "--------- SKIPPING SCRIPT $test ---------"
     continue

--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -69,10 +69,11 @@ trap print_last_run EXIT
 python_version=$(python --version 2>&1)
 
 for test in "${all_tests[@]}"; do
+  CURRENT_TEST="$test"
   if [[ "$python_version" != "Python 3.10"* ]] && [[ ! "${full_python_matrix_tests[*]}" =~ "$test" ]] ; then
     echo "--------- SKIPPING SCRIPT $test ---------"
   fi
-  if [[ "$CURRENT_TEST" == "test-ingest-notion.sh" ]]; then
+  if [[ "$test" == "test-ingest-notion.sh" ]]; then
     echo "--------- RUNNING SCRIPT $test --- IGNORING FAILURES"
     set +e
     echo "Running ./test_unstructured_ingest/$test"

--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -8,7 +8,7 @@ cd "$SCRIPT_DIR"/.. || exit 1
 # NOTE(crag): sets number of tesseract threads to 1 which may help with more reproducible outputs
 export OMP_THREAD_LIMIT=1
 
-scripts=(
+all_tests=(
 'test-ingest-s3.sh'
 'test-ingest-s3-minio.sh'
 'test-ingest-azure.sh'
@@ -45,29 +45,45 @@ scripts=(
 'test-ingest-sharepoint.sh'
 )
 
-CURRENT_SCRIPT="none"
+full_python_matrix_tests=(
+  'test-ingest-sharepoint.sh'
+  'test-ingest-local.sh'
+  'test-ingest-local-single-file.sh'
+  'test-ingest-local-single-file-with-encoding.sh'
+  'test-ingest-local-single-file-with-pdf-infer-table-structure.sh'
+  'test-ingest-s3.sh'
+  'test-ingest-delta-table.sh'
+  'test-ingest-google-drive.sh'
+  'test-ingest-gcs.sh'
+)
+
+CURRENT_TEST="none"
 
 function print_last_run() {
-  if [ "$CURRENT_SCRIPT" != "none" ]; then
-    echo "Last ran script: $CURRENT_SCRIPT"
+  if [ "$CURRENT_TEST" != "none" ]; then
+    echo "Last ran script: $CURRENT_TEST"
   fi
 }
 
 trap print_last_run EXIT
 
-for script in "${scripts[@]}"; do
-  CURRENT_SCRIPT=$script
-  if [[ "$CURRENT_SCRIPT" == "test-ingest-notion.sh" ]]; then
-    echo "--------- RUNNING SCRIPT $script --- IGNORING FAILURES"
+python_version=$(python --version 2>&1)
+
+for test in "${all_tests[@]}"; do
+  if [[ "$python_version" != "Python 3.10"* ]] && [[ ! "${full_python_matrix_tests[*]}" =~ "$test" ]] ; then
+    echo "--------- SKIPPING SCRIPT $test ---------"
+  fi
+  if [[ "$CURRENT_TEST" == "test-ingest-notion.sh" ]]; then
+    echo "--------- RUNNING SCRIPT $test --- IGNORING FAILURES"
     set +e
-    echo "Running ./test_unstructured_ingest/$script"
-    ./test_unstructured_ingest/"$script"
+    echo "Running ./test_unstructured_ingest/$test"
+    ./test_unstructured_ingest/"$test"
     set -e
-    echo "--------- FINISHED SCRIPT $script ---------"
+    echo "--------- FINISHED SCRIPT $test ---------"
   else
-    echo "--------- RUNNING SCRIPT $script ---------"
-    echo "Running ./test_unstructured_ingest/$script"
-    ./test_unstructured_ingest/"$script"
-    echo "--------- FINISHED SCRIPT $script ---------"
+    echo "--------- RUNNING SCRIPT $test ---------"
+    echo "Running ./test_unstructured_ingest/$test"
+    ./test_unstructured_ingest/"$test"
+    echo "--------- FINISHED SCRIPT $test ---------"
   fi
 done

--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -70,7 +70,7 @@ python_version=$(python --version 2>&1)
 
 for test in "${all_tests[@]}"; do
   CURRENT_TEST="$test"
-  if [[ "$python_version" != "Python 3.10"* ]] && [[ ! "${full_python_matrix_tests[*]}" =~ "$test" ]] ; then
+  if [[ "$python_version" != "Python 3.10"* ]] && [[ ! "${full_python_matrix_tests[*]}" =~ $test ]] ; then
     echo "--------- SKIPPING SCRIPT $test ---------"
   fi
   if [[ "$test" == "test-ingest-notion.sh" ]]; then


### PR DESCRIPTION
We’re probably unfairly (to the test) making a large volume of new connections and requests to test services when all of our ingest tests run across the full python test matrix and when a lot of PRs a firing at once. Lets limit the full matrix run to a select few, but still have all ingest tests run on python v3.10. This is done by checking the version and skipping in ingest-test.sh.

Bonus: Bumps ingest test fixture workflow to use 3.10. This technically shouldn't make a difference, but since we're making 3.10 the default of the matrix strategy, it probably makes sense to use 3.10 for the ingest fixture generation as well for consistency.

## Testing
- [example](https://github.com/Unstructured-IO/unstructured/actions/runs/6460319121/job/17537900978?pr=1687) running all tests in 3.10
- [example](https://github.com/Unstructured-IO/unstructured/actions/runs/6460319121/job/17537899999?pr=1687) skipping/running the expected tests in 3.8