### PR TITLE
Update fsspecs-specific source connector docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.29-dev1
+## 0.10.29-dev2
 
 ### Enhancements
 

--- a/docs/source/source_connectors/azure.rst
+++ b/docs/source/source_connectors/azure.rst
@@ -30,7 +30,12 @@ Run Locally
 
         import os
 
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import AzureRunner
 
         if __name__ == "__main__":
@@ -42,11 +47,15 @@ Run Locally
                 ),
                 read_config=ReadConfig(),
                 partition_config=PartitionConfig(),
+                fsspec_config=FsspecConfig(
+                    remote_url="abfs://container1/",
+                ),
             )
             runner.run(
                 remote_url="abfs://container1/",
                 account_name="azureunstructured1",
             )
+
 
 Run via the API
 ---------------
@@ -61,7 +70,12 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
 
         import os
 
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import AzureRunner
 
         if __name__ == "__main__":
@@ -76,11 +90,15 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
                     partition_by_api=True,
                     api_key=os.getenv("UNSTRUCTURED_API_KEY"),
                 ),
+                fsspec_config=FsspecConfig(
+                    remote_url="abfs://container1/",
+                ),
             )
             runner.run(
                 remote_url="abfs://container1/",
                 account_name="azureunstructured1",
             )
+
 
 Additionally, you will need to pass the ``--partition-endpoint`` if you're running the API locally. You can find more information about the ``unstructured`` API `here <https://github.com/Unstructured-IO/unstructured-api>`_.
 

--- a/docs/source/source_connectors/azure.rst
+++ b/docs/source/source_connectors/azure.rst
@@ -52,7 +52,6 @@ Run Locally
                 ),
             )
             runner.run(
-                remote_url="abfs://container1/",
                 account_name="azureunstructured1",
             )
 
@@ -95,7 +94,6 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
                 ),
             )
             runner.run(
-                remote_url="abfs://container1/",
                 account_name="azureunstructured1",
             )
 

--- a/docs/source/source_connectors/box.rst
+++ b/docs/source/source_connectors/box.rst
@@ -32,7 +32,12 @@ Run Locally
 
         import os
 
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import BoxRunner
 
         if __name__ == "__main__":
@@ -44,12 +49,15 @@ Run Locally
                 ),
                 read_config=ReadConfig(),
                 partition_config=PartitionConfig(),
+                fsspec_config=FsspecConfig(
+                    remote_url="box://utic-test-ingest-fixtures",
+                    recursive=True,
+                ),
             )
             runner.run(
                 box_app_config=os.getenv("BOX_APP_CONFIG_PATH"),
-                recursive=True,
-                remote_url="box://utic-test-ingest-fixtures",
             )
+
 
 Run via the API
 ---------------
@@ -79,7 +87,12 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
 
         import os
 
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import BoxRunner
 
         if __name__ == "__main__":
@@ -94,12 +107,15 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
                     partition_by_api=True,
                     api_key=os.getenv("UNSTRUCTURED_API_KEY"),
                 ),
+                fsspec_config=FsspecConfig(
+                    remote_url="box://utic-test-ingest-fixtures",
+                    recursive=True,
+                ),
             )
             runner.run(
                 box_app_config=os.getenv("BOX_APP_CONFIG_PATH"),
-                recursive=True,
-                remote_url="box://utic-test-ingest-fixtures",
             )
+
 
 Additionally, you will need to pass the ``--partition-endpoint`` if you're running the API locally. You can find more information about the ``unstructured`` API `here <https://github.com/Unstructured-IO/unstructured-api>`_.
 

--- a/docs/source/source_connectors/dropbox.rst
+++ b/docs/source/source_connectors/dropbox.rst
@@ -49,9 +49,7 @@ Run Locally
                 partition_config=PartitionConfig(),
                 fsspec_config=FsspecConfig(remote_url="dropbox:// /", recursive=True),
             )
