### PR TITLE
fix: sectioner does not consider separator length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.10.28-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* **Fix unnecessary mid-text chunk-splitting.** The "pre-chunker" did not consider separator blank-line ("\n\n") length when grouping elements for a single chunk. As a result, sections were frequently over-populated producing a over-sized chunk that required mid-text splitting.
+
 ## 0.10.27
 
 ### Enhancements

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -5,7 +5,11 @@ from typing import List
 import pytest
 
 from unstructured.chunking.title import (
+    _NonTextSection,
     _split_elements_by_title_and_table,
+    _TableSection,
+    _TextSection,
+    _TextSectionBuilder,
     chunk_by_title,
 )
 from unstructured.documents.coordinates import CoordinateSystem
@@ -15,6 +19,7 @@ from unstructured.documents.elements import (
     CoordinatesMetadata,
     Element,
     ElementMetadata,
+    ListItem,
     RegexMetadata,
     Table,
     Text,
@@ -190,6 +195,7 @@ def test_split_elements_by_title_and_table():
         Text("It is storming outside."),
         CheckBox(),
     ]
+
     sections = _split_elements_by_title_and_table(
         elements,
         multipage_sections=True,
@@ -198,29 +204,40 @@ def test_split_elements_by_title_and_table():
         max_characters=500,
     )
 
-    assert sections == [
-        [
-            Title("A Great Day"),
-            Text("Today is a great day."),
-            Text("It is sunny outside."),
-        ],
-        [
-            Table("<table></table>"),
-        ],
-        [
-            Title("An Okay Day"),
-            Text("Today is an okay day."),
-            Text("It is rainy outside."),
-        ],
-        [
-            Title("A Bad Day"),
-            Text("Today is a bad day."),
-            Text("It is storming outside."),
-        ],
-        [
-            CheckBox(),
-        ],
+    section = next(sections)
+    assert isinstance(section, _TextSection)
+    assert section.elements == [
+        Title("A Great Day"),
+        Text("Today is a great day."),
+        Text("It is sunny outside."),
     ]
+    # --
+    section = next(sections)
+    assert isinstance(section, _TableSection)
+    assert section.table == Table("<table></table>")
+    # ==
+    section = next(sections)
+    assert isinstance(section, _TextSection)
+    assert section.elements == [
+        Title("An Okay Day"),
+        Text("Today is an okay day."),
+        Text("It is rainy outside."),
+    ]
+    # --
+    section = next(sections)
+    assert isinstance(section, _TextSection)
+    assert section.elements == [
+        Title("A Bad Day"),
+        Text("Today is a bad day."),
+        Text("It is storming outside."),
+    ]
+    # --
+    section = next(sections)
+    assert isinstance(section, _NonTextSection)
+    assert section.element == CheckBox()
+    # --
+    with pytest.raises(StopIteration):
+        next(sections)
 
 
 def test_chunk_by_title():
@@ -657,3 +674,131 @@ def test_chunk_by_title_drops_extra_metadata():
     )
 
     assert str(chunks[1]) == str(CompositeElement("An Okay Day\n\nToday is an okay day."))
