### PR TITLE
rfctr(chunking): extract BasePreChunker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.6-dev3
+## 0.11.6-dev4
 
 ### Enhancements
 

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -5,7 +5,7 @@ from typing import List
 import pytest
 
 from unstructured.chunking.base import ChunkingOptions, TablePreChunk, TextPreChunk
-from unstructured.chunking.title import _split_elements_by_title_and_table, chunk_by_title
+from unstructured.chunking.title import _ByTitlePreChunker, chunk_by_title
 from unstructured.documents.coordinates import CoordinateSystem
 from unstructured.documents.elements import (
     CheckBox,
@@ -55,7 +55,7 @@ def test_split_elements_by_title_and_table():
         CheckBox(),
     ]
 
-    pre_chunks = _split_elements_by_title_and_table(elements, opts=ChunkingOptions.new())
+    pre_chunks = _ByTitlePreChunker.iter_pre_chunks(elements, opts=ChunkingOptions.new())
 
     pre_chunk = next(pre_chunks)
     assert isinstance(pre_chunk, TextPreChunk)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.6-dev3"  # pragma: no cover
+__version__ = "0.11.6-dev4"  # pragma: no cover


### PR DESCRIPTION
The `_split_elements_by_title_and_table()` function fulfills the pre-chunker role for `chunk_by_title()`, but most of its operation is not strategy-specific and can be reused by other chunking strategies.

Extract `BasePreChunker` and use it as the base class for `_ByTitlePreChunker` which now only needs to provide the boundary predicates specific to that strategy.