### PR TITLE
Jj/1798 languages warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.25-dev3
+## 0.10.25-dev4
 
 ### Enhancements
 
@@ -10,6 +10,7 @@
 ### Fixes
 
 * **Import PDFResourceManager more directly** We were importing `PDFResourceManager` from `pdfminer.converter` which was causing an error for some users. We changed to import from the actual location of `PDFResourceManager`, which is `pdfminer.pdfinterp`.
+* **Fix language detection of elements with empty strings** This resolves a warning message that was raised by `langdetect` if the language was attempted to be detected on an empty string. Language detection is now skipped for empty strings.
 
 ## 0.10.24
 

--- a/test_unstructured/partition/test_lang.py
+++ b/test_unstructured/partition/test_lang.py
@@ -1,83 +1,97 @@
 import pytest
 
-from unstructured.partition import lang
+from unstructured.documents.elements import (
+    NarrativeText,
+    PageBreak,
+)
+from unstructured.partition.lang import (
+    apply_lang_metadata,
+    detect_languages,
+    prepare_languages_for_tesseract,
+)
 
 
 def test_prepare_languages_for_tesseract_with_one_language():
     languages = ["en"]
-    assert lang.prepare_languages_for_tesseract(languages) == "eng"
+    assert prepare_languages_for_tesseract(languages) == "eng"
 
 
 def test_prepare_languages_for_tesseract_special_case():
     languages = ["osd"]
-    assert lang.prepare_languages_for_tesseract(languages) == "osd"
+    assert prepare_languages_for_tesseract(languages) == "osd"
 
     languages = ["equ"]
-    assert lang.prepare_languages_for_tesseract(languages) == "equ"
+    assert prepare_languages_for_tesseract(languages) == "equ"
 
 
 def test_prepare_languages_for_tesseract_removes_empty_inputs():
     languages = ["kbd", "es"]
-    assert lang.prepare_languages_for_tesseract(languages) == "spa+spa_old"
+    assert prepare_languages_for_tesseract(languages) == "spa+spa_old"
 
 
 def test_prepare_languages_for_tesseract_includes_variants():
     languages = ["chi"]
-    assert (
-        lang.prepare_languages_for_tesseract(languages)
-        == "chi_sim+chi_sim_vert+chi_tra+chi_tra_vert"
-    )
+    assert prepare_languages_for_tesseract(languages) == "chi_sim+chi_sim_vert+chi_tra+chi_tra_vert"
 
 
 def test_prepare_languages_for_tesseract_with_multiple_languages():
     languages = ["ja", "afr", "en", "equ"]
-    assert lang.prepare_languages_for_tesseract(languages) == "jpn+jpn_vert+afr+eng+equ"
+    assert prepare_languages_for_tesseract(languages) == "jpn+jpn_vert+afr+eng+equ"
 
 
 def test_prepare_languages_for_tesseract_warns_nonstandard_language(caplog):
     languages = ["zzz", "chi"]
-    assert (
-        lang.prepare_languages_for_tesseract(languages)
-        == "chi_sim+chi_sim_vert+chi_tra+chi_tra_vert"
-    )
+    assert prepare_languages_for_tesseract(languages) == "chi_sim+chi_sim_vert+chi_tra+chi_tra_vert"
     assert "not a valid standard language code" in caplog.text
 
 
 def test_prepare_languages_for_tesseract_warns_non_tesseract_language(caplog):
     languages = ["kbd", "eng"]
-    assert lang.prepare_languages_for_tesseract(languages) == "eng"
+    assert prepare_languages_for_tesseract(languages) == "eng"
     assert "not a language supported by Tesseract" in caplog.text
 
 
 def test_detect_languages_english_auto():
     text = "This is a short sentence."
-    assert lang.detect_languages(text) == ["eng"]
+    assert detect_languages(text) == ["eng"]
 
 
 def test_detect_languages_english_provided():
     text = "This is another short sentence."
     languages = ["en"]
-    assert lang.detect_languages(text, languages) == ["eng"]
+    assert detect_languages(text, languages) == ["eng"]
 
 
 def test_detect_languages_korean_auto():
     text = "안녕하세요"
-    assert lang.detect_languages(text) == ["kor"]
+    assert detect_languages(text) == ["kor"]
 
 
 def test_detect_languages_gets_multiple_languages():
     text = "My lubimy mleko i chleb."
-    assert lang.detect_languages(text) == ["ces", "pol", "slk"]
+    assert detect_languages(text) == ["ces", "pol", "slk"]
 
 
 def test_detect_languages_warns_for_auto_and_other_input(caplog):
     text = "This is another short sentence."
     languages = ["en", "auto", "rus"]
-    assert lang.detect_languages(text, languages) == ["eng"]
+    assert detect_languages(text, languages) == ["eng"]
     assert "rest of the inputted languages will be ignored" in caplog.text
 
 
 def test_detect_languages_raises_TypeError_for_invalid_languages():
     with pytest.raises(TypeError):
         text = "This is a short sentence."
-        lang.detect_languages(text, languages="eng") == ["eng"]
+        detect_languages(text, languages="eng") == ["eng"]
+
+
+def test_apply_lang_metadata_has_no_warning_for_PageBreak(caplog):
+    elements = [NarrativeText("Sample text."), PageBreak("")]
+    elements = list(
+        apply_lang_metadata(
+            elements=elements,
+            languages=["auto"],
+            detect_language_per_element=True,
+        ),
+    )
+    assert "No features in text." not in [rec.message for rec in caplog.records]

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.25-dev3"  # pragma: no cover
+__version__ = "0.10.25-dev4"  # pragma: no cover

--- a/unstructured/partition/lang.py
+++ b/unstructured/partition/lang.py
@@ -235,7 +235,7 @@ def detect_languages(
     # gets overwritten after elements have been returned by _html and _text,
     # so `languages` would be detected twice.
     # Also return None if there is no text.
-    if languages[0] == "" or text.strip == "":
+    if languages[0] == "" or text.strip() == "":
         return None
 
     # If text contains special characters (like ñ, å, or Korean/Mandarin/etc.) it will NOT default


### PR DESCRIPTION
### Summary
Closes #1798 
Fixes language detection of elements with empty strings: This resolves a warning message that was raised by `langdetect` if the language was attempted to be detected on an empty string. Language detection is now skipped for empty strings.

### Testing
on the main branch this will log the warning "No features in text", but it will not log anything on this branch.
```
from unstructured.documents.elements import NarrativeText, PageBreak
from unstructured.partition.lang import apply_lang_metadata

elements = [NarrativeText("Sample text."), PageBreak("")]
elements = list(
        apply_lang_metadata(
            elements=elements,
            languages=["auto"],
            detect_language_per_element=True,
        ),
    )
```

### Other
Also changes imports in test_lang.py so imports are explicit