### PR TITLE
fix: package download dir

### DIFF
--- a/unstructured/nlp/tokenize.py
+++ b/unstructured/nlp/tokenize.py
@@ -1,4 +1,5 @@
 import sys
+from os import environ
 from functools import lru_cache
 from typing import List, Tuple
 
@@ -17,10 +18,11 @@ CACHE_MAX_SIZE: Final[int] = 128
 
 def _download_nltk_package_if_not_present(package_name: str, package_category: str):
     """If the required nlt package is not present, download it."""
+    download_dir = environ.get("NLTK_DATA") or None
     try:
         nltk.find(f"{package_category}/{package_name}")
     except LookupError:
-        nltk.download(package_name)
+        nltk.download(package_name, download_dir)
 
 
 @lru_cache(maxsize=CACHE_MAX_SIZE)


### PR DESCRIPTION
`nltk` package provide an environnement variable to change the download [path](https://github.com/nltk/nltk/blob/d7b428daa90b41edc5adaf92755cab7aec7f5df2/nltk/data.py#L71)
this is useful for AWS Lambda who is read-only instead of `/tmp` [directory](https://docs.aws.amazon.com/lambda/latest/dg/API_EphemeralStorage.html)