### PR TITLE
test: Add test to ensure languages trickle down to ocr

### DIFF
--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -1072,7 +1072,7 @@ def test_partition_model_name_default_to_None():
         ),
     ],
 )
-def test_ocr_language_passes_through_ocr_only(strategy, ocr_func):
+def test_ocr_language_passes_through(strategy, ocr_func):
     # Create an exception that will be raised directly after OCR is called to stop execution
     class CallException(Exception):
         pass

--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -1057,3 +1057,13 @@ def test_partition_model_name_default_to_None():
         )
     except AttributeError:
         pytest.fail("partition_pdf() raised AttributeError unexpectedly!")
+
+
+def test_ocr_language_passes_through():
+    with mock.patch(
+        "unstructured_pytesseract.run_and_get_multiple_output", return_value="ab"
+    ) as mock_thing:
+        pdf.partition_pdf(
+            "example-docs/layout-parser-paper-fast.pdf", strategy="ocr_only", ocr_languages="kor"
+        )
+        mock_thing.assert_called_with(mock.ANY, extensions=mock.ANY, lang="kor")


### PR DESCRIPTION
Closes [#93](https://github.com/Unstructured-IO/unstructured-inference/issues/93).

Adds a test to ensure language parameters are passed all the way from `partition_pdf` down to the OCR calls.

#### Testing:

CI should pass.