### PR TITLE
Add back environment to unblock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,7 @@ jobs:
 
 
   test_ingest_dest:
+    environment: ci
     strategy:
       matrix:
         python-version: ["3.8","3.9","3.10","3.11"]


### PR DESCRIPTION
Azure federated branch subject doesn’t work with merge queues.