### PR TITLE
fix: fix eval ci to skip the overwrite if none exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Features
 
-* **Add ad-hoc fields to ElementMetadata instance.** End-users can now add their own metadata fields simply by assigning to an element-metadata attribute-name of their choice, like `element.metadata.coefficient = 0.58`. These fields will round-trip through JSON and can be accessed with dotted notation.
+* **Add ad-hoc fields to `ElementMetadata` instance.** End-users can now add their own metadata fields simply by assigning to an element-metadata attribute-name of their choice, like `element.metadata.coefficient = 0.58`. These fields will round-trip through JSON and can be accessed with dotted notation.
 * **MongoDB Destination Connector.** New destination connector added to all CLI ingest commands to support writing partitioned json output to mongodb.
 
 ### Fixes

--- a/test_unstructured_ingest/check-diff-evaluation-metrics.sh
+++ b/test_unstructured_ingest/check-diff-evaluation-metrics.sh
@@ -35,6 +35,13 @@ function cleanup() {
 
 trap cleanup EXIT
 
+function check_output_folder() {
+    if [ ! -d "$TMP_METRICS_LATEST_RUN_DIR" ]; then
+        # there is no evaluation output to perform action
+        exit 0
+    fi
+}
+
 # to update ingest test fixtures, run scripts/ingest-test-fixtures-update.sh on x86_64
 if [ "$OVERWRITE_FIXTURES" != "false" ]; then
     # remove folder if it exists
@@ -44,12 +51,10 @@ if [ "$OVERWRITE_FIXTURES" != "false" ]; then
     fi
     # force copy (overwrite) files from metrics-tmp (new eval metrics) to metrics (old eval metrics)
     mkdir -p "$METRICS_DIR"
-    if [ ! -d "$TMP_METRICS_LATEST_RUN_DIR" ]; then
-        echo "There is no evaluation output for $EVAL_NAME. Skipping the overwrite."
-        exit 0
-    fi
+    check_output_folder
     cp -rf "$TMP_METRICS_LATEST_RUN_DIR" "$OUTPUT_ROOT/metrics"
 elif ! diff -ru "$METRICS_DIR" "$TMP_METRICS_LATEST_RUN_DIR" ; then  
+    check_output_folder
     "$SCRIPT_DIR"/clean-permissions-files.sh "$TMP_METRICS_LATEST_RUN_DIR"
     diff -ru "$METRICS_DIR" "$TMP_METRICS_LATEST_RUN_DIR"> metricsdiff.txt
     diffstat -c metricsdiff.txt

--- a/test_unstructured_ingest/check-diff-evaluation-metrics.sh
+++ b/test_unstructured_ingest/check-diff-evaluation-metrics.sh
@@ -44,6 +44,10 @@ if [ "$OVERWRITE_FIXTURES" != "false" ]; then
     fi
     # force copy (overwrite) files from metrics-tmp (new eval metrics) to metrics (old eval metrics)
     mkdir -p "$METRICS_DIR"
+    if [ ! -d "$TMP_METRICS_LATEST_RUN_DIR" ]; then
+        echo "There is no evaluation output for $EVAL_NAME. Skipping the overwrite."
+        exit 0
+    fi
     cp -rf "$TMP_METRICS_LATEST_RUN_DIR" "$OUTPUT_ROOT/metrics"
 elif ! diff -ru "$METRICS_DIR" "$TMP_METRICS_LATEST_RUN_DIR" ; then  
     "$SCRIPT_DIR"/clean-permissions-files.sh "$TMP_METRICS_LATEST_RUN_DIR"

--- a/test_unstructured_ingest/evaluation-metrics.sh
+++ b/test_unstructured_ingest/evaluation-metrics.sh
@@ -62,6 +62,7 @@ SOURCE_LIST=(
 read -ra output_args <<< "$(generate_args "output" "$OUTPUT_DIR" "${OUTPUT_LIST[@]}")"
 read -ra source_args <<< "$(generate_args "source" "$SOURCE_DIR" "${SOURCE_LIST[@]}")"
 
+# mkdir export_dir is handled in python script
 PYTHONPATH=. ./unstructured/ingest/evaluate.py \
     $METRIC_STRATEGY "${output_args[@]}" "${source_args[@]}" \
     --export_dir "$EXPORT_DIR"

--- a/unstructured/metrics/evaluate.py
+++ b/unstructured/metrics/evaluate.py
@@ -9,6 +9,8 @@ from typing import List, Optional, Tuple, Union
 import click
 import pandas as pd
 
+from tqdm import tqdm
+
 from unstructured.metrics.element_type import (
     calculate_element_type_percent_match,
     get_element_type_frequency,
@@ -40,6 +42,7 @@ def measure_text_edit_distance(
     export_dir: str = "metrics",
     grouping: Optional[str] = None,
     weights: Tuple[int, int, int] = (2, 1, 1),
+    visualize: bool = False,
 ) -> None:
     """
     Loops through the list of structured output from all of `output_dir` or selected files from
@@ -61,7 +64,8 @@ def measure_text_edit_distance(
     rows = []
 
     # assumption: output file name convention is name-of-file.doc.json
-    for doc in output_list:  # type: ignore
+    # NOTE(klaijan) - disable=True means to not show, disable=False means to show the progress bar
+    for doc in tqdm(output_list, leave=False, disable=not visualize):  # type: ignore
         filename = (doc.split("/")[-1]).split(".json")[0]
         doctype = filename.rsplit(".", 1)[-1]
         fn_txt = filename + ".txt"
@@ -118,6 +122,7 @@ def measure_element_type_accuracy(
     output_list: Optional[List[str]] = None,
     source_list: Optional[List[str]] = None,
     export_dir: str = "metrics",
+    visualize: bool = False,
 ):
     """
     Loops through the list of structured output from all of `output_dir` or selected files from
@@ -134,7 +139,8 @@ def measure_element_type_accuracy(
 
     rows = []
 
-    for doc in output_list:  # type: ignore
+    # NOTE(klaijan) - disable=True means to not show, disable=False means to show the progress bar
+    for doc in tqdm(output_list, leave=False, disable=not visualize):  # type: ignore
         filename = (doc.split("/")[-1]).split(".json")[0]
         doctype = filename.rsplit(".", 1)[-1]
         fn_json = filename + ".json"

--- a/unstructured/metrics/evaluate.py
+++ b/unstructured/metrics/evaluate.py
@@ -8,7 +8,6 @@ from typing import List, Optional, Tuple, Union
 
 import click
 import pandas as pd
-
 from tqdm import tqdm
 
 from unstructured.metrics.element_type import (


### PR DESCRIPTION
Currently the `check-diff-evaluation-metrics` only runs when there is file to perform evaluation on. Add the checking condition to skip the action when there is none. Additionally, more refactoring and `visualize` option for both evaluation calculation functions is also added.