### PR TITLE
fix: import PDFResourceManager from pdfinterp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.25-dev1
+## 0.10.25-dev2
 
 ### Enhancements
 
@@ -7,6 +7,8 @@
 * **Add AWS bedrock embedding connector** `unstructured.embed.bedrock` now provides a connector to use AWS bedrock's `titan-embed-text` model to generate embeddings for elements. This features requires valid AWS bedrock setup and an internet connectionto run.
 
 ### Fixes
+
+* **Import PDFResourceManager more directly** We were importing `PDFResourceManager` from `pdfminer.converter` which was causing an error for some users. We changed to import from the actual location of `PDFResourceManager`, which is `pdfminer.pdfinterp`.
 
 ## 0.10.24
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.25-dev1"  # pragma: no cover
+__version__ = "0.10.25-dev2"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -9,7 +9,7 @@ from typing import IO, Any, BinaryIO, Iterator, List, Optional, Sequence, Tuple,
 import numpy as np
 import pdf2image
 import PIL
-from pdfminer.converter import PDFPageAggregator, PDFResourceManager
+from pdfminer.converter import PDFPageAggregator
 from pdfminer.layout import (
     LAParams,
     LTChar,
@@ -18,7 +18,7 @@ from pdfminer.layout import (
     LTItem,
     LTTextBox,
 )
-from pdfminer.pdfinterp import PDFPageInterpreter
+from pdfminer.pdfinterp import PDFPageInterpreter, PDFResourceManager
 from pdfminer.pdfpage import PDFPage
 from pdfminer.pdftypes import PDFObjRef
 from pdfminer.utils import open_filename


### PR DESCRIPTION
Closes #1763.

**Import PDFResourceManager more directly** We were importing `PDFResourceManager` from `pdfminer.converter` which was causing an error for some users. We changed to import from the actual location of `PDFResourceManager`, which is `pdfminer.pdfinterp`.

#### Testing:

Importing `partition_pdf` should raise an error on `main` if `pdfminer.six` is version `20201018` but on this branch it will import successfully.