### PR TITLE
build: larger images for docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         docker-platform: ["linux/arm64", "linux/amd64"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: set-short-sha
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
@@ -75,7 +75,7 @@ jobs:
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
   publish-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: [set-short-sha, build-images]
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}


### PR DESCRIPTION
Build and publish docker images on larger runner to work around the space issue here: https://github.com/Unstructured-IO/unstructured/actions/runs/6871101034/job/18689403845 .