### PR TITLE
feat: calculate metric for percent of text missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.20-dev7
+## 0.10.20-dev8
 
 ### Enhancements
 
@@ -14,7 +14,7 @@
 *
 ### Features
 
-* **Adds `bag_of_words` function** In order to count the word frequency to evaluate extraction accuracy.
+* **Adds `bag_of_words` and `percent_missing_text` functions** In order to count the word frequencies in two input texts and calculate the percentage of text missing relative to the source document.
 * **Adds `edit_distance` calculation metrics** In order to benchmark the cleaned, extracted text with unstructured, `edit_distance` (`Levenshtein distance`) is included.
 * **Adds detection_origin field to metadata** Problem: Currently isn't an easy way to find out how an element was created. With this change that information is added. Importance: With this information the developers and users are now able to know how an element was created to make decisions on how to use it. In order tu use this feature
 setting UNSTRUCTURED_INCLUDE_DEBUG_METADATA=true is needed.

--- a/test_unstructured/metrics/test_text_extraction.py
+++ b/test_unstructured/metrics/test_text_extraction.py
@@ -211,7 +211,7 @@ def test_bag_of_words(text, expected):
         ),
     ],
 )
-def test_calculate_percent_missing_text_edge(output_text, source_text, expected_percentage):
+def test_calculate_percent_missing_text(output_text, source_text, expected_percentage):
     assert (
         text_extraction.calculate_percent_missing_text(output_text, source_text)
         == expected_percentage

--- a/test_unstructured/metrics/test_text_extraction.py
+++ b/test_unstructured/metrics/test_text_extraction.py
@@ -179,3 +179,40 @@ def test_calculate_edit_distance_with_filename(filename, expected_score, expecte
 )
 def test_bag_of_words(text, expected):
     assert text_extraction.bag_of_words(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("output_text", "source_text", "expected_percentage"),
+    [
+        (
+            "extra",
+            "",
+            0,
+        ),
+        (
+            "",
+            "Source text has a sentence.",
+            1,
+        ),
+        (
+            "The original s e n t e n c e is normal.",
+            "The original sentence is normal...",
+            0.2,
+        ),
+        (
+            "We saw 23% improvement in this quarter.",
+            "We saw 23% improvement in sales this quarter.",
+            0.12,
+        ),
+        (
+            "no",
+            "Is it possible to have more than everything missing?",
+            1,
+        ),
+    ],
+)
+def test_calculate_percent_missing_text_edge(output_text, source_text, expected_percentage):
+    assert (
+        text_extraction.calculate_percent_missing_text(output_text, source_text)
+        == expected_percentage
+    )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.20-dev7"  # pragma: no cover
+__version__ = "0.10.20-dev8"  # pragma: no cover

--- a/unstructured/metrics/text_extraction.py
+++ b/unstructured/metrics/text_extraction.py
@@ -82,3 +82,50 @@ def bag_of_words(text: str) -> Dict[str, int]:
                     bow[incorrect_word] = 1
             i = j
     return bow
+
+
+def calculate_percent_missing_text(
+    output: str,
+    source: str,
+) -> float:
+    """
+    Creates the bag of words (BOW) found in each input text and their frequencies, then compares the 
+    output BOW against the source BOW to calculate the % of text from the source text missing from
+    the output text.
+
+    Takes "clean, concatenated text" (CCT) from a document output and the ground truth source text 
+    as inputs.
+
+    If the output text contains all words from the source text and then some extra, result will be
+    0% missing text - this calculation does not penalize duplication.
+    
+    A spaced-out word (ex. h e l l o) is considered missing; individual characters of a word
+    will not be counted as separate words.
+
+    Returns the percentage of missing text represented as a decimal between 0 and 1.
+    """
+    output_bow = bag_of_words(output)
+    source_bow = bag_of_words(source)
+
+    # get total words in source bow while counting missing words
+    total_source_word_count = 0 
+    total_missing_word_count = 0
+
+    for source_word, source_count in source_bow.items():
+        total_source_word_count += source_count
+        if source_word not in output_bow:
+            # entire count is missing
+            total_missing_word_count += source_count
+        else:
+            output_count = output_bow[source_word]
+            total_missing_word_count += max(source_count - output_count, 0)
+
+    
+    # calculate percent missing text
+    if total_source_word_count == 0:
+        return 0 # nothing missing because nothing in source document
+    
+    fraction_missing = round(total_missing_word_count / total_source_word_count, 2)
+    return min(fraction_missing, 1) #limit to 100%
+            
+

--- a/unstructured/metrics/text_extraction.py
+++ b/unstructured/metrics/text_extraction.py
@@ -55,6 +55,13 @@ def calculate_edit_distance(
 
 
 def bag_of_words(text: str) -> Dict[str, int]:
+    """
+    Outputs the bag of words (BOW) found in the input text and their frequencies.
+
+    Takes "clean, concatenated text" (CCT) from a document as input.
+
+    Removes sentence punctuation, but not punctuation within a word (ex. apostrophes).
+    """
     bow: Dict[str, int] = {}
     incorrect_word: str = ""
     words = clean_bullets(remove_sentence_punctuation(text.lower(), ["-", "'"])).split()
@@ -89,16 +96,16 @@ def calculate_percent_missing_text(
     source: str,
 ) -> float:
     """
-    Creates the bag of words (BOW) found in each input text and their frequencies, then compares the 
+    Creates the bag of words (BOW) found in each input text and their frequencies, then compares the
     output BOW against the source BOW to calculate the % of text from the source text missing from
     the output text.
 
-    Takes "clean, concatenated text" (CCT) from a document output and the ground truth source text 
+    Takes "clean, concatenated text" (CCT) from a document output and the ground truth source text
     as inputs.
 
     If the output text contains all words from the source text and then some extra, result will be
     0% missing text - this calculation does not penalize duplication.
-    
+
     A spaced-out word (ex. h e l l o) is considered missing; individual characters of a word
     will not be counted as separate words.
 
@@ -108,7 +115,7 @@ def calculate_percent_missing_text(
     source_bow = bag_of_words(source)
 
     # get total words in source bow while counting missing words
-    total_source_word_count = 0 
+    total_source_word_count = 0
     total_missing_word_count = 0
 
     for source_word, source_count in source_bow.items():
@@ -120,12 +127,9 @@ def calculate_percent_missing_text(
             output_count = output_bow[source_word]
             total_missing_word_count += max(source_count - output_count, 0)
 
-    
     # calculate percent missing text
     if total_source_word_count == 0:
-        return 0 # nothing missing because nothing in source document
-    
-    fraction_missing = round(total_missing_word_count / total_source_word_count, 2)
-    return min(fraction_missing, 1) #limit to 100%
-            
+        return 0  # nothing missing because nothing in source document
 
+    fraction_missing = round(total_missing_word_count / total_source_word_count, 2)
+    return min(fraction_missing, 1)  # limit to 100%


### PR DESCRIPTION
### Summary
Missing text is a particularly important metric of quality for the Unstructured library because information from the document is not being captured and therefore not usable by downstream applications.

Add function to calculate the percent of text missing relative to the source transcription. Function takes 2 text strings (output and source) as input, and returns the percentage of text missing as a decimal.

### Technical Details
- The 2 input strings are both assumed to already contain clean and concatenated text (CCT)
- Implementation compares the bags of words (frequency counts for each word present in the text) of each input text
- Duplicated/extra text is not penalized
- Value is limited to the range [0, 1]

### Test
- Several edge cases are covered in the test function (missing text, duplicated text, spaced out words, etc).
- Can test other cases or text inputs by calling the function with 2 CCT strings as "output" and "source"