### PR TITLE
Add check for duplicate click options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,11 @@ jobs:
       uses: KengoTODA/actions-setup-docker-compose@v1
       with:
         version: '2.22.0'
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 30
+      with:
+        limit-access-to-actor: true
     - name: Test Ingest (unit)
       run: |
         source .venv/bin/activate
@@ -391,7 +396,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    # need to checkout otherwise paths-filter will fail on merge-queue trigger 
+    # need to checkout otherwise paths-filter will fail on merge-queue trigger
     - uses: actions/checkout@v3
     - if: github.ref != 'refs/heads/main'
       uses: dorny/paths-filter@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,11 +264,6 @@ jobs:
       uses: KengoTODA/actions-setup-docker-compose@v1
       with:
         version: '2.22.0'
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 30
-      with:
-        limit-access-to-actor: true
     - name: Test Ingest (unit)
       run: |
         source .venv/bin/activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Enhancements
 
+* **Duplicate CLI param check** Given that many of the options associated with the `Click` based cli ingest commands are added dynamically from a number of configs, a check was incorporated to make sure there were no duplicate entries to prevent new configs from overwriting already added options.
+
 ### Features
 
 * **Adds HuggingFaceEmbeddingEncoder** The HuggingFace Embedding Encoder uses a local embedding model as opposed to using an API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.25-dev4
+## 0.10.25-dev5
 
 ### Enhancements
 

--- a/Makefile
+++ b/Makefile
@@ -354,8 +354,8 @@ check-version:
 .PHONY: tidy
 tidy:
 	ruff . --select I,UP015,UP032,UP034,UP018,COM,C4,PT,SIM,PLR0402 --fix-only || true
-	black  .
 	autoflake --in-place .
+	black  .
 
 ## version-sync:            update __version__.py with most recent version from CHANGELOG.md
 .PHONY: version-sync

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ python_functions = test_ it_ they_ but_ and_
 
 [autoflake]
 expand_star_imports=true
-ignore_pass_statements=true
+ignore_pass_statements=false
 recursive=true
 quiet=true
 remove_all_unused_imports=true

--- a/test_unstructured/nlp/test_partition.py
+++ b/test_unstructured/nlp/test_partition.py
@@ -1,2 +1,1 @@
 # flake8: noqa
-pass

--- a/test_unstructured_ingest/test-ingest-biomed-api.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-api.sh
@@ -34,7 +34,6 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --verbose \
     --api-from "2019-01-02" \
     --api-until "2019-01-02+00:03:10" \
-    --decay .3 \
     --max-request-time 30 \
     --max-retries 5 \
     --work-dir "$WORK_DIR"

--- a/test_unstructured_ingest/test-ingest-biomed-path.sh
+++ b/test_unstructured_ingest/test-ingest-biomed-path.sh
@@ -31,7 +31,6 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --reprocess \
     --output-dir "$OUTPUT_DIR" \
     --verbose \
-    --decay .3 \
     --max-request-time 30 \
     --max-retries 5 \
     --path "oa_pdf/07/07/sbaa031.073.PMC7234218.pdf" \

