### PR TITLE
fix: image may be scaled too large for tesseract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixes
 
+* **Fix a bug where image can be scaled too large for tesseract** Adds a limit to prevent auto-scaling an image beyond the maximum size `tesseract` can handle for ocr layout detection
+
 ## 0.11.3
 
 ### Enhancements

--- a/test_unstructured/partition/pdf_image/test_ocr.py
+++ b/test_unstructured/partition/pdf_image/test_ocr.py
@@ -468,3 +468,28 @@ def test_get_table_tokens(mock_ocr_layout):
         ]
 
         assert table_tokens == expected_tokens
+
+
+def test_auto_zoom_not_exceed_tesseract_limit(monkeypatch):
+    monkeypatch.setenv("TESSERACT_MIN_TEXT_HEIGHT", "1000")
+    monkeypatch.setenv("TESSERACT_OPTIMUM_TEXT_HEIGHT", "100000")
+    monkeypatch.setattr(
+        unstructured_pytesseract,
+        "image_to_data",
+        lambda *args, **kwargs: pd.DataFrame(
+            {
+                "left": [10, 20, 30, 0],
+                "top": [5, 15, 25, 0],
+                "width": [15, 25, 35, 0],
+                "height": [10, 20, 30, 0],
+                "text": ["Hello", "World", "!", ""],
+            },
+        ),
+    )
+
+    image = Image.new("RGB", (1000, 1000))
+    assert [region.text for region in ocr.get_ocr_layout_tesseract(image)] == [
+        "Hello",
+        "World",
+        "!",
+    ]

--- a/test_unstructured/partition/pdf_image/test_ocr.py
+++ b/test_unstructured/partition/pdf_image/test_ocr.py
@@ -488,6 +488,7 @@ def test_auto_zoom_not_exceed_tesseract_limit(monkeypatch):
     )
 
     image = Image.new("RGB", (1000, 1000))
+    # tests that the code can run instead of oom and OCR results make sense
     assert [region.text for region in ocr.get_ocr_layout_tesseract(image)] == [
         "Hello",
         "World",

--- a/unstructured/partition/pdf_image/ocr.py
+++ b/unstructured/partition/pdf_image/ocr.py
@@ -26,6 +26,7 @@ from unstructured.documents.elements import ElementType
 from unstructured.logger import logger
 from unstructured.partition.utils.config import env_config
 from unstructured.partition.utils.constants import (
+    IMAGE_COLOR_DEPTH,
     OCR_AGENT_PADDLE,
     OCR_AGENT_TESSERACT,
     SUBREGION_THRESHOLD_FOR_OCR,
@@ -460,7 +461,9 @@ def get_ocr_layout_tesseract(
         text_height < env_config.TESSERACT_MIN_TEXT_HEIGHT
         or text_height > env_config.TESSERACT_MAX_TEXT_HEIGHT
     ):
-        max_zoom = max(0, np.round(np.sqrt(TESSERACT_MAX_SIZE / np.prod(image.size) / 32), 1))
+        max_zoom = max(
+            0, np.round(np.sqrt(TESSERACT_MAX_SIZE / np.prod(image.size) / IMAGE_COLOR_DEPTH), 1)
+        )
         # rounding avoids unnecessary precision and potential numerical issues associated
         # with numbers very close to 1 inside cv2 image processing
         zoom = min(

--- a/unstructured/partition/pdf_image/ocr.py
+++ b/unstructured/partition/pdf_image/ocr.py
@@ -29,6 +29,7 @@ from unstructured.partition.utils.constants import (
     OCR_AGENT_PADDLE,
     OCR_AGENT_TESSERACT,
     SUBREGION_THRESHOLD_FOR_OCR,
+    TESSERACT_MAX_SIZE,
     TESSERACT_TEXT_HEIGHT,
     OCRMode,
     Source,
@@ -459,9 +460,13 @@ def get_ocr_layout_tesseract(
         text_height < env_config.TESSERACT_MIN_TEXT_HEIGHT
         or text_height > env_config.TESSERACT_MAX_TEXT_HEIGHT
     ):
+        max_zoom = max(0, np.round(np.sqrt(TESSERACT_MAX_SIZE / np.prod(image.size) / 32), 1))
         # rounding avoids unnecessary precision and potential numerical issues associated
         # with numbers very close to 1 inside cv2 image processing
-        zoom = np.round(env_config.TESSERACT_OPTIMUM_TEXT_HEIGHT / text_height, 1)
+        zoom = min(
+            np.round(env_config.TESSERACT_OPTIMUM_TEXT_HEIGHT / text_height, 1),
+            max_zoom,
+        )
         ocr_df = unstructured_pytesseract.image_to_data(
             np.array(zoom_image(image, zoom)),
             lang=ocr_languages,

--- a/unstructured/partition/utils/constants.py
+++ b/unstructured/partition/utils/constants.py
@@ -38,3 +38,6 @@ DEFAULT_PADDLE_LANG = os.getenv("DEFAULT_PADDLE_LANG", "en")
 TESSERACT_TEXT_HEIGHT = "height"
 
 TESSERACT_LANGUAGES_SPLITTER = "+"
+
+# 2 ** 31 - 1, max byte size for image data
+TESSERACT_MAX_SIZE = 2147483647

--- a/unstructured/partition/utils/constants.py
+++ b/unstructured/partition/utils/constants.py
@@ -41,3 +41,6 @@ TESSERACT_LANGUAGES_SPLITTER = "+"
 
 # 2 ** 31 - 1, max byte size for image data
 TESSERACT_MAX_SIZE = 2147483647
+
+# default image colors
+IMAGE_COLOR_DEPTH = 32


### PR DESCRIPTION
This PR addresses [CORE-2965](https://unstructured-ai.atlassian.net/browse/CORE-2965) by limiting zoom factor so that the scaled image can still be processed by tesseract.

- tesseract has a 2^31 byte limit on image data
- occasionally an image may be scaled too much and larger than that size
- fix limits the scaling factor so that we never scale an image larger than what tesseract can handle

## test

A unit test is added in this PR to test a unlikely case where we'd scale an image a few thousand times and massively exceed the limit without the fix. 

Unstructured reviewers can also use the document in the ticket to test.


[CORE-2965]: https://unstructured-ai.atlassian.net/browse/CORE-2965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