### PR TITLE
build(fixtures-update): run on smaller worker

### DIFF
--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -75,9 +75,10 @@ jobs:
           make install-all-ingest
 
   update-fixtures-and-pr:
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
+      MAX_PROCESSES: 2
     needs: [setup_ingest]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Run fixtures-update workflow on smaller github runner until larger one is available again.