### PR TITLE
feat: add missing chunk params in unstructured-ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.0-dev6
+## 0.11.0-dev7
 
 ### Enhancements
 
@@ -10,6 +10,7 @@
 
 * **Add ad-hoc fields to ElementMetadata instance.** End-users can now add their own metadata fields simply by assigning to an element-metadata attribute-name of their choice, like `element.metadata.coefficient = 0.58`. These fields will round-trip through JSON and can be accessed with dotted notation.
 * **MongoDB Destination Connector** New destination connector added to all CLI ingest commands to support writing partitioned json output to mongodb.
+* **Add missing chunking parameters to unstructured-cli** Updates unstructured-ingest cli to accept an argument for combine-text-under-n-chars and adds logic to support passing through the new-after-n-chars argument to the chunk_by_title function. This allows users to fully take advantage of all chunking options through unstructured-ingest. 
 
 ### Fixes
 

--- a/test_unstructured_ingest/expected-structured-output/chunking/example-docs/spring-weather.html.json.json
+++ b/test_unstructured_ingest/expected-structured-output/chunking/example-docs/spring-weather.html.json.json
@@ -1,0 +1,376 @@
+[
+  {
+    "type": "CompositeElement",
+    "element_id": "6f6f35b5f7a7eb8791eceace69392ac4",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "News Around NOAA\n\nNational Program"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "62c26d2e16774d2334bd804c7bb6a711",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Are You Weather-Ready for the Spring?"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "30b0ecb2eb6c83617d611d2de6c680f6",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Weather.gov >\n\nNews Around NOAA > Are You Weather-Ready for the Spring?"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "b4a523a3230f3ba50b4f18f2b3d9fae3",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Weather Safety                                                                                                        Air Quality                                                                            Beach Hazards                                                                            Cold                                                                            Cold Water                                                                            Drought                                                                            Floods                                                                            Fog                                                                            Heat                                                                             Hurricanes                                                                             Lightning Safety                                                                            Rip Currents                                                                            Safe Boating                                                                            Space Weather                                                                            Sun (Ultraviolet Radiation)                                                                             Thunderstorms & Tornadoes                                                                            Tornado                                                           "
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "a79f3e1bfe43afc617248084f9b36a04",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "                 Tsunami                                                                            Wildfire                                                                            Wind                                                                            Winter"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "45c26cf3457e6d18985a435e2c0fcc65",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Safety Campaigns                                                                                                        Seasonal Safety Campaigns                                                                            #SafePlaceSelfie                                                                            Deaf & Hard of Hearing                                                                            Intellectual Disabilities                                                                            Spanish-language Content                                                                            The Great Outdoors"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "77f5acc603de9a165ed87a5c3fbaf14a",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Ambassador                                                                                                        About WRN Ambassadors                                                                            Become an Ambassador                                                                            Ambassadors of Excellence                                                                            People of WRN                                                                             FAQS                                                                            Tell Your Success Story                                                                             Success Stories                                                                            Tri-fold                                                                            Aviation                                                                             Current Ambassadors                                                                            Brochure                                                                            En Español"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "8f19bcaabbd1bafa5e9826ac69766c8b",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Education                                                                                                        NWS Education Home                                                                            Be A Force Of Nature                                                                            WRN Kids Flyer                                                                            Wireless Emergency Alerts                                                                            NOAA Weather Radio                                                                            Mobile Weather                                                                            Brochures                                                                            Hourly Weather Forecast                                                                            Citizen Science                                                                            Intellectual Disabilities"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "1245f9cf9e019713391e4ee3bac54a63",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Collaboration                                                                                                        Get Involved                                                                             Social Media                                                                            WRN Ambassadors ​                                                                            Enterprise Resources                                                                            StormReady                                                                            TsunamiReady                                                                            NWSChat (core partners only)                                                                            InteractiveNWS (iNWS) (core partners only)​                                                                            SKYWARN"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "23dfa7f98424dbf86e00b3d500096dfa",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "News & Events                                                                                                        Latest News                                                                            Calendar                                                                            Meetings & Workshops                                                                            NWS Aware Newsletter"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "a2245214c0f91bb434496e9c71c62ebe",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "International\n\nAbout                                                                                                        Contact Us                                                                             What is WRN?                                                                             WRN FAQ                                                                            WRN Brochure                                                                            Hazard Simplification                                                                            IDSS Brochure                                                                            Roadmap                                                                            Strategic Plan                                                                            WRN International                                                                            Social Science"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "6cbcf8c11f8c0781bd9ecc7f67169ff0",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "The spring season is all about change – a rebirth both literally and figuratively. Even though the spring season doesn’t officially (astronomically, that is) begin until March 20 this year, climatologically, it starts March 1."
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "7184168da442c6ef28553b274bf2be8f",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "As cold winter nights are replaced by the warmth of longer daylight hours, the National Weather Service invites you to do two important things that may save your life or the life of a loved one."
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "f3be9748ecd68b20d706548129baa22d",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "First, take steps to better prepare for the seasonal hazards weather can throw at you.\nThis could include a spring cleaning of your storm shelter or ensuring your emergency kit is fully stocked. Take a look at our infographics and social media posts to help you become “weather-ready.”"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "126c3cd201fb259cfeabc6bffc0b5473",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Second, encourage others to become Weather-Ready as well. Share the message by taking advantage of our vast array of weather safety content – everything posted on our Spring Safety website is freely available, and we encourage sharing on social media networks. Also remember those who are most vulnerable, like an elderly family member or neighbor who might have limited mobility or is isolated. Reach out to those who are at higher risk of being impacted by extreme weather, and help them get prepared. This simple act of caring could become heroic."
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "c1944fb037f3e1cb14969bc59a7dd9c2",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "This spring, the campaign is focused on heat dangers. Heat illness and death can occur even in spring’s moderately warm weather. The majority of all heat-related deaths occur outside of heat waves and roughly a third of child hot car deaths occur outside of the summer months. Learn more by viewing the infographics that are now available."
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "fa1b939ef6159d95260bc095f58ebbc2",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Stay safe this spring, and every season, by being informed, prepared, and Weather-Ready."
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "47d5d0d27a35a36d7467dfc8b6e089b3",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "US Dept of Commerce\n                        National Oceanic and Atmospheric Administration\n                        National Weather Service\n                        News Around NOAA1325 East West HighwaySilver Spring, MD 20910Comments? Questions? Please Contact Us."
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "5bdfff08707ea2abf9c40d815b0f4125",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Disclaimer\n\nInformation Quality"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "b049c908898220e478060b8a90515a09",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Help\n\nGlossary\n\nPrivacy Policy"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "c70ae8c30a61c450d2c5148d1b6a0447",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "Freedom of Information Act (FOIA)"
+  },
+  {
+    "type": "CompositeElement",
+    "element_id": "3e549b5eab00757e20cba261932731b6",
+    "metadata": {
+      "data_source": {
+        "url": "example-docs/spring-weather.html.json",
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      },
+      "filetype": "application/json",
+      "page_number": 1
+    },
+    "text": "About Us\n\nCareer Opportunities"
+  }
+]

