### PR TITLE
Fix: ModuleNotFoundError for `partition.utils.ocr_models`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.24-dev2
+## 0.10.24-dev1
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
-## 0.10.24-dev0
+## 0.10.24-dev1
 
 ### Enhancements
 
 * **Ingest compression utilities and fsspec connector support** Generic utility code added to handle files that get pulled from a source connector that are either tar or zip compressed and uncompress them locally. This is then processed using a local source connector. Currently this functionality has been incorporated into the fsspec connector and all those inheriting from it (currently: Azure Blob Storage, Google Cloud Storage, S3, Box, and Dropbox).
 
 ### Features
+
+* **Fix paddle model file not discoverable** Fixes issue where ocr_models/paddle_ocr.py file is not discoverable on PyPI by adding
+an `__init__.py` file under the folder.
 
 ### Fixes
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.24-dev2"  # pragma: no cover
+__version__ = "0.10.24-dev1"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.24-dev0"  # pragma: no cover
+__version__ = "0.10.24-dev1"  # pragma: no cover


### PR DESCRIPTION
### Summary

Fix https://github.com/Unstructured-IO/unstructured-api/issues/286 where `partition/utils/ocr_models` folder is not uploaded to PyPI since its missing an `__init__.py` file