### PR TITLE
bug: fsspec output filepath including base directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.1-dev1
+## 0.11.1-dev2
 
 ### Enhancements
 
@@ -8,6 +8,7 @@
 
 * **Do not extract text of `<style>` tags in HTML.** `<style>` tags containing CSS in invalid positions previously contributed to element text. Do not consider text node of a `<style>` element as textual content.
 * **Fix DOCX merged table cell repeats cell text.** Only include text for a merged cell, not for each underlying cell spanned by the merge.
+* **Fix output filepath for fsspec-based source connectors** Previously the base directory was being included in the output filepath unnecessarily.
 
 ## 0.11.0
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.1-dev1"  # pragma: no cover
+__version__ = "0.11.1-dev2"  # pragma: no cover

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -69,10 +69,10 @@ class FsspecIngestDoc(IngestDocCleanupMixin, BaseIngestDoc):
 
     @property
     def _output_filename(self):
-        return (
-            Path(self.processor_config.output_dir)
-            / f"{self.remote_file_path.replace(f'{self.connector_config.dir_path}/', '')}.json"
+        filename = (
+            f"{self.remote_file_path.replace(self.connector_config.path_without_protocol, '')}.json"
         )
+        return Path(self.processor_config.output_dir) / filename
 
     def _create_full_tmp_dir_path(self):
         """Includes "directories" in the object path"""


### PR DESCRIPTION
### Description
When passing in a remote path for fsspec-based source connectors, the base directory was always being included in the output path itself. This was updated to exclude the base directory any only include any child directories relative to the base one. 