-            runner.run(
-                remote_url="dropbox:// /",
-            )
+            runner.run()
 
 Run via the API
 ---------------
@@ -103,9 +101,7 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
                 ),
                 fsspec_config=FsspecConfig(remote_url="dropbox:// /", recursive=True),
             )
-            runner.run(
-                remote_url="dropbox:// /",
-            )
+            runner.run()
 
 
 Additionally, you will need to pass the ``--partition-endpoint`` if you're running the API locally. You can find more information about the ``unstructured`` API `here <https://github.com/Unstructured-IO/unstructured-api>`_.

--- a/docs/source/source_connectors/dropbox.rst
+++ b/docs/source/source_connectors/dropbox.rst
@@ -30,6 +30,8 @@ Run Locally
 
       .. code:: python
 
+        import os
+
         from unstructured.ingest.interfaces import (
             FsspecConfig,
             PartitionConfig,
@@ -49,7 +51,7 @@ Run Locally
                 partition_config=PartitionConfig(),
                 fsspec_config=FsspecConfig(remote_url="dropbox:// /", recursive=True),
             )
-            runner.run()
+            runner.run(token=os.getenv("DROPBOX_ACCESS_TOKEN"))
 
 Run via the API
 ---------------
@@ -101,7 +103,7 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
                 ),
                 fsspec_config=FsspecConfig(remote_url="dropbox:// /", recursive=True),
             )
-            runner.run()
+            runner.run(token=os.getenv("DROPBOX_ACCESS_TOKEN"))
 
 
 Additionally, you will need to pass the ``--partition-endpoint`` if you're running the API locally. You can find more information about the ``unstructured`` API `here <https://github.com/Unstructured-IO/unstructured-api>`_.

--- a/docs/source/source_connectors/dropbox.rst
+++ b/docs/source/source_connectors/dropbox.rst
@@ -30,9 +30,12 @@ Run Locally
 
       .. code:: python
 
-        import os
-
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import DropboxRunner
 
         if __name__ == "__main__":
@@ -44,11 +47,10 @@ Run Locally
                 ),
                 read_config=ReadConfig(),
                 partition_config=PartitionConfig(),
+                fsspec_config=FsspecConfig(remote_url="dropbox:// /", recursive=True),
             )
             runner.run(
                 remote_url="dropbox:// /",
-                token=os.getenv("DROPBOX_TOKEN"),
-                recursive=True,
             )
 
 Run via the API
@@ -79,7 +81,12 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
 
         import os
 
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import DropboxRunner
 
         if __name__ == "__main__":
@@ -94,12 +101,12 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
                     partition_by_api=True,
                     api_key=os.getenv("UNSTRUCTURED_API_KEY"),
                 ),
+                fsspec_config=FsspecConfig(remote_url="dropbox:// /", recursive=True),
             )
             runner.run(
                 remote_url="dropbox:// /",
-                token=os.getenv("DROPBOX_TOKEN"),
-                recursive=True,
             )
+
 
 Additionally, you will need to pass the ``--partition-endpoint`` if you're running the API locally. You can find more information about the ``unstructured`` API `here <https://github.com/Unstructured-IO/unstructured-api>`_.
 

--- a/docs/source/source_connectors/google_cloud_storage.rst
+++ b/docs/source/source_connectors/google_cloud_storage.rst
@@ -31,7 +31,12 @@ Run Locally
 
         import os
 
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import GCSRunner
 
         if __name__ == "__main__":
@@ -43,11 +48,12 @@ Run Locally
                 ),
                 read_config=ReadConfig(),
                 partition_config=PartitionConfig(),
+                fsspec_config=FsspecConfig(
+                    remote_url="gs://utic-test-ingest-fixtures-public/", recursive=True
+                ),
             )
-            runner.run(
-                remote_url="gs://utic-test-ingest-fixtures-public/",
-                recursive=True,
-            )
+            runner.run()
+
 
 Run via the API
 ---------------