--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -19,7 +19,7 @@ all_tests=(
 'test-ingest-salesforce.sh'
 'test-ingest-box.sh'
 'test-ingest-discord.sh'
-# 'test-ingest-dropbox.sh'
+'test-ingest-dropbox.sh'
 'test-ingest-github.sh'
 'test-ingest-gitlab.sh'
 'test-ingest-google-drive.sh'
@@ -82,7 +82,6 @@ for test in "${all_tests[@]}"; do
     echo "--------- SKIPPING SCRIPT $test ---------"
     continue
   fi
-
   if [[ "${tests_to_ignore[*]}" =~ $test ]]; then
     echo "--------- RUNNING SCRIPT $test --- IGNORING FAILURES"
     set +e

--- a/test_unstructured_ingest/unit/test_cli.py
+++ b/test_unstructured_ingest/unit/test_cli.py
@@ -1,0 +1,18 @@
+import click
+import pytest
+
+from unstructured.ingest.cli.interfaces import CliMixin
+
+
+def test_add_params():
+    @click.command()
+    def sample_cmd():
+        pass
+
+    options = [
+        click.Option(["--opt1"]),
+        click.Option(["--opt1"]),
+    ]
+    cmd = sample_cmd
+    with pytest.raises(ValueError):
+        CliMixin.add_params(cmd=cmd, params=options)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.25-dev4"  # pragma: no cover
+__version__ = "0.10.25-dev5"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -26,13 +26,9 @@ from unstructured.partition.utils.constants import UNSTRUCTURED_INCLUDE_DEBUG_ME
 class NoID(abc.ABC):
     """Class to indicate that an element do not have an ID."""
 
-    pass
-
 
 class UUID(abc.ABC):
     """Class to indicate that an element should have a UUID."""
-
-    pass
 
 
 @dc.dataclass
@@ -531,23 +527,17 @@ class Formula(Text):
 
     category = "Formula"
 
-    pass
-
 
 class CompositeElement(Text):
     """A section of text consisting of a combination of elements."""
 
     category = "CompositeElement"
 
-    pass
-
 
 class FigureCaption(Text):
     """An element for capturing text associated with figure captions."""
 
     category = "FigureCaption"
-
-    pass
 
 
 class NarrativeText(Text):
@@ -556,15 +546,11 @@ class NarrativeText(Text):
 
     category = "NarrativeText"
 
-    pass
-
 
 class ListItem(Text):
     """ListItem is a NarrativeText element that is part of a list."""
 
     category = "ListItem"
-
-    pass
 
 
 class Title(Text):
@@ -572,30 +558,23 @@ class Title(Text):
 
     category = "Title"
 
-    pass
-
 
 class Address(Text):
     """A text element for capturing addresses."""
 
     category = "Address"
 
-    pass
-
 
 class EmailAddress(Text):
     """A text element for capturing addresses"""
 
     category = "EmailAddress"
-    pass
 
 
 class Image(Text):
     """A text element for capturing image metadata."""
 
     category = "Image"
-
-    pass
 
 
 class PageBreak(Text):
@@ -609,15 +588,11 @@ class Table(Text):
 
     category = "Table"
 
-    pass
-
 
 class TableChunk(Table):
     """An element for capturing chunks of tables."""
 
     category = "Table"
-
-    pass
 
 
 class Header(Text):
@@ -625,15 +600,11 @@ class Header(Text):
 
     category = "Header"
 
-    pass
-
 
 class Footer(Text):
     """An element for capturing document footers."""
 
     category = "Footer"
-
-    pass
 
 
 TYPE_TO_TEXT_ELEMENT_MAP: Dict[str, Any] = {

--- a/unstructured/documents/email_elements.py
+++ b/unstructured/documents/email_elements.py
@@ -10,13 +10,9 @@ from unstructured.documents.elements import UUID, Element, NoID, Text
 class NoDatestamp(ABC):
     """Class to indicate that an element do not have a datetime stamp."""
 
-    pass
-
 
 class EmailElement(Element):
     """An email element is a section of the email."""
-
-    pass
 
 
 class Name(EmailElement):
@@ -84,15 +80,11 @@ class BodyText(List[Text]):
 
     category = "BodyText"
 
-    pass
-
 
 class Recipient(Name):
     """A text element for capturing the recipient information of an email"""
 
     category = "Recipient"
-
-    pass
 
 
 class Sender(Name):
@@ -100,15 +92,11 @@ class Sender(Name):
 
     category = "Sender"
 
-    pass
-
 
 class Subject(Text, EmailElement):
     """A text element for capturing the subject information of an email"""
 
     category = "Subject"
-
-    pass
 
 
 class MetaData(Name):
@@ -117,15 +105,11 @@ class MetaData(Name):
 
     category = "MetaData"
 
-    pass
-
 
 class ReceivedInfo(Name):
     """A text element for capturing header information of an email (e.g. IP addresses, etc)."""
 
     category = "ReceivedInfo"
-
-    pass
 
 
 class Attachment(Name):
@@ -133,5 +117,3 @@ class Attachment(Name):
     images, etc)."""
 
     category = "Attachment"
-
-    pass

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -74,43 +74,29 @@ class TagsMixin:
 class HTMLText(TagsMixin, Text):
     """Text with tag information."""
 
-    pass
-
 
 class HTMLAddress(TagsMixin, Address):
     """Address with tag information."""
-
-    pass
 
 
 class HTMLEmailAddress(TagsMixin, EmailAddress):
     """EmailAddress with tag information"""
 
-    pass
-
 
 class HTMLTitle(TagsMixin, Title):
     """Title with tag information."""
-
-    pass
 
 
 class HTMLNarrativeText(TagsMixin, NarrativeText):
     """NarrativeText with tag information."""
 
-    pass
-
 
 class HTMLListItem(TagsMixin, ListItem):
     """NarrativeText with tag information."""
 
-    pass
-
 
 class HTMLTable(TagsMixin, Table):
     """NarrativeText with tag information"""
-
-    pass
 
 
 class HTMLDocument(XMLDocument):

--- a/unstructured/embed/interfaces.py
+++ b/unstructured/embed/interfaces.py
@@ -9,19 +9,16 @@ class BaseEmbeddingEncoder(ABC):
     def initialize(self):
         """Initializes the embedding encoder class. Should also validate the instance
         is properly configured: e.g., embed a single a element"""
-        pass
 
     @property
     @abstractmethod
     def num_of_dimensions(self) -> Tuple[int]:
         """Number of dimensions for the embedding vector."""
-        pass
 
     @property
     @abstractmethod
     def is_unit_vector(self) -> bool:
         """Denotes if the embedding vector is a unit vector."""
-        pass
 
     @abstractmethod
     def embed_documents(self, elements: List[Element]) -> List[Element]:

--- a/unstructured/ingest/cli/cmds/airtable.py
+++ b/unstructured/ingest/cli/cmds/airtable.py
@@ -21,7 +21,7 @@ class AirtableCliConfig(BaseConfig, CliMixin):
     personal_access_token: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--personal-access-token"],
@@ -66,7 +66,7 @@ class AirtableCliConfig(BaseConfig, CliMixin):
                 """,
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="airtable", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/azure.py
+++ b/unstructured/ingest/cli/cmds/azure.py
@@ -24,7 +24,7 @@ class AzureCliConfig(BaseConfig, CliMixin):
     connection_string: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--account-key"],
@@ -43,7 +43,7 @@ class AzureCliConfig(BaseConfig, CliMixin):
                 help="Azure Blob Storage or DataLake connection string.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="azure", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/azure_cognitive_search.py
+++ b/unstructured/ingest/cli/cmds/azure_cognitive_search.py
@@ -1,4 +1,5 @@
 import logging
+import typing as t
 from dataclasses import dataclass
 
 import click
@@ -22,7 +23,7 @@ class AzureCognitiveSearchCliWriteConfig(BaseConfig, CliMixin):
     index: str
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--key"],
@@ -48,7 +49,7 @@ class AzureCognitiveSearchCliWriteConfig(BaseConfig, CliMixin):
                 help="The name of the index to connect to",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.command(name="azure-cognitive-search")

--- a/unstructured/ingest/cli/cmds/biomed.py
+++ b/unstructured/ingest/cli/cmds/biomed.py
@@ -27,7 +27,7 @@ class BiomedCliConfig(BaseConfig, CliMixin):
     max_retries: int = 1
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--api-id"],
@@ -65,7 +65,7 @@ class BiomedCliConfig(BaseConfig, CliMixin):
                 help="Max requests to OA Web Service API.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="biomed", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/biomed.py
+++ b/unstructured/ingest/cli/cmds/biomed.py
@@ -21,10 +21,8 @@ class BiomedCliConfig(BaseConfig, CliMixin):
     api_id: t.Optional[str] = None
     api_from: t.Optional[str] = None
     api_until: t.Optional[str] = None
-    decay: float = 0.3
     path: t.Optional[str] = None
     max_request_time: int = 45
-    max_retries: int = 1
 
     @staticmethod
     def get_cli_options() -> t.List[click.Option]:
@@ -45,11 +43,6 @@ class BiomedCliConfig(BaseConfig, CliMixin):
                 help="Until parameter for OA Web Service API.",
             ),
             click.Option(
-                ["--decay"],
-                default=0.3,
-                help="(In float) Factor to multiply the delay between retries.",
-            ),
-            click.Option(
                 ["--path"],
                 default=None,
                 help="PMC Open Access FTP Directory Path.",
@@ -58,11 +51,6 @@ class BiomedCliConfig(BaseConfig, CliMixin):
                 ["--max-request-time"],
                 default=45,
                 help="(In seconds) Max request time to OA Web Service API.",
-            ),
-            click.Option(
-                ["--max-retries"],
-                default=1,
-                help="Max requests to OA Web Service API.",
             ),
         ]
         return options

