### PR TITLE
fix: partition html fail with table without tbody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * **Fix language detection of elements with empty strings** This resolves a warning message that was raised by `langdetect` if the language was attempted to be detected on an empty string. Language detection is now skipped for empty strings.
 * **Fix chunks breaking on regex-metadata matches.** Fixes "over-chunking" when `regex_metadata` was used, where every element that contained a regex-match would start a new chunk.
 * **Fix regex-metadata match offsets not adjusted within chunk.** Fixes incorrect regex-metadata match start/stop offset in chunks where multiple elements are combined.
-* **Fix html partition fail on tables without `tbody` tag** HTML tables may sometimes use `thead` tag instead of `tbody` tag for table contents. We added logic to check `thead` tag if `tbody` tag is not found.
+* **Fix html partition fail on tables without `tbody` tag** HTML tables may sometimes just contain headers without body (`tbody` tag)
 
 ## 0.10.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.25-dev5
+## 0.10.25-dev6
 
 ### Enhancements
 
@@ -15,6 +15,7 @@
 * **Fix language detection of elements with empty strings** This resolves a warning message that was raised by `langdetect` if the language was attempted to be detected on an empty string. Language detection is now skipped for empty strings.
 * **Fix chunks breaking on regex-metadata matches.** Fixes "over-chunking" when `regex_metadata` was used, where every element that contained a regex-match would start a new chunk.
 * **Fix regex-metadata match offsets not adjusted within chunk.** Fixes incorrect regex-metadata match start/stop offset in chunks where multiple elements are combined.
+* **Fix html partition fail on tables without `tbody` tag** HTML tables may sometimes use `thead` tag instead of `tbody` tag for table contents. We added logic to check `thead` tag if `tbody` tag is not found.
 
 ## 0.10.24
 

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -677,13 +677,7 @@ def test_partition_html_respects_detect_language_per_element():
 @pytest.mark.parametrize(
     ("tag", "expected"),
     [
-        (
-            "thead",
-            (
-                "<table><br><tbody><br><tr><td>Header 1</td><td>Header "
-                "2</td></tr><br></tbody><br></table>"
-            ),
-        ),
+        ("thead", ""),
         ("foo", ""),
     ],
 )

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -672,3 +672,28 @@ def test_partition_html_respects_detect_language_per_element():
     elements = partition_html(filename=filename, detect_language_per_element=True)
     langs = [element.metadata.languages for element in elements]
     assert langs == [["eng"], ["spa", "eng"], ["eng"], ["eng"], ["spa"]]
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        (
+            "thead",
+            (
+                "<table><br><tbody><br><tr><td>Header 1</td><td>Header "
+                "2</td></tr><br></tbody><br></table>"
+            ),
+        ),
+        ("foo", ""),
+    ],
+)
+def test_partition_html_with_table_without_tbody(tag, expected):
+    table_html = f"""
+    <table>
+      <{tag}>
+        <tr><th>Header 1</th><th>Header 2</th></tr>
+        </{tag}>
+    </table>
+    """
+    partitions = partition_html(text=table_html)
+    assert partitions[0].metadata.text_as_html == expected

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.25-dev5"  # pragma: no cover
+__version__ = "0.10.25-dev6"  # pragma: no cover

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -39,7 +39,7 @@ TEXT_TAGS: Final[List[str]] = ["p", "a", "td", "span", "font"]
 LIST_ITEM_TAGS: Final[List[str]] = ["li", "dd"]
 LIST_TAGS: Final[List[str]] = ["ul", "ol", "dl"]
 HEADING_TAGS: Final[List[str]] = ["h1", "h2", "h3", "h4", "h5", "h6"]
-TABLE_TAGS: Final[List[str]] = ["table", "tbody", "td", "tr"]
+TABLE_TAGS: Final[List[str]] = ["table", "tbody", "td", "tr", "thead"]
 TEXTBREAK_TAGS: Final[List[str]] = ["br"]
 PAGEBREAK_TAGS: Final[List[str]] = ["hr"]
 EMPTY_TAGS: Final[List[str]] = PAGEBREAK_TAGS + TEXTBREAK_TAGS
@@ -494,8 +494,8 @@ def _process_leaf_table_item(
         if not nested_table:
             rows = tag_elem.findall("tr")
             if not rows:
-                body = tag_elem.find("tbody")
-                rows = body.findall("tr")
+                body = tag_elem.find("tbody") or tag_elem.find("thead")
+                rows = body.findall("tr") if body else []
             if len(rows) > 0:
                 table_data = [list(row.itertext()) for row in rows]
                 html_table = tabulate(table_data, tablefmt="html")

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -39,7 +39,7 @@ TEXT_TAGS: Final[List[str]] = ["p", "a", "td", "span", "font"]
 LIST_ITEM_TAGS: Final[List[str]] = ["li", "dd"]
 LIST_TAGS: Final[List[str]] = ["ul", "ol", "dl"]
 HEADING_TAGS: Final[List[str]] = ["h1", "h2", "h3", "h4", "h5", "h6"]
-TABLE_TAGS: Final[List[str]] = ["table", "tbody", "td", "tr", "thead"]
+TABLE_TAGS: Final[List[str]] = ["table", "tbody", "td", "tr"]
 TEXTBREAK_TAGS: Final[List[str]] = ["br"]
 PAGEBREAK_TAGS: Final[List[str]] = ["hr"]
 EMPTY_TAGS: Final[List[str]] = PAGEBREAK_TAGS + TEXTBREAK_TAGS
@@ -494,7 +494,7 @@ def _process_leaf_table_item(
         if not nested_table:
             rows = tag_elem.findall("tr")
             if not rows:
-                body = tag_elem.find("tbody") or tag_elem.find("thead")
+                body = tag_elem.find("tbody")
                 rows = body.findall("tr") if body else []
             if len(rows) > 0:
                 table_data = [list(row.itertext()) for row in rows]


### PR DESCRIPTION
This PR resolves #1807 
- fix a bug where when a table tagged content does not contain `tbody` tag but `thead` tag for the rows the code fails
- now when there is no `tbody` in a table section we try to look for `thead` isntead
- when both are not found return empty table