### PR TITLE
fix: chunks break on regex-meta changes and regex-meta start/stop not adjusted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixes
 
 * **Import PDFResourceManager more directly** We were importing `PDFResourceManager` from `pdfminer.converter` which was causing an error for some users. We changed to import from the actual location of `PDFResourceManager`, which is `pdfminer.pdfinterp`.
+* **Fix chunks breaking on regex-metadata matches.** Fixes "over-chunking" when `regex_metadata` was used, where every element that contained a regex-match would start a new chunk.
+* **Fix regex-metadata match offsets not adjusted within chunk.** Fixes incorrect regex-metadata match start/stop offset in chunks where multiple elements are combined.
 
 ## 0.10.24
 

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -64,10 +64,6 @@ def test_split_elements_by_title_and_table():
     ]
 
 
-@pytest.mark.xfail(reason="regex_metadata was wrong type", raises=AssertionError, strict=True)
-# -- `ElementMetadata.regex_metadata` is `Dict[str, List[RegexMetadata]]`, not `List[RegexMetadata]`
-# -- when this is fixed, this test fails by isolating a chunk for "Today is a bad day", which is
-# -- where the regex-metadata appears.
 def test_chunk_by_title():
     elements: List[Element] = [
         Title("A Great Day", metadata=ElementMetadata(emphasized_text_contents=["Day"])),
@@ -218,11 +214,6 @@ def test_chunk_by_title_does_not_break_on_regex_metadata_change():
     ]
 
 
-@pytest.mark.xfail(
-    reason="bug: regex_metadata of second and later section elements is discarded",
-    raises=AssertionError,
-    strict=True,
-)
 def test_chunk_by_title_consolidates_and_adjusts_offsets_of_regex_metadata():
     """ElementMetadata.regex_metadata of chunk is union of regex_metadatas of its elements.
 

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -183,6 +183,46 @@ def test_chunk_by_title_separates_by_page_number():
     ]
 
 
+@pytest.mark.xfail(
+    reason="bug: chunks break on regex_metadata differences", raises=AssertionError, strict=True
+)
+def test_chunk_by_title_does_not_break_on_regex_metadata_change():
+    """Sectioner is insensitive to regex-metadata changes.
+
+    A regex-metadata match in an element does not signify a semantic boundary and a section should
+    not be split based on such a difference.
+    """
+    elements: List[Element] = [
+        Title(
+            "Lorem Ipsum",
+            metadata=ElementMetadata(
+                regex_metadata={"ipsum": [RegexMetadata(text="Ipsum", start=6, end=11)]}
+            ),
+        ),
+        Text(
+            "Lorem ipsum dolor sit amet consectetur adipiscing elit.",
+            metadata=ElementMetadata(
+                regex_metadata={"dolor": [RegexMetadata(text="dolor", start=12, end=17)]}
+            ),
+        ),
+        Text(
+            "In rhoncus ipsum sed lectus porta volutpat.",
+            metadata=ElementMetadata(
+                regex_metadata={"ipsum": [RegexMetadata(text="ipsum", start=11, end=16)]}
+            ),
+        ),
+    ]
+
+    chunks = chunk_by_title(elements)
+
+    assert chunks == [
+        CompositeElement(
+            "Lorem Ipsum\n\nLorem ipsum dolor sit amet consectetur adipiscing elit.\n\nIn rhoncus"
+            " ipsum sed lectus porta volutpat."
+        )
+    ]
+
+
 @pytest.mark.xfail(reason="regex_metadata was wrong type", raises=AssertionError, strict=True)
 def test_chunk_by_title_groups_across_pages():
     elements: List[Element] = [

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -107,7 +107,6 @@ def test_chunk_by_title():
     )
 
 
-@pytest.mark.xfail(reason="regex_metadata was wrong type", raises=AssertionError, strict=True)
 def test_chunk_by_title_respects_section_change():
     elements: List[Element] = [
         Title("A Great Day", metadata=ElementMetadata(section="first")),
@@ -145,7 +144,6 @@ def test_chunk_by_title_respects_section_change():
     ]
 
 
-@pytest.mark.xfail(reason="regex_metadata was wrong type", raises=AssertionError, strict=True)
 def test_chunk_by_title_separates_by_page_number():
     elements: List[Element] = [
         Title("A Great Day", metadata=ElementMetadata(page_number=1)),
@@ -183,9 +181,6 @@ def test_chunk_by_title_separates_by_page_number():
     ]
 
 
-@pytest.mark.xfail(
-    reason="bug: chunks break on regex_metadata differences", raises=AssertionError, strict=True
-)
 def test_chunk_by_title_does_not_break_on_regex_metadata_change():
     """Sectioner is insensitive to regex-metadata changes.
 
