### PR TITLE
chore: improve logging sensitive fields in ingest CLI

### DIFF
--- a/unstructured/ingest/cli/common.py
+++ b/unstructured/ingest/cli/common.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Optional
 
@@ -58,22 +59,34 @@ def run_init_checks(
         )
 
 
-def log_options(options: dict, verbose=False):
-    ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)
+def hide_sensitive_fields(data: dict) -> dict:
     sensitive_fields = [
         "account_name",
-        "account_key",
-        "api_key",
-        "token",
         "client_id",
-        "client_cred",
     ]
-    options_to_log = options.copy()
-    options_to_log.update(
-        {
-            k: "*******"
-            for k, v in options_to_log.items()
-            if k in sensitive_fields and v is not None
-        },
-    )
+    sensitive_triggers = ["key", "cred", "token"]
+    new_data = data.copy()
+    for k, v in new_data.items():
+        if (
+            any([s in k.lower() for s in sensitive_triggers])  # noqa: C419
+            or k.lower() in sensitive_fields
+        ):
+            new_data[k] = "*******"
+        if isinstance(v, dict):
+            new_data[k] = hide_sensitive_fields(v)
+        if isinstance(v, str):
+            try:
+                json_data = json.loads(v)
+                if isinstance(json_data, dict):
+                    updated_data = hide_sensitive_fields(json_data)
+                    new_data[k] = json.dumps(updated_data)
+            except json.JSONDecodeError:
+                pass
+
+    return new_data
+
+
+def log_options(options: dict, verbose=False):
+    ingest_log_streaming_init(logging.DEBUG if verbose else logging.INFO)
+    options_to_log = hide_sensitive_fields(options)
     logger.debug(f"options: {options_to_log}")

