### PR TITLE
drop cloud cli deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,20 +410,6 @@ jobs:
     steps:
     # actions/checkout MUST come before auth
     - uses: 'actions/checkout@v4'
-    - name: 'Google Cloud Auth'
-      uses: 'google-github-actions/auth@v1'
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-        create_credentials_file: true
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v1'
-    - name: 'Az CLI login'
-      uses: azure/login@v1
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.0-dev2
+## 0.11.0-dev3
 
 ### Enhancements
 

--- a/test_unstructured_ingest/dest/azure.sh
+++ b/test_unstructured_ingest/dest/azure.sh
@@ -18,7 +18,9 @@ fi
 
 CONTAINER=utic-ingest-test-fixtures-output
 DIRECTORY=$(uuidgen)
-REMOTE_URL="abfs://$CONTAINER/$DIRECTORY/"
+DIRECTORY="test"
+REMOTE_URL_RAW="$CONTAINER/$DIRECTORY/"
+REMOTE_URL="abfs://$REMOTE_URL_RAW"
 
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR"/cleanup.sh
@@ -26,14 +28,13 @@ function cleanup() {
   cleanup_dir "$OUTPUT_DIR"
   cleanup_dir "$WORK_DIR"
 
-  echo "deleting azure storage blob directory $CONTAINER/$DIRECTORY"
-  az storage fs directory delete -f "$CONTAINER" -n "$DIRECTORY" --connection-string "$AZURE_DEST_CONNECTION_STR" --yes
+  python "$SCRIPT_DIR"/python/test-azure-output.py down \
+  --connection-string "$AZURE_DEST_CONNECTION_STR" \
+  --container "$CONTAINER" \
+  --blob-path "$DIRECTORY"
 
 }
 trap cleanup EXIT
-
-# Create directory to use for testing
-az storage fs directory create -f "$CONTAINER" --n "$DIRECTORY" --connection-string "$AZURE_DEST_CONNECTION_STR"
 
 RUN_SCRIPT=${RUN_SCRIPT:-./unstructured/ingest/main.py}
 PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
@@ -51,9 +52,8 @@ PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
     --connection-string "$AZURE_DEST_CONNECTION_STR"
 
 # Simply check the number of files uploaded
-expected_num_files=1
-num_files_in_azure=$(az storage blob list -c "$CONTAINER" --prefix "$DIRECTORY"/example-docs/ --connection-string "$AZURE_DEST_CONNECTION_STR" | jq 'length')
-if [ "$num_files_in_azure" -ne "$expected_num_files" ]; then
-    echo "Expected $expected_num_files files to be uploaded to azure, but found $num_files_in_azure files."
-    exit 1
-fi
+python "$SCRIPT_DIR"/python/test-azure-output.py check \
+--expected-files 1 \
+--connection-string "$AZURE_DEST_CONNECTION_STR" \
+--container "$CONTAINER" \
+--blob-path "$DIRECTORY"

--- a/test_unstructured_ingest/dest/gcs.sh
+++ b/test_unstructured_ingest/dest/gcs.sh
@@ -10,7 +10,10 @@ OUTPUT_ROOT=${OUTPUT_ROOT:-$SCRIPT_DIR}
 OUTPUT_DIR=$OUTPUT_ROOT/structured-output/$OUTPUT_FOLDER_NAME
 WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
 max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
-DESTINATION_GCS="gs://utic-test-ingest-fixtures-output/$(uuidgen)"
+BUCKET="utic-test-ingest-fixtures-output"
+DIRECTORY=$(uuidgen)
+DIRECTORY="test"
+DESTINATION_GCS="gs://$BUCKET/$DIRECTORY"
 CI=${CI:-"false"}
 
 if [ -z "$GCP_INGEST_SERVICE_KEY" ]; then
@@ -31,10 +34,10 @@ function cleanup() {
     cleanup_dir "$DOWNLOAD_DIR"
   fi
 
-  if gcloud storage ls "$DESTINATION_GCS"; then
-    echo "deleting $DESTINATION_GCS"
-    gcloud storage rm --recursive "$DESTINATION_GCS"
-  fi
+  python "$SCRIPT_DIR"/python/test-gcs-output.py down \
+  --service-account-file "$GCP_INGEST_SERVICE_KEY_FILE" \
+  --bucket "$BUCKET" \
+  --blob-path "$DIRECTORY"
 
 }
 
@@ -55,9 +58,8 @@ PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
     --remote-url "$DESTINATION_GCS"
 
 # Simply check the number of files uploaded
-expected_num_files=1
-num_files_in_gcs=$(gcloud storage ls "$DESTINATION_GCS"/example-docs/ | wc -l )
-if [ "$num_files_in_gcs" -ne "$expected_num_files" ]; then
-    echo "Expected $expected_num_files files to be uploaded to gcs, but found $num_files_in_gcs files."
-    exit 1
-fi
+python "$SCRIPT_DIR"/python/test-gcs-output.py check \
+--expected-files 1 \
+--service-account-file "$GCP_INGEST_SERVICE_KEY_FILE" \
+--bucket "$BUCKET" \
+--blob-path "$DIRECTORY"

