### PR TITLE
Fix: element extraction not working when using "auto" strategy for pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.7-dev2
+## 0.11.7-dev3
 
 ### Enhancements
 
@@ -10,6 +10,8 @@
 * **Store base64 encoded image data in metadata fields.** Rather than saving to file, stores base64 encoded data of the image bytes and the mimetype for the image in metadata fields: `image_base64` and `image_mime_type` (if that is what the user specifies by some other param like `pdf_extract_to_payload`). This would allow the API to have parity with the library.
 
 ### Fixes
+
+* **Fix element extraction not working when using "auto" strategy for pdf and image** If element extraction is specified, the "auto" strategy falls back to the "hi_res" strategy.
 
 ## 0.11.6
 
@@ -27,8 +29,8 @@
 * **Add Elasticsearch destination connector.** Problem: After ingesting data from a source, users might want to move their data into a destination. Elasticsearch is a popular storage solution for various functionality such as search, or providing intermediary caches within data pipelines. Feature: Added Elasticsearch destination connector to be able to ingest documents from any supported source, embed them and write the embeddings / documents into Elasticsearch.
 
 ### Fixes
-* **Enable --fields argument omission for elasticsearch connector** Solves two bugs where removing the optional parameter --fields broke the connector due to an integer processing error and using an elasticsearch config for a destination connector resulted in a serialization issue when optional parameter --fields was not provided.
 
+* **Enable --fields argument omission for elasticsearch connector** Solves two bugs where removing the optional parameter --fields broke the connector due to an integer processing error and using an elasticsearch config for a destination connector resulted in a serialization issue when optional parameter --fields was not provided.
 * **Add hi_res_model_name** Adds kwarg to relevant functions and add comments that model_name is to be deprecated.
 
 ## 0.11.5