+
+
+def test_it_considers_separator_length_when_sectioning():
+    """Sectioner includes length of separators when computing remaining space."""
+    elements: List[Element] = [
+        Title("Chunking Priorities"),  # 19 chars
+        ListItem("Divide text into manageable chunks"),  # 34 chars
+        ListItem("Preserve semantic boundaries"),  # 28 chars
+        ListItem("Minimize mid-text chunk-splitting"),  # 33 chars
+    ]  # 114 chars total but 120 chars with separators
+
+    chunks = chunk_by_title(elements, max_characters=115)
+
+    assert chunks == [
+        CompositeElement(
+            "Chunking Priorities"
+            "\n\nDivide text into manageable chunks"
+            "\n\nPreserve semantic boundaries"
+        ),
+        CompositeElement("Minimize mid-text chunk-splitting"),
+    ]
+
+
+# == Sections ====================================================================================
+
+
+class Describe_NonTextSection:
+    """Unit-test suite for `unstructured.chunking.title._NonTextSection objects."""
+
+    def it_provides_access_to_its_element(self):
+        checkbox = CheckBox()
+        section = _NonTextSection(checkbox)
+        assert section.element is checkbox
+
+
+class Describe_TableSection:
+    """Unit-test suite for `unstructured.chunking.title._TableSection objects."""
+
+    def it_provides_access_to_its_table(self):
+        table = Table("<table></table>")
+        section = _TableSection(table)
+        assert section.table is table
+
+
+class Describe_TextSection:
+    """Unit-test suite for `unstructured.chunking.title._TextSection objects."""
+
+    def it_provides_access_to_its_elements(self):
+        elements: List[Element] = [
+            Title("Introduction"),
+            Text(
+                "Lorem ipsum dolor sit amet consectetur adipiscing elit. In rhoncus ipsum sed"
+                "lectus porta volutpat.",
+            ),
+        ]
+        section = _TextSection(elements)
+        assert section.elements == elements
+
+
+class Describe_TextSectionBuilder:
+    """Unit-test suite for `unstructured.chunking.title._TextSection objects."""
+
+    def it_is_empty_on_construction(self):
+        builder = _TextSectionBuilder(maxlen=50)
+
+        assert builder.text_length == 0
+        assert builder.remaining_space == 50
+
+    def it_accumulates_elements_added_to_it(self):
+        builder = _TextSectionBuilder(maxlen=150)
+
+        builder.add_element(Title("Introduction"))
+        assert builder.text_length == 12
+        assert builder.remaining_space == 136
+
+        builder.add_element(
+            Text(
+                "Lorem ipsum dolor sit amet consectetur adipiscing elit. In rhoncus ipsum sed"
+                "lectus porta volutpat."
+            )
+        )
+        assert builder.text_length == 112
+        assert builder.remaining_space == 36
+
+    def it_generates_a_TextSection_when_flushed_and_resets_itself_to_empty(self):
+        builder = _TextSectionBuilder(maxlen=150)
+        builder.add_element(Title("Introduction"))
+        builder.add_element(
+            Text(
+                "Lorem ipsum dolor sit amet consectetur adipiscing elit. In rhoncus ipsum sed"
+                "lectus porta volutpat."
+            )
+        )
+
+        section = next(builder.flush())
+
+        assert isinstance(section, _TextSection)
+        assert section.elements == [
+            Title("Introduction"),
+            Text(
+                "Lorem ipsum dolor sit amet consectetur adipiscing elit. In rhoncus ipsum sed"
+                "lectus porta volutpat.",
+            ),
+        ]
+        assert builder.text_length == 0
+        assert builder.remaining_space == 150
+
+    def but_it_does_not_generate_a_TextSection_on_flush_when_empty(self):
+        builder = _TextSectionBuilder(maxlen=150)
+
+        sections = list(builder.flush())
+
+        assert sections == []
+        assert builder.text_length == 0
+        assert builder.remaining_space == 150
+
+    def it_considers_separator_length_when_computing_text_length_and_remaining_space(self):
+        builder = _TextSectionBuilder(maxlen=50)
+        builder.add_element(Text("abcde"))
+        builder.add_element(Text("fghij"))
+
+        # -- .text_length includes a separator ("\n\n", len==2) between each text-segment,
+        # -- so 5 + 2 + 5 = 12 here, not 5 + 5 = 10
+        assert builder.text_length == 12
+        # -- .remaining_space is reduced by the length (2) of the trailing separator which would go
+        # -- between the current text and that of the next element if one was added.
+        # -- So 50 - 12 - 2 = 36 here, not 50 - 12 = 38
+        assert builder.remaining_space == 36

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.27"  # pragma: no cover
+__version__ = "0.10.28-dev0"  # pragma: no cover

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -287,10 +287,13 @@ _P = ParamSpec("_P")
 
 
 def add_chunking_strategy() -> Callable[[Callable[_P, List[Element]]], Callable[_P, List[Element]]]:
