### PR TITLE
rfctr(chunking): move add_chunking_strategy() decorator up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.4-dev13
+## 0.11.4-dev14
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.4-dev13"  # pragma: no cover
+__version__ = "0.11.4-dev14"  # pragma: no cover

--- a/unstructured/chunking/__init__.py
+++ b/unstructured/chunking/__init__.py
@@ -1,0 +1,70 @@
+"""Chunking module initializer.
+
+Provides the the `@add_chunking_strategy()` decorator.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable, Dict, List
+
+from typing_extensions import ParamSpec
+
+from unstructured.chunking.title import chunk_by_title
+from unstructured.documents.elements import Element
+
+_P = ParamSpec("_P")
+
+
+def add_chunking_strategy() -> Callable[[Callable[_P, List[Element]]], Callable[_P, List[Element]]]:
+    """Decorator for chunking text.
+
+    Chunks the element sequence produced by the partitioner it decorates when a `chunking_strategy`
+    argument is present in the partitioner call and it names an available chunking strategy.
+    """
+
+    def decorator(func: Callable[_P, List[Element]]) -> Callable[_P, List[Element]]:
+        if func.__doc__ and (
+            "chunking_strategy" in func.__code__.co_varnames
+            and "chunking_strategy" not in func.__doc__
+        ):
+            func.__doc__ += (
+                "\nchunking_strategy"
+                + "\n\tStrategy used for chunking text into larger or smaller elements."
+                + "\n\tDefaults to `None` with optional arg of 'by_title'."
+                + "\n\tAdditional Parameters:"
+                + "\n\t\tmultipage_sections"
+                + "\n\t\t\tIf True, sections can span multiple pages. Defaults to True."
+                + "\n\t\tcombine_text_under_n_chars"
+                + "\n\t\t\tCombines elements (for example a series of titles) until a section"
+                + "\n\t\t\treaches a length of n characters."
+                + "\n\t\tnew_after_n_chars"
+                + "\n\t\t\tCuts off new sections once they reach a length of n characters"
+                + "\n\t\t\ta soft max."
+                + "\n\t\tmax_characters"
+                + "\n\t\t\tChunks elements text and text_as_html (if present) into chunks"
+                + "\n\t\t\tof length n characters, a hard max."
+            )
+
+        @functools.wraps(func)
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> List[Element]:
+            elements = func(*args, **kwargs)
+            sig = inspect.signature(func)
+            params: Dict[str, Any] = dict(**dict(zip(sig.parameters, args)), **kwargs)
+            for param in sig.parameters.values():
+                if param.name not in params and param.default is not param.empty:
+                    params[param.name] = param.default
+            if params.get("chunking_strategy") == "by_title":
+                elements = chunk_by_title(
+                    elements,
+                    multipage_sections=params.get("multipage_sections", True),
+                    combine_text_under_n_chars=params.get("combine_text_under_n_chars", 500),
+                    new_after_n_chars=params.get("new_after_n_chars", 500),
+                    max_characters=params.get("max_characters", 500),
+                )
+            return elements
+
+        return wrapper
+
+    return decorator

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -5,7 +5,7 @@ from typing import IO, BinaryIO, List, Optional, Union, cast
 import pandas as pd
 from lxml.html.soupparser import fromstring as soupparser_fromstring
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import (
     Element,
     ElementMetadata,

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from typing import IO, Any, List, Optional
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.common import (

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -37,7 +37,7 @@ from docx.text.run import Run
 from tabulate import tabulate
 from typing_extensions import TypeAlias
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.cleaners.core import clean_bullets
 from unstructured.documents.elements import (
     Address,

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -27,7 +27,7 @@ if sys.version_info < (3, 8):
 else:
     from typing import Final
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.cleaners.core import clean_extra_whitespace, replace_mime_encodings
 from unstructured.cleaners.extract import (
     extract_datetimetz,

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -1,6 +1,6 @@
 from typing import IO, List, Optional
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.html import convert_and_partition_html

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -2,7 +2,7 @@ from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional
 
 import requests
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.documents.html import HTMLDocument
 from unstructured.documents.xml import VALID_PARSERS

--- a/unstructured/partition/md.py
+++ b/unstructured/partition/md.py
@@ -3,7 +3,7 @@ from typing import IO, List, Optional, Union
 import markdown
 import requests
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.documents.xml import VALID_PARSERS
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype

--- a/unstructured/partition/msg.py
+++ b/unstructured/partition/msg.py
@@ -4,7 +4,7 @@ from typing import IO, Callable, Dict, List, Optional
 
 import msg_parser
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, ElementMetadata, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.logger import logger

--- a/unstructured/partition/odt.py
+++ b/unstructured/partition/odt.py
@@ -1,6 +1,6 @@
 from typing import Any, BinaryIO, List, Optional
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.common import (

--- a/unstructured/partition/org.py
+++ b/unstructured/partition/org.py
@@ -1,6 +1,6 @@
 from typing import IO, List, Optional
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.html import convert_and_partition_html

--- a/unstructured/partition/pdf_image/image.py
+++ b/unstructured/partition/pdf_image/image.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import add_metadata
 from unstructured.logger import logger

--- a/unstructured/partition/pdf_image/pdf.py
+++ b/unstructured/partition/pdf_image/pdf.py
@@ -34,7 +34,7 @@ from pdfminer.pdftypes import PDFObjRef
 from pdfminer.utils import open_filename
 from PIL import Image as PILImage
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.cleaners.core import (
     clean_extra_whitespace_with_index_run,
     index_adjustment_after_clean_extra_whitespace,

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from typing import IO, List, Optional
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.common import (

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -14,7 +14,7 @@ from pptx.shapes.shapetree import _BaseGroupShapes  # pyright: ignore [reportPri
 from pptx.slide import Slide
 from pptx.text.text import _Paragraph  # pyright: ignore [reportPrivateUsage]
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import (
     Element,
     ElementMetadata,

--- a/unstructured/partition/rst.py
+++ b/unstructured/partition/rst.py
@@ -1,6 +1,6 @@
 from typing import IO, List, Optional
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.html import convert_and_partition_html

--- a/unstructured/partition/rtf.py
+++ b/unstructured/partition/rtf.py
@@ -1,6 +1,6 @@
 from typing import IO, List, Optional
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.html import convert_and_partition_html

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -3,7 +3,7 @@ import re
 import textwrap
 from typing import IO, Any, Callable, List, Optional, Tuple
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.cleaners.core import (
     auto_paragraph_grouper,
     clean_bullets,

--- a/unstructured/partition/xlsx.py
+++ b/unstructured/partition/xlsx.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from lxml.html.soupparser import fromstring as soupparser_fromstring
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.cleaners.core import clean_bullets
 from unstructured.documents.elements import (
     Element,

--- a/unstructured/partition/xml.py
+++ b/unstructured/partition/xml.py
@@ -5,7 +5,7 @@ from typing import IO, BinaryIO, Iterator, List, Optional, Union, cast
 
 from lxml import etree
 
-from unstructured.chunking.title import add_chunking_strategy
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import (
     Element,
     ElementMetadata,


### PR DESCRIPTION
The chunking subpackage `unstructured.chunking` currently contains only the `title` module and the `@add_chunking_strategy()` decorator is located in that module even though it has no special relationship to the `by_title` chunking strategy.

Move it to the `__init__.py` module such that it is exported from `unstructured.chunking`. Adjust all references, pretty much one per partitioner, to import it from there.

This prepares the way for further separation of the chunking package into modules, including a new `character` module for the `by_character` chunking strategy.