### PR TITLE
build(ci): use larger CI runners for setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.8","3.9","3.10","3.11" ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
     needs: [setup]

--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -39,7 +39,7 @@ jobs:
         run: |-
           az account show
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && contains(github.event.head_commit.message, 'ingest-test-fixtures-update'))


### PR DESCRIPTION
Hopefully avoid incomplete cache issues. Though to be fair, there is no solid evidence pointing to runner size as the source of the issue.