### PR TITLE
support passing credentials from memory for google connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 0.10.29-dev2
+## 0.10.29-dev3
 
 ### Enhancements
 
 * **Add include_header argument for partition_csv and partition_tsv** Now supports retaining header rows in CSV and TSV documents element partitioning.
 * **Add retry logic for all source connectors** All http calls being made by the ingest source connectors have been isolated and wrapped by the `SourceConnectionNetworkError` custom error, which triggers the retry logic, if enabled, in the ingest pipeline.
+* **Google Drive source connector supports credentials from memory** Originally, the connector expected a filepath to pull the credentials from when creating the client. This was expanded to support passing that information from memory as a dict if access to the file system might not be available.
 
 ### Features
 

--- a/test_unstructured_ingest/test-ingest-gcs-dest.sh
+++ b/test_unstructured_ingest/test-ingest-gcs-dest.sh
@@ -49,7 +49,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --input-path example-docs/fake-memo.pdf \
     --work-dir "$WORK_DIR" \
     gcs \
-    --token "$GCP_INGEST_SERVICE_KEY_FILE" \
+    --service-account-key "$GCP_INGEST_SERVICE_KEY_FILE" \
     --remote-url "$DESTINATION_GCS"
 
 # Simply check the number of files uploaded

--- a/test_unstructured_ingest/test-ingest-gcs.sh
+++ b/test_unstructured_ingest/test-ingest-gcs.sh
@@ -40,7 +40,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --reprocess \
     --output-dir "$OUTPUT_DIR" \
     --verbose \
-    --token "$GCP_INGEST_SERVICE_KEY_FILE" \
+    --service-account-key "$GCP_INGEST_SERVICE_KEY_FILE" \
     --recursive \
     --remote-url gs://utic-test-ingest-fixtures/ \
     --work-dir "$WORK_DIR"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.29-dev2"  # pragma: no cover
+__version__ = "0.10.29-dev3"  # pragma: no cover

--- a/unstructured/ingest/cli/cmds/gcs.py
+++ b/unstructured/ingest/cli/cmds/gcs.py
@@ -13,13 +13,13 @@ CMD_NAME = "gcs"
 
 @dataclass
 class GcsCliConfig(BaseConfig, CliMixin):
-    token: t.Optional[t.Union[dict, Path]] = None
+    service_account_key: t.Optional[t.Union[dict, Path]] = None
 
     @staticmethod
     def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
-                ["--token"],
+                ["--service-account-key"],
                 default=None,
                 type=FileOrJson(),
                 help="Either the file path of the credentials file to use or a json string of "

--- a/unstructured/ingest/cli/cmds/gcs.py
+++ b/unstructured/ingest/cli/cmds/gcs.py
@@ -1,12 +1,11 @@
 import typing as t
 from dataclasses import dataclass
+from pathlib import Path
 
 import click
 
 from unstructured.ingest.cli.base.src import BaseSrcCmd
-from unstructured.ingest.cli.interfaces import (
-    CliMixin,
-)
+from unstructured.ingest.cli.interfaces import CliMixin, FileOrJson
 from unstructured.ingest.interfaces import BaseConfig
 
 CMD_NAME = "gcs"
@@ -14,7 +13,7 @@ CMD_NAME = "gcs"
 
 @dataclass
 class GcsCliConfig(BaseConfig, CliMixin):
-    token: t.Optional[str] = None
+    token: t.Optional[t.Union[dict, Path]] = None
 
     @staticmethod
     def get_cli_options() -> t.List[click.Option]:
@@ -22,9 +21,9 @@ class GcsCliConfig(BaseConfig, CliMixin):
             click.Option(
                 ["--token"],
                 default=None,
-                help="Token used to access Google Cloud. GCSFS will attempt to use your "
-                "default gcloud creds or get creds from the google metadata service "
-                "or fall back to anonymous access.",
+                type=FileOrJson(),
+                help="Either the file path of the credentials file to use or a json string of "
+                "those values to use for authentication",
             ),
         ]
         return options

