### PR TITLE
fix: #1461 Footer should appear at section start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Enhancements
 
-* **Improve natural reading order** Some `OCR` elements with only spaces in the text have full-page width in the bounding box, which causes the `xycut` sorting to not work as expected. Now the logic to parse OCR results removes any elements with only spaces (more than one space).
+* **Improve natural reading order.** Some `OCR` elements with only spaces in the text have full-page width in the bounding box, which causes the `xycut` sorting to not work as expected. Now the logic to parse OCR results removes any elements with only spaces (more than one space).
 * **Ingest compression utilities and fsspec connector support** Generic utility code added to handle files that get pulled from a source connector that are either tar or zip compressed and uncompress them locally. This is then processed using a local source connector. Currently this functionality has been incorporated into the fsspec connector and all those inheriting from it (currently: Azure Blob Storage, Google Cloud Storage, S3, Box, and Dropbox).
 * **Ingest destination connectors support for writing raw list of elements** Along with the default write method used in the ingest pipeline to write the json content associated with the ingest docs, each destination connector can now also write a raw list of elements to the desired downstream location without having an ingest doc associated with it.
 
@@ -63,6 +63,7 @@ an `__init__.py` file under the folder.
 * **Fixes failure when flagging for embeddings through unstructured-ingest** Currently adding the embedding parameter to any connector results in a failure on the copy stage. This is resolves the issue by adding the IngestDoc to the context map in the embedding node's `run` method. This allows users to specify that connectors fetch embeddings without failure.
 * **Fix ingest pipeline reformat nodes not discoverable** Fixes issue where  reformat nodes raise ModuleNotFoundError on import. This was due to the directory was missing `__init__.py` in order to make it discoverable.
 * **Fix default language in ingest CLI** Previously the default was being set to english which injected potentially incorrect information to downstream language detection libraries. By setting the default to None allows those libraries to better detect what language the text is in the doc being processed.
+* **Fix DOCX footers appear at section start.** Previously Footer elements appeared at the end of the document section in which they are defined. Footers, like Headers, applly to all pages that follow them, until superceded by a new footer definition. Therefore, like Header elements, they belong at the beginning of the section in which they are defined.
 
 ## 0.10.21
 

--- a/test_unstructured/partition/docx/test_docx.py
+++ b/test_unstructured/partition/docx/test_docx.py
@@ -119,7 +119,7 @@ def test_partition_docx_processes_table(filename="example-docs/fake_table.docx")
 def test_partition_docx_grabs_header_and_footer(filename="example-docs/handbook-1p.docx"):
     elements = partition_docx(filename=filename)
     assert elements[0] == Header("US Trustee Handbook")
-    assert elements[-1] == Footer("Copyright")
+    assert elements[1] == Footer("Copyright")
     for element in elements:
         assert element.metadata.filename == "handbook-1p.docx"
 