--- a/test_unstructured_ingest/src/chunking.sh
+++ b/test_unstructured_ingest/src/chunking.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Test chunking by running the ingest script with the chunking flag and parameters each 
+# assigned with values that will impact the output. The output is then compared to the
+# expected output.
+
+set -e
+
+SRC_PATH=$(dirname "$(realpath "$0")")
+SCRIPT_DIR=$(dirname "$SRC_PATH")
+cd "$SCRIPT_DIR"/.. || exit 1
+OUTPUT_FOLDER_NAME=chunking
+OUTPUT_ROOT=${OUTPUT_ROOT:-$SCRIPT_DIR}
+OUTPUT_DIR=$OUTPUT_ROOT/structured-output/$OUTPUT_FOLDER_NAME
+WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
+max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR"/cleanup.sh
+# shellcheck disable=SC2317
+function cleanup() {
+  cleanup_dir "$OUTPUT_DIR"
+  cleanup_dir "$WORK_DIR"
+}
+trap cleanup EXIT
+
+RUN_SCRIPT=${RUN_SCRIPT:-./unstructured/ingest/main.py}
+PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
+    local \
+    --num-processes "$max_processes" \
+    --metadata-exclude coordinates,filename,file_directory,metadata.data_source.date_created,metadata.data_source.date_modified,metadata.data_source.date_processed,metadata.last_modified,metadata.detection_class_prob,metadata.parent_id,metadata.category_depth \
+    --output-dir "$OUTPUT_DIR" \
+    --verbose \
+    --reprocess \
+    --chunk-elements \
+    --chunk-combine-text-under-n-chars 20\
+    --chunk-new-after-n-chars 30 \
+    --chunk-max-characters 100 \
+    --input-path example-docs/spring-weather.html.json \
+    --work-dir "$WORK_DIR"
+
+set +e
+"$SCRIPT_DIR"/check-diff-expected-output.sh $OUTPUT_FOLDER_NAME
+EXIT_CODE=$?
+set -e
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+    echo "The last script run exited with a non-zero exit code: $EXIT_CODE."
+    # Handle the error or exit
+fi
+
+"$SCRIPT_DIR"/evaluation-ingest-cp.sh "$OUTPUT_DIR" "$OUTPUT_FOLDER_NAME"
+
+exit $EXIT_CODE
+
+
+    # --chunk-elements \
+    # --chunk-combine-text-under-n-chars 200\
+    # --chunk-new-after-n-chars 2500\
+    # --chunk-max-characters 38000\

