### PR TITLE
expand retry logic in source connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.10.29-dev0
+## 0.10.29-dev1
 
 ### Enhancements
 
 * **Add include_header argument for partition_csv and partition_tsv** Now supports retaining header rows in CSV and TSV documents element partitioning.
+* **Add retry logic for all source connectors** All http calls being made by the ingest source connectors have been isolated and wrapped by the `SourceConnectionNetworkError` custom error, which triggers the retry logic, if enabled, in the ingest pipeline.
 
 ### Features
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.29-dev0"  # pragma: no cover
+__version__ = "0.10.29-dev1"  # pragma: no cover

--- a/unstructured/ingest/connector/biomed.py
+++ b/unstructured/ingest/connector/biomed.py
@@ -136,11 +136,15 @@ class BiomedIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
 
             if dir_:
                 dir_.mkdir(parents=True, exist_ok=True)
+        self._retrieve()
+        logger.debug(f"File downloaded: {self.file_meta.download_filepath}")
+
+    @SourceConnectionNetworkError.wrap
+    def _retrieve(self):
         urllib.request.urlretrieve(
             self.file_meta.ftp_path,  # type: ignore
             self.file_meta.download_filepath,
         )
-        logger.debug(f"File downloaded: {self.file_meta.download_filepath}")
 
 
 class BiomedSourceConnector(SourceConnectorCleanupMixin, BaseSourceConnector):

--- a/unstructured/ingest/connector/confluence.py
+++ b/unstructured/ingest/connector/confluence.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import (
     BaseConnectorConfig,
     BaseIngestDoc,
@@ -111,6 +111,7 @@ class ConfluenceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             "page_id": self.document_meta.document_id,
         }
 
+    @SourceConnectionNetworkError.wrap
     @requires_dependencies(["atlassian"], extras="Confluence")
     def _get_page(self):
         from atlassian import Confluence

