### PR TITLE
Fix: TypeError - 'Link' object is not iterable

### DIFF
--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -82,7 +82,7 @@ def partition_epub(
 
     # open issue that might resolve the chapter mapping of text
     # https://github.com/aerkalov/ebooklib/issues/289
-    if not isintance(book.toc, Iterable):
+    if not isinstance(book.toc, Iterable):
         book.toc = [book.toc]
 
     for item in book.toc:

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -1,5 +1,6 @@
 import tempfile
 import warnings
+from collection.abc import Iterable
 from typing import IO, List, Optional
 
 from ebooklib import epub
@@ -81,6 +82,9 @@ def partition_epub(
 
     # open issue that might resolve the chapter mapping of text
     # https://github.com/aerkalov/ebooklib/issues/289
+    if not isintance(book.toc, Iterable):
+        book.toc = [book.toc]
+
     for item in book.toc:
         # Some toc items may be tuple of multiple items, but all have the same href
         if isinstance(item, tuple):

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -1,6 +1,6 @@
 import tempfile
 import warnings
-from collection.abc import Iterable
+from collections.abc import Iterable
 from typing import IO, List, Optional
 
 from ebooklib import epub


### PR DESCRIPTION
In the ebooklib code below, `book.toc` may not iterable and may be a Link class.
https://github.com/aerkalov/ebooklib/blob/1cb3d2c251f82c4702c2aff0ed7aea375babf251/ebooklib/epub.py#L1567-L1588

In this case, it throws "TypeError: 'Link' object is not iterable" exception, 
so fixed to convert to a list if it is not iterable.

About 1% of epub files got this error.