### PR TITLE
fix: update slack link to link shortener

### DIFF
--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -143,7 +143,7 @@
         </div>
         <article role="main">
           <div class="social social--main" style="margin-top: 1em; display: flex; justify-content: right; gap: 8px">
-            <a href="https://unstructuredw-kbe4326.slack.com/ssb/redirect"
+            <a href="https://short.unstructured.io/pzw05l7"
               class="button--primary" target="_blank">Join <span aria-label="slack"
                 class="slack-icon"></span></span></a>
             <div class="github-stars github-stars--top-page"></div>

--- a/docs/source/_templates/sidebar/brand.html
+++ b/docs/source/_templates/sidebar/brand.html
@@ -31,7 +31,7 @@ Hope your day's going well. :)
 </a>
 <div class="social social--sidebar" style="margin-top: 1em; display: flex; justify-content: right; gap: 8px">
   <a
-    href="https://join.slack.com/t/unstructuredw-kbe4326/shared_invite/zt-23kciff0y-bvzXxJkgtbXe5POo_rxMkw"
+    href="https://short.unstructured.io/pzw05l7"
     class="button--primary" target="_blank">Join <span aria-label="slack" class="slack-icon"></span></span></a>
     <div class="github-stars github-stars--sidebar"></div>
 </div>

--- a/docs/source/ingest/destination_connectors.rst
+++ b/docs/source/ingest/destination_connectors.rst
@@ -3,7 +3,7 @@ Destination Connectors
 
 Connect to your favorite data storage platforms for effortless batch processing of your files.
 We are constantly adding new data connectors and if you don't see your favorite platform let us know
-in our community `Slack. <https://unstructuredw-kbe4326.slack.com/ssb/redirect>`_
+in our community `Slack. <https://short.unstructured.io/pzw05l7>`_
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/ingest/source_connectors.rst
+++ b/docs/source/ingest/source_connectors.rst
@@ -3,7 +3,7 @@ Source Connectors
 
 Connect to your favorite data storage platforms for effortless batch processing of your files.
 We are constantly adding new data connectors and if you don'table see your favorite platform let us know
-in our community `Slack. <https://unstructuredw-kbe4326.slack.com/ssb/redirect>`_
+in our community `Slack. <https://short.unstructured.io/pzw05l7>`_
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Per @tabossert we're now using a link shortener behind which we can rotate the link to keep it current. That way we (🤞 ) never have to update this here again.

#### Testing:

Links should work. No more links should exist in the documentation except this one.