### PR TITLE
fix: filename missing from image metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@
 ### Fixes
 
 * **Adds `typing-extensions` as an explicit dependency** This package is an implicit dependency, but the module is being imported directly in `unstructured.documents.elements` so the dependency should be explicit in case changes in other dependencies lead to `typing-extensions` being dropped as a dependency.
-* ** Stop passing `extract_tables` to unstructured-inference ** since it is now supported in unstructured instead. Also noted the table
-output regressioin for PDF files.
-* **Fix a bug on Table partitioning** Previously the `skip_infer_table_types` variable used in partition was not being passed down to specific file partitioners. Now you can utilize the `skip_infer_table_types` list variable in partition to pass the filetype you want to exclude `text_as_html` metadata field for, or the `infer_table_structure` boolean variable on the file specific partitioning function.
+* **Stop passing `extract_tables` to `unstructured-inference` since it is now supported in `unstructured` instead** Table extraction previously occurred in `unstructured-inference`, but that logic, except for the table model itself, is now a part of the `unstructured` library. Thus the parameter triggering table extraction is no longer passed to the `unstructured-inference` package. Also noted the table output regression for PDF files.
+* **Fix a bug in Table partitioning** Previously the `skip_infer_table_types` variable used in `partition` was not being passed down to specific file partitioners. Now you can utilize the `skip_infer_table_types` list variable when calling `partition` to specify the filetypes for which you want to skip table extraction, or the `infer_table_structure` boolean variable on the file specific partitioning function.
 * **Fix partition docx without sections** Some docx files, like those from teams output, do not contain sections and it would produce no results because the code assumes all components are in sections. Now if no sections is detected from a document we iterate through the paragraphs and return contents found in the paragraphs.
 
 ## 0.10.25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.26-dev6
+## 0.10.26-dev7
 
 ### Enhancements
 
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+* **Fixes elements partitioned from an image file missing certain metadata** Metadata for image files, like file type, was being handled differently from other file types. This caused a bug where other metadata, like the file name, was being missed. This change brought metadata handling for image files to be more in line with the handling for other file types so that file name and other metadata fields are being captured.
 * **Adds `typing-extensions` as an explicit dependency** This package is an implicit dependency, but the module is being imported directly in `unstructured.documents.elements` so the dependency should be explicit in case changes in other dependencies lead to `typing-extensions` being dropped as a dependency.
 * **Stop passing `extract_tables` to `unstructured-inference` since it is now supported in `unstructured` instead** Table extraction previously occurred in `unstructured-inference`, but that logic, except for the table model itself, is now a part of the `unstructured` library. Thus the parameter triggering table extraction is no longer passed to the `unstructured-inference` package. Also noted the table output regression for PDF files.
 * **Fix a bug in Table partitioning** Previously the `skip_infer_table_types` variable used in `partition` was not being passed down to specific file partitioners. Now you can utilize the `skip_infer_table_types` list variable when calling `partition` to specify the filetypes for which you want to skip table extraction, or the `infer_table_structure` boolean variable on the file specific partitioning function.

--- a/test_unstructured/partition/pdf_image/test_image.py
+++ b/test_unstructured/partition/pdf_image/test_image.py
@@ -550,7 +550,7 @@ def test_partition_image_raises_TypeError_for_invalid_languages():
         image.partition_image(filename=filename, strategy="hi_res", languages="eng")
 
 
-@pytest.fixture
+@pytest.fixture()
 def inference_results():
     page = layout.PageLayout(
         number=1,
@@ -571,7 +571,8 @@ def test_partition_image_has_filetype(inference_results):
         return_value=inference_results,
     ) as mock_inference_func:
         elements = image.partition_image(
-            filename=os.path.join(doc_path, filename), strategy="hi_res"
+            filename=os.path.join(doc_path, filename),
+            strategy="hi_res",
         )
     # Make sure we actually went down the path we expect.
     mock_inference_func.assert_called_once()

--- a/test_unstructured/partition/pdf_image/test_image.py
+++ b/test_unstructured/partition/pdf_image/test_image.py
@@ -547,3 +547,10 @@ def test_partition_image_raises_TypeError_for_invalid_languages():
     filename = "example-docs/layout-parser-paper-fast.jpg"
     with pytest.raises(TypeError):
         image.partition_image(filename=filename, strategy="hi_res", languages="eng")
+
+
+def test_partition_image_has_filetype():
+    filename = "example-docs/layout-parser-paper-fast.jpg"
+    elements = image.partition_image(filename=filename, strategy="hi_res")
+    filenames = [el.metadata.filename for el in elements]
+    assert all(f_name == filename for f_name in filenames)

--- a/test_unstructured/partition/pdf_image/test_image.py
+++ b/test_unstructured/partition/pdf_image/test_image.py
@@ -563,13 +563,16 @@ def inference_results():
 
 
 def test_partition_image_has_filetype(inference_results):
-    filename = "example-docs/layout-parser-paper-fast.jpg"
+    doc_path = "example-docs"
+    filename = "layout-parser-paper-fast.jpg"
     # Mock inference call with known return results
     with mock.patch(
         "unstructured_inference.inference.layout.process_file_with_model",
         return_value=inference_results,
     ) as mock_inference_func:
-        elements = image.partition_image(filename=filename, strategy="hi_res")
+        elements = image.partition_image(
+            filename=os.path.join(doc_path, filename), strategy="hi_res"
+        )
     # Make sure we actually went down the path we expect.
     mock_inference_func.assert_called_once()
     # Unpack element but also make sure there is only one