--- a/unstructured/ingest/cli/cmds/box.py
+++ b/unstructured/ingest/cli/cmds/box.py
@@ -22,7 +22,7 @@ class BoxCliConfig(BaseConfig, CliMixin):
     box_app_config: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--box-app-config"],
@@ -30,7 +30,7 @@ class BoxCliConfig(BaseConfig, CliMixin):
                 help="Path to Box app credentials as json file.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="box", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/confluence.py
+++ b/unstructured/ingest/cli/cmds/confluence.py
@@ -27,7 +27,7 @@ class ConfluenceCliConfig(BaseConfig, CliMixin):
     max_num_of_spaces: int = 500
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--api-token"],
@@ -71,7 +71,7 @@ class ConfluenceCliConfig(BaseConfig, CliMixin):
                 "--spaces and --num-of-spaces cannot be used at the same time",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="confluence", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/delta_table.py
+++ b/unstructured/ingest/cli/cmds/delta_table.py
@@ -81,7 +81,7 @@ class DeltaTableCliWriteConfig(BaseConfig, CliMixin):
     mode: t.Literal["error", "append", "overwrite", "ignore"] = "error"
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--write-column"],
@@ -99,7 +99,7 @@ class DeltaTableCliWriteConfig(BaseConfig, CliMixin):
                 "If 'ignore', will not write anything if table already exists.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.command(name="delta-table")

