### PR TITLE
Fix: replace wrong logger for paddle info 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.28-dev1
+## 0.10.28-dev2
 
 ### Enhancements
 
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+* **Fix wrong logger for paddle info** Replace the logger from unstructured-inference with the logger from unstructured for paddle_ocr.py module.
 * **Fix ingest pipeline to be able to use chunking and embedding together** Problem: When ingest pipeline was using chunking and embedding together, embedding outputs were empty and the outputs of chunking couldn't be re-read into memory and be forwarded to embeddings. Fix: Added CompositeElement type to TYPE_TO_TEXT_ELEMENT_MAP to be able to process CompositeElements with unstructured.staging.base.isd_to_elements
 * **Fix unnecessary mid-text chunk-splitting.** The "pre-chunker" did not consider separator blank-line ("\n\n") length when grouping elements for a single chunk. As a result, sections were frequently over-populated producing a over-sized chunk that required mid-text splitting.
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.28-dev1"  # pragma: no cover
+__version__ = "0.10.28-dev2"  # pragma: no cover

--- a/unstructured/partition/utils/ocr_models/paddle_ocr.py
+++ b/unstructured/partition/utils/ocr_models/paddle_ocr.py
@@ -1,6 +1,6 @@
 import functools
 
-from unstructured_inference.logger import logger
+from unstructured.logger import logger
 
 
 @functools.lru_cache(maxsize=None)


### PR DESCRIPTION
### Summary

The logger from `paddle_ocr.py` is wrong, it should be `from unstructured.logger` since the module is in unst repo

### Test
* install this branch of unst to an unst-api env with `pip install -e .`
* in unst-api repo, run `OCR_AGENT=paddle make run-web-app`
* curl with:
```
curl -X 'POST'   'http://0.0.0.0:8000/general/v0/general' \
-H 'accept: application/json'  \
-H 'Content-Type: multipart/form-data'  \
-F 'files=@sample-docs/layout-parser-paper.pdf'  \
-F 'strategy=hi_res'  \
-F 'pdf_infer_table_structure=True' \
 | jq -C . | less -R
```
you should be able to see log like 
```
2023-10-27 10:31:48,691 unstructured INFO Processing OCR with paddle...
2023-10-27 10:31:48,969 unstructured INFO Loading paddle with CPU on language=en...
```
not 
```
2023-10-27 10:16:08,654 unstructured_inference INFO Loading paddle with CPU on language=en...
```
even paddle is not installed