### PR TITLE
fix: flaky chunk metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * **Fix PDF tried to loop through None** Previously the PDF annotation extraction tried to loop through `annots` that resolved out as None. A logical check added to avoid such error.
 * **Ingest session handler not being shared correctly** All ingest docs that leverage the session handler should only need to set it once per process. It was recreating it each time because the right values weren't being set nor available given how dataclasses work in python.
 * **Ingest download-only fix** Previously the download only flag was being checked after the doc factory pipeline step, which occurs before the files are actually downloaded by the source node. This check was moved after the source node to allow for the files to be downloaded first before exiting the pipeline.
+* **Fix flaky chunk-metadata.** Prior implementation was sensitive to element order in the section resulting in metadata values sometimes being dropped. Also, not all metadata items can be consolidated across multiple elements (e.g. coordinates) and so are now dropped from consolidated metadata.
 
 ## 0.10.28
 

--- a/test_unstructured/documents/test_elements.py
+++ b/test_unstructured/documents/test_elements.py
@@ -1,3 +1,4 @@
+import dataclasses as dc
 import json
 from functools import partial
 
@@ -12,6 +13,7 @@ from unstructured.documents.coordinates import (
 )
 from unstructured.documents.elements import (
     UUID,
+    ConsolidationStrategy,
     CoordinatesMetadata,
     Element,
     ElementMetadata,
@@ -230,3 +232,14 @@ def test_metadata_from_dict_extra_fields():
     assert "new_field" not in metadata_dict
     assert "new_field" not in metadata_dict["coordinates"]
     assert "new_field" not in metadata_dict["data_source"]
+
+
+def test_there_is_a_consolidation_strategy_for_every_ElementMetadata_field():
+    metadata_field_names = sorted(f.name for f in dc.fields(ElementMetadata))
+    consolidation_strategies = ConsolidationStrategy.field_consolidation_strategies()
+
+    for field_name in metadata_field_names:
+        assert field_name in consolidation_strategies, (
+            f"ElementMetadata field `.{field_name}` does not have a consolidation strategy."
+            f" Add one in `ConsolidationStrategy.field_consolidation_strategies()."
+        )

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -4,6 +4,7 @@ import abc
 import copy
 import dataclasses as dc
 import datetime
+import enum
 import functools
 import hashlib
 import inspect
@@ -136,6 +137,9 @@ class Link(TypedDict):
 
 @dc.dataclass
 class ElementMetadata:
+    # NOTE(scanny): if you ADD a field here you must specify a consolidation strategy for it below
+    # in ConsolidationStrategy.field_consolidation_strategies() to be used when combining elements
+    # during chunking.
     coordinates: Optional[CoordinatesMetadata] = None
     data_source: Optional[DataSourceMetadata] = None
     filename: Optional[str] = None
@@ -147,10 +151,10 @@ class ElementMetadata:
     category_depth: Optional[int] = None
     image_path: Optional[str] = None
 
-    # Languages in element. TODO(newelh) - More strongly type languages
+    # Languages in element.
     languages: Optional[List[str]] = None
 
-    # Page numbers currenlty supported for PDF, HTML and PPT documents
+    # Page numbers currently supported for DOCX, HTML, PDF, and PPTX documents
     page_number: Optional[int] = None
 
     # Page name. The sheet name in XLXS documents.
@@ -263,6 +267,70 @@ class ElementMetadata:
         if self.last_modified is not None:
             dt = datetime.datetime.fromisoformat(self.last_modified)
         return dt
+
+
+class ConsolidationStrategy(enum.Enum):
+    """Methods by which a metadata field can be consolidated across a collection of elements.
+
+    These are assigned to `ElementMetadata` field-names immediately below. Metadata consolidation is
+    part of the chunking process and may arise elsewhere as well.
+    """
+
+    DROP = "drop"
+    """Do not include this field in the consolidated metadata object."""
+
+    FIRST = "first"
+    """Use the first value encountered, omit if not present in any elements."""
+
+    LIST_CONCATENATE = "LIST_CONCATENATE"
+    """Concatenate the list values across elements. Only suitable for fields of `List` type."""
+
+    LIST_UNIQUE = "list_unique"
+    """Union list values across elements, preserving order. Only suitable for `List` fields."""
+
+    REGEX = "regex"
+    """Combine regex-metadata of elements, adjust start and stop offsets for concatenated text."""
+
+    @classmethod
+    def field_consolidation_strategies(cls) -> Dict[str, ConsolidationStrategy]:
+        """Mapping from ElementMetadata field-name to its consolidation strategy.
+
+        Note that only _TextSection objects ("pre-chunks" containing only `Text` elements that are
+        not `Table`) have their metadata consolidated, so these strategies are only applicable for
+        non-Table Text elements.
+        """
+        return {
+            "attached_to_filename": cls.FIRST,
+            "category_depth": cls.DROP,
+            "coordinates": cls.DROP,
+            "data_source": cls.FIRST,
+            "detection_class_prob": cls.DROP,
+            "detection_origin": cls.DROP,
+            "emphasized_text_contents": cls.LIST_CONCATENATE,
+            "emphasized_text_tags": cls.LIST_CONCATENATE,
+            "file_directory": cls.FIRST,
+            "filename": cls.FIRST,
+            "filetype": cls.FIRST,
+            "header_footer_type": cls.DROP,
+            "image_path": cls.DROP,
+            "is_continuation": cls.DROP,  # -- not expected, added by chunking, not before --
+            "languages": cls.LIST_UNIQUE,
+            "last_modified": cls.FIRST,
+            "link_texts": cls.LIST_CONCATENATE,
+            "link_urls": cls.LIST_CONCATENATE,
+            "links": cls.DROP,  # -- deprecated field --
+            "max_characters": cls.DROP,  # -- unused, remove from ElementMetadata --
+            "page_name": cls.FIRST,
+            "page_number": cls.FIRST,
+            "parent_id": cls.DROP,
+            "regex_metadata": cls.REGEX,
+            "section": cls.FIRST,
+            "sent_from": cls.FIRST,
+            "sent_to": cls.FIRST,
+            "subject": cls.FIRST,
+            "text_as_html": cls.DROP,  # -- not expected, only occurs in _TableSection --
+            "url": cls.FIRST,
+        }
 
 
 _P = ParamSpec("_P")


### PR DESCRIPTION
**Executive Summary.**  When the elements in a _section_ are combined into a _chunk_, the metadata in each of the elements is _consolidated_ into a single `ElementMetadata` instance. There are two main problems with the current implementation:

1. The current algorithm simply uses the metadata of the first element as the metadata for the chunk. This produces:
	- **empty chunk metadata** when the first element has no metadata, such as a `PageBreak("")`
	- **missing chunk metadata** when the first element contains only partial metadata such as a `Header()` or `Footer()`
	- **misleading  metadata** when the first element contains values applicable only to that element, such as `category_depth`, `coordinates` (bounding-box), `header_footer_type`, or `parent_id`
2. Second, list metadata such as `emphasized_text_content`, `emphasized_text_tags`, `link_texts` and `link_urls` is only combined when it is unique within the combined list. These lists are "unzipped" pairs. For example, the first `link_texts` corresponds to the first `link_urls` value. When an item is removed from one (because it matches a prior entry) and not the other (say same text "here" but different URL) the positional correspondence is broken and downstream processing will at best be wrong, at worst raise an exception.

### Technical Discussion
Element metadata cannot be determined in the general case simply by sampling that of the first element. At the same time, a simple union of all values is also not sufficient. To effectively consolidate the current variety of metadata fields we need four distinct strategies, selecting which to apply to each field based on that fields provenance and other characteristics.

The four strategies are:
- `FIRST` - Select the first non-`None` value across all the elements. Several fields are determined by the document source (`filename`, `file_directory`, etc.) and will not change within the output of a single partitioning run. They might not appear in every element, but they will be the same whenever they do appear. This strategy takes the first one that appears, if any, as proxy for the value for the entire chunk.
- `LIST` - Consolidate the four list fields like `emphasized_text_content` and `link_urls` by concatenating them in element order (no set semantics apply). All values from `elements[n]` appear before those from `elements[n+1]` and existing order is preserved.
- `LIST_UNIQUE` - Combine only unique elements across the (list) values of the elements, preserving order in which a unique item first appeared.
- `REGEX` - Regex metadata has its own rules, including adjusting the `start` and `end` offset of each match based its new position in the concatenated text.
- `DROP` - Not all metadata can or should appear in a chunk. For example, a chunk cannot be guaranteed to have a single `category_depth` or `parent_id`.

Other strategies such as `COORDINATES` could be added to consolidate the bounding box of the chunk from the coordinates of its elements, roughly `min(lefts)`, `max(rights)`, etc. Others could be `LAST`, `MAJORITY`, or `SUM` depending on how metadata evolves.

The proposed strategy assignments are these:

- `attached_to_filename`: FIRST,
- `category_depth`: DROP,
- `coordinates`: DROP,
- `data_source`: FIRST,
- `detection_class_prob`: DROP,  # -- ? confirm --
- `detection_origin`: DROP,      # -- ? confirm --
- `emphasized_text_contents`: LIST,
- `emphasized_text_tags`: LIST,
- `file_directory`: FIRST,
- `filename`: FIRST,
- `filetype`: FIRST,
- `header_footer_type`: DROP,
- `image_path`: DROP,
- `is_continuation`: DROP,  # -- not expected, added by chunking, not before --
- `languages`: LIST_UNIQUE,
- `last_modified`: FIRST,
- `link_texts`: LIST,
- `link_urls`: LIST,
- `links`: DROP,            # -- deprecated field --
- `max_characters`: DROP,   # -- unused in code, probably remove from ElementMetadata --
- `page_name`: FIRST,
- `page_number`: FIRST,
- `parent_id`: DROP,
- `regex_metadata`: REGEX,
- `section`: FIRST,  # -- section unconditionally breaks on new section --
- `sent_from`: FIRST,
- `sent_to`: FIRST,
- `subject`: FIRST,
- `text_as_html`: DROP,     # -- not expected, only occurs in TableSection --
- `url`: FIRST,

**Assumptions:**
- each .eml file is partitioned->chunked separately (not in batches), therefore
  sent-from, sent-to, and subject will not change within a section.

### Implementation
Implementation of this behavior requires two steps:
1. **Collect** all non-`None` values from all elements, each in a sequence by field-name. Fields not populated in any of the elements do not appear in the collection.
```python
all_meta = {
    "filename": ["memo.docx", "memo.docx"]
    "link_texts": [["here", "here"], ["and here"]]
    "parent_id": ["f273a7cb", "808b4ced"]
}
```
2. **Apply** the specified strategy to each item in the overall collection to produce the consolidated chunk meta (see implementation).

### Factoring
For the following reasons, the implementation of metadata consolidation is extracted from its current location in `chunk_by_title()` to a handful of collaborating methods in `_TextSection`.
- The current implementation of metadata consolidation "inline" in `chunk_by_title()` already has too many moving pieces to be understood without extended study. Adding strategies to that would make it worse.
- `_TextSection` is the only section type where metadata is consolidated (the other two types always have exactly one element so already exactly one metadata.)
- `_TextSection` is already the expert on all the information required to consolidate metadata, in particular the elements that make up the section and their text.

Some other problems were also fixed in that transition, such as mutation of elements during the consolidation process.

### Technical Risk: adding new `ElementMetadata` field breaks metadata

If each metadata field requires a strategy assignment to be consolidated and a developer adds a new `ElementMetadata` field without adding a corresponding strategy mapping, metadata consolidation could break or produce incorrect results.

This risk can be mitigated multiple ways:
1. Add a test that verifies a strategy is defined for each (Recommended).
2. Define a default strategy, either `DROP` or `FIRST` for scalar types, `LIST` for list types.
3. Raise an exception when an unknown metadata field is encountered.

This PR implements option 1 such that a developer will be notified before merge if they add a new metadata field but do not define a strategy for it.

### Other Considerations
- If end-users can in-future add arbitrary metadata fields _before_ chunking, then we'll need to define metadata-consolidation behavior for such fields. Depending on how we implement user-defined metadata fields we might:
	- Require explicit definition of a new metadata field before use, perhaps with a method like `ElementMetadata.add_custom_field()` which requires a consolidation strategy to be defined (and/or has a default value).
	- Have a default strategy, perhaps `DROP` or `FIRST`, or `LIST` if the field is type `list`.

### Further Context
Metadata is only consolidated for `TextSection` because the other two section types (`TableSection` and `NonTextSection`) can only contain a single element.

---

## Further discussion on consolidation strategy by field

### document-static
These fields are very likely to be the same for all elements in a single document:

- `attached_to_filename`
- `data_source`
- `file_directory`
- `filename`
- `filetype`
- `last_modified`
- `sent_from`
- `sent_to`
- `subject`
- `url`

*Consolidation strategy:* `FIRST` - use first one found, if any.

### section-static
These fields are very likely to be the same for all elements in a single section, which is the scope we really care about for metadata consolidation:

- `section` - an EPUB document-section unconditionally starts new section.

*Consolidation strategy:* `FIRST` - use first one found, if any.

### consolidated list-items
These `List` fields are consolidated by concatenating the lists from each element that has one:

- `emphasized_text_contents`
- `emphasized_text_tags`
- `link_texts`
- `link_urls`
- `regex_metadata` - special case, this one gets indexes adjusted too.

*Consolidation strategy:* `LIST` - concatenate lists across elements.

### dynamic
These fields are likely to hold unique data for each element:

- `category_depth`
- `coordinates`
- `image_path`
- `parent_id`

*Consolidation strategy:*
- `DROP` as likely misleading.
- `COORDINATES` strategy could be added to compute the bounding box from all bounding boxes.
- Consider allowing if they are all the same, perhaps an `ALL` strategy.

### slow-changing
These fields are somewhere in-between, likely to be common between multiple elements but varied within a document:

- `header_footer_type` - *strategy:* drop as not-consolidatable
- `languages` - *strategy:* take first occurence
- `page_name` - *strategy:* take first occurence
- `page_number` - *strategy:* take first occurence, will all be the same when `multipage_sections` is `False`. Worst-case semantics are "this chunk began on this page".

### N/A
These field types do not figure in metadata-consolidation:

- `detection_class_prob` - I'm thinking this is for debug and should not appear in chunks, but need confirmation.
- `detection_origin` - for debug only
- `is_continuation` - is _produced_ by chunking, never by partitioning (not in our code anyway).
- `links` (deprecated, probably should be dropped)
- `max_characters` - is unused as far as I can tell, is unreferenced in source code. Should be removed from `ElementMetadata` as far as I can tell.
- `text_as_html` - only appears in a `Table` element, each of which appears in its own section so needs no consolidation. Never appears in `TextSection`.

*Consolidation strategy:* `DROP` any that appear (several never will)