### PR TITLE
fix: remove `.max_characters` from ElementMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.30-dev3
+## 0.10.30-dev4
 
 ### Enhancements
 

--- a/test_unstructured/staging/test_base_staging.py
+++ b/test_unstructured/staging/test_base_staging.py
@@ -157,7 +157,6 @@ def test_default_pandas_dtypes():
             emphasized_text_tags=["emphasized", "text", "tags"],
             text_as_html="text_as_html",
             regex_metadata={"key": [RegexMetadata(text="text", start=0, end=4)]},
-            max_characters=2,
             is_continuation=True,
             detection_class_prob=0.5,
         ),

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.30-dev3"  # pragma: no cover
+__version__ = "0.10.30-dev4"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -188,7 +188,6 @@ class ElementMetadata:
     regex_metadata: Optional[Dict[str, List[RegexMetadata]]] = None
 
     # Chunking metadata fields
-    max_characters: Optional[int] = None
     is_continuation: Optional[bool] = None
 
     # Detection Model Class Probabilities from Unstructured-Inference Hi-Res


### PR DESCRIPTION
This metadata field is assumedly vestigial and is unused by any code in the repo. `max_characters` is an optional argument to `chunk_by_title()` and has meaning in that context, but is not written to the metadata.

Remove this unused field.