### PR TITLE
test: speed up chipper schema test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.25-dev4
+## 0.10.25-dev6
 
 ### Enhancements
 

--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 from PIL import Image
 from unstructured_inference.inference import layout
+from unstructured_inference.models.chipper import UnstructuredChipperModel
 
 from test_unstructured.unit_utils import assert_round_trips_through_JSON, example_doc_path
 from unstructured.chunking.title import chunk_by_title
@@ -998,11 +999,18 @@ def test_check_annotations_within_element(threshold, expected):
 
 @pytest.fixture(scope="session")
 def chipper_results():
-    elements = pdf.partition_pdf(
-        "example-docs/layout-parser-paper-fast.pdf",
-        strategy="hi_res",
-        model_name="chipper",
-    )
+    parent = layout.LayoutElement.from_coords(0, 1, 2, 4, text="")
+    chipper_output = [
+        parent,
+        layout.LayoutElement.from_coords(5, 6, 7, 8, text="child", parent=parent),
+    ]
+
+    with mock.patch.object(UnstructuredChipperModel, "predict", return_value=chipper_output):
+        elements = pdf.partition_pdf(
+            "example-docs/layout-parser-paper-fast.pdf",
+            strategy="hi_res",
+            model_name="chipper",
+        )
     return elements
 
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.25-dev4"  # pragma: no cover
+__version__ = "0.10.25-dev6"  # pragma: no cover


### PR DESCRIPTION
The chipper test is really about testing that the chipper v2 schema gets translated properly when handled by partitioning. With that in mind we don't really need to hit the model. This PR mocks the model itself, which saves about 30 seconds of test time.

#### Testing:

Run `pytest test_unstructured/partition/pdf_image/test_pdf.py` on this branch and `main`.

For me the durations are:
2 minutes and 40 seconds on this branch
3 minutes and 12 seconds on `main` branch