### PR TITLE
fix: ModuleNotFoundError for unstructured metrics folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.25-dev6
+## 0.10.25-dev7
 
 ### Enhancements
 
@@ -16,6 +16,8 @@
 * **Fix chunks breaking on regex-metadata matches.** Fixes "over-chunking" when `regex_metadata` was used, where every element that contained a regex-match would start a new chunk.
 * **Fix regex-metadata match offsets not adjusted within chunk.** Fixes incorrect regex-metadata match start/stop offset in chunks where multiple elements are combined.
 * **Map source cli command configs when destination set** Due to how the source connector is dynamically called when the destination connector is set via the CLI, the configs were being set incorrectoy, causing the source connector to break. The configs were fixed and updated to take into account Fsspec-specific connectors.
+* **Fix metrics folder not discoverable** Fixes issue where unstructured/metrics folder is not discoverable on PyPI by adding
+an `__init__.py` file under the folder.
 
 ## 0.10.24
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.25-dev6"  # pragma: no cover
+__version__ = "0.10.25-dev7"  # pragma: no cover


### PR DESCRIPTION
### Summary
Fix `ModuleNotFoundError: No module named 'unstructured.metrics'` where the unstructured/metrics folder is not discoverable from a package import since its missing an __init__.py file. 