--- a/unstructured/ingest/cli/cmds/delta_table.py
+++ b/unstructured/ingest/cli/cmds/delta_table.py
@@ -24,7 +24,7 @@ class DeltaTableCliConfig(BaseConfig, CliMixin):
     without_files: bool = False
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--table-uri"],
@@ -51,7 +51,7 @@ class DeltaTableCliConfig(BaseConfig, CliMixin):
                 help="If set, will load table without tracking files.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="delta-table", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/discord.py
+++ b/unstructured/ingest/cli/cmds/discord.py
@@ -24,7 +24,7 @@ class DiscordCliConfig(BaseConfig, CliMixin):
     period: t.Optional[int] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--token"],
@@ -45,7 +45,7 @@ class DiscordCliConfig(BaseConfig, CliMixin):
                 "discord channels, must be a number",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="discord", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/dropbox.py
+++ b/unstructured/ingest/cli/cmds/dropbox.py
@@ -1,4 +1,5 @@
 import logging
+import typing as t
 from dataclasses import dataclass
 
 import click
@@ -21,7 +22,7 @@ class DropboxCliConfig(BaseConfig, CliMixin):
     token: str
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--token"],
@@ -29,7 +30,7 @@ class DropboxCliConfig(BaseConfig, CliMixin):
                 help="Dropbox access token.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="dropbox", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/elasticsearch.py
+++ b/unstructured/ingest/cli/cmds/elasticsearch.py
@@ -23,7 +23,7 @@ class ElasticsearchCliConfig(BaseConfig, CliMixin):
     jq_query: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--index-name"],
@@ -47,7 +47,7 @@ class ElasticsearchCliConfig(BaseConfig, CliMixin):
                 "Example: --jq-query '{meta, body}'",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="elasticsearch", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/gcs.py
+++ b/unstructured/ingest/cli/cmds/gcs.py
@@ -22,7 +22,7 @@ class GcsCliConfig(BaseConfig, CliMixin):
     token: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--token"],
@@ -32,7 +32,7 @@ class GcsCliConfig(BaseConfig, CliMixin):
                 "or fall back to anonymous access.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="gcs", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/github.py
+++ b/unstructured/ingest/cli/cmds/github.py
@@ -24,7 +24,7 @@ class GithubCliConfig(BaseConfig, CliMixin):
     git_file_glob: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--url"],
@@ -56,7 +56,7 @@ class GithubCliConfig(BaseConfig, CliMixin):
                 "types of files are accepted, e.g. '*.html,*.txt'",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="github", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/gitlab.py
+++ b/unstructured/ingest/cli/cmds/gitlab.py
@@ -24,7 +24,7 @@ class GitlabCliConfig(BaseConfig, CliMixin):
     git_file_glob: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--url"],
@@ -56,7 +56,7 @@ class GitlabCliConfig(BaseConfig, CliMixin):
                 "files are accepted, e.g. '*.html,*.txt'",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="gitlab", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/google_drive.py
+++ b/unstructured/ingest/cli/cmds/google_drive.py
@@ -24,7 +24,7 @@ class GoogleDriveCliConfig(BaseConfig, CliMixin):
     extension: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--drive-id"],
@@ -45,7 +45,7 @@ class GoogleDriveCliConfig(BaseConfig, CliMixin):
                 help="Filters the files to be processed based on extension e.g. .jpg, .docx, etc.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="google-drive", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/jira.py
+++ b/unstructured/ingest/cli/cmds/jira.py
@@ -27,7 +27,7 @@ class JiraCliConfig(BaseConfig, CliMixin):
     issues: t.Optional[t.List[str]] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--api-token"],
@@ -73,7 +73,7 @@ class JiraCliConfig(BaseConfig, CliMixin):
                 "find or obtain keys. Alternatively, use API to obtain ids.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="jira", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/local.py
+++ b/unstructured/ingest/cli/cmds/local.py
@@ -23,7 +23,7 @@ class LocalCliConfig(BaseConfig, CliMixin):
     file_glob: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--input-path"],
@@ -39,7 +39,7 @@ class LocalCliConfig(BaseConfig, CliMixin):
                 "local files are accepted, e.g. '*.html,*.txt'",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="local", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/notion.py
+++ b/unstructured/ingest/cli/cmds/notion.py
@@ -20,7 +20,7 @@ from unstructured.ingest.runner import NotionRunner
 
 @dataclass
 class NotionCliConfig(BaseConfig, CliMixin):
-    api_key: str
+    notion_api_key: str
     page_ids: t.Optional[t.List[str]]
     database_ids: t.Optional[t.List[str]]
     max_retries: t.Optional[int] = None
@@ -30,7 +30,7 @@ class NotionCliConfig(BaseConfig, CliMixin):
     def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
-                ["--api-key"],
+                ["--notion-api-key"],
                 required=True,
                 type=str,
                 help="API key for Notion api",

