### PR TITLE
remove test login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,30 +16,6 @@ permissions:
   contents: read
 
 jobs:
-  test_logins:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: 'actions/checkout@v4'
-    - name: 'Google Cloud Auth'
-      uses: 'google-github-actions/auth@v1'
-      id: gauth
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v1'
-    - name: 'run gcloud command'
-      run: |-
-        gcloud projects list
-    - name: 'Az CLI login'
-      uses: azure/login@v1
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    - name: 'azure test command'
-      run: |-
-        az account show
   setup:
     strategy:
       matrix:


### PR DESCRIPTION
This was only used for debugging on a branch, not needed here.  It was failing because it didn't have the environment var set to "ci".