### PR TITLE
chore: ingest-script cleanup, better skip condition

### DIFF
--- a/test_unstructured_ingest/cleanup.sh
+++ b/test_unstructured_ingest/cleanup.sh
@@ -4,7 +4,9 @@
 function cleanup_dir() {
   # NOTE(crag): for developers that want to always clean up .json outputs, etc., set
   # UNSTRUCTURED_CLEANUP_DEV_FIXTURES=1
-  if [ "$CI" != "true" ] && [ -z "$UNSTRUCTURED_CLEANUP_DEV_FIXTURES" ] ; then
+    if [ "$CI" != "true" ] && \
+       [ -n "$UNSTRUCTURED_CLEANUP_DEV_FIXTURES" ] && \
+       [ "$UNSTRUCTURED_CLEANUP_DEV_FIXTURES" != "0" ] ; then
     return 0
   fi
   local dir_to_cleanup="${1}"

--- a/test_unstructured_ingest/cleanup.sh
+++ b/test_unstructured_ingest/cleanup.sh
@@ -3,7 +3,7 @@
 
 function cleanup_dir() {
   # NOTE(crag): for developers that want to always clean up .json outputs, etc., set
-  # UNSTRUCTURED_CLEANUP_DEV_FIXTURES=1
+  # export UNSTRUCTURED_CLEANUP_DEV_FIXTURES=1
     if [ "$CI" != "true" ] && \
        [ -n "$UNSTRUCTURED_CLEANUP_DEV_FIXTURES" ] && \
        [ "$UNSTRUCTURED_CLEANUP_DEV_FIXTURES" != "0" ] ; then


### PR DESCRIPTION
When testing ingest tests, one often wants to keep the .json output or generated metrics files around for inspection after the fact. This updates the bash condition to actually honor the comment that mentions

    # export UNSTRUCTURED_CLEANUP_DEV_FIXTURES=1
    
** Test Instructions **

Run:

    export UNSTRUCTURED_CLEANUP_DEV_FIXTURES=1
    ./test_unstructured_ingest/src/s3.sh
    ./test_unstructured_ingest/evaluation-metrics.sh text-extraction
    
and witness test directories/files do not get cleaned up. E.g., `test_unstructured_ingest/metrics-tmp/`. One can also add a `set -x` at the top of test_unstructured_ingest/cleanup.sh to see what is getting skipped (it's a lot!).