@@ -223,7 +218,6 @@ def test_chunk_by_title_does_not_break_on_regex_metadata_change():
     ]
 
 
-@pytest.mark.xfail(reason="regex_metadata was wrong type", raises=AssertionError, strict=True)
 def test_chunk_by_title_groups_across_pages():
     elements: List[Element] = [
         Title("A Great Day", metadata=ElementMetadata(page_number=1)),

--- a/test_unstructured/documents/test_elements.py
+++ b/test_unstructured/documents/test_elements.py
@@ -16,6 +16,7 @@ from unstructured.documents.elements import (
     Element,
     ElementMetadata,
     NoID,
+    RegexMetadata,
     Text,
 )
 
@@ -187,6 +188,24 @@ def test_element_to_dict():
         "element_id": "awt32t1",
     }
     assert element.to_dict() == expected
+
+
+def test_regex_metadata_round_trips_through_JSON():
+    """metadata.regex_metadata should appear at full depth in JSON."""
+    regex_metadata = {
+        "mail-stop": [RegexMetadata(text="MS-107", start=18, end=24)],
+        "version": [
+            RegexMetadata(text="current=v1.7.2", start=7, end=21),
+            RegexMetadata(text="supersedes=v1.7.2", start=22, end=40),
+        ],
+    }
+    metadata = ElementMetadata(regex_metadata=regex_metadata)
+
+    metadata_json = json.dumps(metadata.to_dict())
+    deserialized_metadata = ElementMetadata.from_dict(json.loads(metadata_json))
+    reserialized_metadata_json = json.dumps(deserialized_metadata.to_dict())
+
+    assert reserialized_metadata_json == metadata_json
 
 
 def test_metadata_from_dict_extra_fields():

--- a/test_unstructured_ingest/test-ingest.sh
+++ b/test_unstructured_ingest/test-ingest.sh
@@ -69,6 +69,11 @@ trap print_last_run EXIT
 
 python_version=$(python --version 2>&1)
 
+tests_to_ignore=(
+  'test-ingest-notion.sh'
+  "test-ingest-dropbox.sh"
+)
+
 for test in "${all_tests[@]}"; do
   CURRENT_TEST="$test"
   # IF: python_version is not 3.10 (wildcarded to match any subminor version) AND the current test is not in full_python_matrix_tests
@@ -77,7 +82,8 @@ for test in "${all_tests[@]}"; do
     echo "--------- SKIPPING SCRIPT $test ---------"
     continue
   fi
