### PR TITLE
Chore: specify default language parameter to paddle with `DEFAULT_PADDLE_LANG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.10.31-dev1
+## 0.10.31-dev2
 
 ### Enhancements
+* **Temporary Support for paddle language parameter** User can specify langage code for paddle with ENV `PADDLE_LANG` before we have the language mapping for paddle.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.10.31-dev2
 
 ### Enhancements
-* **Temporary Support for paddle language parameter** User can specify langage code for paddle with ENV `PADDLE_LANG` before we have the language mapping for paddle.
+* **Temporary Support for paddle language parameter** User can specify default langage code for paddle with ENV `DEFAULT_PADDLE_LANG` before we have the language mapping for paddle.
 
 ### Features
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10.31-dev1"  # pragma: no cover
+__version__ = "0.10.31-dev2"  # pragma: no cover

--- a/unstructured/partition/utils/constants.py
+++ b/unstructured/partition/utils/constants.py
@@ -22,7 +22,7 @@ OCR_AGENT_PADDLE = "paddle"
 SUBREGION_THRESHOLD_FOR_OCR = 0.5
 UNSTRUCTURED_INCLUDE_DEBUG_METADATA = os.getenv("UNSTRUCTURED_INCLUDE_DEBUG_METADATA", False)
 
-DEFAULT_PADDLE_LANG = "en"
+DEFAULT_PADDLE_LANG = os.getenv("DEFAULT_PADDLE_LANG", "en")
 
 # this field is defined by pytesseract/unstructured.pytesseract
 TESSERACT_TEXT_HEIGHT = "height"

--- a/unstructured/partition/utils/constants.py
+++ b/unstructured/partition/utils/constants.py
@@ -22,6 +22,7 @@ OCR_AGENT_PADDLE = "paddle"
 SUBREGION_THRESHOLD_FOR_OCR = 0.5
 UNSTRUCTURED_INCLUDE_DEBUG_METADATA = os.getenv("UNSTRUCTURED_INCLUDE_DEBUG_METADATA", False)
 
+DEFAULT_PADDLE_LANG = "en"
 
 # this field is defined by pytesseract/unstructured.pytesseract
 TESSERACT_TEXT_HEIGHT = "height"

--- a/unstructured/partition/utils/constants.py
+++ b/unstructured/partition/utils/constants.py
@@ -22,6 +22,8 @@ OCR_AGENT_PADDLE = "paddle"
 SUBREGION_THRESHOLD_FOR_OCR = 0.5
 UNSTRUCTURED_INCLUDE_DEBUG_METADATA = os.getenv("UNSTRUCTURED_INCLUDE_DEBUG_METADATA", False)
 
+# Note(yuming): Default language for paddle OCR
+# soon will be able to specify the language down through partition() as well
 DEFAULT_PADDLE_LANG = os.getenv("DEFAULT_PADDLE_LANG", "en")
 
 # this field is defined by pytesseract/unstructured.pytesseract

--- a/unstructured/partition/utils/ocr_models/paddle_ocr.py
+++ b/unstructured/partition/utils/ocr_models/paddle_ocr.py
@@ -1,5 +1,4 @@
 import functools
-import os
 
 from unstructured.logger import logger
 from unstructured.partition.utils.constants import DEFAULT_PADDLE_LANG
@@ -11,9 +10,6 @@ def load_agent(language: str = DEFAULT_PADDLE_LANG):
     from unstructured_paddleocr import PaddleOCR
 
     """Loads the PaddleOCR agent as a global variable to ensure that we only load it once."""
-    # Note(yuming): Temporary fix to pass language parameter to paddle
-    # should be removed once we have the language mapping for paddle
-    language = os.getenv("PADDLE_LANG", DEFAULT_PADDLE_LANG)
 
     # Disable signal handlers at C++ level upon failing
     # ref: https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/

--- a/unstructured/partition/utils/ocr_models/paddle_ocr.py
+++ b/unstructured/partition/utils/ocr_models/paddle_ocr.py
@@ -1,14 +1,19 @@
 import functools
+import os
 
 from unstructured.logger import logger
+from unstructured.partition.utils.constants import DEFAULT_PADDLE_LANG
 
 
 @functools.lru_cache(maxsize=None)
-def load_agent(language: str = "en"):
+def load_agent(language: str = DEFAULT_PADDLE_LANG):
     import paddle
     from unstructured_paddleocr import PaddleOCR
 
     """Loads the PaddleOCR agent as a global variable to ensure that we only load it once."""
+    # Note(yuming): Temporary fix to pass language parameter to paddle
+    # should be removed once we have the language mapping for paddle
+    language = os.getenv("PADDLE_LANG", DEFAULT_PADDLE_LANG)
 
     # Disable signal handlers at C++ level upon failing
     # ref: https://www.paddlepaddle.org.cn/documentation/docs/en/api/paddle/


### PR DESCRIPTION
Close: https://github.com/Unstructured-IO/unstructured-api/issues/247

### Summary
User now can specify default [paddle lang code](https://github.com/Mushroomcat9998/PaddleOCR/blob/main/doc/doc_en/multi_languages_en.md#5-support-languages-and-abbreviations) with env `DEFAULT_PADDLE_LANG` before we have the language mapping for paddle

### Test
* in your unstructured API env, cd to unstructured repo and install it locally with `pip install -e .`
* check out to this branch
* run paddle on intel chip:
```
pip install paddlepaddle
pip install "unstructured.PaddleOCR"
export OCR_AGENT=paddle
export DEFAULT_PADDLE_LANG=ch
make run-web-app
```
* curl:
```
curl  -X 'POST'  'http://localhost:8000/general/v0/general'   -H 'accept: application/json'  -F 'files=@sample-docs/english-and-korean.png'   | jq -C . | less -R
```
* expected to see `INFO Loading paddle with CPU on language=ch...` in log info

