### PR TITLE
rfctr: extract ChunkingOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.11.5-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
 ## 0.11.4
 
 ### Enhancements

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -1,0 +1,113 @@
+"""Unit-test suite for the `unstructured.chunking.base` module."""
+
+from __future__ import annotations
+
+import pytest
+
+from unstructured.chunking.base import ChunkingOptions
+
+
+class DescribeChunkingOptions:
+    """Unit-test suite for `unstructured.chunking.model.ChunkingOptions objects."""
+
+    @pytest.mark.parametrize("max_characters", [0, -1, -42])
+    def it_rejects_max_characters_not_greater_than_zero(self, max_characters: int):
+        with pytest.raises(
+            ValueError,
+            match=f"'max_characters' argument must be > 0, got {max_characters}",
+        ):
+            ChunkingOptions.new(max_characters=max_characters)
+
+    def it_does_not_complain_when_specifying_max_characters_by_itself(self):
+        """Caller can specify `max_characters` arg without specifying any others.
+
+        In particular, When `combine_text_under_n_chars` is not specified it defaults to the value
+        of `max_characters`; it has no fixed default value that can be greater than `max_characters`
+        and trigger an exception.
+        """
+        try:
+            ChunkingOptions.new(max_characters=50)
+        except ValueError:
+            pytest.fail("did not accept `max_characters` as option by itself")
+
+    @pytest.mark.parametrize("n_chars", [-1, -42])
+    def it_rejects_combine_text_under_n_chars_for_n_less_than_zero(self, n_chars: int):
+        with pytest.raises(
+            ValueError,
+            match=f"'combine_text_under_n_chars' argument must be >= 0, got {n_chars}",
+        ):
+            ChunkingOptions.new(combine_text_under_n_chars=n_chars)
+
+    def it_accepts_0_for_combine_text_under_n_chars_to_disable_chunk_combining(self):
+        """Specifying `combine_text_under_n_chars=0` is how a caller disables chunk-combining."""
+        opts = ChunkingOptions.new(combine_text_under_n_chars=0)
+        assert opts.combine_text_under_n_chars == 0
+
+    def it_does_not_complain_when_specifying_combine_text_under_n_chars_by_itself(self):
+        """Caller can specify `combine_text_under_n_chars` arg without specifying other options."""
+        try:
+            opts = ChunkingOptions.new(combine_text_under_n_chars=50)
+        except ValueError:
+            pytest.fail("did not accept `combine_text_under_n_chars` as option by itself")
+
+        assert opts.combine_text_under_n_chars == 50
+
+    def it_silently_accepts_combine_text_under_n_chars_greater_than_maxchars(self):
+        """`combine_text_under_n_chars` > `max_characters` doesn't affect chunking behavior.
+
+        So rather than raising an exception or warning, we just cap that value at `max_characters`
+        which is the behavioral equivalent.
+        """
+        try:
+            opts = ChunkingOptions.new(max_characters=500, combine_text_under_n_chars=600)
+        except ValueError:
+            pytest.fail("did not accept `combine_text_under_n_chars` greater than `max_characters`")
+
+        assert opts.combine_text_under_n_chars == 500
+
+    @pytest.mark.parametrize("n_chars", [-1, -42])
+    def it_rejects_new_after_n_chars_for_n_less_than_zero(self, n_chars: int):
+        with pytest.raises(
+            ValueError,
+            match=f"'new_after_n_chars' argument must be >= 0, got {n_chars}",
+        ):
+            ChunkingOptions.new(new_after_n_chars=n_chars)
+
+    def it_does_not_complain_when_specifying_new_after_n_chars_by_itself(self):
+        """Caller can specify `new_after_n_chars` arg without specifying any other options.
+
+        In particular, `combine_text_under_n_chars` value is adjusted down to the
+        `new_after_n_chars` value when the default for `combine_text_under_n_chars` exceeds the
+        value of `new_after_n_chars`.
+        """
+        try:
+            opts = ChunkingOptions.new(new_after_n_chars=200)
+        except ValueError:
+            pytest.fail("did not accept `new_after_n_chars` as option by itself")
+
+        assert opts.soft_max == 200
+        assert opts.combine_text_under_n_chars == 200
+
+    def it_accepts_0_for_new_after_n_chars_to_put_each_element_into_its_own_chunk(self):
+        """Specifying `new_after_n_chars=0` places each element into its own pre-chunk.
+
+        This puts each element into its own chunk, although long chunks are still split.
+        """
+        opts = ChunkingOptions.new(new_after_n_chars=0)
+        assert opts.soft_max == 0
+
+    def it_silently_accepts_new_after_n_chars_greater_than_maxchars(self):
+        """`new_after_n_chars` > `max_characters` doesn't affect chunking behavior.
+
+        So rather than raising an exception or warning, we just cap that value at `max_characters`
+        which is the behavioral equivalent.
+        """
+        try:
+            opts = ChunkingOptions.new(max_characters=444, new_after_n_chars=555)
+        except ValueError:
+            pytest.fail("did not accept `new_after_n_chars` greater than `max_characters`")
+
+        assert opts.soft_max == 444
+
+    def it_knows_the_text_separator_string(self):
+        assert ChunkingOptions.new().text_separator == "\n\n"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.4"  # pragma: no cover
+__version__ = "0.11.5-dev0"  # pragma: no cover

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -1,0 +1,152 @@
+"""Chunking objects not specific to a particular chunking strategy."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from typing_extensions import Self
+
+from unstructured.utils import lazyproperty
+
+
+class ChunkingOptions:
+    """Specifies parameters of optional chunking behaviors."""
+
+    def __init__(
+        self,
+        combine_text_under_n_chars: Optional[int] = None,
+        max_characters: int = 500,
+        multipage_sections: bool = True,
+        new_after_n_chars: Optional[int] = None,
+        overlap: int = 0,
+    ):
+        self._combine_text_under_n_chars_arg = combine_text_under_n_chars
+        self._max_characters = max_characters
+        self._multipage_sections = multipage_sections
+        self._new_after_n_chars_arg = new_after_n_chars
+        self._overlap = overlap
+
+    @classmethod
+    def new(
+        cls,
+        combine_text_under_n_chars: Optional[int] = None,
+        max_characters: int = 500,
+        multipage_sections: bool = True,
+        new_after_n_chars: Optional[int] = None,
+        overlap: int = 0,
+    ) -> Self:
+        """Construct validated instance.
+
+        Raises `ValueError` on invalid arguments like overlap > max_chars.
+        """
+        self = cls(
+            combine_text_under_n_chars,
+            max_characters,
+            multipage_sections,
+            new_after_n_chars,
+            overlap,
+        )
+        self._validate()
+        return self
+
+    @lazyproperty
+    def combine_text_under_n_chars(self) -> int:
+        """Combine consecutive text pre-chunks if former is smaller than this and both will fit.
+
+        - Does not combine table chunks with text chunks even if they would both fit in the
+          chunking window.
+        - Does not combine text chunks if together they would exceed the chunking window.
+        - Defaults to `max_characters` when not specified.
+        - Is reduced to `new_after_n_chars` when it exceeds that value.
+        """
+        max_characters = self._max_characters
+        soft_max = self.soft_max
+        arg = self._combine_text_under_n_chars_arg
+
+        # -- `combine_text_under_n_chars` defaults to `max_characters` when not specified and is
+        # -- capped at max-chars
+        combine_text_under_n_chars = max_characters if arg is None or arg > max_characters else arg
+
+        # -- `new_after_n_chars` takes precendence on conflict with `combine_text_under_n_chars` --
+        return soft_max if combine_text_under_n_chars > soft_max else combine_text_under_n_chars
+
+    @lazyproperty
+    def hard_max(self) -> int:
+        """The maximum size for a chunk.
+
+        A pre-chunk will only exceed this size when it contains exactly one element which by itself
+        exceeds this size. Such a pre-chunk is subject to mid-text splitting later in the chunking
+        process.
+        """
+        return self._max_characters
+
+    @lazyproperty
+    def multipage_sections(self) -> bool:
+        """When False, break pre-chunks on page-boundaries."""
+        return self._multipage_sections
+
+    @lazyproperty
+    def overlap(self) -> int:
+        """The number of characters to overlap text when splitting chunks mid-text.
+
+        The actual overlap will not exceed this number of characters but may be less as required to
+        respect splitting-character boundaries.
+        """
+        return self._overlap
+
+    @lazyproperty
+    def soft_max(self) -> int:
+        """A pre-chunk of this size or greater is considered full.
+
+        ??? Is a value of 0 valid? It would produce the behavior: "put each element into its own
+        chunk".
+        """
+        max_chars = self._max_characters
+        new_after_n_chars = self._new_after_n_chars_arg
+        return (
+            max_chars
+            if (new_after_n_chars is None or new_after_n_chars < 0 or new_after_n_chars > max_chars)
+            else new_after_n_chars
+        )
+
+    @lazyproperty
+    def text_separator(self) -> str:
+        """The string to insert between elements when concatenating their text for a chunk.
+
+        Right now this is just "\n\n" (a blank line in plain text), but having this here rather
+        than as a module-level constant provides a way for us to easily make it user-configurable
+        in future if we want to.
+        """
+        return "\n\n"
+
+    def _validate(self) -> None:
+        """Raise ValueError if requestion option-set is invalid."""
+        max_characters = self._max_characters
+        # -- chunking window must have positive length --
+        if max_characters <= 0:
+            raise ValueError(f"'max_characters' argument must be > 0," f" got {max_characters}")
+
+        # -- `combine_text_under_n_chars == 0` is valid (suppresses chunk combination)
+        # -- but a negative value is not
+        combine_text_under_n_chars = self._combine_text_under_n_chars_arg
+        if combine_text_under_n_chars is not None and combine_text_under_n_chars < 0:
+            raise ValueError(
+                f"'combine_text_under_n_chars' argument must be >= 0,"
+                f" got {combine_text_under_n_chars}"
+            )
+
+        # -- a negative value for `new_after_n_chars` is assumed to
+        # -- be a mistake the caller will want to know about
+        new_after_n_chars = self._new_after_n_chars_arg
+        if new_after_n_chars is not None and new_after_n_chars < 0:
+            raise ValueError(
+                f"'new_after_n_chars' argument must be >= 0," f" got {new_after_n_chars}"
+            )
+
+        # -- overlap must be less than max-chars or the chunk text will
+        # -- never be consumed
+        # TODO: consider a heuristic like never overlap more than half,
+        # otherwise there could be corner cases leading to an infinite
+        # loop (I think).
+        if self._overlap >= max_characters:
+            raise ValueError(f"'overlap' must be less than max_characters," f" got {self._overlap}")


### PR DESCRIPTION
Chunking options for things like chunk-size are largely independent of chunking strategy. Further, validating the args and applying defaults based on call arguments is sophisticated to make its use easy for the caller. These details distract from what the chunker is actually doing and would need to be repeated for every chunking strategy if left where they are.

Extract these settings and the rules governing chunking behavior based on options into its own immutable object that can be passed to any component that is subject to optional behavior (pretty much all of them).