-    """Decorator for chuncking text. Uses title elements to identify sections within the document
-    for chunking. Splits off a new section when a title is detected or if metadata changes,
-    which happens when page numbers or sections change. Cuts off sections once they have exceeded
-    a character length of max_characters."""
+    """Decorator for chunking text.
+
+    Uses title elements to identify sections within the document for chunking. Splits off a new
+    section when a title is detected or if metadata changes, which happens when page numbers or
+    sections change. Cuts off sections once they have exceeded a character length of
+    max_characters.
+    """
 
     def decorator(func: Callable[_P, List[Element]]) -> Callable[_P, List[Element]]:
         if func.__doc__ and (
@@ -300,7 +303,7 @@ def add_chunking_strategy() -> Callable[[Callable[_P, List[Element]]], Callable[
             func.__doc__ += (
                 "\nchunking_strategy"
                 + "\n\tStrategy used for chunking text into larger or smaller elements."
-                + "\n\tDefaluts to `None` withoptional arg of 'by_title'."
+                + "\n\tDefaults to `None` with optional arg of 'by_title'."
                 + "\n\tAdditional Parameters:"
                 + "\n\t\tmultipage_sections"
                 + "\n\t\t\tIf True, sections can span multiple pages. Defaults to True."
@@ -308,8 +311,8 @@ def add_chunking_strategy() -> Callable[[Callable[_P, List[Element]]], Callable[
                 + "\n\t\t\tCombines elements (for example a series of titles) until a section"
                 + "\n\t\t\treaches a length of n characters."
                 + "\n\t\tnew_after_n_chars"
-                + "\n\t\t\t Cuts off new sections once they reach a length of n characters"
-                + "\n\t\t\t a soft max."
+                + "\n\t\t\tCuts off new sections once they reach a length of n characters"
+                + "\n\t\t\ta soft max."
                 + "\n\t\tmax_characters"
                 + "\n\t\t\tChunks elements text and text_as_html (if present) into chunks"
                 + "\n\t\t\tof length n characters, a hard max."

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -8,19 +8,21 @@ from __future__ import annotations
 import copy
 import functools
 import inspect
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, cast
 
 from typing_extensions import ParamSpec
 
 from unstructured.documents.elements import (
     CompositeElement,
     Element,
-    ElementMetadata,
     Table,
     TableChunk,
     Text,
     Title,
 )
+
+# -- goes between text of each element when element-text is concatenated to form chunk --
+TEXT_SEPARATOR = "\n\n"
 
 
 def chunk_table_element(element: Table, max_characters: int = 500) -> List[Table | TableChunk]:
@@ -121,6 +123,7 @@ def chunk_by_title(
     # ----------------------------------------------------------------
 
     chunked_elements: List[Element] = []
+
     sections = _split_elements_by_title_and_table(
         elements,
         multipage_sections=multipage_sections,
@@ -128,24 +131,21 @@ def chunk_by_title(
         new_after_n_chars=new_after_n_chars,
         max_characters=max_characters,
     )
+
     for section in sections:
-        if not section:
+        if isinstance(section, _NonTextSection):
+            chunked_elements.append(section.element)
             continue
 
-        first_element = section[0]
-
-        if not isinstance(first_element, Text):
-            chunked_elements.extend(section)
-            continue
-
-        elif isinstance(first_element, Table):
-            chunked_elements.extend(chunk_table_element(first_element, max_characters))
+        elif isinstance(section, _TableSection):
+            chunked_elements.extend(chunk_table_element(section.table, max_characters))
             continue
 
         text = ""
-        metadata = first_element.metadata
+        metadata = section.elements[0].metadata
         start_char = 0
-        for element_idx, element in enumerate(section):
+
+        for element_idx, element in enumerate(section.elements):
             # -- concatenate all element text in section into `text` --
             if isinstance(element, Text):
                 # -- add a blank line between "squashed" elements --
@@ -198,59 +198,89 @@ def _split_elements_by_title_and_table(
     combine_text_under_n_chars: int,
     new_after_n_chars: int,
     max_characters: int,
-) -> List[List[Element]]:
-    sections: List[List[Element]] = []
-    section: List[Element] = []
+) -> Iterator[_TextSection | _TableSection | _NonTextSection]:
+    """Implements "sectioner" responsibilities.
 
-    for i, element in enumerate(elements):
-        metadata_differs = False
-        if i > 0:
-            last_element = elements[i - 1]
-            metadata_differs = _metadata_differs(
-                element.metadata,
-                last_element.metadata,
-                include_pages=not multipage_sections,
-            )
+    A _section_ can be thought of as a "pre-chunk", generally determining the size and contents of a
+    chunk formed by the subsequent "chunker" process. The only exception occurs when a single
+    element is too big to fit in the chunk window and the chunker splits it into two or more chunks
+    divided mid-text. The sectioner never divides an element mid-text.
 
-        section_length = sum([len(str(element)) for element in section])
+    The sectioner's responsibilities are:
 
-        new_section = (
-            (section_length + len(str(element)) > max_characters)
-            or (isinstance(element, Title) and section_length > combine_text_under_n_chars)
-            or (metadata_differs or section_length > new_after_n_chars)
+        * **Segregate semantic units.** Identify semantic unit boundaries and segregate elements on
+          either side of those boundaries into different sections. In this case, the primary
+          indicator of a semantic boundary is a `Title` element. A page-break (change in
+          page-number) is also a semantic boundary when `multipage_sections` is `False`.
+
+        * **Minimize chunk count for each semantic unit.** Group the elements within a semantic unit
+          into sections as big as possible without exceeding the chunk window size.
+
+        * **Minimize chunks that must be split mid-text.** Precompute the text length of each
+          section and only produce a section that exceeds the chunk window size when there is a
+          single element with text longer than that window.
+    """
+    section_builder = _TextSectionBuilder(max_characters)
+
+    prior_element = None
+
+    for element in elements:
+        metadata_differs = (
+            _metadata_differs(element, prior_element, ignore_page_numbers=multipage_sections)
+            if prior_element
+            else False
         )
-        if not isinstance(element, Text) or isinstance(element, Table):
-            sections.append(section)
-            sections.append([element])
-            section = []
-        elif new_section:
-            if len(section) > 0:
-                sections.append(section)
-            section = [element]
+
+        # -- start new section when necessary --
+        if (
+            # TODO(scanny): this is where disassociated-titles are coming from (attempting to
+            # combine sections at the element level). This is fixed in the next PR.
+            (
+                isinstance(element, Title)
+                and section_builder.text_length > combine_text_under_n_chars
+            )
+            # -- adding this element would exceed hard-maxlen for section --
+            or section_builder.remaining_space < len(str(element))
+            # -- section already meets or exceeds soft-maxlen --
+            or section_builder.text_length >= new_after_n_chars
+            # -- a semantic boundary is indicated by metadata change since prior element --
+            or metadata_differs
+            # -- table and non-text elements go in a section by themselves --
+            or isinstance(element, Table)
+            or not isinstance(element, Text)
+        ):
+            # -- complete any work-in-progress section --
+            yield from section_builder.flush()
+
+        # -- emit table and checkbox immediately since they are always isolated --
+        if isinstance(element, Table):
+            yield _TableSection(table=element)
+        elif not isinstance(element, Text):
+            yield _NonTextSection(element)
+        # -- but accumulate text elements for consolidation into a composite chunk --
         else:
-            # if existing section plus new section will go above max, start new section
-            section.append(element)
+            section_builder.add_element(element)
 
-    if len(section) > 0:
-        sections.append(section)
+        prior_element = element
 
-    return sections
+    # -- flush "tail" section, any partially-filled section after last element is processed --
+    yield from section_builder.flush()
 
 
 def _metadata_differs(
-    metadata1: ElementMetadata,
-    metadata2: ElementMetadata,
-    include_pages: bool = True,
+    element: Element, preceding_element: Element, ignore_page_numbers: bool
 ) -> bool:
     """True when metadata differences between two elements indicate a semantic boundary.
 
-    Currently this is only a page-number change or a section change.
+    Currently this is only a section change and optionally a page-number change.
     """
+    metadata1 = preceding_element.metadata
+    metadata2 = element.metadata
     if metadata1.section != metadata2.section:
         return True
-    if include_pages and metadata1.page_number != metadata2.page_number:
-        return True
-    return False
+    if ignore_page_numbers:
+        return False
+    return metadata1.page_number != metadata2.page_number
 
 
 _P = ParamSpec("_P")
@@ -306,3 +336,126 @@ def add_chunking_strategy() -> Callable[[Callable[_P, List[Element]]], Callable[
         return wrapper
 
     return decorator
+
+
+class _NonTextSection:
+    """A section composed of a single `Element` that does not subclass `Text`.
+
+    Currently, only `CheckBox` fits that description
+    """
+
+    def __init__(self, element: Element) -> None:
+        self._element = element
+
+    @property
+    def element(self) -> Element:
+        """The non-text element of this section (currently only CheckBox is non-text)."""
+        return self._element
+
+
+class _TableSection:
+    """A section composed of a single Table element."""
+
+    def __init__(self, table: Table) -> None:
+        self._table = table
+
+    @property
+    def table(self) -> Table:
+        """The `Table` element of this section."""
+        return self._table
+
+
+class _TextSection:
+    """A sequence of elements that belong to the same semantic unit within a document.
+
+    The name "section" derives from the idea of a document-section, a heading followed by the
+    paragraphs "under" that heading. That structure is not found in all documents and actual section
+    content can vary, but that's the concept.
+
+    This object is purposely immutable.
+    """
+
+    def __init__(self, elements: Iterable[Element]) -> None:
+        self._elements = list(elements)
+
+    @property
+    def elements(self) -> List[Element]:
+        """The elements of this text-section."""
+        return self._elements
+
+
+class _TextSectionBuilder:
+    """An element accumulator suitable for incrementally forming a section.
+
+    Provides monitoring properties like `.remaining_space` and `.text_length` a sectioner can use
+    to determine whether it should add the next element in the element stream.
+
+    `.flush()` is used to build a `TextSection` object from the accumulated elements. This method
+    returns an interator that generates zero-or-one `TextSection` object and is used like so:
+
+        yield from builder.flush()
+
+    If no elements have been accumulated, no `TextSection` is generated. Flushing the builder clears
+    the elements it contains so it is ready to build the next text-section.
+    """
+
+    def __init__(self, maxlen: int) -> None:
+        self._maxlen = maxlen
+        self._separator_len = len(TEXT_SEPARATOR)
+        self._elements: List[Element] = []
+
+        # == these working values probably represent premature optimization but improve performance
+        # -- and I expect will be welcome when processing a million elements
+
+        # -- only includes non-empty element text, e.g. PageBreak.text=="" is not included --
+        self._text_segments: List[str] = []
+        # -- combined length of text-segments, not including separators --
+        self._text_len: int = 0
+
+    def add_element(self, element: Element) -> None:
+        """Add `element` to this section."""
+        self._elements.append(element)
+        if isinstance(element, Text) and element.text:
+            self._text_segments.append(element.text)
+            self._text_len += len(element.text)
+
+    def flush(self) -> Iterator[_TextSection]:
+        """Generate zero-or-one `Section` object and clear the accumulator.
+
+        Suitable for use to emit a Section when the maximum size has been reached or a semantic
+        boundary has been reached. Also to clear out a terminal section at the end of an element
+        stream.
+        """
+        if not self._elements:
+            return
+        # -- clear builder before yield so we're not sensitive to the timing of how/when this
+        # -- iterator is exhausted and can add eleemnts for the next section immediately.
+        elements = self._elements[:]
+        self._elements.clear()
+        self._text_segments.clear()
+        self._text_len = 0
+        yield _TextSection(elements)
+
+    @property
+    def remaining_space(self) -> int:
+        """Maximum text-length of an element that can be added without exceeding maxlen."""
+        # -- include length of trailing separator that will go before next element text --
+        separators_len = self._separator_len * len(self._text_segments)
+        return self._maxlen - self._text_len - separators_len
+
+    @property
+    def text_length(self) -> int:
+        """Length of the text in this section.
+
+        This value represents the chunk-size that would result if this section was flushed in its
+        current state. In particular, it does not include the length of a trailing separator (since
+        that would only appear if an additional element was added).
+
+        Not suitable for judging remaining space, use `.remaining_space` for that value.
+        """
+        # -- number of text separators present in joined text of elements. This includes only
+        # -- separators *between* text segments, not one at the end. Note there are zero separators
+        # -- for both 0 and 1 text-segments.
+        n = len(self._text_segments)
+        separator_count = n - 1 if n else 0
+        return self._text_len + (separator_count * self._separator_len)


### PR DESCRIPTION
### sectioner-does-not-consider-separator-length

**Executive Summary.** A primary responsibility of the sectioner is to minimize the number of chunks that need to be split mid-text. It does this by computing text-length of the section being formed and "finishing" the section when adding another element would extend its text beyond the window size.

When element-text is consolidated into a chunk, the text of each element is joined, separated by a "blank-line" (`"\n\n"`). The sectioner does not currently consider the added length of separators (2-chars each) and so forms sections that need to be split mid-text when chunked.

Chunk-splitting should only be necessary when the text of a single element is longer than the chunking window.

**Example**

  ```python
    elements: List[Element] = [
        Title("Chunking Priorities"),  # 19 chars
        ListItem("Divide text into manageable chunks"),  # 34 chars
        ListItem("Preserve semantic boundaries"),  # 28 chars
        ListItem("Minimize mid-text chunk-splitting"),  # 33 chars
    ]  # 114 chars total but 120 chars with separators

    chunks = chunk_by_title(elements, max_characters=115)
  ```

  Want:

  ```python
[
    CompositeElement(
        "Chunking Priorities"
        "\n\nDivide text into manageable chunks"
        "\n\nPreserve semantic boundaries"
    ),
    CompositeElement("Minimize mid-text chunk-splitting"),
]
  ```

  Got:

  ```python
[
    CompositeElement(
        "Chunking Priorities"
        "\n\nDivide text into manageable chunks"
        "\n\nPreserve semantic boundaries"
        "\n\nMinimize mid-text chunk-spli"),
    )
    CompositeElement("tting")
  ```

### Technical Summary

Because the sectioner does not consider separator (`"\n\n"`) length when it computes the space remaining in the section, it over-populates the section and when the chunker concatenates the element text (each separated by the separator) the text exceeds the window length and the chunk must be split mid-text, even though there was an even element boundary it could have been split on.

### Fix

Consider separator length in the space-remaining computation.

The solution here extracts both the `section.text_length` and `section.space_remaining` computations to a `_TextSectionBuilder` object which removes the need for the sectioner (`_split_elements_by_title_and_table()`) to deal with primitives (List[Element], running text length, separator length, etc.) and allows it to focus on the rules of when to start a new section.

This solution may seem like overkill at the moment and indeed it would be except it forms the foundation for adding section-level chunk combination (fix: dissociated title elements) in the next PR. The objects introduced here will gain several additional responsibilities in the next few chunking PRs in the pipeline and will earn their place.