--- a/test_unstructured/partition/pdf_image/test_image.py
+++ b/test_unstructured/partition/pdf_image/test_image.py
@@ -562,7 +562,7 @@ def inference_results():
     return doc
 
 
-def test_partition_image_has_filetype(inference_results):
+def test_partition_image_has_filename(inference_results):
     doc_path = "example-docs"
     filename = "layout-parser-paper-fast.jpg"
     # Mock inference call with known return results

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.26-dev6"  # pragma: no cover
+__version__ = "0.10.26-dev7"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -540,7 +540,47 @@ def _is_code_mime_type(mime_type: str) -> bool:
 _P = ParamSpec("_P")
 
 
-def add_metadata_with_filetype(
+def add_metadata(func: Callable[_P, List[Element]]) -> Callable[_P, List[Element]]:
+    @functools.wraps(func)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> List[Element]:
+        elements = func(*args, **kwargs)
+        sig = inspect.signature(func)
+        params: Dict[str, Any] = dict(**dict(zip(sig.parameters, args)), **kwargs)
+        for param in sig.parameters.values():
+            if param.name not in params and param.default is not param.empty:
+                params[param.name] = param.default
+        include_metadata = params.get("include_metadata", True)
+        if include_metadata:
+            if params.get("metadata_filename"):
+                params["filename"] = params.get("metadata_filename")
+
+            metadata_kwargs = {
+                kwarg: params.get(kwarg) for kwarg in ("filename", "url", "text_as_html")
+            }
+            # NOTE (yao): do not use cast here as cast(None) still is None
+            if not str(kwargs.get("model_name", "")).startswith("chipper"):
+                # NOTE(alan): Skip hierarchy if using chipper, as it should take care of that
+                elements = set_element_hierarchy(elements)
+
+            for element in elements:
+                # NOTE(robinson) - Attached files have already run through this logic
+                # in their own partitioning function
+                if element.metadata.attached_to_filename is None:
+                    _add_element_metadata(
+                        element,
+                        **metadata_kwargs,  # type: ignore
+                    )
+
+            return elements
+        else:
+            return _remove_element_metadata(
+                elements,
+            )
+
+    return wrapper
+
+
+def add_filetype(
     filetype: FileType,
 ) -> Callable[[Callable[_P, List[Element]]], Callable[_P, List[Element]]]:
     """..."""
@@ -559,14 +599,6 @@ def add_metadata_with_filetype(
                 if params.get("metadata_filename"):
                     params["filename"] = params.get("metadata_filename")
 
-                metadata_kwargs = {
-                    kwarg: params.get(kwarg) for kwarg in ("filename", "url", "text_as_html")
-                }
-                # NOTE (yao): do not use cast here as cast(None) still is None
-                if not str(kwargs.get("model_name", "")).startswith("chipper"):
-                    # NOTE(alan): Skip hierarchy if using chipper, as it should take care of that
-                    elements = set_element_hierarchy(elements)
-
                 for element in elements:
                     # NOTE(robinson) - Attached files have already run through this logic
                     # in their own partitioning function
@@ -574,7 +606,6 @@ def add_metadata_with_filetype(
                         _add_element_metadata(
                             element,
                             filetype=FILETYPE_TO_MIMETYPE[filetype],
-                            **metadata_kwargs,  # type: ignore
                         )
 
                 return elements
@@ -584,5 +615,16 @@ def add_metadata_with_filetype(
                 )
 
         return wrapper
+
+    return decorator
+
+
+def add_metadata_with_filetype(
+    filetype: FileType,
+) -> Callable[[Callable[_P, List[Element]]], Callable[_P, List[Element]]]:
+    """..."""
+
+    def decorator(func: Callable[_P, List[Element]]) -> Callable[_P, List[Element]]:
+        return add_filetype(filetype=filetype)(add_metadata(func))
 
     return decorator

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -2,13 +2,13 @@ from typing import List, Optional
 
 from unstructured.chunking.title import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
+from unstructured.file_utils.filetype import add_metadata
 from unstructured.logger import logger
 from unstructured.partition.common import exactly_one
 from unstructured.partition.lang import (
     convert_old_ocr_languages_to_languages,
 )
 from unstructured.partition.pdf import partition_pdf_or_image
-from unstructured.file_utils.filetype import add_metadata
 
 
 @process_metadata()

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -8,9 +8,11 @@ from unstructured.partition.lang import (
     convert_old_ocr_languages_to_languages,
 )
 from unstructured.partition.pdf import partition_pdf_or_image
+from unstructured.file_utils.filetype import add_metadata
 
 
 @process_metadata()
+@add_metadata
 @add_chunking_strategy()
 def partition_image(
     filename: str = "",


### PR DESCRIPTION
Closes [#1859](https://github.com/Unstructured-IO/unstructured/issues/1859).

* **Fixes elements partitioned from an image file missing certain metadata** Metadata for image files, like file type, was being handled differently from other file types. This caused a bug where other metadata, like the file name, was being missed. This change brought metadata handling for image files to be more in line with the handling for other file types so that file name and other metadata fields are being captured.

Additionally:
* Added test to verify filename is being captured in metadata
* Cleaned up `CHANGELOG.md` formatting

#### Testing:
The following produces output `None` on `main`, but outputs the filename `layout-parser-paper-fast.jpg` on this branch:
```python
from unstructured.partition.auto import partition
elements = partition("example-docs/layout-parser-paper-fast.jpg")
print(elements[0].metadata.filename)

```