### PR TITLE
chore: add more parametrization to ingestion test

### DIFF
--- a/test_unstructured_ingest/check-diff-expected-output.sh
+++ b/test_unstructured_ingest/check-diff-expected-output.sh
@@ -43,7 +43,7 @@ if [ "$OVERWRITE_FIXTURES" != "false" ]; then
         rm -rf "$EXPECTED_OUTPUT_DIR"
     fi
     mkdir -p "$EXPECTED_OUTPUT_DIR"
-    cp -rf "$OUTPUT_DIR" "$SCRIPT_DIR/expected-structured-output"
+    cp -rf "$OUTPUT_DIR" "$OUTPUT_ROOT/expected-structured-output"
 elif ! diff -ru "$EXPECTED_OUTPUT_DIR" "$OUTPUT_DIR" ; then
     "$SCRIPT_DIR"/json-to-clean-text-folder.sh "$EXPECTED_OUTPUT_DIR" "$EXPECTED_OUTPUT_DIR_TEXT"
     "$SCRIPT_DIR"/json-to-clean-text-folder.sh "$OUTPUT_DIR" "$OUTPUT_DIR_TEXT"


### PR DESCRIPTION
- allow the overwrite destination to be set to the `OUTPUT_ROOT` instead of default to script dir.

## test
run

```bash
OVERWRITE_FIXTURES=true OUTPUT_ROOT=/tmp ./test_unstructured_ingest/src/s3.sh
```

with this change we should find new files generated under `/tmp/expected-structured-output/s3`. 
Without this change there will be no such new files.