-  if [[ "$test" == "test-ingest-notion.sh" ]]; then
+
+  if [[ "${tests_to_ignore[*]}" =~ $test ]]; then
     echo "--------- RUNNING SCRIPT $test --- IGNORING FAILURES"
     set +e
     echo "Running ./test_unstructured_ingest/$test"

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -16,7 +16,6 @@ from unstructured.documents.elements import (
     CompositeElement,
     Element,
     ElementMetadata,
-    RegexMetadata,
     Table,
     TableChunk,
     Text,
@@ -120,7 +119,7 @@ def chunk_by_title(
         text = ""
         metadata = first_element.metadata
         start_char = 0
-        for element in section:
+        for element_idx, element in enumerate(section):
             # -- concatenate all element text in section into `text` --
             if isinstance(element, Text):
                 # -- add a blank line between "squashed" elements --
@@ -128,24 +127,30 @@ def chunk_by_title(
                 start_char = len(text)
                 text += element.text
 
-            # -- "chunk" metadata should include union of list-items in all its elements. Also,
-            # -- metadata like regex_metadata that records start and/or end positions of related
-            # -- text need those offsets adjusted.
+            # -- "chunk" metadata should include union of list-items in all its elements --
             for attr, value in vars(element.metadata).items():
                 if isinstance(value, list):
                     value = cast(List[Any], value)
                     # -- get existing (list) value from chunk_metadata --
                     _value = getattr(metadata, attr, []) or []
-
-                    # TODO: this mutates the original, work on a copy instead.
-                    if attr == "regex_metadata":
-                        value = cast(List[RegexMetadata], value)
-                        for item in value:
-                            item["start"] += start_char
-                            item["end"] += start_char
-
                     _value.extend(item for item in value if item not in _value)
                     setattr(metadata, attr, _value)
+
+            # -- consolidate any `regex_metadata` matches, adjusting the match start/end offsets --
+            element_regex_metadata = element.metadata.regex_metadata
+            # -- skip the first element because it is "alredy consolidated" and otherwise this would
+            # -- duplicate it.
+            if element_regex_metadata and element_idx > 0:
+                if metadata.regex_metadata is None:
+                    metadata.regex_metadata = {}
+                chunk_regex_metadata = metadata.regex_metadata
+                for regex_name, matches in element_regex_metadata.items():
+                    for m in matches:
+                        m["start"] += start_char
+                        m["end"] += start_char
+                    chunk_matches = chunk_regex_metadata.get(regex_name, [])
+                    chunk_matches.extend(matches)
+                    chunk_regex_metadata[regex_name] = chunk_matches
 
         # Check if text exceeds max_characters
         if len(text) > max_characters:

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -1,4 +1,4 @@
-"""Implementation of chunking.
+"""Implementation of chunking by title.
 
 Main entry point is the `@add_chunking_strategy()` decorator.
 """

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -1,4 +1,4 @@
-from typing import IO, TYPE_CHECKING, Dict, List, Optional
+from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional
 
 import requests
 
@@ -47,7 +47,7 @@ def partition_html(
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
     detection_origin: Optional[str] = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> List[Element]:
     """Partitions an HTML document into its constituent elements.
 


### PR DESCRIPTION
**Executive Summary.** Introducing strict type-checking as preparation for adding the chunk-overlap feature revealed a type mismatch for regex-metadata between chunking tests and the (authoritative) ElementMetadata definition. The implementation of regex-metadata aspects of chunking passed the tests but did not produce the appropriate behaviors in production where the actual data-structure was different. This PR fixes these two bugs.

1. **Over-chunking.** The presence of `regex-metadata` in an element was incorrectly being interpreted as a semantic boundary, leading to such elements being isolated in their own chunks.

2. **Discarded regex-metadata.** regex-metadata present on the second or later elements in a section (chunk) was discarded.


**Technical Summary**

The type of `ElementMetadata.regex_metadata` is `Dict[str, List[RegexMetadata]]`. `RegexMetadata` is a `TypedDict` like `{"text": "this matched", "start": 7, "end": 19}`.

Multiple regexes can be specified, each with a name like "mail-stop", "version", etc. Each of those may produce its own set of matches, like:

```python
>>> element.regex_metadata
{
    "mail-stop": [{"text": "MS-107", "start": 18, "end": 24}],
    "version": [
        {"text": "current: v1.7.2", "start": 7, "end": 21},
        {"text": "supersedes: v1.7.0", "start": 22, "end": 40},
    ],
}
```

*Forensic analysis*
* The regex-metadata feature was added by Matt Robinson on 06/16/2023 commit: 4ea71683. The regex_metadata data structure is the same as when it was added.

* The chunk-by-title feature was added by Matt Robinson on 08/29/2023 commit: f6a745a7. The mistaken regex-metadata data structure in the tests is present in that commit.

Looks to me like a mis-remembering of the regex-metadata data-structure and insufficient type-checking rigor (type-checker strictness level set too low) to warn of the mistake.


**Over-chunking Behavior**

The over-chunking looked like this:

Chunking three elements with regex metadata should combine them into a single chunk (`CompositeElement` object), subject to maximum size rules (default 500 chars).

```python
elements: List[Element] = [
    Title(
        "Lorem Ipsum",
        metadata=ElementMetadata(
            regex_metadata={"ipsum": [RegexMetadata(text="Ipsum", start=6, end=11)]}
        ),
    ),
    Text(
        "Lorem ipsum dolor sit amet consectetur adipiscing elit.",
        metadata=ElementMetadata(
            regex_metadata={"dolor": [RegexMetadata(text="dolor", start=12, end=17)]}
        ),
    ),
    Text(
        "In rhoncus ipsum sed lectus porta volutpat.",
        metadata=ElementMetadata(
            regex_metadata={"ipsum": [RegexMetadata(text="ipsum", start=11, end=16)]}
        ),
    ),
]

chunks = chunk_by_title(elements)

assert chunks == [
    CompositeElement(
        "Lorem Ipsum\n\nLorem ipsum dolor sit amet consectetur adipiscing elit.\n\nIn rhoncus"
        " ipsum sed lectus porta volutpat."
    )
]
```

Observed behavior looked like this:

```python
chunks => [
    CompositeElement('Lorem Ipsum')
    CompositeElement('Lorem ipsum dolor sit amet consectetur adipiscing elit.')
    CompositeElement('In rhoncus ipsum sed lectus porta volutpat.')
]

```

The fix changed the approach from breaking on any metadata field not in a specified group (`regex_metadata` was missing from this group) to only breaking on specified fields (whitelisting instead of blacklisting). This avoids overchunking every time we add a new metadata field and is also simpler and easier to understand. This change in approach is discussed in more detail here #1790.


**Dropping regex-metadata Behavior**

Chunking this section:

```python
elements: List[Element] = [
    Title(
        "Lorem Ipsum",
        metadata=ElementMetadata(
            regex_metadata={"ipsum": [RegexMetadata(text="Ipsum", start=6, end=11)]}
        ),
    ),
    Text(
        "Lorem ipsum dolor sit amet consectetur adipiscing elit.",
        metadata=ElementMetadata(
            regex_metadata={
                "dolor": [RegexMetadata(text="dolor", start=12, end=17)],
                "ipsum": [RegexMetadata(text="ipsum", start=6, end=11)],
            }
        ),
    ),
    Text(
        "In rhoncus ipsum sed lectus porta volutpat.",
        metadata=ElementMetadata(
            regex_metadata={"ipsum": [RegexMetadata(text="ipsum", start=11, end=16)]}
        ),
    ),
]
```

..should produce this regex_metadata on the single produced chunk:

```python
assert chunk == CompositeElement(
    "Lorem Ipsum\n\nLorem ipsum dolor sit amet consectetur adipiscing elit.\n\nIn rhoncus"
    " ipsum sed lectus porta volutpat."
)
assert chunk.metadata.regex_metadata == {
    "dolor": [RegexMetadata(text="dolor", start=25, end=30)],
    "ipsum": [
        RegexMetadata(text="Ipsum", start=6, end=11),
        RegexMetadata(text="ipsum", start=19, end=24),
        RegexMetadata(text="ipsum", start=81, end=86),
    ],
}
```

but instead produced this:

```python
regex_metadata == {"ipsum": [{"text": "Ipsum", "start": 6, "end": 11}]}
```

Which is the regex-metadata from the first element only.

The fix was to remove the consolidation+adjustment process from inside the "list-attribute-processing" loop (because regex-metadata is not a list) and process regex metadata separately.
