### PR TITLE
fix(build): update ingest script loc in Dockerfile

### DIFF
--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -40,7 +40,7 @@ await_container
 # Run the tests
 docker cp test_unstructured_ingest $CONTAINER_NAME:/home/notebook-user
 docker exec -u root "$CONTAINER_NAME" /bin/bash -c "chown -R 1000:1000 /home/notebook-user/test_unstructured_ingest"
-docker exec "$CONTAINER_NAME" /bin/bash -c "/home/notebook-user/test_unstructured_ingest/test-ingest-wikipedia.sh"
+docker exec "$CONTAINER_NAME" /bin/bash -c "/home/notebook-user/test_unstructured_ingest/src/wikipedia.sh"
 
 result=$?
 exit $result


### PR DESCRIPTION
Fixes docker-smoke-test.sh to reference the new location for the wikipedia ingest script, which was moved in https://github.com/Unstructured-IO/unstructured/pull/1951 . This fix should allow the docker image build to complete on merges to main.

Reference to recent failed job:
https://github.com/Unstructured-IO/unstructured/actions/runs/6819416096/job/18546724401