@@ -127,7 +127,8 @@ def test_partition_docx_grabs_header_and_footer(filename="example-docs/handbook-
 def test_partition_docx_includes_pages_if_present(filename="example-docs/handbook-1p.docx"):
     elements = partition_docx(filename=filename, include_page_breaks=False)
     assert "PageBreak" not in [elem.category for elem in elements]
-    assert elements[1].metadata.page_number == 1
+    # -- elements 0 and 1 are Header and Footer respectively --
+    assert elements[2].metadata.page_number == 1
     assert elements[-2].metadata.page_number == 2
     for element in elements:
         assert element.metadata.filename == "handbook-1p.docx"
@@ -136,7 +137,8 @@ def test_partition_docx_includes_pages_if_present(filename="example-docs/handboo
 def test_partition_docx_includes_page_breaks(filename="example-docs/handbook-1p.docx"):
     elements = partition_docx(filename=filename, include_page_breaks=True)
     assert "PageBreak" in [elem.category for elem in elements]
-    assert elements[1].metadata.page_number == 1
+    # -- elements 0 and 1 are Header and Footer respectively --
+    assert elements[2].metadata.page_number == 1
     assert elements[-2].metadata.page_number == 2
     for element in elements:
         assert element.metadata.filename == "handbook-1p.docx"

--- a/test_unstructured_ingest/expected-structured-output/box/handbook-1p.docx.json
+++ b/test_unstructured_ingest/expected-structured-output/box/handbook-1p.docx.json
@@ -22,6 +22,28 @@
     "text": "US Trustee Handbook"
   },
   {
+    "type": "Footer",
+    "element_id": "8dfc77ab4089e09d4397e12306086c19",
+    "metadata": {
+      "data_source": {
+        "url": "box://utic-test-ingest-fixtures/handbook-1p.docx",
+        "version": 279067178702899831567111695812844052273,
+        "record_locator": {
+          "protocol": "box",
+          "remote_file_path": "utic-test-ingest-fixtures/handbook-1p.docx"
+        },
+        "date_created": "2023-07-08T20:47:31-07:00",
+        "date_modified": "2023-07-08T20:47:31-07:00"
+      },
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "languages": [
+        "eng"
+      ],
+      "header_footer_type": "primary"
+    },
+    "text": "Copyright"
+  },
+  {
     "type": "Title",
     "element_id": "8ed906945500938a06129c30763f300e",
     "metadata": {
@@ -339,27 +361,5 @@
       "page_number": 2
     },
     "text": "Although this Handbook is not intended to be a complete statutory reference, the standing trustee’s primary statutory duties are set forth in 11 U.S.C. § 1302, which incorporates by reference some of the duties of chapter 7 trustees found in 11 U.S.C. § 704.  These duties include, but are not limited to, the following:"
-  },
-  {
-    "type": "Footer",
-    "element_id": "8dfc77ab4089e09d4397e12306086c19",
-    "metadata": {
-      "data_source": {
-        "url": "box://utic-test-ingest-fixtures/handbook-1p.docx",
-        "version": 279067178702899831567111695812844052273,
-        "record_locator": {
-          "protocol": "box",
-          "remote_file_path": "utic-test-ingest-fixtures/handbook-1p.docx"
-        },
-        "date_created": "2023-07-08T20:47:31-07:00",
-        "date_modified": "2023-07-08T20:47:31-07:00"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "languages": [
-        "eng"
-      ],
-      "header_footer_type": "primary"
-    },
-    "text": "Copyright"
   }
 ]

--- a/test_unstructured_ingest/expected-structured-output/dropbox/handbook-1p.docx.json
+++ b/test_unstructured_ingest/expected-structured-output/dropbox/handbook-1p.docx.json
@@ -20,6 +20,26 @@
     "text": "US Trustee Handbook"
   },
   {
+    "type": "Footer",
+    "element_id": "8dfc77ab4089e09d4397e12306086c19",
+    "metadata": {
+      "data_source": {
+        "url": "dropbox:///handbook-1p.docx",
+        "version": 295786627629610762742246339824936813778,
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "/handbook-1p.docx"
+        }
+      },
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "languages": [
+        "eng"
+      ],
+      "header_footer_type": "primary"
+    },
+    "text": "Copyright"
+  },
+  {
     "type": "Title",
     "element_id": "8ed906945500938a06129c30763f300e",
     "metadata": {
@@ -309,25 +329,5 @@
       "page_number": 2
     },
     "text": "Although this Handbook is not intended to be a complete statutory reference, the standing trustee’s primary statutory duties are set forth in 11 U.S.C. § 1302, which incorporates by reference some of the duties of chapter 7 trustees found in 11 U.S.C. § 704.  These duties include, but are not limited to, the following:"
-  },
-  {
-    "type": "Footer",
-    "element_id": "8dfc77ab4089e09d4397e12306086c19",
-    "metadata": {
-      "data_source": {
-        "url": "dropbox:///handbook-1p.docx",
-        "version": 295786627629610762742246339824936813778,
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/handbook-1p.docx"
-        }
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "languages": [
-        "eng"
-      ],
-      "header_footer_type": "primary"
-    },
-    "text": "Copyright"
   }
 ]

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -290,6 +290,7 @@ class _DocxPartitioner:
         for section_idx, section in enumerate(self._document.sections):
             yield from self._iter_section_page_breaks(section_idx, section)
             yield from self._iter_section_headers(section)
+            yield from self._iter_section_footers(section)
 
             for block_item in _SectBlockItemIterator.iter_sect_block_items(section, self._document):
                 # -- a block-item can only be a Paragraph ... --
@@ -300,8 +301,6 @@ class _DocxPartitioner:
                 # -- ... or a Table --
                 else:
                     yield from self._iter_table_element(block_item)
-
-            yield from self._iter_section_footers(section)
 
     @lazyproperty
     def _document(self) -> Document:


### PR DESCRIPTION
It's an easy intuitive mistake to make, that a header element appears at the beginning of a section and footers appear at the end. However a footer is just like a header in that it applies to all pages that follow it, until superceded by a new footer, if any.

Emit footers at the beginning of the section they're defined in, not at the end.