--- a/unstructured/ingest/cli/cmds/gcs.py
+++ b/unstructured/ingest/cli/cmds/gcs.py
@@ -1,6 +1,5 @@
 import typing as t
 from dataclasses import dataclass
-from pathlib import Path
 
 import click
 
@@ -13,7 +12,7 @@ CMD_NAME = "gcs"
 
 @dataclass
 class GcsCliConfig(BaseConfig, CliMixin):
-    service_account_key: t.Optional[t.Union[dict, Path]] = None
+    service_account_key: t.Optional[t.Union[dict, str]] = None
 
     @staticmethod
     def get_cli_options() -> t.List[click.Option]:

--- a/unstructured/ingest/cli/cmds/google_drive.py
+++ b/unstructured/ingest/cli/cmds/google_drive.py
@@ -12,7 +12,7 @@ from unstructured.ingest.interfaces import BaseConfig
 @dataclass
 class GoogleDriveCliConfig(BaseConfig, CliMixin):
     drive_id: str
-    token: t.Union[dict, Path]
+    service_account_key: t.Union[dict, Path]
     extension: t.Optional[str] = None
 
     @staticmethod
@@ -25,7 +25,7 @@ class GoogleDriveCliConfig(BaseConfig, CliMixin):
                 help="Google Drive File or Folder ID.",
             ),
             click.Option(
-                ["--token"],
+                ["--service-account-key"],
                 required=True,
                 type=FileOrJson(),
                 help="Either the file path of the credentials file to use or a json string of "

--- a/unstructured/ingest/cli/cmds/google_drive.py
+++ b/unstructured/ingest/cli/cmds/google_drive.py
@@ -1,20 +1,18 @@
 import typing as t
 from dataclasses import dataclass
+from pathlib import Path
 
 import click
 
 from unstructured.ingest.cli.base.src import BaseSrcCmd
-from unstructured.ingest.cli.interfaces import (
-    CliMixin,
-    CliRecursiveConfig,
-)
+from unstructured.ingest.cli.interfaces import CliMixin, CliRecursiveConfig, FileOrJson
 from unstructured.ingest.interfaces import BaseConfig
 
 
 @dataclass
 class GoogleDriveCliConfig(BaseConfig, CliMixin):
     drive_id: str
-    service_account_key: str
+    token: t.Union[dict, Path]
     extension: t.Optional[str] = None
 
     @staticmethod
@@ -27,10 +25,11 @@ class GoogleDriveCliConfig(BaseConfig, CliMixin):
                 help="Google Drive File or Folder ID.",
             ),
             click.Option(
-                ["--service-account-key"],
+                ["--token"],
                 required=True,
-                type=str,
-                help="Path to the Google Drive service account json file.",
+                type=FileOrJson(),
+                help="Either the file path of the credentials file to use or a json string of "
+                "those values to use for authentication",
             ),
             click.Option(
                 ["--extension"],

--- a/unstructured/ingest/cli/cmds/google_drive.py
+++ b/unstructured/ingest/cli/cmds/google_drive.py
@@ -1,6 +1,5 @@
 import typing as t
 from dataclasses import dataclass
-from pathlib import Path
 
 import click
 
@@ -12,7 +11,7 @@ from unstructured.ingest.interfaces import BaseConfig
 @dataclass
 class GoogleDriveCliConfig(BaseConfig, CliMixin):
     drive_id: str
-    service_account_key: t.Union[dict, Path]
+    service_account_key: t.Union[dict, str]
     extension: t.Optional[str] = None
 
     @staticmethod

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -34,7 +34,7 @@ class FileOrJson(click.ParamType):
         # check if valid file
         full_path = os.path.abspath(os.path.expanduser(value))
         if os.path.isfile(full_path):
-            return Path(full_path)
+            return str(Path(full_path).resolve())
         if isinstance(value, str):
             try:
                 return json.loads(value)

--- a/unstructured/ingest/connector/google_drive.py
+++ b/unstructured/ingest/connector/google_drive.py
@@ -38,7 +38,7 @@ class GoogleDriveSessionHandle(BaseSessionHandle):
 
 
 @requires_dependencies(["googleapiclient"], extras="google-drive")
-def create_service_account_object(key_path, id=None):
+def create_service_account_object(key_path: t.Union[str, dict], id=None):
     """
     Creates a service object for interacting with Google Drive.
 
@@ -60,7 +60,7 @@ def create_service_account_object(key_path, id=None):
     try:
         if isinstance(key_path, dict):
             creds = service_account.Credentials.from_service_account_info(key_path)
-        elif os.path.isfile(key_path):
+        elif isinstance(key_path, str):
             os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = key_path
             creds, _ = default()
         else:
@@ -94,7 +94,7 @@ class SimpleGoogleDriveConfig(ConfigSessionHandleMixin, BaseConnectorConfig):
 
     # Google Drive Specific Options
     drive_id: str
-    service_account_key: str
+    service_account_key: t.Union[str, dict]
     extension: t.Optional[str] = None
     recursive: bool = False
 

--- a/unstructured/ingest/connector/google_drive.py
+++ b/unstructured/ingest/connector/google_drive.py
@@ -53,12 +53,21 @@ def create_service_account_object(key_path, id=None):
         Service account object
     """
     from google.auth import default, exceptions
+    from google.oauth2 import service_account
     from googleapiclient.discovery import build
     from googleapiclient.errors import HttpError
 
     try:
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = key_path
-        creds, _ = default()
+        if isinstance(key_path, dict):
+            creds = service_account.Credentials.from_service_account_info(key_path)
+        elif os.path.isfile(key_path):
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = key_path
+            creds, _ = default()
+        else:
+            raise ValueError(
+                f"key path not recognized as a dictionary or a file path: "
+                f"[{type(key_path)}] {key_path}",
+            )
         service = build("drive", "v3", credentials=creds)
 
         if id:

--- a/unstructured/ingest/runner/gcs.py
+++ b/unstructured/ingest/runner/gcs.py
@@ -1,6 +1,5 @@
 import logging
 import typing as t
-from pathlib import Path
 
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner.base_runner import FsspecBaseRunner
@@ -10,7 +9,7 @@ from unstructured.ingest.runner.utils import update_download_dir_remote_url
 class GCSRunner(FsspecBaseRunner):
     def run(
         self,
-        service_account_key: t.Optional[t.Union[dict, Path]] = None,
+        service_account_key: t.Optional[t.Union[dict, str]] = None,
         **kwargs,
     ):
         ingest_log_streaming_init(logging.DEBUG if self.processor_config.verbose else logging.INFO)
@@ -26,9 +25,7 @@ class GCSRunner(FsspecBaseRunner):
 
         connector_config = SimpleGcsConfig.from_dict(self.fsspec_config.to_dict())  # type: ignore
         access_kwargs = {}
-        if service_account_key and isinstance(service_account_key, Path):
-            access_kwargs["token"] = str(service_account_key.resolve())
-        elif service_account_key:
+        if service_account_key:
             access_kwargs["token"] = service_account_key
 
         connector_config.access_kwargs = access_kwargs

--- a/unstructured/ingest/runner/gcs.py
+++ b/unstructured/ingest/runner/gcs.py
@@ -1,5 +1,6 @@
 import logging
 import typing as t
+from pathlib import Path
 
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner.base_runner import FsspecBaseRunner
@@ -9,7 +10,7 @@ from unstructured.ingest.runner.utils import update_download_dir_remote_url
 class GCSRunner(FsspecBaseRunner):
     def run(
         self,
-        token: t.Optional[str] = None,
+        service_account_key: t.Optional[t.Union[dict, Path]] = None,
         **kwargs,
     ):
         ingest_log_streaming_init(logging.DEBUG if self.processor_config.verbose else logging.INFO)
@@ -24,7 +25,13 @@ class GCSRunner(FsspecBaseRunner):
         from unstructured.ingest.connector.gcs import GcsSourceConnector, SimpleGcsConfig
 
         connector_config = SimpleGcsConfig.from_dict(self.fsspec_config.to_dict())  # type: ignore
-        connector_config.access_kwargs = {"token": token}
+        access_kwargs = {}
+        if service_account_key and isinstance(service_account_key, Path):
+            access_kwargs["token"] = str(service_account_key.resolve())
+        elif service_account_key:
+            access_kwargs["token"] = service_account_key
+
+        connector_config.access_kwargs = access_kwargs
 
         source_doc_connector = GcsSourceConnector(  # type: ignore
             connector_config=connector_config,

--- a/unstructured/ingest/runner/google_drive.py
+++ b/unstructured/ingest/runner/google_drive.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import typing as t
+from pathlib import Path
 
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner.base_runner import Runner
@@ -10,7 +11,7 @@ from unstructured.ingest.runner.utils import update_download_dir_hash
 class GoogleDriveRunner(Runner):
     def run(
         self,
-        service_account_key: str,
+        service_account_key: t.Union[Path, dict],
         drive_id: str,
         recursive: bool = False,
         extension: t.Optional[str] = None,
@@ -34,6 +35,8 @@ class GoogleDriveRunner(Runner):
             SimpleGoogleDriveConfig,
         )
 
+        if isinstance(service_account_key, Path):
+            service_account_key = str(service_account_key.resolve())
         source_doc_connector = GoogleDriveSourceConnector(  # type: ignore
             connector_config=SimpleGoogleDriveConfig(
                 drive_id=drive_id,

--- a/unstructured/ingest/runner/google_drive.py
+++ b/unstructured/ingest/runner/google_drive.py
@@ -1,7 +1,6 @@
 import hashlib
 import logging
 import typing as t
-from pathlib import Path
 
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
 from unstructured.ingest.runner.base_runner import Runner
@@ -11,7 +10,7 @@ from unstructured.ingest.runner.utils import update_download_dir_hash
 class GoogleDriveRunner(Runner):
     def run(
         self,
-        service_account_key: t.Union[Path, dict],
+        service_account_key: t.Union[str, dict],
         drive_id: str,
         recursive: bool = False,
         extension: t.Optional[str] = None,
@@ -35,8 +34,6 @@ class GoogleDriveRunner(Runner):
             SimpleGoogleDriveConfig,
         )
 
-        if isinstance(service_account_key, Path):
-            service_account_key = str(service_account_key.resolve())
         source_doc_connector = GoogleDriveSourceConnector(  # type: ignore
             connector_config=SimpleGoogleDriveConfig(
                 drive_id=drive_id,

--- a/unstructured/ingest/runner/writers/gcs.py
+++ b/unstructured/ingest/runner/writers/gcs.py
@@ -5,7 +5,7 @@ from unstructured.ingest.interfaces import BaseDestinationConnector
 
 def gcs_writer(
     remote_url: str,
-    token: t.Optional[str],
+    service_account_key: t.Optional[str],
     verbose: bool = False,
     **kwargs,
 ) -> BaseDestinationConnector:
@@ -19,6 +19,6 @@ def gcs_writer(
         write_config=FsspecWriteConfig(),
         connector_config=SimpleGcsConfig(
             remote_url=remote_url,
-            access_kwargs={"token": token},
+            access_kwargs={"token": service_account_key},
         ),
     )


### PR DESCRIPTION
### Description

### Google Drive
The existing service account parameter was expanded to support either a file path or a json value to generate the credentials when instantiating the google drive client.

### GCS
Google Cloud Storage already supports the value being passed in, from their docstring:
> - you may supply a token generated by the
      [gcloud](https://cloud.google.com/sdk/docs/)
      utility; this is either a python dictionary, the name of a file
      containing the JSON returned by logging in with the gcloud CLI tool,
      or a Credentials object.


I tested this locally:

```python
from gcsfs import GCSFileSystem
import json

with open("/Users/romanisecke/.ssh/google-cloud-unstructured-ingest-test-d4fc30286d9d.json") as json_file:
    json_data = json.load(json_file)
    print(json_data)

    fs = GCSFileSystem(token=json_data)
    print(fs.ls(path="gs://utic-test-ingest-fixtures/"))
```
`['utic-test-ingest-fixtures/ideas-page.html', 'utic-test-ingest-fixtures/nested-1', 'utic-test-ingest-fixtures/nested-2']`
