### PR TITLE
feat: improve dataclass use for encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 * **Add intra-chunk overlap capability.** Implement overlap for split-chunks where text-splitting is used to divide an oversized chunk into two or more chunks that fit in the chunking window. Note this capability is not yet available from the API but will shortly be made accessible using a new `overlap` kwarg on partition functions.
+* **Update encoders to leverage dataclasses** All encoders now follow a class approach which get annotated with the dataclass decorator. Similar to the connectors, it uses a nested dataclass for the configs required to configure a client as well as a field/property approach to cache the client. This makes sure any variable associated with the class exists as a dataclass field.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.7-dev1
+## 0.11.7-dev2
 
 ### Enhancements
 

--- a/test_unstructured/embed/test_openai.py
+++ b/test_unstructured/embed/test_openai.py
@@ -7,8 +7,8 @@ def test_embed_documents_does_not_break_element_to_dict(mocker):
     mock_client = mocker.MagicMock()
     mock_client.embed_documents.return_value = [1, 2]
 
-    # Mock get_openai_client to return our mock_client
-    mocker.patch.object(OpenAIEmbeddingEncoder, "get_openai_client", return_value=mock_client)
+    # Mock create_client to return our mock_client
+    mocker.patch.object(OpenAIEmbeddingEncoder, "create_client", return_value=mock_client)
 
     encoder = OpenAIEmbeddingEncoder(config=OpenAiEmbeddingConfig(api_key="api_key"))
     elements = encoder.embed_documents(

--- a/test_unstructured/embed/test_openai.py
+++ b/test_unstructured/embed/test_openai.py
@@ -1,5 +1,5 @@
 from unstructured.documents.elements import Text
-from unstructured.embed.openai import OpenAIEmbeddingEncoder
+from unstructured.embed.openai import OpenAiEmbeddingConfig, OpenAIEmbeddingEncoder
 
 
 def test_embed_documents_does_not_break_element_to_dict(mocker):
@@ -10,7 +10,7 @@ def test_embed_documents_does_not_break_element_to_dict(mocker):
     # Mock get_openai_client to return our mock_client
     mocker.patch.object(OpenAIEmbeddingEncoder, "get_openai_client", return_value=mock_client)
 
-    encoder = OpenAIEmbeddingEncoder(api_key="api_key")
+    encoder = OpenAIEmbeddingEncoder(config=OpenAiEmbeddingConfig(api_key="api_key"))
     elements = encoder.embed_documents(
         elements=[Text("This is sentence 1"), Text("This is sentence 2")],
     )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.7-dev1"  # pragma: no cover
+__version__ = "0.11.7-dev2"  # pragma: no cover

--- a/unstructured/embed/bedrock.py
+++ b/unstructured/embed/bedrock.py
@@ -31,7 +31,7 @@ class BedrockEmbeddingEncoder(BaseEmbeddingEncoder):
     @property
     def client(self) -> "BedrockEmbeddings":
         if self._client is None:
-            self._client = self.get_bedrock_client()
+            self._client = self.create_client()
         return self._client
 
     @property
@@ -44,7 +44,7 @@ class BedrockEmbeddingEncoder(BaseEmbeddingEncoder):
         self.initialize()
 
     def initialize(self):
-        self.bedrock_client = self.get_bedrock_client()
+        self.bedrock_client = self.create_client()
 
     def num_of_dimensions(self):
         return np.shape(self.exemplary_embedding)
@@ -73,10 +73,7 @@ class BedrockEmbeddingEncoder(BaseEmbeddingEncoder):
         ["boto3", "numpy", "langchain"],
         extras="bedrock",
     )
-    def get_bedrock_client(self):
-        if getattr(self, "bedrock_client", None):
-            return self.bedrock_client
-
+    def create_client(self) -> "BedrockEmbeddings":
         # delay import only when needed
         import boto3
         from langchain.embeddings import BedrockEmbeddings

--- a/unstructured/embed/bedrock.py
+++ b/unstructured/embed/bedrock.py
@@ -1,21 +1,44 @@
 from dataclasses import dataclass