--- a/unstructured/ingest/cli/cmds/notion.py
+++ b/unstructured/ingest/cli/cmds/notion.py
@@ -27,7 +27,7 @@ class NotionCliConfig(BaseConfig, CliMixin):
     max_time: t.Optional[float] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--api-key"],
@@ -48,7 +48,7 @@ class NotionCliConfig(BaseConfig, CliMixin):
                 help="Notion database IDs to pull text from",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="notion", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/onedrive.py
+++ b/unstructured/ingest/cli/cmds/onedrive.py
@@ -27,7 +27,7 @@ class OnedriveCliConfig(BaseConfig, CliMixin):
     authority_url: t.Optional[str] = "https://login.microsoftonline.com"
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--client-id"],
@@ -67,7 +67,7 @@ class OnedriveCliConfig(BaseConfig, CliMixin):
                 "https://login.microsoftonline.com",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="onedrive", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/outlook.py
+++ b/unstructured/ingest/cli/cmds/outlook.py
@@ -28,7 +28,7 @@ class OutlookCliConfig(BaseConfig, CliMixin):
     authority_url: t.Optional[str] = "https://login.microsoftonline.com"
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--client-id"],
@@ -68,7 +68,7 @@ class OutlookCliConfig(BaseConfig, CliMixin):
                 "https://login.microsoftonline.com",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="outlook", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/reddit.py
+++ b/unstructured/ingest/cli/cmds/reddit.py
@@ -26,7 +26,7 @@ class RedditCliConfig(BaseConfig, CliMixin):
     search_query: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--client-id"],
@@ -69,7 +69,7 @@ class RedditCliConfig(BaseConfig, CliMixin):
                 help="user agent request header to use when calling Reddit API",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="reddit", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/s3.py
+++ b/unstructured/ingest/cli/cmds/s3.py
@@ -23,7 +23,7 @@ class S3CliConfig(BaseConfig, CliMixin):
     endpoint_url: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--anonymous"],
@@ -39,7 +39,7 @@ class S3CliConfig(BaseConfig, CliMixin):
                 "connecting to non-AWS S3 buckets.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="s3", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/salesforce.py
