### PR TITLE
feat: update encoders to be dataclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.7-dev0
+## 0.11.7-dev1
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.7-dev0"  # pragma: no cover
+__version__ = "0.11.7-dev1"  # pragma: no cover

--- a/unstructured/embed/bedrock.py
+++ b/unstructured/embed/bedrock.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List
 
 import numpy as np
@@ -10,16 +11,13 @@ from unstructured.ingest.error import EmbeddingEncoderConnectionError
 from unstructured.utils import requires_dependencies
 
 
+@dataclass
 class BedrockEmbeddingEncoder(BaseEmbeddingEncoder):
-    def __init__(
-        self,
-        aws_access_key_id: str,
-        aws_secret_access_key: str,
-        region_name: str = "us-west-2",
-    ):
-        self.aws_access_key_id = aws_access_key_id
-        self.aws_secret_access_key = aws_secret_access_key
-        self.region_name = region_name
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    region_name: str = "us-west-2"
+
+    def __post_init__(self):
         self.initialize()
 
     def initialize(self):

--- a/unstructured/embed/huggingface.py
+++ b/unstructured/embed/huggingface.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 import numpy as np
@@ -10,19 +11,14 @@ from unstructured.ingest.error import EmbeddingEncoderConnectionError
 from unstructured.utils import requires_dependencies
 
 
+@dataclass
 class HuggingFaceEmbeddingEncoder(BaseEmbeddingEncoder):
-    def __init__(
-        self,
-        model_name: Optional[str] = "sentence-transformers/all-MiniLM-L6-v2",
-        model_kwargs: Optional[dict] = {"device": "cpu"},
-        encode_kwargs: Optional[dict] = {"normalize_embeddings": False},
-        cache_folder: Optional[dict] = None,
-    ):
-        self.model_name = model_name
-        self.model_kwargs = model_kwargs
-        self.encode_kwargs = encode_kwargs
-        self.cache_folder = cache_folder
+    model_name: Optional[str] = ("sentence-transformers/all-MiniLM-L6-v2",)
+    model_kwargs: Optional[dict] = field(default_factory=lambda: {"device": "cpu"})
+    encode_kwargs: Optional[dict] = field(default_factory=lambda: {"normalize_embeddings": False})
+    cache_folder: Optional[dict] = None
 
+    def __post_init__(self):
         self.initialize()
 
     def initialize(self):

--- a/unstructured/embed/huggingface.py
+++ b/unstructured/embed/huggingface.py
@@ -13,7 +13,7 @@ from unstructured.utils import requires_dependencies
 
 @dataclass
 class HuggingFaceEmbeddingEncoder(BaseEmbeddingEncoder):
-    model_name: Optional[str] = ("sentence-transformers/all-MiniLM-L6-v2",)
+    model_name: Optional[str] = "sentence-transformers/all-MiniLM-L6-v2"
     model_kwargs: Optional[dict] = field(default_factory=lambda: {"device": "cpu"})
     encode_kwargs: Optional[dict] = field(default_factory=lambda: {"normalize_embeddings": False})
     cache_folder: Optional[dict] = None

--- a/unstructured/embed/interfaces.py
+++ b/unstructured/embed/interfaces.py
@@ -1,10 +1,14 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import List, Tuple
+
+from dataclasses_json import DataClassJsonMixin
 
 from unstructured.documents.elements import Element
 
 
-class BaseEmbeddingEncoder(ABC):
+@dataclass
+class BaseEmbeddingEncoder(DataClassJsonMixin, ABC):
     @abstractmethod
     def initialize(self):
         """Initializes the embedding encoder class. Should also validate the instance

--- a/unstructured/embed/openai.py
+++ b/unstructured/embed/openai.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List
 
 import numpy as np
@@ -10,10 +11,12 @@ from unstructured.ingest.error import EmbeddingEncoderConnectionError
 from unstructured.utils import requires_dependencies
 
 
+@dataclass
 class OpenAIEmbeddingEncoder(BaseEmbeddingEncoder):
-    def __init__(self, api_key: str, model_name: str = "text-embedding-ada-002"):
-        self.api_key = api_key
-        self.model_name = model_name
+    api_key: str
+    model_name: str = "text-embedding-ada-002"
+
+    def __post_init__(self):
         self.initialize()
 
     def initialize(self):


### PR DESCRIPTION
### Description
Convert all encoders to be based off dataclasses. Purpose: this will allow encoders to be used in a generic way amongst other  dataclasses. Otherwise, it'll break validation in those parent dataclasses. 