### PR TITLE
fix: fsspec destination path malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.25-dev6
+## 0.10.25-dev7
 
 ### Enhancements
 
@@ -16,6 +16,7 @@
 * **Fix chunks breaking on regex-metadata matches.** Fixes "over-chunking" when `regex_metadata` was used, where every element that contained a regex-match would start a new chunk.
 * **Fix regex-metadata match offsets not adjusted within chunk.** Fixes incorrect regex-metadata match start/stop offset in chunks where multiple elements are combined.
 * **Map source cli command configs when destination set** Due to how the source connector is dynamically called when the destination connector is set via the CLI, the configs were being set incorrectoy, causing the source connector to break. The configs were fixed and updated to take into account Fsspec-specific connectors.
+* **Fsspec destination connector path construction** The way the destination path for where to upload content in the base fsspec destination connector didn't take into account all edge cases and this would cause the path to be malformed and potentially break the upload. Fix put in place to more robustly create that destination path.
 
 ## 0.10.24
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.25-dev6"  # pragma: no cover
+__version__ = "0.10.25-dev7"  # pragma: no cover

--- a/unstructured/ingest/cli/cmds/azure_cognitive_search.py
+++ b/unstructured/ingest/cli/cmds/azure_cognitive_search.py
@@ -14,8 +14,6 @@ from unstructured.ingest.cli.utils import conform_click_options, orchestrate_run
 from unstructured.ingest.interfaces import BaseConfig
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 
-pass
-
 
 @dataclass
 class AzureCognitiveSearchCliWriteConfig(BaseConfig, CliMixin):

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -255,13 +255,13 @@ class FsspecDestinationConnector(BaseDestinationConnector):
             filename.strip(os.sep) if filename else filename
         )  # Make sure filename doesn't begin with file seperator
         output_path = str(PurePath(output_folder, filename)) if filename else output_folder
-        full_output_path = f"s3://{output_path}"
+        full_output_path = f"{self.connector_config.protocol}://{output_path}"
         logger.debug(f"uploading content to {full_output_path}")
         fs.write_text(full_output_path, json.dumps(json_list, indent=indent), encoding=encoding)
 
     def write(self, docs: t.List[BaseIngestDoc]) -> None:
         for doc in docs:
-            file_path = doc.base_filename
+            file_path = doc.base_output_filename
             filename = file_path if file_path else None
             with open(doc._output_filename) as json_file:
                 logger.debug(f"uploading content from {doc._output_filename}")

--- a/unstructured/ingest/connector/local.py
+++ b/unstructured/ingest/connector/local.py
@@ -38,6 +38,13 @@ class LocalIngestDoc(BaseIngestDoc):
     registry_name: str = "local"
 
     @property
+    def base_filename(self) -> t.Optional[str]:
+        download_path = str(Path(self.connector_config.input_path).resolve())
+        full_path = str(self.filename)
+        base_path = full_path.replace(download_path, "")
+        return base_path
+
+    @property
     def filename(self):
         """The filename of the local file to be processed"""
         return Path(self.path)
@@ -56,7 +63,7 @@ class LocalIngestDoc(BaseIngestDoc):
         """
         input_path = Path(self.connector_config.input_path)
         basename = (
-            f"{Path(self.path).name}.json"
+            f"{self.base_filename}.json"
             if input_path.is_file()
             else f"{Path(self.path).relative_to(input_path)}.json"
         )

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -283,6 +283,15 @@ class BaseIngestDoc(IngestDocJsonMixin, ABC):
         return None
 
     @property
+    def base_output_filename(self) -> t.Optional[str]:
+        if self.processor_config.output_dir and self._output_filename:
+            output_path = str(Path(self.processor_config.output_dir).resolve())
+            full_path = str(self._output_filename)
+            base_path = full_path.replace(output_path, "")
+            return base_path
+        return None
+
+    @property
     @abstractmethod
     def _output_filename(self):
         """Filename of the structured output for this doc."""


### PR DESCRIPTION
### Description  
The way the destination path for where to upload content in the base fsspec destination connector didn't take into account all edge cases and this would cause the path to be malformed and potentially break the upload. Fix put in place to more robustly create that destination path.