+++ b/unstructured/ingest/cli/cmds/salesforce.py
@@ -26,7 +26,7 @@ class SalesforceCliConfig(BaseConfig, CliMixin):
     categories: t.List[str]
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         possible_categories = ["Account", "Case", "Campaign", "EmailMessage", "Lead"]
         options = [
             click.Option(
@@ -57,7 +57,7 @@ class SalesforceCliConfig(BaseConfig, CliMixin):
                 "Currently only {}.".format(", ".join(possible_categories)),
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="salesforce", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/sharepoint.py
+++ b/unstructured/ingest/cli/cmds/sharepoint.py
@@ -26,7 +26,7 @@ class SharepointCliConfig(BaseConfig, CliMixin):
     files_only: bool = False
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--client-id"],
@@ -66,7 +66,7 @@ class SharepointCliConfig(BaseConfig, CliMixin):
                 help="Process only files.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="sharepoint", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/slack.py
+++ b/unstructured/ingest/cli/cmds/slack.py
@@ -25,7 +25,7 @@ class SlackCliConfig(BaseConfig, CliMixin):
     end_date: t.Optional[str] = None
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--token"],
@@ -56,7 +56,7 @@ class SlackCliConfig(BaseConfig, CliMixin):
                 "YYYY-MM-DD+HH:MM:SS or YYYY-MM-DDTHH:MM:SStz",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="slack", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/cmds/wikipedia.py
+++ b/unstructured/ingest/cli/cmds/wikipedia.py
@@ -1,4 +1,5 @@
 import logging
+import typing as t
 from dataclasses import dataclass
 
 import click
@@ -21,7 +22,7 @@ class WikipediaCliConfig(BaseConfig, CliMixin):
     auto_suggest: bool = True
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--page-title"],
@@ -37,7 +38,7 @@ class WikipediaCliConfig(BaseConfig, CliMixin):
                 " Set to False if the wrong Wikipedia page is fetched.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 @click.group(name="wikipedia", invoke_without_command=True, cls=Group)

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -58,8 +58,25 @@ class DelimitedString(click.ParamType):
 class CliMixin:
     @staticmethod
     @abstractmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         pass
+
+    def add_cli_options(self, cmd: click.Command) -> None:
+        options_to_add = self.get_cli_options()
+        self.add_params(cmd, params=options_to_add)
+
+    @staticmethod
+    def add_params(cmd: click.Command, params: t.List[click.Parameter]):
+        existing_opts = []
+        for param in cmd.params:
+            existing_opts.extend(param.opts)
+
+        for param in params:
+            for opt in param.opts:
+                if opt in existing_opts:
+                    raise ValueError(f"{opt} is already defined on the command {cmd.name}")
+                existing_opts.append(opt)
+                cmd.params.append(param)
 
 
 class CliRetryStrategyConfig(RetryStrategyConfig, CliMixin):

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -61,11 +61,11 @@ class CliMixin:
     def get_cli_options() -> t.List[click.Option]:
         pass
 
-    def add_cli_options(self, cmd: click.Command) -> None:
-        options_to_add = self.get_cli_options()
-        self.add_params(cmd, params=options_to_add)
+    @classmethod
+    def add_cli_options(cls, cmd: click.Command) -> None:
+        options_to_add = cls.get_cli_options()
+        CliMixin.add_params(cmd, params=options_to_add)
 
-    @staticmethod
     def add_params(cmd: click.Command, params: t.List[click.Parameter]):
         existing_opts = []
         for param in cmd.params:
@@ -81,7 +81,7 @@ class CliMixin:
 
 class CliRetryStrategyConfig(RetryStrategyConfig, CliMixin):
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--max-retries"],
@@ -98,7 +98,7 @@ class CliRetryStrategyConfig(RetryStrategyConfig, CliMixin):
                 "of back off strategy if http calls fail",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
     @classmethod
     def from_dict(
@@ -120,7 +120,7 @@ class CliRetryStrategyConfig(RetryStrategyConfig, CliMixin):
 
 class CliProcessorConfig(ProcessorConfig, CliMixin):
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--reprocess"],
@@ -158,12 +158,12 @@ class CliProcessorConfig(ProcessorConfig, CliMixin):
             ),
             click.Option(["-v", "--verbose"], is_flag=True, default=False),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 class CliReadConfig(ReadConfig, CliMixin):
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--download-dir"],
@@ -199,12 +199,12 @@ class CliReadConfig(ReadConfig, CliMixin):
                 help="If specified, process at most the specified number of documents.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 class CliPartitionConfig(PartitionConfig, CliMixin):
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--skip-infer-table-types"],
@@ -287,14 +287,14 @@ class CliPartitionConfig(PartitionConfig, CliMixin):
                 help="API Key for partition endpoint.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 class CliRecursiveConfig(BaseConfig, CliMixin):
     recursive: bool
 
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--recursive"],
@@ -304,12 +304,12 @@ class CliRecursiveConfig(BaseConfig, CliMixin):
                 "otherwise stop at the files in provided folder level.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 class CliFilesStorageConfig(FileStorageConfig, CliMixin):
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--remote-url"],
@@ -332,12 +332,12 @@ class CliFilesStorageConfig(FileStorageConfig, CliMixin):
                 "otherwise stop at the files in provided folder level.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
 
 class CliEmbeddingConfig(EmbeddingConfig, CliMixin):
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--embedding-api-key"],
@@ -349,7 +349,7 @@ class CliEmbeddingConfig(EmbeddingConfig, CliMixin):
                 default=None,
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
     @classmethod
     def from_dict(
@@ -379,7 +379,7 @@ class CliEmbeddingConfig(EmbeddingConfig, CliMixin):
 
 class CliChunkingConfig(ChunkingConfig, CliMixin):
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--chunk-elements"],
@@ -404,7 +404,7 @@ class CliChunkingConfig(ChunkingConfig, CliMixin):
                 show_default=True,
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
     @classmethod
     def from_dict(
@@ -440,7 +440,7 @@ class CliChunkingConfig(ChunkingConfig, CliMixin):
 
 class CliPermissionsConfig(PermissionsConfig, CliMixin):
     @staticmethod
-    def add_cli_options(cmd: click.Command) -> None:
+    def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
                 ["--permissions-application-id"],
@@ -458,7 +458,7 @@ class CliPermissionsConfig(PermissionsConfig, CliMixin):
                 help="e.g https://contoso.onmicrosoft.com to get permissions data within tenant.",
             ),
         ]
-        cmd.params.extend(options)
+        return options
 
     @classmethod
     def from_dict(

--- a/unstructured/ingest/cli/utils.py
+++ b/unstructured/ingest/cli/utils.py
@@ -65,7 +65,10 @@ def add_options(cmd: click.Command, extras=t.List[t.Type[CliMixin]]) -> click.Co
     ]
     configs.extend(extras)
     for config in configs:
-        config.add_cli_options(cmd)
+        try:
+            config.add_cli_options(cmd=cmd)
+        except ValueError as e:
+            raise ValueError(f"failed to set configs from {config.__name__}: {e}")
     return cmd
 
 

--- a/unstructured/ingest/connector/biomed.py
+++ b/unstructured/ingest/connector/biomed.py
@@ -9,7 +9,7 @@ import requests
 from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
 
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import (
     BaseConnectorConfig,
     BaseIngestDoc,
@@ -187,7 +187,7 @@ class BiomedSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):
             adapter = HTTPAdapter()
             session.mount("http://", adapter)
             session.mount("https://", adapter)
-            response = session.get(endpoint_url, timeout=self.connector_config.request_timeout)
+            response = self._get_request(session=session, endpoint_url=endpoint_url)
             soup = BeautifulSoup(response.content, features="lxml")
             urls = [link["href"] for link in soup.find_all("link")]
 
@@ -201,6 +201,10 @@ class BiomedSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):
             files.extend(urls_to_metadata(urls))
 
         return files
+
+    @SourceConnectionNetworkError.wrap
+    def _get_request(self, session: requests.Session, endpoint_url: str) -> requests.Response:
+        return session.get(endpoint_url, timeout=self.connector_config.request_timeout)
 
     def _list_objects(self) -> t.List[BiomedFileMeta]:
         files = []

--- a/unstructured/ingest/connector/biomed.py
+++ b/unstructured/ingest/connector/biomed.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import requests
 from bs4 import BeautifulSoup
 from requests.adapters import HTTPAdapter
-from urllib3.util import Retry
 
 from unstructured.ingest.error import SourceConnectionError
 from unstructured.ingest.interfaces import (
@@ -46,9 +45,7 @@ class SimpleBiomedConfig(BaseConnectorConfig):
     id_: t.Optional[str]
     from_: t.Optional[str]
     until: t.Optional[str]
-    max_retries: int = 5
     request_timeout: int = 45
-    decay: float = 0.3
 
     def validate_api_inputs(self):
         valid = False
@@ -187,11 +184,7 @@ class BiomedSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):
 
         while endpoint_url:
             session = requests.Session()
-            retries = Retry(
-                total=self.connector_config.max_retries,
-                backoff_factor=self.connector_config.decay,
-            )
-            adapter = HTTPAdapter(max_retries=retries)
+            adapter = HTTPAdapter()
             session.mount("http://", adapter)
             session.mount("https://", adapter)
             response = session.get(endpoint_url, timeout=self.connector_config.request_timeout)

--- a/unstructured/ingest/connector/discord.py
+++ b/unstructured/ingest/connector/discord.py
@@ -37,8 +37,6 @@ class SimpleDiscordConfig(BaseConnectorConfig):
             except ValueError:
                 raise ValueError("--discord-period must be an integer")
 
-        pass
-
 
 @dataclass
 class DiscordIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):