--- a/test_unstructured_ingest/src/chunking.sh
+++ b/test_unstructured_ingest/src/chunking.sh
@@ -52,9 +52,3 @@ fi
 "$SCRIPT_DIR"/evaluation-ingest-cp.sh "$OUTPUT_DIR" "$OUTPUT_FOLDER_NAME"
 
 exit $EXIT_CODE
-
-
-    # --chunk-elements \
-    # --chunk-combine-text-under-n-chars 200\
-    # --chunk-new-after-n-chars 2500\
-    # --chunk-max-characters 38000\

--- a/test_unstructured_ingest/test-ingest-src.sh
+++ b/test_unstructured_ingest/test-ingest-src.sh
@@ -49,6 +49,7 @@ all_tests=(
 
 full_python_matrix_tests=(
   'sharepoint.sh'
+  'chunking.sh'
   'local.sh'
   'local-single-file.sh'
   'local-single-file-with-encoding.sh'

--- a/test_unstructured_ingest/test-ingest-src.sh
+++ b/test_unstructured_ingest/test-ingest-src.sh
@@ -14,6 +14,7 @@ all_tests=(
 'azure.sh'
 'biomed-api.sh'
 'biomed-path.sh'
+'chunking.sh'
 # NOTE(yuming): The pdf-fast-reprocess test should be put after any tests that save downloaded files
 'pdf-fast-reprocess.sh'
 'salesforce.sh'

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.0-dev6"  # pragma: no cover
+__version__ = "0.11.0-dev7"  # pragma: no cover

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -468,13 +468,19 @@ class CliChunkingConfig(ChunkingConfig, CliMixin):
                 default=False,
             ),
             click.Option(
-                ["--chunk-combine-under-n-chars"],
+                ["--chunk-combine-text-under-n-chars"],
                 type=int,
                 default=500,
                 show_default=True,
             ),
             click.Option(
                 ["--chunk-new-after-n-chars"],
+                type=int,
+                default=1500,
+                show_default=True,
+            ),
+            click.Option(
+                ["--chunk-max-characters"],
                 type=int,
                 default=1500,
                 show_default=True,
@@ -503,9 +509,9 @@ class CliChunkingConfig(ChunkingConfig, CliMixin):
                 new_kvs["chunk_elements"] = chunk_elements
             new_kvs.update(
                 {
-                    k[len("chunking_") :]: v  # noqa: E203
+                    k[len("chunk_") :]: v  # noqa: E203
                     for k, v in kvs.items()
-                    if k.startswith("chunking_")
+                    if k.startswith("chunk_")
                 },
             )
             if len(new_kvs.keys()) == 0:

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -191,6 +191,7 @@ class ChunkingConfig(BaseConfig):
     multipage_sections: bool = True
     combine_text_under_n_chars: int = 500
     max_characters: int = 1500
+    new_after_n_chars: t.Optional[int] = None
 
     def chunk(self, elements: t.List[Element]) -> t.List[Element]:
         if self.chunk_elements:
@@ -199,6 +200,7 @@ class ChunkingConfig(BaseConfig):
                 multipage_sections=self.multipage_sections,
                 combine_text_under_n_chars=self.combine_text_under_n_chars,
                 max_characters=self.max_characters,
+                new_after_n_chars=self.new_after_n_chars,
             )
         else:
             return elements


### PR DESCRIPTION
New arguments have been added to our chunking strategy. Furthermore it looks like we may not have been previously passing through existing parameters. We should support all chunking arguments in the ingest cli.

This PR exposes all current chunking options to the unstructured-ingest cli and passes them through to the call to `chunk_by_title`.

## Changes
- Add cli params for missing max_characters argument
- Add logic to pass through the new_after_n_chars argument to `chunk_by_title`
- Add explicit chunking test that validates these options passed through by validating against expected results

## Note
we should probably not append .json in the case that the input is json. unrelated to this PR, but noting as something follow up on.