### PR TITLE
fix:  ingest destination test failure with missing output

### DIFF
--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -31,7 +31,7 @@ fi
 IMAGE_NAME="unstructured-ubuntu:latest"
 CREATION_TIMESTAMP=$(docker inspect --format='{{.Created}}' "$IMAGE_NAME")
 CREATION_DATE=$(date -d "$CREATION_TIMESTAMP" +%s)
-CURRENT_DATE=$(uuidgen)
+CURRENT_DATE=$(date +%s)
 AGE_DAYS=$(( (CURRENT_DATE - CREATION_DATE) / 86400 ))
 if [ "$AGE_DAYS" -gt 6 ]; then
     echo "WARNING: The image \"$IMAGE_NAME\" is more than 7 days old ($AGE_DAYS days)."

--- a/scripts/ingest-test-fixtures-update.sh
+++ b/scripts/ingest-test-fixtures-update.sh
@@ -31,7 +31,7 @@ fi
 IMAGE_NAME="unstructured-ubuntu:latest"
 CREATION_TIMESTAMP=$(docker inspect --format='{{.Created}}' "$IMAGE_NAME")
 CREATION_DATE=$(date -d "$CREATION_TIMESTAMP" +%s)
-CURRENT_DATE=$(date +%s)
+CURRENT_DATE=$(uuidgen)
 AGE_DAYS=$(( (CURRENT_DATE - CREATION_DATE) / 86400 ))
 if [ "$AGE_DAYS" -gt 6 ]; then
     echo "WARNING: The image \"$IMAGE_NAME\" is more than 7 days old ($AGE_DAYS days)."

--- a/test_unstructured_ingest/dest/azure-cognitive-search.sh
+++ b/test_unstructured_ingest/dest/azure-cognitive-search.sh
@@ -12,7 +12,7 @@ OUTPUT_FOLDER_NAME=azure-cog-search-dest
 max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
 
 DOWNLOAD_DIR=$SCRIPT_DIR/download/$OUTPUT_FOLDER_NAME
-DESTINATION_INDEX="utic-test-ingest-fixtures-output-$(date +%s)"
+DESTINATION_INDEX="utic-test-ingest-fixtures-output-$(uuidgen)"
 # The vector configs on the schema currently only exist on versions:
 # 2023-07-01-Preview, 2021-04-30-Preview, 2020-06-30-Preview
 API_VERSION=2023-07-01-Preview

--- a/test_unstructured_ingest/dest/azure.sh
+++ b/test_unstructured_ingest/dest/azure.sh
@@ -17,7 +17,7 @@ if [ -z "$AZURE_DEST_CONNECTION_STR" ]; then
 fi
 
 CONTAINER=utic-ingest-test-fixtures-output
-DIRECTORY=$(date +%s)
+DIRECTORY=$(uuidgen)
 REMOTE_URL="abfs://$CONTAINER/$DIRECTORY/"
 
 # shellcheck disable=SC1091

--- a/test_unstructured_ingest/dest/box.sh
+++ b/test_unstructured_ingest/dest/box.sh
@@ -11,7 +11,7 @@
 #OUTPUT_DIR=$OUTPUT_ROOT/structured-output/$OUTPUT_FOLDER_NAME
 #WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
 #max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
-#DESTINATION_BOX="box://utic-dev-tech-fixtures/utic-ingest-test-fixtures-output/$(date +%s)/"
+#DESTINATION_BOX="box://utic-dev-tech-fixtures/utic-ingest-test-fixtures-output/$(uuidgen)/"
 #
 #CI=${CI:-"false"}
 #

--- a/test_unstructured_ingest/dest/dropbox.sh
+++ b/test_unstructured_ingest/dest/dropbox.sh
@@ -10,7 +10,7 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-$SCRIPT_DIR}
 OUTPUT_DIR=$OUTPUT_ROOT/structured-output/$OUTPUT_FOLDER_NAME
 WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
 max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
-DESTINATION_DROPBOX="/test-output/$(date +%s)"
+DESTINATION_DROPBOX="/test-output/$(uuidgen)"
 CI=${CI:-"false"}
 
 if [ -z "$DROPBOX_APP_KEY" ] || [ -z "$DROPBOX_APP_SECRET" ] || [ -z "$DROPBOX_REFRESH_TOKEN" ]; then

--- a/test_unstructured_ingest/dest/gcs.sh
+++ b/test_unstructured_ingest/dest/gcs.sh
@@ -10,7 +10,7 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-$SCRIPT_DIR}
 OUTPUT_DIR=$OUTPUT_ROOT/structured-output/$OUTPUT_FOLDER_NAME
 WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
 max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
-DESTINATION_GCS="gs://utic-test-ingest-fixtures-output/$(date +%s)"
+DESTINATION_GCS="gs://utic-test-ingest-fixtures-output/$(uuidgen)"
 CI=${CI:-"false"}
 
 if [ -z "$GCP_INGEST_SERVICE_KEY" ]; then

--- a/test_unstructured_ingest/dest/s3.sh
+++ b/test_unstructured_ingest/dest/s3.sh
@@ -10,7 +10,7 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-$SCRIPT_DIR}
 OUTPUT_DIR=$OUTPUT_ROOT/structured-output/$OUTPUT_FOLDER_NAME
 WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
 max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
-DESTINATION_S3="s3://utic-dev-tech-fixtures/utic-ingest-test-fixtures-output/$(date +%s)/"
+DESTINATION_S3="s3://utic-dev-tech-fixtures/utic-ingest-test-fixtures-output/$(uuidgen)/"
 CI=${CI:-"false"}
 
 # shellcheck disable=SC1091

--- a/test_unstructured_ingest/src/sharepoint-embed-cog-index.sh
+++ b/test_unstructured_ingest/src/sharepoint-embed-cog-index.sh
@@ -10,7 +10,7 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-$SCRIPT_DIR}
 OUTPUT_DIR=$OUTPUT_ROOT/structured-output/$OUTPUT_FOLDER_NAME
 WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
 DOWNLOAD_DIR=$SCRIPT_DIR/download/$OUTPUT_FOLDER_NAME
-DESTINATION_INDEX="utic-test-ingest-fixtures-output-$(date +%s)"
+DESTINATION_INDEX="utic-test-ingest-fixtures-output-$(uuidgen)"
 # The vector configs on the schema currently only exist on versions:
 # 2023-07-01-Preview, 2021-04-30-Preview, 2020-06-30-Preview
 API_VERSION=2023-07-01-Preview


### PR DESCRIPTION
Intermittently the various destination test will fail with:

```
{noformat}--- Cleanup done ---
gs://utic-test-ingest-fixtures-output/1699377964/example-docs/
deleting gs://utic-test-ingest-fixtures-output/1699377964
Removing objects:
  

ERROR: (gcloud.storage.rm) The following URLs matched no objects or files:
-gs://utic-test-ingest-fixtures-output/1699377964
Last ran script: gcs.sh
Error: Process completed with exit code 1.{noformat}
```

Reference trace [here](https://github.com/Unstructured-IO/unstructured/actions/runs/6787927424/job/18452240764?pr=2020)

After some investigation it looks like this error is due to collisions that occur because we’re assuming 1s date accuracy is sufficient when generating (and deleting) "unique" test destination location names. The likelihood is actually pretty high given that we run these tests against a test matrix.

Instead we should just use a uuid for these unique destinations.

## Changes

- Use uuidgen instead of `date +%s` for unique destinations
