### PR TITLE
build(ci): bring back medium runners where appropriate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,10 +271,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8","3.9","3.10","3.11"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
-      MAX_PROCESSES: 2
     needs: [setup_ingest, lint]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -75,10 +75,9 @@ jobs:
           make install-all-ingest
 
   update-fixtures-and-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
-      MAX_PROCESSES: 2
     needs: [setup_ingest]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Now that "medium" runners are available in GitHub Actions again, re-enable them.

Intentionally not reverting https://github.com/Unstructured-IO/unstructured/commit/76213ecba7cfbab4163f052d89084e66f4a07d74 the change to the setup-ingest job since additional CPU shouldn't make a difference (e.g. it ran in 5 minutes here: https://github.com/Unstructured-IO/unstructured/commit/76213ecba7cfbab4163f052d89084e66f4a07d74 ).