--- a/unstructured/ingest/connector/local.py
+++ b/unstructured/ingest/connector/local.py
@@ -44,11 +44,9 @@ class LocalIngestDoc(BaseIngestDoc):
 
     def cleanup_file(self):
         """Not applicable to local file system"""
-        pass
 
     def get_file(self):
         """Not applicable to local file system"""
-        pass
 
     @property
     def _output_filename(self) -> Path:
@@ -76,11 +74,9 @@ class LocalSourceConnector(BaseSourceConnector):
 
     def cleanup(self, cur_dir=None):
         """Not applicable to local file system"""
-        pass
 
     def initialize(self):
         """Not applicable to local file system"""
-        pass
 
     def _list_files(self):
         if self.connector_config.input_path_is_file:

--- a/unstructured/ingest/connector/notion/connector.py
+++ b/unstructured/ingest/connector/notion/connector.py
@@ -26,7 +26,7 @@ class SimpleNotionConfig(BaseConnectorConfig):
     page_ids: t.List[str]
     database_ids: t.List[str]
     recursive: bool
-    api_key: str
+    notion_api_key: str
 
 
 @dataclass
@@ -293,7 +293,7 @@ class NotionSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):
         # Pin the version of the api to avoid schema changes
         self.client = NotionClient(
             notion_version=NOTION_API_VERSION,
-            auth=self.connector_config.api_key,
+            auth=self.connector_config.notion_api_key,
             logger=logger,
             log_level=logger.level,
             retry_strategy_config=self.retry_strategy_config,
@@ -361,7 +361,7 @@ class NotionSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):
                     retry_strategy_config=self.retry_strategy_config,
                     read_config=self.read_config,
                     page_id=page_id,
-                    api_key=self.connector_config.api_key,
+                    api_key=self.connector_config.notion_api_key,
                 )
                 for page_id in self.connector_config.page_ids
             ]
@@ -373,7 +373,7 @@ class NotionSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):
                     retry_strategy_config=self.retry_strategy_config,
                     read_config=self.read_config,
                     database_id=database_id,
-                    api_key=self.connector_config.api_key,
+                    api_key=self.connector_config.notion_api_key,
                 )
                 for database_id in self.connector_config.database_ids
             ]
@@ -411,7 +411,7 @@ class NotionSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):
                         retry_strategy_config=self.retry_strategy_config,
                         read_config=self.read_config,
                         page_id=page_id,
-                        api_key=self.connector_config.api_key,
+                        api_key=self.connector_config.notion_api_key,
                     )
                     for page_id in child_pages
                 ]
