### PR TITLE
feat(chunking): add inter-chunk overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.9-dev2
+## 0.11.9-dev3
 
 ### Enhancements
 
@@ -17,6 +17,7 @@
 ### Enhancements
 
 * **Add SaaS API User Guide.** This documentation serves as a guide for Unstructured SaaS API users to register, receive an API key and URL, and manage your account and billing information.
+* **Add inter-chunk overlap capability.** Implement overlap between chunks. This applies to all chunks prior to any text-splitting of oversized chunks so is a distinct behavior; overlap at text-splits of oversized chunks is independent of inter-chunk overlap (distinct chunk boundaries) and can be requested separately. Note this capability is not yet available from the API but will shortly be made accessible using a new `overlap_all` kwarg on partition functions.
 
 ### Features
 

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -141,6 +141,15 @@ class DescribeChunkingOptions:
 
         assert opts.soft_max == 444
 
+    def it_knows_how_much_overlap_to_apply_to_split_chunks(self):
+        assert ChunkingOptions.new(overlap=10).overlap == 10
+
+    def and_it_uses_the_same_value_for_inter_chunk_overlap_when_asked_to_overlap_all_chunks(self):
+        assert ChunkingOptions.new(overlap=10, overlap_all=True).inter_chunk_overlap == 10
+
+    def but_it_does_not_overlap_pre_chunks_by_default(self):
+        assert ChunkingOptions.new(overlap=10).inter_chunk_overlap == 0
+
     def it_knows_the_text_separator_string(self):
         assert ChunkingOptions.new().text_separator == "\n\n"
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.9-dev2"  # pragma: no cover
+__version__ = "0.11.9-dev3"  # pragma: no cover

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -94,6 +94,7 @@ class ChunkingOptions:
         multipage_sections: bool = True,
         new_after_n_chars: Optional[int] = None,
         overlap: int = 0,
+        overlap_all: bool = False,
         text_splitting_separators: Sequence[str] = (),
     ):
         self._combine_text_under_n_chars_arg = combine_text_under_n_chars
@@ -101,6 +102,7 @@ class ChunkingOptions:
         self._multipage_sections = multipage_sections
         self._new_after_n_chars_arg = new_after_n_chars
         self._overlap = overlap
+        self._overlap_all = overlap_all
         self._text_splitting_separators = text_splitting_separators
 
     @classmethod
@@ -111,6 +113,7 @@ class ChunkingOptions:
         multipage_sections: bool = True,
         new_after_n_chars: Optional[int] = None,
         overlap: int = 0,
+        overlap_all: bool = False,
         text_splitting_separators: Sequence[str] = (),
     ) -> Self:
         """Construct validated instance.
@@ -123,6 +126,7 @@ class ChunkingOptions:
             multipage_sections,
             new_after_n_chars,
             overlap,
+            overlap_all,
             text_splitting_separators,
         )
         self._validate()
@@ -158,6 +162,15 @@ class ChunkingOptions:
         process.
         """
         return self._max_characters
+
+    @lazyproperty
+    def inter_chunk_overlap(self) -> int:
+        """Characters of overlap to add between chunks.
+
+        This applies only to boundaries between chunks formed from whole elements and not to
+        text-splitting boundaries that arise from splitting an oversized element.
+        """
+        return self.overlap if self._overlap_all else 0
 
     @lazyproperty
     def multipage_sections(self) -> bool:


### PR DESCRIPTION
Reviewer: This PR probably reviews faster commit-by-commit. Each of the commits is groomed and focuses on a separate clear aspect of this implementation.

This  PR adds inter-chunk overlap capability to chunking. It does not yet expose it via the API.

Inter-chunk overlap is overlap between whole pre-chunks, prior to any text-splitting required for oversized chunks. Contrast with intra-chunk overlap implemented in the prior PR which implements overlap on these latter text-splitting boundaries.

Inter-chunk overlap is disabled by default since a pre-chunk already has a "clean" semantic boundary (composed of whole elements) and adding overlap there introduces noise from the adjacent context. If the user wants inter-chunk overlap they must specify `overlap_all=True` in the options. Inter-chunk overlap uses the same `overlap` length value used by intra-chunk overlap and does not overlap when that value is 0.