### PR TITLE
fix: update chipper example notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.29-dev3
+## 0.10.29-dev4
 
 ### Enhancements
 
@@ -11,6 +11,7 @@
 
 ### Fixes
 
+* **Chipper example notebook failing** The example notebook demonstrating Chipper should use the public version of Chipper. The notebook was also updated to use the newer install method, and cell was added that allowed a user to execute the notebook according to the instructions provided in the notebook.
 * **Ingest session handler not being shared correctly** All ingest docs that leverage the session handler should only need to set it once per process. It was recreating it each time because the right values weren't being set nor available given how dataclasses work in python.
 * **Ingest download-only fix** Previously the download only flag was being checked after the doc factory pipeline step, which occurs before the files are actually downloaded by the source node. This check was moved after the source node to allow for the files to be downloaded first before exiting the pipeline.
 

--- a/examples/chipper-local-inference/chipper-local-inference.ipynb
+++ b/examples/chipper-local-inference/chipper-local-inference.ipynb
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "filename = \"../../example-docs/DA-1p.pdf\"  #\n",
-    "model_name = \"chipper\""
+    "model_name = \"chipperv1\""
    ]
   },
   {

--- a/examples/chipper-local-inference/chipper-local-inference.ipynb
+++ b/examples/chipper-local-inference/chipper-local-inference.ipynb
@@ -10,8 +10,7 @@
     "This notebook demonstrates and explains how to parse a PDF file using `chipper` model locally through our main libraries. If you want to run this notebook in Google Colab taking into account that making an inference using `chipper` in CPU can take while; switching the runtime from \"CPU\" to GPU `T4` (or any other available) will reduce the runtime and is strongly recommended. You can use the following commands to install the required libraries:\n",
     "\n",
     "```{python}\n",
-    "!pip install unstructured --quiet\n",
-    "!pip install unstructured-inference --quiet\n",
+    "!pip install \"unstructured[pdf]\" --quiet\n",
     "!apt-get update -y && apt-get install -y poppler-utils --quiet\n",
     "```"
    ]

--- a/examples/chipper-local-inference/chipper-local-inference.ipynb
+++ b/examples/chipper-local-inference/chipper-local-inference.ipynb
@@ -355,7 +355,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
+   "metadata": {
+    "id": "6Y_Rcuvq0Ga5"
+   },
+   "outputs": [],
+   "source": [
+    "filename = \"../../example-docs/DA-1p.pdf\"  #\n",
+    "model_name = \"chipperv1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {
     "id": "zlk7GGew_cu_"
    },

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.29-dev3"  # pragma: no cover
+__version__ = "0.10.29-dev4"  # pragma: no cover


### PR DESCRIPTION
Closes #1956.

Updates chipper example notebook to use `chipperv1`. Also updates the install instructions and adds a cell so that the notebook instructions can be followed as written.

#### Testing:

Run the notebook `examples/chipper-local-inference/chipper-local-inference.ipynb`, following the instructions in the notebook and verify that all cells execute properly.