### PR TITLE
bug: omit session handler from serialization to avoid mp issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.11.9-dev3
+## 0.11.9-dev4
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11.9-dev3"  # pragma: no cover
+__version__ = "0.11.9-dev4"  # pragma: no cover

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -299,6 +299,8 @@ class IngestDocJsonMixin(EnhancedDataClassJsonMixin):
 
     def to_dict(self, **kwargs) -> t.Dict[str, Json]:
         as_dict = _asdict(self, **kwargs)
+        if "_session_handle" in as_dict:
+            as_dict.pop("_session_handle", None)
         self.add_props(as_dict=as_dict, props=self.properties_to_serialize)
         if getattr(self, "_source_metadata") is not None:
             self.add_props(as_dict=as_dict, props=self.metadata_properties)

--- a/unstructured/ingest/pipeline/source.py
+++ b/unstructured/ingest/pipeline/source.py
@@ -28,14 +28,8 @@ class Reader(SourceNode):
             # Still need to fetch metadata if file exists locally
             doc.update_source_metadata()
         else:
-            # TODO: update all to use doc.to_json(redact_sensitive=True) once session handler
-            # can be serialized
-            try:
-                serialized_doc = doc.to_json(redact_sensitive=True)
-                logger.debug(f"Fetching {serialized_doc} - PID: {os.getpid()}")
-            except Exception as e:
-                logger.warning("failed to print full doc: ", e)
-                logger.debug(f"Fetching {doc.__class__.__name__} - PID: {os.getpid()}")
+            serialized_doc = doc.to_json(redact_sensitive=True)
+            logger.debug(f"Fetching {serialized_doc} - PID: {os.getpid()}")
             if self.retry_strategy:
                 self.retry_strategy(doc.get_file)
             else:


### PR DESCRIPTION
### Description
The session handler variable can be anything, because it's specific to the SDK being used for the connector. This can break the serialization depending on what that is. To avoid this all together, the session handler itself is not serialized. Instead, it needs to be recreated if an object is serialized and then deserialized. 
