### PR TITLE
build: release commit for 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.4-dev14
+## 0.11.4
 
 ### Enhancements
 
@@ -21,7 +21,7 @@
 * **Update partition_csv to handle different delimiters** CSV files containing both non-comma delimiters and commas in the data were throwing an error in Pandas. `partition_csv` now identifies the correct delimiter before the file is processed.
 * **partition returning cid code in `hi_res`** occasionally pdfminer can fail to decode the text in an pdf file and return cid code as text. Now when this happens the text from OCR is used.
 
-## 0.11.3
+## 0.11.2
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.4-dev14"  # pragma: no cover
+__version__ = "0.11.4"  # pragma: no cover


### PR DESCRIPTION
also cleans up the CHANGELOG to reflect the previous release of 0.11.2