--- a/test_unstructured_ingest/python/test-azure-output.py
+++ b/test_unstructured_ingest/python/test-azure-output.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+import click
+from azure.storage.blob import ContainerClient
+
+
+@click.group(name="azure-ingest")
+def cli():
+    pass
+
+
+@cli.command()
+@click.option("--connection-string", type=str, required=True)
+@click.option("--container", type=str, required=True)
+@click.option("--blob-path", type=str, required=True)
+def down(connection_string: str, container: str, blob_path: str):
+    container_client = ContainerClient.from_connection_string(
+        conn_str=connection_string, container_name=container
+    )
+    blob_list = [b.name for b in list(container_client.list_blobs(name_starts_with=blob_path))]
+    print(f"deleting all content from {container}/{blob_path}")
+    # Delete all content in folder first
+    container_client.delete_blobs(*[b for b in blob_list if b != blob_path])
+
+    # Delete folder itself
+    container_client.delete_blob(blob_path)
+
+
+@cli.command()
+@click.option("--connection-string", type=str, required=True)
+@click.option("--container", type=str, required=True)
+@click.option("--blob-path", type=str, required=True)
+@click.option("--expected-files", type=int, required=True)
+def check(connection_string: str, container: str, blob_path: str, expected_files: int):
+    container_client = ContainerClient.from_connection_string(
+        conn_str=connection_string, container_name=container
+    )
+    blob_json_list = [
+        b.name
+        for b in list(container_client.list_blobs(name_starts_with="test"))
+        if b.name.endswith("json")
+    ]
+    found = len(blob_json_list)
+    print(
+        f"Checking that the number of files found ({found}) "
+        f"matches what's expected: {expected_files}"
+    )
+    assert (
+        found == expected_files
+    ), f"number of files found ({found}) doesn't match what's expected: {expected_files}"
+    print("successfully checked the number of files!")
+
+
+if __name__ == "__main__":
+    cli()

--- a/test_unstructured_ingest/python/test-gcs-output.py
+++ b/test_unstructured_ingest/python/test-gcs-output.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+import click
+from google.cloud import storage
+from google.oauth2 import service_account
+
+
+@click.group(name="gcs-ingest")
+def cli():
+    pass
+
+
+@cli.command()
+@click.option("--service-account-file", type=click.Path(), required=True)
+@click.option("--bucket", type=str, required=True)
+@click.option("--blob-path", type=str, required=True)
+def down(service_account_file: str, bucket: str, blob_path: str):
+    credentials = service_account.Credentials.from_service_account_file(
+        filename=service_account_file
+    )
+
+    storage_client = storage.Client(credentials=credentials)
+    for blob in storage_client.list_blobs(bucket_or_name=bucket, prefix=blob_path):
+        print(f"deleting {blob.name}")
+        blob.delete()
+
+
+@cli.command()
+@click.option("--service-account-file", type=click.Path(), required=True)
+@click.option("--bucket", type=str, required=True)
+@click.option("--blob-path", type=str, required=True)
+@click.option("--expected-files", type=int, required=True)
+def check(service_account_file: str, bucket: str, blob_path: str, expected_files: int):
+    credentials = service_account.Credentials.from_service_account_file(
+        filename=service_account_file
+    )
+
+    storage_client = storage.Client(credentials=credentials)
+    blob_json_list = [
+        f.name
+        for f in storage_client.list_blobs(bucket_or_name=bucket, prefix=blob_path)
+        if f.name.endswith("json")
+    ]
+    found = len(blob_json_list)
+    print(
+        f"Checking that the number of files found ({found}) "
+        f"matches what's expected: {expected_files}"
+    )
+    assert (
+        found == expected_files
+    ), f"number of files found ({found}) doesn't match what's expected: {expected_files}"
+    print("successfully checked the number of files!")
+
+
+if __name__ == "__main__":
+    cli()

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.0-dev2"  # pragma: no cover
+__version__ = "0.11.0-dev3"  # pragma: no cover

--- a/unstructured/ingest/cli/cmds/azure.py
+++ b/unstructured/ingest/cli/cmds/azure.py
@@ -40,6 +40,24 @@ class AzureCliConfig(CliConfig):
         return options
 
 
+@dataclass
+class AzureCliWriteConfig(CliConfig):
+    overwrite: bool = False
+
+    @staticmethod
+    def get_cli_options() -> t.List[click.Option]:
+        options = [
+            click.Option(
+                ["--overwrite"],
+                is_flag=True,
+                default=False,
+                show_default=True,
+                help="If set, will overwrite content if content already exists",
+            )
+        ]
+        return options
+
+
 def get_base_src_cmd() -> BaseSrcCmd:
     cmd_cls = BaseSrcCmd(cmd_name=CMD_NAME, cli_config=AzureCliConfig, is_fsspec=True)
     return cmd_cls
@@ -48,5 +66,10 @@ def get_base_src_cmd() -> BaseSrcCmd:
 def get_base_dest_cmd():
     from unstructured.ingest.cli.base.dest import BaseDestCmd
 
-    cmd_cls = BaseDestCmd(cmd_name=CMD_NAME, cli_config=AzureCliConfig, is_fsspec=True)
+    cmd_cls = BaseDestCmd(
+        cmd_name=CMD_NAME,
+        cli_config=AzureCliConfig,
+        is_fsspec=True,
+        additional_cli_options=[AzureCliWriteConfig],
+    )
     return cmd_cls


### PR DESCRIPTION
### Description
To not require additional dependencies on cloud-related CLIs (i.e. gcloud and az), using python and the existing dependencies already used to run out code to interact with those providers for overhead work associated with destination ingest tests. 