--- a/test_unstructured/partition/pdf_image/test_image.py
+++ b/test_unstructured/partition/pdf_image/test_image.py
@@ -649,7 +649,6 @@ def test_partition_image_element_extraction(
         if file_mode == "filename":
             elements = image.partition_image(
                 filename=filename,
-                strategy="hi_res",
                 extract_element_types=extract_element_types,
                 extract_to_payload=extract_to_payload,
                 image_output_dir_path=tmpdir,
@@ -658,7 +657,6 @@ def test_partition_image_element_extraction(
             with open(filename, "rb") as f:
                 elements = image.partition_image(
                     file=f,
-                    strategy="hi_res",
                     extract_element_types=extract_element_types,
                     extract_to_payload=extract_to_payload,
                     image_output_dir_path=tmpdir,

--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -1169,7 +1169,6 @@ def test_partition_pdf_element_extraction(
         if file_mode == "filename":
             elements = pdf.partition_pdf(
                 filename=filename,
-                strategy="hi_res",
                 extract_element_types=extract_element_types,
                 extract_to_payload=extract_to_payload,
                 image_output_dir_path=tmpdir,
@@ -1178,7 +1177,6 @@ def test_partition_pdf_element_extraction(
             with open(filename, "rb") as f:
                 elements = pdf.partition_pdf(
                     file=f,
-                    strategy="hi_res",
                     extract_element_types=extract_element_types,
                     extract_to_payload=extract_to_payload,
                     image_output_dir_path=tmpdir,

--- a/test_unstructured/partition/test_strategies.py
+++ b/test_unstructured/partition/test_strategies.py
@@ -53,28 +53,6 @@ def test_is_pdf_text_extractable(filename, from_file, expected):
     assert bool(extractable) is expected
 
 
-def test_determine_image_auto_strategy():
-    strategy = strategies._determine_image_auto_strategy()
-    assert strategy == PartitionStrategy.HI_RES
-
-
-@pytest.mark.parametrize(
-    ("pdf_text_extractable", "infer_table_structure", "expected"),
-    [
-        (True, True, PartitionStrategy.HI_RES),
-        (False, True, PartitionStrategy.HI_RES),
-        (True, False, PartitionStrategy.FAST),
-        (False, False, PartitionStrategy.OCR_ONLY),
-    ],
-)
-def test_determine_pdf_auto_strategy(pdf_text_extractable, infer_table_structure, expected):
-    strategy = strategies._determine_pdf_auto_strategy(
-        pdf_text_extractable=pdf_text_extractable,
-        infer_table_structure=infer_table_structure,
-    )
-    assert strategy is expected
-
-
 @pytest.mark.parametrize(
     ("pdf_text_extractable", "infer_table_structure"),
     [
@@ -91,3 +69,56 @@ def test_determine_pdf_or_image_fast_strategy(pdf_text_extractable, infer_table_
         infer_table_structure=infer_table_structure,
     )
     assert strategy == PartitionStrategy.FAST
+
+
+@pytest.mark.parametrize(
+    (
+        "pdf_text_extractable",
+        "infer_table_structure",
+        "extract_images_in_pdf",
+        "extract_element_types",
+        "expected",
+    ),
+    [
+        (True, True, True, ["Image"], PartitionStrategy.HI_RES),
+        (True, True, True, [], PartitionStrategy.HI_RES),
+        (True, True, False, ["Image"], PartitionStrategy.HI_RES),
+        (True, True, False, [], PartitionStrategy.HI_RES),
+        (True, False, True, ["Image"], PartitionStrategy.HI_RES),
+        (True, False, True, [], PartitionStrategy.HI_RES),
+        (True, False, False, ["Image"], PartitionStrategy.HI_RES),
+        (True, False, False, [], PartitionStrategy.FAST),
+        (False, True, True, ["Image"], PartitionStrategy.HI_RES),
+        (False, True, True, [], PartitionStrategy.HI_RES),
+        (False, True, False, ["Image"], PartitionStrategy.HI_RES),
+        (False, True, False, [], PartitionStrategy.HI_RES),
+        (False, False, True, ["Image"], PartitionStrategy.HI_RES),
+        (False, False, True, [], PartitionStrategy.HI_RES),
+        (False, False, False, ["Image"], PartitionStrategy.HI_RES),
+        (False, False, False, [], PartitionStrategy.OCR_ONLY),
+    ],
+)
+def test_determine_pdf_auto_strategy(
+    pdf_text_extractable,
+    infer_table_structure,
+    extract_images_in_pdf,
+    extract_element_types,
+    expected,
+):
+    strategy = strategies.determine_pdf_or_image_strategy(
+        strategy=PartitionStrategy.AUTO,
+        is_image=False,
+        pdf_text_extractable=pdf_text_extractable,
+        infer_table_structure=infer_table_structure,
+        extract_images_in_pdf=extract_images_in_pdf,
+        extract_element_types=extract_element_types,
+    )
+    assert strategy == expected
+
+
+def test_determine_image_auto_strategy():
+    strategy = strategies.determine_pdf_or_image_strategy(
+        strategy=PartitionStrategy.AUTO,
+        is_image=True,
+    )
+    assert strategy == PartitionStrategy.HI_RES

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.7-dev2"  # pragma: no cover
+__version__ = "0.11.7-dev3"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -519,13 +519,15 @@ def partition_pdf_or_image(
 
     strategy = determine_pdf_or_image_strategy(
         strategy,
-        file=file,
         is_image=is_image,
         pdf_text_extractable=pdf_text_extractable,
         infer_table_structure=infer_table_structure,
         extract_images_in_pdf=extract_images_in_pdf,
         extract_element_types=extract_element_types,
     )
+
+    if file is not None:
+        file.seek(0)
 
     if strategy == PartitionStrategy.HI_RES:
         # NOTE(robinson): Catches a UserWarning that occurs when detectron is called

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -517,15 +517,14 @@ def partition_pdf_or_image(
             logger.error(e)
             logger.warning("PDF text extraction failed, skip text extraction...")
 
-    extract_element = extract_images_in_pdf or bool(extract_element_types)
-
     strategy = determine_pdf_or_image_strategy(
         strategy,
         file=file,
         is_image=is_image,
         pdf_text_extractable=pdf_text_extractable,
         infer_table_structure=infer_table_structure,
-        extract_element=extract_element,
+        extract_images_in_pdf=extract_images_in_pdf,
+        extract_element_types=extract_element_types,
     )
 
     if strategy == PartitionStrategy.HI_RES:

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -517,13 +517,15 @@ def partition_pdf_or_image(
             logger.error(e)
             logger.warning("PDF text extraction failed, skip text extraction...")
 
+    extract_element = extract_images_in_pdf or bool(extract_element_types)
+
     strategy = determine_pdf_or_image_strategy(
         strategy,
         file=file,
         is_image=is_image,
-        infer_table_structure=infer_table_structure,
         pdf_text_extractable=pdf_text_extractable,
-        extract_images_in_pdf=extract_images_in_pdf,
+        infer_table_structure=infer_table_structure,
+        extract_element=extract_element,
     )
 
     if strategy == PartitionStrategy.HI_RES:

--- a/unstructured/partition/strategies.py
+++ b/unstructured/partition/strategies.py
@@ -1,5 +1,4 @@
-from tempfile import SpooledTemporaryFile
-from typing import BinaryIO, List, Optional, Union
+from typing import List, Optional
 
 from unstructured.logger import logger
 from unstructured.partition.utils.constants import PartitionStrategy
@@ -24,7 +23,6 @@ def validate_strategy(strategy: str, is_image: bool = False):
 
 def determine_pdf_or_image_strategy(
     strategy: str,
-    file: Optional[Union[bytes, BinaryIO, SpooledTemporaryFile]] = None,
     is_image: bool = False,
     pdf_text_extractable: bool = False,
     infer_table_structure: bool = False,
@@ -46,9 +44,6 @@ def determine_pdf_or_image_strategy(
                 infer_table_structure=infer_table_structure,
                 extract_element=extract_element,
             )
-
-    if file is not None:
-        file.seek(0)  # type: ignore
 
     if all(
         [not unstructured_inference_installed, not pytesseract_installed, not pdf_text_extractable],

--- a/unstructured/partition/strategies.py
+++ b/unstructured/partition/strategies.py
@@ -28,7 +28,7 @@ def determine_pdf_or_image_strategy(
     is_image: bool = False,
     pdf_text_extractable: bool = False,
     infer_table_structure: bool = False,
-    extract_images_in_pdf: bool = False,
+    extract_element: bool = False,
 ):
     """Determines what strategy to use for processing PDFs or images, accounting for fallback
     logic if some dependencies are not available."""
@@ -42,7 +42,7 @@ def determine_pdf_or_image_strategy(
             strategy = _determine_pdf_auto_strategy(
                 pdf_text_extractable=pdf_text_extractable,
                 infer_table_structure=infer_table_structure,
-                extract_images_in_pdf=extract_images_in_pdf,
+                extract_element=extract_element,
             )
 
     if file is not None:
@@ -97,13 +97,13 @@ def _determine_image_auto_strategy():
 def _determine_pdf_auto_strategy(
     pdf_text_extractable: bool = False,
     infer_table_structure: bool = False,
-    extract_images_in_pdf: bool = False,
+    extract_element: bool = False,
 ):
     """If "auto" is passed in as the strategy, determines what strategy to use
     for PDFs."""
     # NOTE(robinson) - Currently "hi_res" is the only strategy where
     # infer_table_structure and extract_images_in_pdf are used.
-    if infer_table_structure or extract_images_in_pdf:
+    if infer_table_structure or extract_element:
         return PartitionStrategy.HI_RES
 
     if pdf_text_extractable:

--- a/unstructured/partition/strategies.py
+++ b/unstructured/partition/strategies.py
@@ -1,5 +1,5 @@
 from tempfile import SpooledTemporaryFile
-from typing import BinaryIO, Optional, Union
+from typing import BinaryIO, List, Optional, Union
 
 from unstructured.logger import logger
 from unstructured.partition.utils.constants import PartitionStrategy
@@ -28,7 +28,8 @@ def determine_pdf_or_image_strategy(
     is_image: bool = False,
     pdf_text_extractable: bool = False,
     infer_table_structure: bool = False,
-    extract_element: bool = False,
+    extract_images_in_pdf: bool = False,
+    extract_element_types: Optional[List[str]] = None,
 ):
     """Determines what strategy to use for processing PDFs or images, accounting for fallback
     logic if some dependencies are not available."""
@@ -36,6 +37,7 @@ def determine_pdf_or_image_strategy(
     unstructured_inference_installed = dependency_exists("unstructured_inference")
 
     if strategy == PartitionStrategy.AUTO:
+        extract_element = extract_images_in_pdf or bool(extract_element_types)
         if is_image:
             strategy = _determine_image_auto_strategy()
         else:


### PR DESCRIPTION
Closes #2323.

### Summary
- update logic to return "hi_res" if either `extract_images_in_pdf` or `extract_element_types` is set
- refactor: remove unused `file` parameter from `determine_pdf_or_image_strategy()`
### Testing
```
from unstructured.partition.pdf import partition_pdf

elements = partition_pdf(
    filename="example-docs/embedded-images-tables.pdf",
    extract_element_types=["Image"],
    extract_to_payload=True,
)

image_elements = [el for el in elements if el.category == ElementType.IMAGE]
print(image_elements)
```