### PR TITLE
chore: fix Makefile ingest targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,84 +112,84 @@ install-all-ingest:
 
 .PHONY: install-ingest-google-drive
 install-ingest-google-drive:
-	python3 -m pip install -r requirements/ingest-google-drive.txt
+	python3 -m pip install -r requirements/ingest/google-drive.txt
 
 ## install-ingest-s3:       install requirements for the s3 connector
 .PHONY: install-ingest-s3
 install-ingest-s3:
-	python3 -m pip install -r requirements/ingest-s3.txt
+	python3 -m pip install -r requirements/ingest/s3.txt
 
 .PHONY: install-ingest-gcs
 install-ingest-gcs:
-	python3 -m pip install -r requirements/ingest-gcs.txt
+	python3 -m pip install -r requirements/ingest/gcs.txt
 
 .PHONY: install-ingest-dropbox
 install-ingest-dropbox:
-	python3 -m pip install -r requirements/ingest-dropbox.txt
+	python3 -m pip install -r requirements/ingest/dropbox.txt
 
 .PHONY: install-ingest-azure
 install-ingest-azure:
-	python3 -m pip install -r requirements/ingest-azure.txt
+	python3 -m pip install -r requirements/ingest/azure.txt
 
 .PHONY: install-ingest-box
 install-ingest-box:
-	python3 -m pip install -r requirements/ingest-box.txt
+	python3 -m pip install -r requirements/ingest/box.txt
 
 .PHONY: install-ingest-delta-table
 install-ingest-delta-table:
-	python3 -m pip install -r requirements/ingest-delta-table.txt
+	python3 -m pip install -r requirements/ingest/delta-table.txt
 
 .PHONY: install-ingest-discord
 install-ingest-discord:
-	pip install -r requirements/ingest-discord.txt
+	pip install -r requirements/ingest/discord.txt
 
 .PHONY: install-ingest-github
 install-ingest-github:
-	python3 -m pip install -r requirements/ingest-github.txt
+	python3 -m pip install -r requirements/ingest/github.txt
 
 .PHONY: install-ingest-biomed
 install-ingest-biomed:
-	python3 -m pip install -r requirements/ingest-biomed.txt
+	python3 -m pip install -r requirements/ingest/biomed.txt
 
 .PHONY: install-ingest-gitlab
 install-ingest-gitlab:
-	python3 -m pip install -r requirements/ingest-gitlab.txt
+	python3 -m pip install -r requirements/ingest/gitlab.txt
 
 .PHONY: install-ingest-onedrive
 install-ingest-onedrive:
-	python3 -m pip install -r requirements/ingest-onedrive.txt
+	python3 -m pip install -r requirements/ingest/onedrive.txt
 
 .PHONY: install-ingest-outlook
 install-ingest-outlook:
-	python3 -m pip install -r requirements/ingest-outlook.txt
+	python3 -m pip install -r requirements/ingest/outlook.txt
 
 .PHONY: install-ingest-reddit
 install-ingest-reddit:
-	python3 -m pip install -r requirements/ingest-reddit.txt
+	python3 -m pip install -r requirements/ingest/reddit.txt
 
 .PHONY: install-ingest-slack
 install-ingest-slack:
-	pip install -r requirements/ingest-slack.txt
+	pip install -r requirements/ingest/slack.txt
 
 .PHONY: install-ingest-wikipedia
 install-ingest-wikipedia:
-	python3 -m pip install -r requirements/ingest-wikipedia.txt
+	python3 -m pip install -r requirements/ingest/wikipedia.txt
 
 .PHONY: install-ingest-elasticsearch
 install-ingest-elasticsearch:
-	python3 -m pip install -r requirements/ingest-elasticsearch.txt
+	python3 -m pip install -r requirements/ingest/elasticsearch.txt
 
 .PHONY: install-ingest-confluence
 install-ingest-confluence:
-	python3 -m pip install -r requirements/ingest-confluence.txt
+	python3 -m pip install -r requirements/ingest/confluence.txt
 
 .PHONY: install-ingest-airtable
 install-ingest-airtable:
-	python3 -m pip install -r requirements/ingest-airtable.txt
+	python3 -m pip install -r requirements/ingest/airtable.txt
 
 .PHONY: install-ingest-sharepoint
 install-ingest-sharepoint:
-	python3 -m pip install -r requirements/ingest-sharepoint.txt
+	python3 -m pip install -r requirements/ingest/sharepoint.txt
 
 .PHONY: install-ingest-local
 install-ingest-local:
@@ -197,23 +197,23 @@ install-ingest-local:
 
 .PHONY: install-ingest-notion
 install-ingest-notion:
-	python3 -m pip install -r requirements/ingest-notion.txt
+	python3 -m pip install -r requirements/ingest/notion.txt
 
 .PHONY: install-ingest-salesforce
 install-ingest-salesforce:
-	python3 -m pip install -r requirements/ingest-salesforce.txt
+	python3 -m pip install -r requirements/ingest/salesforce.txt
 
 .PHONY: install-ingest-jira
 install-ingest-jira:
-	python3 -m pip install -r requirements/ingest-jira.txt
+	python3 -m pip install -r requirements/ingest/jira.txt
 
 .PHONY: install-embed-huggingface
 install-embed-huggingface:
-	python3 -m pip install -r requirements/embed-huggingface.txt
+	python3 -m pip install -r requirements/ingest/embed-huggingface.txt
 
 .PHONY: install-unstructured-inference
 install-unstructured-inference:
-	python3 -m pip install -r requirements/local-inference.txt
+	python3 -m pip install -r requirements/ingest/local-inference.txt
 
 ## install-local-inference: installs requirements for local inference
 .PHONY: install-local-inference


### PR DESCRIPTION
Fixes the Makefile `ingest-` targets were broken in https://github.com/Unstructured-IO/unstructured/pull/1799/files. 

**Test Instructions**

    for maketarget in $(grep .PHONY Makefile | grep  install-ingest  | perl -p -e 's/.PHONY://' | tr -d '\n'); do   
      echo $maketarget; make $maketarget
    done