@@ -74,7 +80,12 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
 
         import os
 
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import GCSRunner
 
         if __name__ == "__main__":
@@ -89,11 +100,12 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
                     partition_by_api=True,
                     api_key=os.getenv("UNSTRUCTURED_API_KEY"),
                 ),
+                fsspec_config=FsspecConfig(
+                    remote_url="gs://utic-test-ingest-fixtures-public/", recursive=True
+                ),
             )
-            runner.run(
-                remote_url="gs://utic-test-ingest-fixtures-public/",
-                recursive=True,
-            )
+            runner.run()
+
 
 Additionally, you will need to pass the ``--partition-endpoint`` if you're running the API locally. You can find more information about the ``unstructured`` API `here <https://github.com/Unstructured-IO/unstructured-api>`_.
 

--- a/docs/source/source_connectors/s3.rst
+++ b/docs/source/source_connectors/s3.rst
@@ -30,7 +30,12 @@ Run Locally
 
         import os
 
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import S3Runner
 
         if __name__ == "__main__":
@@ -42,11 +47,14 @@ Run Locally
                 ),
                 read_config=ReadConfig(),
                 partition_config=PartitionConfig(),
+                fsspec_config=FsspecConfig(
+                    remote_url="s3://utic-dev-tech-fixtures/small-pdf-set/",
+                ),
             )
             runner.run(
-                remote_url="s3://utic-dev-tech-fixtures/small-pdf-set/",
                 anonymous=True,
             )
+
 
 Run via the API
 ---------------
@@ -74,7 +82,12 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
 
         import os
 
-        from unstructured.ingest.interfaces import PartitionConfig, ProcessorConfig, ReadConfig
+        from unstructured.ingest.interfaces import (
+            FsspecConfig,
+            PartitionConfig,
+            ProcessorConfig,
+            ReadConfig,
+        )
         from unstructured.ingest.runner import S3Runner
 
         if __name__ == "__main__":
@@ -89,11 +102,14 @@ You can also use upstream connectors with the ``unstructured`` API. For this you
                     partition_by_api=True,
                     api_key=os.getenv("UNSTRUCTURED_API_KEY"),
                 ),
+                fsspec_config=FsspecConfig(
+                    remote_url="s3://utic-dev-tech-fixtures/small-pdf-set/",
+                ),
             )
             runner.run(
-                remote_url="s3://utic-dev-tech-fixtures/small-pdf-set/",
                 anonymous=True,
             )
+
 
 Additionally, you will need to pass the ``--partition-endpoint`` if you're running the API locally. You can find more information about the ``unstructured`` API `here <https://github.com/Unstructured-IO/unstructured-api>`_.
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.29-dev1"  # pragma: no cover
+__version__ = "0.10.29-dev2"  # pragma: no cover

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -84,7 +84,7 @@ class PartitionConfig(BaseConfig):
     flatten_metadata: bool = False
     metadata_exclude: t.List[str] = field(default_factory=list)
     metadata_include: t.List[str] = field(default_factory=list)
-    partition_endpoint: t.Optional[str] = None
+    partition_endpoint: t.Optional[str] = "https://api.unstructured.io/general/v0/general"
     partition_by_api: bool = False
     api_key: t.Optional[str] = None
 

--- a/unstructured/ingest/runner/azure.py
+++ b/unstructured/ingest/runner/azure.py
@@ -9,7 +9,6 @@ from unstructured.ingest.runner.utils import update_download_dir_remote_url
 class AzureRunner(FsspecBaseRunner):
     def run(
         self,
-        remote_url: str,
         account_name: t.Optional[str] = None,
         account_key: t.Optional[str] = None,
         connection_string: t.Optional[str] = None,


### PR DESCRIPTION
### Description
Add in the fsspec configs needed for the fsspec-based connectors

To match the behavior of the original CLI, the default used by the click option was mirrored in the base config for the api endpoint. 