### PR TITLE
rfctr(html): clean types and docs in prep for HTML table parsing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.0-dev4
+## 0.11.0-dev5
 
 ### Enhancements
 

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -1,5 +1,8 @@
+# pyright: reportPrivateUsage=false
+
 import os
 import pathlib
+from typing import Dict, List
 
 import pytest
 from lxml import etree
@@ -169,13 +172,16 @@ def test_construct_text(doc, expected):
             [{"text": "A lone strong text!", "tag": "strong"}],
         ),
         ("<span>I have a</span> tail", "span", [{"text": "I have a", "tag": "span"}]),
-        ("<span>Empty result</span> ", "p", []),
+        ("<p>Text with no emphasized runs</p> ", "p", []),
     ],
 )
-def test_get_emphasized_texts_from_tag(doc, expected, root):
+def test_get_emphasized_texts_from_tag(doc: str, root: str, expected: List[Dict[str, str]]):
     document_tree = etree.fromstring(doc, etree.HTMLParser())
     el = document_tree.find(f".//{root}")
+    assert el is not None
+
     emphasized_texts = html._get_emphasized_texts_from_tag(el)
+
     assert emphasized_texts == expected
 
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.0-dev4"  # pragma: no cover
+__version__ = "0.11.0-dev5"  # pragma: no cover

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -258,7 +258,7 @@ def auto_paragraph_grouper(
 # TODO(robinson) - There's likely a cleaner was to accomplish this and get all of the
 # unicode characters instead of just the quotes. Doing this for now since quotes are
 # an issue that are popping up in the SEC filings tests
-def replace_unicode_quotes(text) -> str:
+def replace_unicode_quotes(text: str) -> str:
     """Replaces unicode bullets in text with the expected character
 
     Example

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -49,6 +49,9 @@ HEADER_OR_FOOTER_TAGS: Final[List[str]] = ["header", "footer"]
 SECTION_TAGS: Final[List[str]] = ["div", "pre"]
 
 
+# -- HTML-specific document-elements and methods -------------------------------------------------
+
+
 class TagsMixin:
     """Mixin that allows a class to retain tag information."""
 
@@ -99,6 +102,27 @@ class HTMLListItem(TagsMixin, ListItem):
 
 class HTMLTable(TagsMixin, Table):
     """NarrativeText with tag information"""
+
+
+def has_table_ancestor(element: TagsMixin) -> bool:
+    """Checks to see if an element has ancestors that are table elements. If so, we consider
+    it to be a table element rather than a section of narrative text."""
+    return any(ancestor in TABLE_TAGS for ancestor in element.ancestortags)
+
+
+def in_header_or_footer(element: TagsMixin) -> bool:
+    """Checks to see if an element is contained within a header or a footer tag."""
+    if any(ancestor in HEADER_OR_FOOTER_TAGS for ancestor in element.ancestortags):
+        return True
+    return False
+
+
+def is_table(element: TagsMixin) -> bool:
+    """Checks to see if an element is a table"""
+    return element.tag in TABLE_TAGS
+
+
+# -- HTML element-tree processing ----------------------------------------------------------------
 
 
 class HTMLDocument(XMLDocument):
@@ -615,24 +639,6 @@ def _has_adjacent_bulleted_spans(
         )
         if all_spans and _is_bulleted:
             return True
-    return False
-
-
-def has_table_ancestor(element: TagsMixin) -> bool:
-    """Checks to see if an element has ancestors that are table elements. If so, we consider
-    it to be a table element rather than a section of narrative text."""
-    return any(ancestor in TABLE_TAGS for ancestor in element.ancestortags)
-
-
-def is_table(element: TagsMixin) -> bool:
-    """Checks to see if an element is a table"""
-    return element.tag in TABLE_TAGS
-
-
-def in_header_or_footer(element: TagsMixin) -> bool:
-    """Checks to see if an element is contained within a header or a footer tag."""
-    if any(ancestor in HEADER_OR_FOOTER_TAGS for ancestor in element.ancestortags):
-        return True
     return False
 
 


### PR DESCRIPTION
There are a cluster of bugs in the HTML parsing code, particularly surrounding table behaviors but also inclusion of style elements, etc.

Clean up typing and docstrings in that neighborhood as a way to familiarize myself with that part of the code-base.