-from typing import List
+from typing import TYPE_CHECKING, List, Optional
 
 import numpy as np
 
 from unstructured.documents.elements import (
     Element,
 )
-from unstructured.embed.interfaces import BaseEmbeddingEncoder
+from unstructured.embed.interfaces import BaseEmbeddingEncoder, EmbeddingConfig
+from unstructured.ingest.enhanced_dataclass import enhanced_field
 from unstructured.ingest.error import EmbeddingEncoderConnectionError
 from unstructured.utils import requires_dependencies
+
+if TYPE_CHECKING:
+    from langchain.embeddings import BedrockEmbeddings
+
+
+@dataclass
+class BedrockEmbeddingConfig(EmbeddingConfig):
+    aws_access_key_id: str = enhanced_field(sensitive=True)
+    aws_secret_access_key: str = enhanced_field(sensitive=True)
+    region_name: str = "us-west-2"
 
 
 @dataclass
 class BedrockEmbeddingEncoder(BaseEmbeddingEncoder):
-    aws_access_key_id: str
-    aws_secret_access_key: str
-    region_name: str = "us-west-2"
+    config: BedrockEmbeddingConfig
+    _client: Optional["BedrockEmbeddings"] = enhanced_field(init=False, default=None)
+    _exemplary_embedding: Optional[List[float]] = enhanced_field(init=False, default=None)
+
+    @property
+    def client(self) -> "BedrockEmbeddings":
+        if self._client is None:
+            self._client = self.get_bedrock_client()
+        return self._client
+
+    @property
+    def exemplary_embedding(self) -> List[float]:
+        if self._exemplary_embedding is None:
+            self._exemplary_embedding = self.client.embed_query("Q")
+        return self._exemplary_embedding
 
     def __post_init__(self):
         self.initialize()
@@ -24,10 +47,10 @@ class BedrockEmbeddingEncoder(BaseEmbeddingEncoder):
         self.bedrock_client = self.get_bedrock_client()
 
     def num_of_dimensions(self):
-        return np.shape(self.examplary_embedding)
+        return np.shape(self.exemplary_embedding)
 
     def is_unit_vector(self):
-        return np.isclose(np.linalg.norm(self.examplary_embedding), 1.0)
+        return np.isclose(np.linalg.norm(self.exemplary_embedding), 1.0)
 
     def embed_query(self, query):
         return np.array(self.bedrock_client.embed_query(query))
@@ -58,13 +81,7 @@ class BedrockEmbeddingEncoder(BaseEmbeddingEncoder):
         import boto3
         from langchain.embeddings import BedrockEmbeddings
 
-        bedrock_runtime = boto3.client(
-            service_name="bedrock-runtime",
-            aws_access_key_id=self.aws_access_key_id,
-            aws_secret_access_key=self.aws_secret_access_key,
-            region_name=self.region_name,
-        )
+        bedrock_runtime = boto3.client(service_name="bedrock-runtime", **self.config.to_dict())
 
         bedrock_client = BedrockEmbeddings(client=bedrock_runtime)
-        self.examplary_embedding = np.array(bedrock_client.embed_query("Q"))
         return bedrock_client

--- a/unstructured/embed/huggingface.py
+++ b/unstructured/embed/huggingface.py
@@ -31,7 +31,7 @@ class HuggingFaceEmbeddingEncoder(BaseEmbeddingEncoder):
     @property
     def client(self) -> "HuggingFaceEmbeddings":
         if self._client is None:
-            self._client = self.get_huggingface_client()
+            self._client = self.create_client()
         return self._client
 
     @property
@@ -51,10 +51,10 @@ class HuggingFaceEmbeddingEncoder(BaseEmbeddingEncoder):
         return np.isclose(np.linalg.norm(self.exemplary_embedding), 1.0)
 
     def embed_query(self, query):
-        return self.hf.embed_query(str(query))
+        return self.client.embed_query(str(query))
 
     def embed_documents(self, elements: List[Element]) -> List[Element]:
-        embeddings = self.hf.embed_documents([str(e) for e in elements])
+        embeddings = self.client.embed_documents([str(e) for e in elements])
         elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
         return elements_with_embeddings
 
