### PR TITLE
feat: support generic inputs for partition kwargs from ingest CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.29-dev9
+## 0.10.29-dev10
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * **Add include_header argument for partition_csv and partition_tsv** Now supports retaining header rows in CSV and TSV documents element partitioning.
 * **Add retry logic for all source connectors** All http calls being made by the ingest source connectors have been isolated and wrapped by the `SourceConnectionNetworkError` custom error, which triggers the retry logic, if enabled, in the ingest pipeline.
 * **Google Drive source connector supports credentials from memory** Originally, the connector expected a filepath to pull the credentials from when creating the client. This was expanded to support passing that information from memory as a dict if access to the file system might not be available.
+* **Add support for generic partition configs in ingest cli** Along with the explicit partition options supported by the cli, an `additional_partition_args` arg was added to allow users to pass in any other arguments that should be added when calling partition(). This helps keep any changes to the input parameters of the partition() exposed in the CLI.
 
 ### Features
 

--- a/test_unstructured_ingest/src/local-single-file.sh
+++ b/test_unstructured_ingest/src/local-single-file.sh
@@ -23,8 +23,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --num-processes "$max_processes" \
     --metadata-exclude coordinates,filename,file_directory,metadata.data_source.date_created,metadata.data_source.date_modified,metadata.data_source.date_processed,metadata.last_modified,metadata.detection_class_prob,metadata.parent_id,metadata.category_depth \
     --output-dir "$OUTPUT_DIR" \
-    --ocr-languages ind+est \
-    --strategy ocr_only \
+    --partition-args '{"strategy":"ocr_only", "languages":["ind", "est"]}' \
     --verbose \
     --reprocess \
     --input-path example-docs/language-docs/UDHR_first_article_all.txt \

--- a/test_unstructured_ingest/src/local-single-file.sh
+++ b/test_unstructured_ingest/src/local-single-file.sh
@@ -23,8 +23,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --num-processes "$max_processes" \
     --metadata-exclude coordinates,filename,file_directory,metadata.data_source.date_created,metadata.data_source.date_modified,metadata.data_source.date_processed,metadata.last_modified,metadata.detection_class_prob,metadata.parent_id,metadata.category_depth \
     --output-dir "$OUTPUT_DIR" \
-    --ocr-languages ind+est \
-    --strategy ocr_only \
+    --additional-partition-args '{"strategy":"ocr_only", "languages":["ind", "est"]}' \
     --verbose \
     --reprocess \
     --input-path example-docs/language-docs/UDHR_first_article_all.txt \

--- a/test_unstructured_ingest/src/local-single-file.sh
+++ b/test_unstructured_ingest/src/local-single-file.sh
@@ -23,7 +23,8 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
     --num-processes "$max_processes" \
     --metadata-exclude coordinates,filename,file_directory,metadata.data_source.date_created,metadata.data_source.date_modified,metadata.data_source.date_processed,metadata.last_modified,metadata.detection_class_prob,metadata.parent_id,metadata.category_depth \
     --output-dir "$OUTPUT_DIR" \
-    --partition-args '{"strategy":"ocr_only", "languages":["ind", "est"]}' \
+    --ocr-languages ind+est \
+    --strategy ocr_only \
     --verbose \
     --reprocess \
     --input-path example-docs/language-docs/UDHR_first_article_all.txt \

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.29-dev9"  # pragma: no cover
+__version__ = "0.10.29-dev10"  # pragma: no cover

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -22,6 +22,27 @@ from unstructured.ingest.interfaces import (
 )
 
 
+class Dict(click.ParamType):
+    name = "dict"
+
+    def convert(
+        self,
+        value: t.Any,
+        param: t.Optional[click.Parameter],
+        ctx: t.Optional[click.Context],
+    ) -> t.Any:
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            self.fail(
+                gettext(
+                    "{value} is not a valid json value.",
+                ).format(value=value),
+                param,
+                ctx,
+            )
+
+
 class FileOrJson(click.ParamType):
     name = "file-or-json"
 
