### PR TITLE
chore: update ingest azure cognitive search endpoint

### DIFF
--- a/test_unstructured_ingest/dest/azure-cognitive-search.sh
+++ b/test_unstructured_ingest/dest/azure-cognitive-search.sh
@@ -28,13 +28,13 @@ source "$SCRIPT_DIR"/cleanup.sh
 function cleanup {
   # Index cleanup
   response_code=$(curl -s -o /dev/null -w "%{http_code}" \
-    "https://utic-test-ingest-fixtures.search.windows.net/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
+    "https://ingest-test-azure-cognitive-search.search.windows.net/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
     --header "api-key: $AZURE_SEARCH_API_KEY" \
     --header 'content-type: application/json')
   if [ "$response_code" == "200" ]; then
     echo "deleting index $DESTINATION_INDEX"
     curl -X DELETE \
-      "https://utic-test-ingest-fixtures.search.windows.net/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
+      "https://ingest-test-azure-cognitive-search.search.windows.net/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
       --header "api-key: $AZURE_SEARCH_API_KEY" \
       --header 'content-type: application/json'
   else
@@ -51,12 +51,13 @@ trap cleanup EXIT
 # Create index
 echo "Creating index $DESTINATION_INDEX"
 response=$(curl -X PUT -s -w "\n%{http_code}" \
-  "https://utic-test-ingest-fixtures.search.windows.net/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
+  "https://ingest-test-azure-cognitive-search.search.windows.net/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
   --header "api-key: $AZURE_SEARCH_API_KEY" \
   --header 'content-type: application/json' \
   --data "@$SCRIPT_DIR/files/azure_cognitive_index_schema.json")
 response_code=$(tail -n1 <<<"$response") # get the last line
 content=$(sed '$ d' <<<"$response")      # get all but the last line which contains the status code
+response_code="${response_code//[$'\t\r\n ']}" # remove all whitespace to allow integer comparison
 
 if [ "$response_code" -lt 400 ]; then
   echo "Index creation success: $response_code"
@@ -89,7 +90,7 @@ while [ "$docs_count_remote" -eq 0 ] && [ "$attempt" -lt 6 ]; do
   sleep 10
 
   # Check the contents of the index
-  docs_count_remote=$(curl "https://utic-test-ingest-fixtures.search.windows.net/indexes/$DESTINATION_INDEX/docs/\$count?api-version=$API_VERSION" \
+  docs_count_remote=$(curl "https://ingest-test-azure-cognitive-search.search.windows.net/indexes/$DESTINATION_INDEX/docs/\$count?api-version=$API_VERSION" \
     --header "api-key: $AZURE_SEARCH_API_KEY" \
     --header 'content-type: application/json' | jq)
 

--- a/test_unstructured_ingest/dest/azure-cognitive-search.sh
+++ b/test_unstructured_ingest/dest/azure-cognitive-search.sh
@@ -58,8 +58,7 @@ response=$(curl -X PUT -s -w "\n%{http_code}" \
   --header 'content-type: application/json' \
   --data "@$SCRIPT_DIR/files/azure_cognitive_index_schema.json")
 response_code=$(echo "$response" | tail -n 1) # get the last line
-content=$(echo "$response" | head -n 1)      # get all but the last line which contains the status code
-
+content=$(echo "$response" | head -n 1)      # get the first line
 if [ "$response_code" -lt 400 ]; then
   echo "Index creation success: $response_code"
 else

--- a/test_unstructured_ingest/dest/azure-cognitive-search.sh
+++ b/test_unstructured_ingest/dest/azure-cognitive-search.sh
@@ -58,7 +58,7 @@ response=$(curl -X PUT -s -w "\n%{http_code}" \
   --header 'content-type: application/json' \
   --data "@$SCRIPT_DIR/files/azure_cognitive_index_schema.json")
 response_code=$(echo "$response" | tail -n 1) # get the last line
-content=$(echo "$response" | head -n 1)      # get the first line
+content=$(echo "$response" | head -n 1)       # get the first line
 if [ "$response_code" -lt 400 ]; then
   echo "Index creation success: $response_code"
 else

--- a/test_unstructured_ingest/dest/azure-cognitive-search.sh
+++ b/test_unstructured_ingest/dest/azure-cognitive-search.sh
@@ -11,6 +11,8 @@ OUTPUT_DIR=$OUTPUT_ROOT/structured-output/$OUTPUT_FOLDER_NAME
 WORK_DIR=$OUTPUT_ROOT/workdir/$OUTPUT_FOLDER_NAME
 max_processes=${MAX_PROCESSES:=$(python3 -c "import os; print(os.cpu_count())")}
 
+AZURE_SEARCH_ENDPOINT="https://ingest-test-azure-cognitive-search.search.windows.net"
+
 random_id=$(uuidgen)
 # index name must be all lowercase
 random_id=$(echo "$random_id" | tr '[:upper:]' '[:lower:]')
@@ -19,8 +21,8 @@ DESTINATION_INDEX="utic-test-ingest-fixtures-output-$random_id"
 # 2023-07-01-Preview, 2021-04-30-Preview, 2020-06-30-Preview
 API_VERSION=2023-07-01-Preview
 
-if [ -z "$AZURE_SEARCH_ENDPOINT" ] && [ -z "$AZURE_SEARCH_API_KEY" ]; then
-  echo "Skipping Azure Cognitive Search ingest test because neither AZURE_SEARCH_ENDPOINT nor AZURE_SEARCH_API_KEY env vars are set."
+if [ -z "$AZURE_SEARCH_API_KEY" ]; then
+  echo "Skipping Azure Cognitive Search ingest test because AZURE_SEARCH_API_KEY env var is not set."
   exit 8
 fi
 # shellcheck disable=SC1091
@@ -28,13 +30,13 @@ source "$SCRIPT_DIR"/cleanup.sh
 function cleanup {
   # Index cleanup
   response_code=$(curl -s -o /dev/null -w "%{http_code}" \
-    "https://ingest-test-azure-cognitive-search.search.windows.net/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
+    "$AZURE_SEARCH_ENDPOINT/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
     --header "api-key: $AZURE_SEARCH_API_KEY" \
     --header 'content-type: application/json')
   if [ "$response_code" == "200" ]; then
     echo "deleting index $DESTINATION_INDEX"
     curl -X DELETE \
-      "https://ingest-test-azure-cognitive-search.search.windows.net/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
+      "$AZURE_SEARCH_ENDPOINT/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
       --header "api-key: $AZURE_SEARCH_API_KEY" \
       --header 'content-type: application/json'
   else
@@ -51,13 +53,12 @@ trap cleanup EXIT
 # Create index
 echo "Creating index $DESTINATION_INDEX"
 response=$(curl -X PUT -s -w "\n%{http_code}" \
-  "https://ingest-test-azure-cognitive-search.search.windows.net/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
+  "$AZURE_SEARCH_ENDPOINT/indexes/$DESTINATION_INDEX?api-version=$API_VERSION" \
   --header "api-key: $AZURE_SEARCH_API_KEY" \
   --header 'content-type: application/json' \
   --data "@$SCRIPT_DIR/files/azure_cognitive_index_schema.json")
-response_code=$(tail -n1 <<<"$response") # get the last line
-content=$(sed '$ d' <<<"$response")      # get all but the last line which contains the status code
-response_code="${response_code//[$'\t\r\n ']}" # remove all whitespace to allow integer comparison
+response_code=$(echo "$response" | tail -n 1) # get the last line
+content=$(echo "$response" | head -n 1)      # get all but the last line which contains the status code
 
 if [ "$response_code" -lt 400 ]; then
   echo "Index creation success: $response_code"
@@ -90,7 +91,7 @@ while [ "$docs_count_remote" -eq 0 ] && [ "$attempt" -lt 6 ]; do
   sleep 10
 
   # Check the contents of the index
-  docs_count_remote=$(curl "https://ingest-test-azure-cognitive-search.search.windows.net/indexes/$DESTINATION_INDEX/docs/\$count?api-version=$API_VERSION" \
+  docs_count_remote=$(curl "$AZURE_SEARCH_ENDPOINT/indexes/$DESTINATION_INDEX/docs/\$count?api-version=$API_VERSION" \
     --header "api-key: $AZURE_SEARCH_API_KEY" \
     --header 'content-type: application/json' | jq)
 


### PR DESCRIPTION
This PR:
- updates ingest azure cognitive search destination connector test to move into a new service.
- changes response parsing logic in the test.