@@ -429,7 +429,7 @@ class NotionSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):
                         retry_strategy_config=self.retry_strategy_config,
                         read_config=self.read_config,
                         database_id=database_id,
-                        api_key=self.connector_config.api_key,
+                        api_key=self.connector_config.notion_api_key,
                     )
                     for database_id in child_databases
                 ]

--- a/unstructured/ingest/connector/slack.py
+++ b/unstructured/ingest/connector/slack.py
@@ -204,7 +204,6 @@ class SlackSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):
 
     def initialize(self):
         """Verify that can get metadata for an object, validates connections info."""
-        pass
 
     def get_ingest_docs(self):
         return [

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -197,7 +197,6 @@ class PermissionsConfig(BaseConfig):
     application_id: t.Optional[str]
     client_cred: t.Optional[str]
     tenant: t.Optional[str]
-    pass
 
 
 @dataclass
@@ -316,7 +315,6 @@ class BaseIngestDoc(IngestDocJsonMixin, ABC):
     @abstractmethod
     def cleanup_file(self):
         """Removes the local copy the file (or anything else) after successful processing."""
-        pass
 
     @staticmethod
     def skip_if_file_exists(func):
@@ -353,7 +351,6 @@ class BaseIngestDoc(IngestDocJsonMixin, ABC):
     @SourceConnectionError.wrap
     def get_file(self):
         """Fetches the "remote" doc and stores it locally on the filesystem."""
-        pass
 
     def has_output(self) -> bool:
         """Determine if structured output for this doc already exists."""
@@ -469,13 +466,11 @@ class BaseSourceConnector(DataClassJsonMixin, ABC):
         temporary download dirs that are empty.
 
         By convention, documents that failed to process are typically not cleaned up."""
-        pass
 
     @abstractmethod
     def initialize(self):
         """Initializes the connector. Should also validate the connector is properly
         configured: e.g., list a single a document from the source."""
-        pass
 
     @abstractmethod
     def get_ingest_docs(self):
@@ -483,7 +478,6 @@ class BaseSourceConnector(DataClassJsonMixin, ABC):
         This does not imply downloading all the raw documents themselves,
         rather each IngestDoc is capable of fetching its content (in another process)
         with IngestDoc.get_file()."""
-        pass
 
 
 @dataclass
@@ -499,7 +493,6 @@ class BaseDestinationConnector(DataClassJsonMixin, ABC):
     def initialize(self):
         """Initializes the connector. Should also validate the connector is properly
         configured."""
-        pass
 
     @abstractmethod
     def write(self, docs: t.List[BaseIngestDoc]) -> None:

--- a/unstructured/ingest/runner/biomed.py
+++ b/unstructured/ingest/runner/biomed.py
@@ -10,9 +10,7 @@ from unstructured.ingest.runner.utils import update_download_dir_hash
 class BiomedRunner(Runner):
     def run(
         self,
-        max_retries: int = 5,
         max_request_time: int = 45,
-        decay: float = 0.3,
         path: t.Optional[str] = None,
         api_id: t.Optional[str] = None,
         api_from: t.Optional[str] = None,
@@ -53,9 +51,7 @@ class BiomedRunner(Runner):
                 id_=api_id,
                 from_=api_from,
                 until=api_until,
-                max_retries=max_retries,
                 request_timeout=max_request_time,
-                decay=decay,
             ),
             read_config=self.read_config,
         )

--- a/unstructured/ingest/runner/notion.py
+++ b/unstructured/ingest/runner/notion.py
@@ -11,7 +11,7 @@ from unstructured.ingest.runner.utils import update_download_dir_hash
 class NotionRunner(Runner):
     def run(
         self,
-        api_key: str,
+        notion_api_key: str,
         recursive: bool = False,
         max_retries: t.Optional[int] = None,
         max_time: t.Optional[float] = None,
@@ -57,7 +57,7 @@ class NotionRunner(Runner):
             connector_config=SimpleNotionConfig(
                 page_ids=page_ids,
                 database_ids=database_ids,
-                api_key=api_key,
+                notion_api_key=notion_api_key,
                 recursive=recursive,
             ),
             read_config=self.read_config,

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -245,7 +245,6 @@ def scarf_analytics():
         gpu_present = True
     except Exception:
         gpu_present = False
-        pass
 
     python_version = ".".join(platform.python_version().split(".")[:2])
 


### PR DESCRIPTION
### Description
Given that many of the options associated with the `Click` based cli ingest commands are added dynamically from a number of configs, a check was incorporated to make sure there were no duplicate entries to prevent new configs from overwriting already added options.

### Issues that were found and fixes:
* duplicate api-key option set on Notion command conflicts with api key used for unstructured api. Added notion prefix.
* retry logic configs had duplicates in biomed. Removed since this is not handled by the pipeline. 