--- a/unstructured/ingest/cli/common.py
+++ b/unstructured/ingest/cli/common.py
@@ -1,10 +1,10 @@
-import json
 import logging
 from typing import Optional
 
 from click import ClickException
 
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
+from unstructured.ingest.utils.logging import hide_sensitive_fields
 
 
 def run_init_checks(
@@ -57,33 +57,6 @@ def run_init_checks(
         logger.warning(
             "Not preserving downloaded files but download_dir is specified",
         )
-
-
-def hide_sensitive_fields(data: dict) -> dict:
-    sensitive_fields = [
-        "account_name",
-        "client_id",
-    ]
-    sensitive_triggers = ["key", "cred", "token"]
-    new_data = data.copy()
-    for k, v in new_data.items():
-        if (
-            any([s in k.lower() for s in sensitive_triggers])  # noqa: C419
-            or k.lower() in sensitive_fields
-        ):
-            new_data[k] = "*******"
-        if isinstance(v, dict):
-            new_data[k] = hide_sensitive_fields(v)
-        if isinstance(v, str):
-            try:
-                json_data = json.loads(v)
-                if isinstance(json_data, dict):
-                    updated_data = hide_sensitive_fields(json_data)
-                    new_data[k] = json.dumps(updated_data)
-            except json.JSONDecodeError:
-                pass
-
-    return new_data
 
 
 def log_options(options: dict, verbose=False):

--- a/unstructured/ingest/connector/airtable.py
+++ b/unstructured/ingest/connector/airtable.py
@@ -1,4 +1,3 @@
-import os
 import typing as t
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -139,7 +138,6 @@ class AirtableIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
     def get_file(self):
         import pandas as pd
 
-        logger.debug(f"Fetching {self} - PID: {os.getpid()}")
         rows, table_url = self._get_table_rows()
         self.update_source_metadata(rows_tuple=(rows, table_url))
         if rows is None:

--- a/unstructured/ingest/connector/confluence.py
+++ b/unstructured/ingest/connector/confluence.py
@@ -1,5 +1,4 @@
 import math
-import os
 import typing as t
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -170,8 +169,6 @@ class ConfluenceIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
     @requires_dependencies(["atlassian"], extras="confluence")
     @BaseSingleIngestDoc.skip_if_file_exists
     def get_file(self):
-        logger.debug(f"Fetching {self} - PID: {os.getpid()}")
-
         # TODO: instead of having a separate connection object for each doc,
         # have a separate connection object for each process
 

--- a/unstructured/ingest/connector/delta_table.py
+++ b/unstructured/ingest/connector/delta_table.py
@@ -100,8 +100,6 @@ class DeltaTableIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
         self.update_source_metadata(fs=fs)
         logger.info(f"using a {fs} filesystem to collect table data")
         self._create_full_tmp_dir_path()
-        logger.debug(f"Fetching {self} - PID: {os.getpid()}")
-
         df = self._get_df(filesystem=fs)
 
         logger.info(f"writing {len(df)} rows to {self.filename}")

--- a/unstructured/ingest/connector/discord.py
+++ b/unstructured/ingest/connector/discord.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import os
 import typing as t
 from dataclasses import dataclass
 from pathlib import Path
@@ -120,8 +119,6 @@ class DiscordIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
     @BaseSingleIngestDoc.skip_if_file_exists
     def get_file(self):
         self._create_full_tmp_dir_path()
-        if self.processor_config.verbose:
-            logger.debug(f"fetching {self} - PID: {os.getpid()}")
 
         messages, jump_url = self._get_messages()
         self.update_source_metadata(messages_tuple=(messages, jump_url))

--- a/unstructured/ingest/connector/elasticsearch.py
+++ b/unstructured/ingest/connector/elasticsearch.py
@@ -1,5 +1,4 @@
 import hashlib
-import os
 import typing as t
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -167,7 +166,6 @@ class ElasticsearchIngestDocBatch(BaseIngestDocBatch):
     @SourceConnectionError.wrap
     @requires_dependencies(["elasticsearch"], extras="elasticsearch")
     def get_files(self):
-        logger.debug(f"Fetching {self} - PID: {os.getpid()}")
         documents = self._get_docs()
         for doc in documents:
             ingest_doc = ElasticsearchIngestDoc(

--- a/unstructured/ingest/connector/fsspec.py
+++ b/unstructured/ingest/connector/fsspec.py
@@ -97,7 +97,6 @@ class FsspecIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
         fs: AbstractFileSystem = get_filesystem_class(self.connector_config.protocol)(
             **self.connector_config.get_access_kwargs(),
         )
-        logger.debug(f"Fetching {self} - PID: {os.getpid()}")
         self._get_file(fs=fs)
         fs.get(rpath=self.remote_file_path, lpath=self._tmp_download_file().as_posix())
         self.update_source_metadata()

--- a/unstructured/ingest/connector/git.py
+++ b/unstructured/ingest/connector/git.py
@@ -1,5 +1,4 @@
 import fnmatch
-import os
 import typing as t
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -59,7 +58,6 @@ class GitIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
     def get_file(self):
         """Fetches the "remote" doc and stores it locally on the filesystem."""
         self._create_full_tmp_dir_path()
-        logger.debug(f"Fetching {self} - PID: {os.getpid()}")
         self._fetch_and_write()
 
     def _fetch_content(self) -> None:

--- a/unstructured/ingest/connector/jira.py
+++ b/unstructured/ingest/connector/jira.py
@@ -1,5 +1,4 @@
 import math
-import os
 import typing as t
 from collections import abc
 from dataclasses import dataclass, field
@@ -326,8 +325,6 @@ class JiraIngestDoc(IngestDocSessionHandleMixin, IngestDocCleanupMixin, BaseSing
     @requires_dependencies(["atlassian"], extras="jira")
     @BaseSingleIngestDoc.skip_if_file_exists
     def get_file(self):
-        logger.debug(f"Fetching {self} - PID: {os.getpid()}")
-
         document = form_templated_string(self.issue, self.parsed_fields)
         self.update_source_metadata()
         self.filename.parent.mkdir(parents=True, exist_ok=True)

--- a/unstructured/ingest/connector/notion/connector.py
+++ b/unstructured/ingest/connector/notion/connector.py
@@ -1,4 +1,3 @@
-import os
 import typing as t
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -82,8 +81,6 @@ class NotionPageIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
         from unstructured.ingest.connector.notion.helpers import extract_page_html
 
         self._create_full_tmp_dir_path()
-
-        logger.debug(f"fetching page {self.page_id} - PID: {os.getpid()}")
 
         client = self.get_client()
 
@@ -205,8 +202,6 @@ class NotionDatabaseIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
         from unstructured.ingest.connector.notion.helpers import extract_database_html
 
         self._create_full_tmp_dir_path()
-
-        logger.debug(f"fetching database {self.database_id} - PID: {os.getpid()}")
 
         client = self.get_client()
 

--- a/unstructured/ingest/connector/reddit.py
+++ b/unstructured/ingest/connector/reddit.py
@@ -1,4 +1,3 @@
-import os
 import typing as t
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -80,7 +79,6 @@ class RedditIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
     def get_file(self):
         """Fetches the "remote" doc and stores it locally on the filesystem."""
         self._create_full_tmp_dir_path()
-        logger.debug(f"Fetching {self} - PID: {os.getpid()}")
         # Write the title plus the body, if any
         post = self.get_post()
         self.update_source_metadata(post=post)

--- a/unstructured/ingest/connector/salesforce.py
+++ b/unstructured/ingest/connector/salesforce.py
@@ -7,7 +7,6 @@ Using JWT authorization
 https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_key_and_cert.htm
 https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_auth_connected_app.htm
 """
-import os
 import typing as t
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -187,8 +186,6 @@ class SalesforceIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
     def get_file(self):
         """Saves individual json records locally."""
         self._create_full_tmp_dir_path()
-        logger.debug(f"Writing file {self.record_id} - PID: {os.getpid()}")
-
         record = self.record
 
         self.update_source_metadata()

--- a/unstructured/ingest/connector/slack.py
+++ b/unstructured/ingest/connector/slack.py
@@ -1,4 +1,3 @@
-import os
 import typing as t
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
@@ -144,9 +143,6 @@ class SlackIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
         """Fetches the data from a slack channel and stores it locally."""
 
         self._create_full_tmp_dir_path()
-
-        if self.processor_config.verbose:
-            logger.debug(f"fetching channel {self.channel} - PID: {os.getpid()}")
 
         result = self._fetch_messages()
         self.update_source_metadata(result=result)

--- a/unstructured/ingest/connector/wikipedia.py
+++ b/unstructured/ingest/connector/wikipedia.py
@@ -1,4 +1,3 @@
-import os
 import typing as t
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -97,7 +96,6 @@ class WikipediaIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
     def get_file(self):
         """Fetches the "remote" doc and stores it locally on the filesystem."""
         self._create_full_tmp_dir_path()
-        logger.debug(f"Fetching {self} - PID: {os.getpid()}")
         self.update_source_metadata()
         with open(self.filename, "w", encoding="utf8") as f:
             f.write(self.text)

--- a/unstructured/ingest/pipeline/interfaces.py
+++ b/unstructured/ingest/pipeline/interfaces.py
@@ -22,6 +22,7 @@ from unstructured.ingest.interfaces import (
     RetryStrategyConfig,
 )
 from unstructured.ingest.logger import ingest_log_streaming_init, logger
+from unstructured.ingest.utils.logging import hide_sensitive_fields
 
 
 @dataclass
@@ -110,7 +111,8 @@ class DocFactoryNode(PipelineNode):
     def initialize(self):
         logger.info(
             f"Running doc factory to generate ingest docs. "
-            f"Source connector: {self.source_doc_connector.to_json()}",
+            f"Source connector: "
+            f"{json.dumps(hide_sensitive_fields(self.source_doc_connector.to_dict()))}",
         )
         super().initialize()
         self.source_doc_connector.initialize()

--- a/unstructured/ingest/pipeline/interfaces.py
+++ b/unstructured/ingest/pipeline/interfaces.py
@@ -215,7 +215,8 @@ class WriteNode(PipelineNode):
     def initialize(self):
         logger.info(
             f"Running write node to upload content. "
-            f"Destination connector: {self.dest_doc_connector.to_json()}]",
+            f"Destination connector: "
+            f"{json.dumps(hide_sensitive_fields(self.dest_doc_connector.to_dict()))}]",
         )
         super().initialize()
         self.dest_doc_connector.initialize()

--- a/unstructured/ingest/pipeline/source.py
+++ b/unstructured/ingest/pipeline/source.py
@@ -1,3 +1,5 @@
+import json
+import os
 import typing as t
 from dataclasses import dataclass
 
@@ -10,6 +12,7 @@ from unstructured.ingest.interfaces import (
 )
 from unstructured.ingest.logger import logger
 from unstructured.ingest.pipeline.interfaces import SourceNode
+from unstructured.ingest.utils.logging import hide_sensitive_fields
 
 # module-level variable to store session handle
 session_handle: t.Optional[BaseSessionHandle] = None
@@ -27,6 +30,10 @@ class Reader(SourceNode):
             # Still need to fetch metadata if file exists locally
             doc.update_source_metadata()
         else:
+            logger.debug(
+                f"Fetching {json.dumps(hide_sensitive_fields(doc.to_dict()))} "
+                f"- PID: {os.getpid()}"
+            )
             if self.retry_strategy:
                 self.retry_strategy(doc.get_file)
             else:
@@ -36,6 +43,10 @@ class Reader(SourceNode):
         return doc.filename
 
     def get_batch(self, doc_batch: BaseIngestDocBatch, ingest_doc_dict: dict) -> t.List[str]:
+        logger.debug(
+            f"Fetching {json.dumps(hide_sensitive_fields(doc_batch.to_dict()))} "
+            f"- PID: {os.getpid()}"
+        )
         if self.retry_strategy:
             self.retry_strategy(doc_batch.get_files)
         else:

--- a/unstructured/ingest/utils/logging.py
+++ b/unstructured/ingest/utils/logging.py
@@ -1,0 +1,29 @@
+import json
+
+
+def hide_sensitive_fields(data: dict) -> dict:
+    sensitive_fields = [
+        "account_name",
+        "client_id",
+    ]
+    sensitive_triggers = ["key", "cred", "token"]
+    new_data = data.copy()
+    for k, v in new_data.items():
+        if (
+            v
+            and any([s in k.lower() for s in sensitive_triggers])  # noqa: C419
+            or k.lower() in sensitive_fields
+        ):
+            new_data[k] = "*******"
+        if isinstance(v, dict):
+            new_data[k] = hide_sensitive_fields(v)
+        if isinstance(v, str):
+            try:
+                json_data = json.loads(v)
+                if isinstance(json_data, dict):
+                    updated_data = hide_sensitive_fields(json_data)
+                    new_data[k] = json.dumps(updated_data)
+            except json.JSONDecodeError:
+                pass
+
+    return new_data


### PR DESCRIPTION
### Description
Create a more robust way to hide sensitive data when logging fields:
* If any of the following strings exist in the key name, omit the value: `["key", "cred", "token"]`
* If the key equals any of the following, omit: `["account_name", "client_id"]`
* If the value itself is a dictionary, run it through the method as well to omit any nested sensitive fields
* If the value is a string that can be converted into json, to the same as above and return the value as a string again