### PR TITLE
swap multiprocessing pool for concurrent.futures ProcessPoolExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.11.1-dev1
+## 0.11.1-dev2
 
 ### Enhancements
+
+* **Leverage concurrent futures pool over multiprocessing pool** The ProcessPoolExecutor from concurrent.futures as been shown to have some improvements over the multiprocessing pool for thread safe workflows. Multiprocessing pool was swapped out for the concurrent.futures executor pool.
 
 ### Features
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.1-dev1"  # pragma: no cover
+__version__ = "0.11.1-dev2"  # pragma: no cover

--- a/unstructured/ingest/pipeline/interfaces.py
+++ b/unstructured/ingest/pipeline/interfaces.py
@@ -1,9 +1,9 @@
 import hashlib
 import json
 import logging
-import multiprocessing as mp
 import typing as t
 from abc import ABC, abstractmethod
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from multiprocessing.managers import DictProxy
 from pathlib import Path
@@ -71,8 +71,8 @@ class PipelineNode(DataClassJsonMixin, ABC):
             else:
                 self.result = self.run()
         else:
-            with mp.Pool(
-                processes=self.pipeline_context.num_processes,
+            with ProcessPoolExecutor(
+                max_workers=self.pipeline_context.num_processes,
                 initializer=ingest_log_streaming_init,
                 initargs=(logging.DEBUG if self.pipeline_context.verbose else logging.INFO,),
             ) as pool:

--- a/unstructured/ingest/pipeline/interfaces.py
+++ b/unstructured/ingest/pipeline/interfaces.py
@@ -76,7 +76,12 @@ class PipelineNode(DataClassJsonMixin, ABC):
                 initializer=ingest_log_streaming_init,
                 initargs=(logging.DEBUG if self.pipeline_context.verbose else logging.INFO,),
             ) as pool:
-                self.result = pool.map(self.run, iterable)
+                result = []
+                for r in pool.map(self.run, iterable):
+                    result.append(r)
+
+                self.result = result
+
         # Remove None which may be caused by failed docs that didn't raise an error
         if isinstance(self.result, t.Iterable):
             self.result = [r for r in self.result if r is not None]

--- a/unstructured/ingest/pipeline/pipeline.py
+++ b/unstructured/ingest/pipeline/pipeline.py
@@ -1,7 +1,7 @@
 import logging
-import multiprocessing as mp
 import typing as t
 from dataclasses import dataclass, field
+from multiprocessing import Manager
 
 from dataclasses_json import DataClassJsonMixin
 
@@ -46,7 +46,7 @@ class Pipeline(DataClassJsonMixin):
             f"with config: {self.pipeline_context.to_json()}",
         )
         self.initialize()
-        manager = mp.Manager()
+        manager = Manager()
         self.pipeline_context.ingest_docs_map = manager.dict()
         dict_docs = self.doc_factory_node()
         dict_docs = [manager.dict(d) for d in dict_docs]

--- a/unstructured/ingest/processor.py
+++ b/unstructured/ingest/processor.py
@@ -1,6 +1,4 @@
-import multiprocessing as mp
 import typing as t
-from contextlib import suppress
 
 from unstructured.ingest.interfaces import (
     BaseDestinationConnector,
@@ -24,9 +22,6 @@ from unstructured.ingest.pipeline import (
     ReformatNode,
     Writer,
 )
-
-with suppress(RuntimeError):
-    mp.set_start_method("spawn")
 
 
 def process_documents(


### PR DESCRIPTION
### Description
The `ProcessPoolExecutor` from `concurrent.futures` as been shown to have some improvements over the multiprocessing pool for thread safe workflows. Multiprocessing pool was swapped out for the concurrent.futures executor pool.