### PR TITLE
docs: add mongodb destination connector to ingest docs

### DIFF
--- a/docs/source/ingest/destination_connectors.rst
+++ b/docs/source/ingest/destination_connectors.rst
@@ -8,5 +8,6 @@ in our community `Slack. <https://short.unstructured.io/pzw05l7>`_
 .. toctree::
    :maxdepth: 1
 
-   destination_connectors/delta_table
    destination_connectors/azure_cognitive_search
+   destination_connectors/delta_table
+   destination_connectors/mongodb


### PR DESCRIPTION
The mongodb documentation page exists but is missing from the list of destination connectors, meaning it's not actually visible in the documentation.