### PR TITLE
fix: model_name being None raises attribution error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.25-dev6
+## 0.10.25-dev7
 
 ### Enhancements
 
@@ -16,6 +16,7 @@
 * **Fix chunks breaking on regex-metadata matches.** Fixes "over-chunking" when `regex_metadata` was used, where every element that contained a regex-match would start a new chunk.
 * **Fix regex-metadata match offsets not adjusted within chunk.** Fixes incorrect regex-metadata match start/stop offset in chunks where multiple elements are combined.
 * **Map source cli command configs when destination set** Due to how the source connector is dynamically called when the destination connector is set via the CLI, the configs were being set incorrectoy, causing the source connector to break. The configs were fixed and updated to take into account Fsspec-specific connectors.
+* **Fix a bug when `parition_pdf` get `model_name=None`** In API usage the `model_name` value is `None` and the `cast` function in `partition_pdf` would return `None` and lead to attribution error. Now we use `str` function to explicit convert the content to string so it is garanteed to have `starts_with` and other string functions as attributes
 
 ## 0.10.24
 

--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -1020,3 +1020,16 @@ def test_chipper_not_losing_parents(chipper_results, chipper_children):
         [el for el in chipper_results if el.id == child.metadata.parent_id]
         for child in chipper_children
     )
+
+
+def test_partition_model_name_default_to_None():
+    filename = "example-docs/DA-1p.pdf"
+    try:
+        pdf.partition_pdf(
+            filename=filename,
+            strategy="hi_res",
+            ocr_languages="eng",
+            model_name=None,
+        )
+    except AttributeError:
+        pytest.fail("partition_pdf() raised AttributeError unexpectedly!")

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.25-dev6"  # pragma: no cover
+__version__ = "0.10.25-dev7"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -7,7 +7,7 @@ import json
 import os
 import re
 import zipfile
-from typing import IO, Any, Callable, Dict, List, Optional, cast
+from typing import IO, Any, Callable, Dict, List, Optional
 
 from typing_extensions import ParamSpec
 
@@ -562,7 +562,8 @@ def add_metadata_with_filetype(
                 metadata_kwargs = {
                     kwarg: params.get(kwarg) for kwarg in ("filename", "url", "text_as_html")
                 }
-                if not cast(str, kwargs.get("model_name", "")).startswith("chipper"):
+                # NOTE (yao): do not use cast here as cast(None) still is None
+                if not str(kwargs.get("model_name", "")).startswith("chipper"):
                     # NOTE(alan): Skip hierarchy if using chipper, as it should take care of that
                     elements = set_element_hierarchy(elements)
 


### PR DESCRIPTION
This PR resolves #1754 
- function wrapper tries to use `cast` to convert kwargs into `str` but when a value is `None` `cast(str, None)` still returns `None`
- fix replaces the conversion to simply using `str()` function call