### PR TITLE
feat(chunking): add overlap on chunk-splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.11.7-dev0
+## 0.11.7-dev1
 
 ### Enhancements
+
+* **Add intra-chunk overlap capability.** Implement overlap for split-chunks where text-splitting is used to divide an oversized chunk into two or more chunks that fit in the chunking window. Note this capability is not yet available from the API but will shortly be made accessible using a new `overlap` kwarg on partition functions.
 
 ### Features
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 license_files = LICENSE.md
 
 [flake8]
+ignore = E203,W503
 max-line-length = 100
 exclude =
     .venv

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.7-dev0"  # pragma: no cover
+__version__ = "0.11.7-dev1"  # pragma: no cover


### PR DESCRIPTION
There are two distinct overlap operations with completely different implementations. This is "intra-chunk" overlap, applying overlap to chunks resulting from text-splitting an oversized element.

So if an oversized element had text "abcd efgh ijkl mnop qrst" and was split at 15 chars with overlap of 5, it would produce "abcd efgh ijkl" and "ijkl mnop qrst". Any inter-chunk overlap from the prior chunk and applied at the beginning of the string (before "abcd") is handled in a separate operation in the next PR.