@@ -72,12 +72,9 @@ class HuggingFaceEmbeddingEncoder(BaseEmbeddingEncoder):
         ["langchain", "sentence_transformers"],
         extras="embed-huggingface",
     )
-    def get_huggingface_client(self) -> "HuggingFaceEmbeddings":
+    def create_client(self) -> "HuggingFaceEmbeddings":
         """Creates a langchain Huggingface python client to embed elements."""
-        if hasattr(self, "hf_client"):
-            return self.hf_client
-
         from langchain.embeddings import HuggingFaceEmbeddings
 
-        hf_client = HuggingFaceEmbeddings(**self.config.to_dict())
-        return hf_client
+        client = HuggingFaceEmbeddings(**self.config.to_dict())
+        return client

--- a/unstructured/embed/interfaces.py
+++ b/unstructured/embed/interfaces.py
@@ -2,13 +2,19 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Tuple
 
-from dataclasses_json import DataClassJsonMixin
-
 from unstructured.documents.elements import Element
+from unstructured.ingest.enhanced_dataclass import EnhancedDataClassJsonMixin
 
 
 @dataclass
-class BaseEmbeddingEncoder(DataClassJsonMixin, ABC):
+class EmbeddingConfig(EnhancedDataClassJsonMixin):
+    pass
+
+
+@dataclass
+class BaseEmbeddingEncoder(EnhancedDataClassJsonMixin, ABC):
+    config: EmbeddingConfig
+
     @abstractmethod
     def initialize(self):
         """Initializes the embedding encoder class. Should also validate the instance

--- a/unstructured/embed/openai.py
+++ b/unstructured/embed/openai.py
@@ -29,7 +29,7 @@ class OpenAIEmbeddingEncoder(BaseEmbeddingEncoder):
     @property
     def client(self) -> "OpenAIEmbeddings":
         if self._client is None:
-            self._client = self.get_openai_client()
+            self._client = self.create_client()
         return self._client
 
     @property
@@ -68,7 +68,7 @@ class OpenAIEmbeddingEncoder(BaseEmbeddingEncoder):
         ["langchain", "openai", "tiktoken"],
         extras="openai",
     )
-    def get_openai_client(self):
+    def create_client(self) -> "OpenAIEmbeddings":
         """Creates a langchain OpenAI python client to embed elements."""
         from langchain.embeddings.openai import OpenAIEmbeddings
 

--- a/unstructured/embed/openai.py
+++ b/unstructured/embed/openai.py
@@ -1,38 +1,57 @@
-from dataclasses import dataclass
-from typing import List
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional
 
 import numpy as np
 
 from unstructured.documents.elements import (
     Element,
 )
-from unstructured.embed.interfaces import BaseEmbeddingEncoder
+from unstructured.embed.interfaces import BaseEmbeddingEncoder, EmbeddingConfig
 from unstructured.ingest.error import EmbeddingEncoderConnectionError
 from unstructured.utils import requires_dependencies
+
+if TYPE_CHECKING:
+    from langchain.embeddings.openai import OpenAIEmbeddings
+
+
+@dataclass
+class OpenAiEmbeddingConfig(EmbeddingConfig):
+    api_key: str
+    model_name: str = "text-embedding-ada-002"
 
 
 @dataclass
 class OpenAIEmbeddingEncoder(BaseEmbeddingEncoder):
-    api_key: str
-    model_name: str = "text-embedding-ada-002"
+    config: OpenAiEmbeddingConfig
+    _client: Optional["OpenAIEmbeddings"] = field(init=False, default=None)
+    _exemplary_embedding: Optional[List[float]] = field(init=False, default=None)
 
-    def __post_init__(self):
-        self.initialize()
+    @property
+    def client(self) -> "OpenAIEmbeddings":
+        if self._client is None:
+            self._client = self.get_openai_client()
+        return self._client
+
+    @property
+    def exemplary_embedding(self) -> List[float]:
+        if self._exemplary_embedding is None:
+            self._exemplary_embedding = self.client.embed_query("Q")
+        return self._exemplary_embedding
 
     def initialize(self):
-        self.openai_client = self.get_openai_client()
+        pass
 
     def num_of_dimensions(self):
-        return np.shape(self.examplary_embedding)
+        return np.shape(self.exemplary_embedding)
 
     def is_unit_vector(self):
-        return np.isclose(np.linalg.norm(self.examplary_embedding), 1.0)
+        return np.isclose(np.linalg.norm(self.exemplary_embedding), 1.0)
 
     def embed_query(self, query):
-        return self.openai_client.embed_query(str(query))
+        return self.client.embed_query(str(query))
 
     def embed_documents(self, elements: List[Element]) -> List[Element]:
-        embeddings = self.openai_client.embed_documents([str(e) for e in elements])
+        embeddings = self.client.embed_documents([str(e) for e in elements])
         elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
         return elements_with_embeddings
 
@@ -50,14 +69,11 @@ class OpenAIEmbeddingEncoder(BaseEmbeddingEncoder):
         extras="openai",
     )
     def get_openai_client(self):
-        if not hasattr(self, "openai_client"):
-            """Creates a langchain OpenAI python client to embed elements."""
-            from langchain.embeddings.openai import OpenAIEmbeddings
+        """Creates a langchain OpenAI python client to embed elements."""
+        from langchain.embeddings.openai import OpenAIEmbeddings
 
-            openai_client = OpenAIEmbeddings(
-                openai_api_key=self.api_key,
-                model=self.model_name,  # type:ignore
-            )
-
-            self.examplary_embedding = openai_client.embed_query("Q")
-            return openai_client
+        openai_client = OpenAIEmbeddings(
+            openai_api_key=self.config.api_key,
+            model=self.config.model_name,  # type:ignore
+        )
+        return openai_client

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -15,7 +15,6 @@ from dataclasses_json.core import Json, _decode_dataclass
 
 from unstructured.chunking.title import chunk_by_title
 from unstructured.documents.elements import DataSourceMetadata
-from unstructured.embed import EMBEDDING_PROVIDER_TO_CLASS_MAP
 from unstructured.embed.interfaces import BaseEmbeddingEncoder, Element
 from unstructured.ingest.enhanced_dataclass import EnhancedDataClassJsonMixin, enhanced_field
 from unstructured.ingest.enhanced_dataclass.core import _asdict
@@ -194,9 +193,20 @@ class EmbeddingConfig(BaseConfig):
             kwargs["api_key"] = self.api_key
         if self.model_name:
             kwargs["model_name"] = self.model_name
+        # TODO make this more dynamic to map to encoder configs
+        if self.provider == "langchain-openai":
+            from unstructured.embed.openai import OpenAiEmbeddingConfig, OpenAIEmbeddingEncoder
 
-        cls = EMBEDDING_PROVIDER_TO_CLASS_MAP[self.provider]
-        return cls(**kwargs)
+            return OpenAIEmbeddingEncoder(config=OpenAiEmbeddingConfig(**kwargs))
+        elif self.provider == "langchain-huggingface":
+            from unstructured.embed.huggingface import (
+                HuggingFaceEmbeddingConfig,
+                HuggingFaceEmbeddingEncoder,
+            )
+
+            return HuggingFaceEmbeddingEncoder(config=HuggingFaceEmbeddingConfig(**kwargs))
+        else:
+            raise ValueError(f"{self.provider} not a recognized encoder")
 
 
 @dataclass


### PR DESCRIPTION
### Description
Leverage a similar pattern to what is used for connectors, where there is a nested config dataclass as a field, along with cached content for things like the client and sample embedding for each. This required an update on the embeddings config in ingest and I left a TODO in there because the current approach breaks on other encoders such as bedrock because the parameters in that config don't map to all encoders. But this keeps the existing functionality working.

This update makes sure all variables associated with the dataclass exist when it's instantiated rather than being added in the `__post_init__()` method or the `initialize()`, allowing other libraries like pydantic to appropriately generate schemas from it.  It also now follows the pattern of the connectors in that each class has a nested config class used to instantiate the client itself as well as a field/property approach used to cache the client.