### PR TITLE
Remove ssh-keyscan and files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.10.31-dev1
+
+### Enhancements
+
+### Features
+
+### Fixes
+* **Remove default user ./ssh folder** The default notebook user during image build would create the known_hosts file with incorrect ownership, this is legacy and no longer needed so it was removed.
+
 ## 0.10.30
 
 ### Enhancements
@@ -12,8 +21,8 @@
 
 ### Fixes
 
-* **Fix logic that determines pdf auto strategy.** Previously, `_determine_pdf_auto_strategy` returned `hi_res` strategy only if `infer_table_structure` was true. It now returns the `hi_res` strategy if either `infer_table_structure` or `extract_images_in_pdf` is true.   
-* **Fix invalid coordinates when parsing tesseract ocr data.** Previously, when parsing tesseract ocr data, the ocr data had invalid bboxes if zoom was set to `0`. A logical check is now added to avoid such error. 
+* **Fix logic that determines pdf auto strategy.** Previously, `_determine_pdf_auto_strategy` returned `hi_res` strategy only if `infer_table_structure` was true. It now returns the `hi_res` strategy if either `infer_table_structure` or `extract_images_in_pdf` is true.
+* **Fix invalid coordinates when parsing tesseract ocr data.** Previously, when parsing tesseract ocr data, the ocr data had invalid bboxes if zoom was set to `0`. A logical check is now added to avoid such error.
 * **Fix ingest partition parameters not being passed to the api.** When using the --partition-by-api flag via unstructured-ingest, none of the partition arguments are forwarded, meaning that these options are disregarded. With this change, we now pass through all of the relevant partition arguments to the api. This allows a user to specify all of the same partition arguments they would locally and have them respected when specifying --partition-by-api.
 * **Support tables in section-less DOCX.** Generalize solution for MS Chat Transcripts exported as DOCX by including tables in the partitioned output when present.
 * **Support tables that contain only numbers when partitioning via `ocr_only`** Tables that contain only numbers are returned as floats in a pandas.DataFrame when the image is converted from `.image_to_data()`. An AttributeError was raised downstream when trying to `.strip()` the floats.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ ENV PATH="/home/usr/.local/bin:${PATH}"
 RUN groupadd --gid ${NB_UID} ${NB_USER}
 RUN useradd --uid ${NB_UID} --gid ${NB_UID} ${NB_USER}
 WORKDIR ${HOME}
-RUN mkdir ${HOME}/.ssh && chmod go-rwx ${HOME}/.ssh \
-  &&  ssh-keyscan -t rsa github.com >> ${HOME}/.ssh/known_hosts
 
 FROM base as deps
 # Copy and install Unstructured

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.30"  # pragma: no cover
+__version__ = "0.10.31-dev1"  # pragma: no cover


### PR DESCRIPTION
This was legacy and is no longer needed.  It also has the effect of incorrect owner for known_hosts of notebook-user

Relates to: #2056 