--- a/unstructured/ingest/connector/discord.py
+++ b/unstructured/ingest/connector/discord.py
@@ -4,7 +4,7 @@ import typing as t
 from dataclasses import dataclass
 from pathlib import Path
 
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import (
     BaseConnectorConfig,
     BaseIngestDoc,
@@ -67,6 +67,7 @@ class DiscordIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
     def _create_full_tmp_dir_path(self):
         self._tmp_download_file().parent.mkdir(parents=True, exist_ok=True)
 
+    @SourceConnectionNetworkError.wrap
     @requires_dependencies(dependencies=["discord"], extras="discord")
     def _get_messages(self):
         """Actually fetches the data from discord."""

--- a/unstructured/ingest/connector/elasticsearch.py
+++ b/unstructured/ingest/connector/elasticsearch.py
@@ -5,7 +5,7 @@ import typing as t
 from dataclasses import dataclass
 from pathlib import Path
 
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import (
     BaseConnectorConfig,
     BaseIngestDoc,
@@ -105,6 +105,7 @@ class ElasticsearchIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         concatenated_values = seperator.join(values)
         return concatenated_values
 
+    @SourceConnectionNetworkError.wrap
     @requires_dependencies(["elasticsearch"], extras="elasticsearch")
     def _get_document(self):
         from elasticsearch import Elasticsearch, NotFoundError

--- a/unstructured/ingest/connector/github.py
+++ b/unstructured/ingest/connector/github.py
@@ -10,7 +10,7 @@ from unstructured.ingest.connector.git import (
     GitSourceConnector,
     SimpleGitConfig,
 )
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import SourceMetadata
 from unstructured.ingest.logger import logger
 from unstructured.utils import requires_dependencies
@@ -70,6 +70,7 @@ class GitHubIngestDoc(GitIngestDoc):
 
         return content_file
 
+    @SourceConnectionNetworkError.wrap
     def _fetch_content(self, content_file):
         contents = b""
         if (

--- a/unstructured/ingest/connector/gitlab.py
+++ b/unstructured/ingest/connector/gitlab.py
@@ -7,7 +7,7 @@ from unstructured.ingest.connector.git import (
     GitSourceConnector,
     SimpleGitConfig,
 )
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import SourceMetadata
 from unstructured.ingest.logger import logger
 from unstructured.utils import requires_dependencies
@@ -55,6 +55,7 @@ class GitLabIngestDoc(GitIngestDoc):
     def source_url(self) -> t.Optional[str]:
         return None
 
+    @SourceConnectionNetworkError.wrap
     @requires_dependencies(["gitlab"], extras="gitlab")
     def _fetch_content(self):
         from gitlab.exceptions import GitlabHttpError

--- a/unstructured/ingest/connector/jira.py
+++ b/unstructured/ingest/connector/jira.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import (
     BaseConnectorConfig,
     BaseIngestDoc,
@@ -262,6 +262,7 @@ class JiraIngestDoc(IngestDocSessionHandleMixin, IngestDocCleanupMixin, BaseInge
             "issue_key": self.file_meta.issue_key,
         }
 
+    @SourceConnectionNetworkError.wrap
     @cached_property
     def issue(self):
         """Gets issue data"""

--- a/unstructured/ingest/connector/jira.py
+++ b/unstructured/ingest/connector/jira.py
@@ -262,8 +262,8 @@ class JiraIngestDoc(IngestDocSessionHandleMixin, IngestDocCleanupMixin, BaseInge
             "issue_key": self.file_meta.issue_key,
         }
 
-    @SourceConnectionNetworkError.wrap
     @cached_property
+    @SourceConnectionNetworkError.wrap
     def issue(self):
         """Gets issue data"""
         jira = self.session_handle.service

--- a/unstructured/ingest/connector/outlook.py
+++ b/unstructured/ingest/connector/outlook.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from itertools import chain
 from pathlib import Path
 
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import (
     BaseConnectorConfig,
     BaseIngestDoc,
@@ -139,13 +139,20 @@ class OutlookIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             exists=True,
         )
 
+    @SourceConnectionNetworkError.wrap
+    def _run_download(self, local_file):
+        client = self.connector_config._get_client()
+        client.users[self.connector_config.user_email].messages[self.message_id].download(
+            local_file,
+        ).execute_query()
+
     @SourceConnectionError.wrap
     @BaseIngestDoc.skip_if_file_exists
     @requires_dependencies(["office365"], extras="outlook")
     def get_file(self):
         """Relies on Office365 python sdk message object to do the download."""
         try:
-            client = self.connector_config._get_client()
+            self.connector_config._get_client()
             self.update_source_metadata()
             if not self.download_dir.is_dir():
                 logger.debug(f"Creating directory: {self.download_dir}")
@@ -158,9 +165,7 @@ class OutlookIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
                 ),
                 "wb",
             ) as local_file:
-                client.users[self.connector_config.user_email].messages[self.message_id].download(
-                    local_file,
-                ).execute_query()
+                self._run_download(local_file=local_file)
 
         except Exception as e:
             logger.error(

--- a/unstructured/ingest/connector/salesforce.py
+++ b/unstructured/ingest/connector/salesforce.py
@@ -19,7 +19,7 @@ from textwrap import dedent
 
 from dateutil import parser  # type: ignore
 
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import (
     BaseConnectorConfig,
     BaseIngestDoc,
@@ -149,13 +149,16 @@ class SalesforceIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         )
         return dedent(eml)
 
-    def get_record(self) -> OrderedDict:
+    @SourceConnectionNetworkError.wrap
+    def _get_response(self):
         client = self.connector_config.get_client()
-
-        # Get record from Salesforce based on id
-        response = client.query_all(
+        return client.query_all(
             f"select FIELDS(STANDARD) from {self.record_type} where Id='{self.record_id}'",
         )
+
+    def get_record(self) -> OrderedDict:
+        # Get record from Salesforce based on id
+        response = self._get_response()
         logger.debug(f"response from salesforce record request: {response}")
         records = response["records"]
         if not records:

--- a/unstructured/ingest/connector/sharepoint.py
+++ b/unstructured/ingest/connector/sharepoint.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from unstructured.file_utils.filetype import EXT_TO_FILETYPE
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import (
     BaseConnectorConfig,
     BaseIngestDoc,
@@ -118,7 +118,7 @@ class SharepointIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
             "site_url": self.site_url,
         }
 
-    @SourceConnectionError.wrap
+    @SourceConnectionNetworkError.wrap
     @requires_dependencies(["office365"], extras="sharepoint")
     def _fetch_file(self, properties_only: bool = False):
         """Retrieves the actual page/file from the Sharepoint instance"""
@@ -277,6 +277,7 @@ class SharepointIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
         logger.info(f"File downloaded: {self.filename}")
 
     @BaseIngestDoc.skip_if_file_exists
+    @SourceConnectionError.wrap
     @requires_dependencies(["office365"])
     def get_file(self):
         if self.is_page:

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -3,7 +3,7 @@ import typing as t
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from unstructured.ingest.error import SourceConnectionError
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.interfaces import (
     BaseConnectorConfig,
     BaseIngestDoc,
@@ -113,6 +113,7 @@ class WikipediaIngestHTMLDoc(WikipediaIngestDoc):
             Path(self.read_config.download_dir) / f"{self.get_filename_prefix()}.html"
         ).resolve()
 
+    @SourceConnectionNetworkError.wrap
     @property
     def text(self):
         return self.page.html()
@@ -130,6 +131,7 @@ class WikipediaIngestTextDoc(WikipediaIngestDoc):
     def filename(self) -> Path:
         return (Path(self.read_config.download_dir) / f"{self.get_filename_prefix()}.txt").resolve()
 
+    @SourceConnectionNetworkError.wrap
     @property
     def text(self):
         return self.page.content
@@ -149,6 +151,7 @@ class WikipediaIngestSummaryDoc(WikipediaIngestDoc):
             Path(self.read_config.download_dir) / f"{self.get_filename_prefix()}-summary.txt"
         ).resolve()
 
+    @SourceConnectionNetworkError.wrap
     @property
     def text(self):
         return self.page.summary

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -113,9 +113,12 @@ class WikipediaIngestHTMLDoc(WikipediaIngestDoc):
             Path(self.read_config.download_dir) / f"{self.get_filename_prefix()}.html"
         ).resolve()
 
-    @SourceConnectionNetworkError.wrap
     @property
     def text(self):
+        return self._get_html()
+
+    @SourceConnectionNetworkError.wrap
+    def _get_html(self):
         return self.page.html()
 
     @property
@@ -131,9 +134,12 @@ class WikipediaIngestTextDoc(WikipediaIngestDoc):
     def filename(self) -> Path:
         return (Path(self.read_config.download_dir) / f"{self.get_filename_prefix()}.txt").resolve()
 
-    @SourceConnectionNetworkError.wrap
     @property
     def text(self):
+        return self._get_content()
+
+    @SourceConnectionNetworkError.wrap
+    def _get_content(self):
         return self.page.content
 
     @property
@@ -151,9 +157,12 @@ class WikipediaIngestSummaryDoc(WikipediaIngestDoc):
             Path(self.read_config.download_dir) / f"{self.get_filename_prefix()}-summary.txt"
         ).resolve()
 
-    @SourceConnectionNetworkError.wrap
     @property
     def text(self):
+        return self._get_summary()
+
+    @SourceConnectionNetworkError.wrap
+    def _get_summary(self):
         return self.page.summary
 
     @property


### PR DESCRIPTION
### Description
All http calls being made by the ingest source connectors have been isolated and wrapped by the `SourceConnectionNetworkError` custom error, which triggers the retry logic, if enabled, in the ingest pipeline.