### PR TITLE
docs: reference max_characters param in chunking documentation

### DIFF
--- a/docs/source/core/chunking.rst
+++ b/docs/source/core/chunking.rst
@@ -15,6 +15,7 @@ for the presence of titles. When a title is detected, a new section is created.
 Tables and non-text elements (such as page breaks or images) are always their
 own section.
 
+Chunks have a set maximum length of ``max_characters``, which defaults to ``500``.
 New sections are also created if changes in metadata occure. Examples of when
 this occurs include when the section of the document or the page number changes
 or when an element comes from an attachment instead of from the main document.


### PR DESCRIPTION
Like other users in the past (e.g #1856), i had the issue of documents being split by the chunk_by_title function in a seemingly random way. This was do to the max_characters kwarg, which is currently not referenced in the documentation.

This PR should help avoid confusion in the future.