@@ -242,31 +263,9 @@ class CliPartitionConfig(PartitionConfig, CliMixin):
                 help="Optional list of document types to skip table extraction on",
             ),
             click.Option(
-                ["--pdf-infer-table-structure"],
-                default=False,
-                help="If set to True, partition will include the table's text "
-                "content in the response.",
-            ),
-            click.Option(
-                ["--strategy"],
-                default="auto",
-                help="The method that will be used to process the documents. "
-                "Default: auto. Other strategies include `fast` and `hi_res`.",
-            ),
-            click.Option(
-                ["--ocr-languages"],
-                default=None,
-                type=DelimitedString(delimiter="+"),
-                help="A list of language packs to specify which languages to use for OCR, "
-                "separated by '+' e.g. 'eng+deu' to use the English and German language packs. "
-                "The appropriate Tesseract "
-                "language pack needs to be installed.",
-            ),
-            click.Option(
-                ["--encoding"],
-                default=None,
-                help="Text encoding to use when reading documents. By default the encoding is "
-                "detected automatically.",
+                ["--partition-args"],
+                type=Dict(),
+                help="A json string representation of values to pass through to partition()",
             ),
             click.Option(
                 ["--fields-include"],

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -257,13 +257,40 @@ class CliPartitionConfig(PartitionConfig, CliMixin):
     def get_cli_options() -> t.List[click.Option]:
         options = [
             click.Option(
+                ["--pdf-infer-table-structure"],
+                default=False,
+                help="If set to True, partition will include the table's text "
+                "content in the response.",
+            ),
+            click.Option(
+                ["--strategy"],
+                default="auto",
+                help="The method that will be used to process the documents. "
+                "Default: auto. Other strategies include `fast` and `hi_res`.",
+            ),
+            click.Option(
+                ["--ocr-languages"],
+                default=None,
+                type=DelimitedString(delimiter="+"),
+                help="A list of language packs to specify which languages to use for OCR, "
+                "separated by '+' e.g. 'eng+deu' to use the English and German language packs. "
+                "The appropriate Tesseract "
+                "language pack needs to be installed.",
+            ),
+            click.Option(
+                ["--encoding"],
+                default=None,
+                help="Text encoding to use when reading documents. By default the encoding is "
+                "detected automatically.",
+            ),
+            click.Option(
                 ["--skip-infer-table-types"],
                 type=DelimitedString(),
                 default=None,
                 help="Optional list of document types to skip table extraction on",
             ),
             click.Option(
-                ["--partition-args"],
+                ["--additional-partition-args"],
                 type=Dict(),
                 help="A json string representation of values to pass through to partition()",
             ),

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -73,11 +73,8 @@ class RetryStrategyConfig(BaseConfig):
 @dataclass
 class PartitionConfig(BaseConfig):
     # where to write structured data outputs
-    pdf_infer_table_structure: bool = False
+    partition_args: dict = field(default_factory=dict)
     skip_infer_table_types: t.Optional[t.List[str]] = None
-    strategy: str = "auto"
-    ocr_languages: t.Optional[t.List[str]] = None
-    encoding: t.Optional[str] = None
     fields_include: t.List[str] = field(
         default_factory=lambda: ["element_id", "text", "type", "metadata", "embeddings"],
     )

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -73,7 +73,11 @@ class RetryStrategyConfig(BaseConfig):
 @dataclass
 class PartitionConfig(BaseConfig):
     # where to write structured data outputs
-    partition_args: dict = field(default_factory=dict)
+    pdf_infer_table_structure: bool = False
+    strategy: str = "auto"
+    ocr_languages: t.Optional[t.List[str]] = None
+    encoding: t.Optional[str] = None
+    additional_partition_args: dict = field(default_factory=dict)
     skip_infer_table_types: t.Optional[t.List[str]] = None
     fields_include: t.List[str] = field(
         default_factory=lambda: ["element_id", "text", "type", "metadata", "embeddings"],

--- a/unstructured/ingest/pipeline/partition.py
+++ b/unstructured/ingest/pipeline/partition.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import typing as t
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -32,19 +31,9 @@ class Partitioner(PartitionNode):
             ):
                 logger.info(f"File exists: {json_path}, skipping partition")
                 return str(json_path)
-            partition_kwargs: t.Dict[str, t.Any] = {
-                "strategy": self.partition_config.strategy,
-                "encoding": self.partition_config.encoding,
-                "pdf_infer_table_structure": self.partition_config.pdf_infer_table_structure,
-                "languages": self.partition_config.ocr_languages,
-            }
-            if self.partition_config.skip_infer_table_types:
-                partition_kwargs[
-                    "skip_infer_table_types"
-                ] = self.partition_config.skip_infer_table_types
             elements = doc.process_file(
                 partition_config=self.partition_config,
-                **partition_kwargs,
+                **self.partition_config.partition_args,
             )
             with open(json_path, "w", encoding="utf8") as output_f:
                 logger.info(f"writing partitioned content to {json_path}")

--- a/unstructured/ingest/pipeline/partition.py
+++ b/unstructured/ingest/pipeline/partition.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import typing as t
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -31,9 +32,20 @@ class Partitioner(PartitionNode):
             ):
                 logger.info(f"File exists: {json_path}, skipping partition")
                 return str(json_path)
+            partition_kwargs: t.Dict[str, t.Any] = {
+                "strategy": self.partition_config.strategy,
+                "encoding": self.partition_config.encoding,
+                "pdf_infer_table_structure": self.partition_config.pdf_infer_table_structure,
+                "languages": self.partition_config.ocr_languages,
+            }
+            if self.partition_config.skip_infer_table_types:
+                partition_kwargs[
+                    "skip_infer_table_types"
+                ] = self.partition_config.skip_infer_table_types
+            partition_kwargs.update(self.partition_config.additional_partition_args)
             elements = doc.process_file(
                 partition_config=self.partition_config,
-                **self.partition_config.partition_args,
+                **partition_kwargs,
             )
             with open(json_path, "w", encoding="utf8") as output_f:
                 logger.info(f"writing partitioned content to {json_path}")

--- a/unstructured/ingest/pipeline/partition.py
+++ b/unstructured/ingest/pipeline/partition.py
@@ -42,7 +42,8 @@ class Partitioner(PartitionNode):
                 partition_kwargs[
                     "skip_infer_table_types"
                 ] = self.partition_config.skip_infer_table_types
-            partition_kwargs.update(self.partition_config.additional_partition_args)
+            if self.partition_config.additional_partition_args:
+                partition_kwargs.update(self.partition_config.additional_partition_args)
             elements = doc.process_file(
                 partition_config=self.partition_config,
                 **partition_kwargs,


### PR DESCRIPTION
### Description
To always support the latest changed to the partition method and the possible kwargs it supports, the ingest CLI has been refactored to take in a valid json string to represent those values to allow a user more flexibility with controlling the partition method.