### PR TITLE
fix: zero divide in under_non_alpha_ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-* **Fixes `under_non_alpha_ratio` dividing by zero** Although this function guarded against a specific cause of division by zero, there were edge cases slipping through like strings tih only whitespace. This update more generally prevents the function from performing a division by zero.
+* **Fixes `under_non_alpha_ratio` dividing by zero** Although this function guarded against a specific cause of division by zero, there were edge cases slipping through like strings with only whitespace. This update more generally prevents the function from performing a division by zero.
 
 ## 0.10.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.23-dev0
+## 0.10.23-dev1
 
 ### Enhancements
 
@@ -7,6 +7,8 @@
 ### Features
 
 ### Fixes
+
+* **Fixes `under_non_alpha_ratio` dividing by zero** Although this function guarded against a specific cause of division by zero, there were edge cases slipping through like strings tih only whitespace. This update more generally prevents the function from performing a division by zero.
 
 ## 0.10.22
 

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -317,3 +317,8 @@ def test_is_us_city_state_zip(text, expected):
 )
 def test_is_email_address(text, expected):
     assert text_type.is_email_address(text) is expected
+
+
+def test_under_non_alpha_ratio_zero_divide():
+    # Threw an error before changes
+    text_type.under_non_alpha_ratio(" ")

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.23-dev0"  # pragma: no cover
+__version__ = "0.10.23-dev1"  # pragma: no cover

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -253,8 +253,7 @@ def under_non_alpha_ratio(text: str, threshold: float = 0.5):
 
     alpha_count = len([char for char in text if char.strip() and char.isalpha()])
     total_count = len([char for char in text if char.strip()])
-    ratio = alpha_count / total_count
-    return ratio < threshold
+    return ((alpha_count / total_count) < threshold) if total_count > 0 else False
 
 
 def exceeds_cap_ratio(text: str, threshold: float = 0.5) -> bool:


### PR DESCRIPTION
The function `under_non_alpha_ratio` in `unstructured.partition.text_type` was producing a divide-by-zero error. After investigation I found this was a possibility when the function was passed a string of all spaces.