### PR TITLE
fix: division by zero bug in pdf partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.20-dev6
+## 0.10.20-dev7
 
 ### Enhancements
 
@@ -25,6 +25,10 @@ setting UNSTRUCTURED_INCLUDE_DEBUG_METADATA=true is needed.
 * **Fixes badly initialized Formula** Problem: YoloX contain new types of elements, when loading a document that contain formulas a new element of that class
 should be generated, however the Formula class inherits from Element instead of Text. After this change the element is correctly created with the correct class
 allowing the document to be loaded. Fix: Change parent class for Formula to Text. Importance: Crucial to be able to load documents that contain formulas.
+* **Fixes a bug where division by zero can happen during pdf parition** * Problem: when checking if
+  an annotation is inside an element the annotation could have zero area, which lead to division by
+  zero. Fix: check if the annotation has an area > 0, if not the annotation is not considered to be
+  part of the element
 
 ## 0.10.19
 

--- a/test_unstructured/partition/pdf-image/test_pdf.py
+++ b/test_unstructured/partition/pdf-image/test_pdf.py
@@ -975,3 +975,24 @@ def test_partition_pdf_word_bbox_not_char(
     except Exception as e:
         raise ("Partitioning fail: %s" % e)
     assert len(elements) == 17
+
+
+@pytest.mark.parametrize(
+    ("threshold", "expected"),
+    [
+        (0.4, [True, False, False, False, False]),
+        (0.1, [True, True, False, False, False]),
+    ],
+)
+def test_check_annotations_within_element(threshold, expected):
+    annotations = [
+        {"bbox": [0, 0, 1, 1], "page_number": 1},
+        {"bbox": [0, 0, 3, 1], "page_number": 1},
+        {"bbox": [0, 0, 1, 1], "page_number": 2},
+        {"bbox": [0, 0, 0, 1], "page_number": 1},
+        {"bbox": [3, 0, 4, 1], "page_number": 1},
+    ]
+    element_bbox = (0, 0, 1, 1)
+    filtered = pdf.check_annotations_within_element(annotations, element_bbox, 1, threshold)
+    results = [annotation in filtered for annotation in annotations]
+    assert results == expected

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.20-dev6"  # pragma: no cover
+__version__ = "0.10.20-dev7"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -1096,10 +1096,12 @@ def check_annotations_within_element(
     """
     annotations_within_element = []
     for annotation in annotation_list:
-        if annotation["page_number"] == page_number and (
-            calculate_intersection_area(element_bbox, annotation["bbox"])
-            / calculate_bbox_area(annotation["bbox"])
-            > threshold
+        area = calculate_bbox_area(annotation["bbox"])
+        # when area is <=0 it is not considered part of any other element
+        if (
+            area
+            and annotation["page_number"] == page_number
+            and (calculate_intersection_area(element_bbox, annotation["bbox"]) / area > threshold)
         ):
             annotations_within_element.append(annotation)
     return annotations_within_element


### PR DESCRIPTION
This PR resolves #1699 

- when check annotation within element first check if the annotation has an area > 0
- if not the annotation is not considered part of the element and no need to compute the overlap over self ratio (so avoids division by zero)

This PR adds a unit test to the `check_annotation_within_element` function. Additionally the file provides in the issue ticket can be used as a test.