### PR TITLE
Add test for the embedding module

### DIFF
--- a/test_unstructured/embed/test_embed_huggingface.py
+++ b/test_unstructured/embed/test_embed_huggingface.py
@@ -1,23 +1,69 @@
+import numpy as np
+
 from unstructured.documents.elements import Text
 from unstructured.embed.huggingface import HuggingFaceEmbeddingEncoder
 
 
 def test_embed_documents_does_not_break_element_to_dict(mocker):
-    # Mocked client with the desired behavior for embed_documents
-    mock_client = mocker.MagicMock()
-    mock_client.embed_documents.return_value = [1, 2]
-
-    # Mock get_openai_client to return our mock_client
-    mocker.patch.object(
-        HuggingFaceEmbeddingEncoder,
-        "get_huggingface_client",
-        return_value=mock_client,
-    )
 
     encoder = HuggingFaceEmbeddingEncoder()
-    elements = encoder.embed_documents(
+
+    doc_embed_result = encoder.embed_documents(
         elements=[Text("This is sentence 1"), Text("This is sentence 2")],
     )
-    assert len(elements) == 2
-    assert elements[0].to_dict()["text"] == "This is sentence 1"
-    assert elements[1].to_dict()["text"] == "This is sentence 2"
+    query_embed_result = encoder.embed_query(Text("This is sentence 1"))
+
+    # Keep the number of elements same
+    assert len(doc_embed_result) == 2
+
+    # Have consistent embedding dimensionality
+    assert (
+        len(doc_embed_result[0].embeddings)
+        == len(doc_embed_result[1].embeddings)
+        == len(query_embed_result)
+        == 384
+    )
+
+    # Keep element text the same
+    assert doc_embed_result[0].to_dict()["text"] == "This is sentence 1"
+    assert doc_embed_result[1].to_dict()["text"] == "This is sentence 2"
+
+    # Generate reproducable / deterministic embeddings
+    assert all(
+        np.isclose(
+            doc_embed_result[0].embeddings[:5],
+            [
+                0.0356232188642025,
+                0.06595201045274734,
+                0.06317725777626038,
+                0.04989251494407654,
+                0.0425567664206028,
+            ],
+        ),
+    )
+
+    assert all(
+        np.isclose(
+            doc_embed_result[1].embeddings[:5],
+            [
+                0.0622941255569458,
+                0.0793377012014389,
+                0.05761214718222618,
+                0.0711262971162796,
+                0.05167127028107643,
+            ],
+        ),
+    )
+
+    assert all(
+        np.isclose(
+            query_embed_result[:5],
+            [
+                0.03562326729297638,
+                0.06595207005739212,
+                0.0631771832704544,
+                0.04989247024059296,
+                0.04255683720111847,
+            ],
+        ),
+    )


### PR DESCRIPTION
Adds an actual test for the embedding module (Huggingface). 

Additional info:
- Found `langchain.embeddings.HuggingFaceEmbeddings` to be deterministic even when there's no seed set
- Took 6.84s to pass the test (without cache, including model download)
- `langchain.embeddings.HuggingFaceEmbeddings` runs in local, making it zero cost

For all these reasons, testing embedding modules with the Huggingface model seems to be making sense