### PR TITLE
feat/clean tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.10.28-dev0
+
+### Enhancements
+
+* **Update unstructured-inference to 0.7.11**
+* **Use clean_pdfminer_inner_elements in pdf processing**  With this update tables doesn't contain nested elements, allowing for better table extraction without duplicate information
+
+### Features
+
+### Fixes
+
+
 ## 0.10.27
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.27"  # pragma: no cover
+__version__ = "0.10.28-dev0"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -426,7 +426,7 @@ def _partition_pdf_or_image_local(
     # NOTE(alan): starting with v2, chipper sorts the elements itself.
     if model_name == "chipper":
         kwargs["sort_mode"] = SORT_MODE_DONT
-
+    final_layout.clean_pdfminer_inner_elements()
     elements = document_to_element_list(
         final_layout,
         sortable=True,


### PR DESCRIPTION
This PR updates `unstructured-inference `to allow cleaning of pdfminer elements from inside tables.

This needs other PR is required to work: https://github.com/Unstructured-IO/unstructured-inference/pull/268