### PR TITLE
chore: move conform dict for better compatibility

### DIFF
--- a/unstructured/ingest/connector/azure_cognitive_search.py
+++ b/unstructured/ingest/connector/azure_cognitive_search.py
@@ -117,6 +117,9 @@ class AzureCognitiveSearchDestinationConnector(BaseDestinationConnector):
     def write_dict(self, *args, elements_dict: t.List[t.Dict[str, t.Any]], **kwargs) -> None:
         import azure.core.exceptions
 
+        for element_dict in elements_dict:
+            self.conform_dict(data=element_dict)
+
         logger.info(
             f"writing {len(elements_dict)} documents to destination "
             f"index at {self.write_config.index}",
@@ -150,8 +153,6 @@ class AzureCognitiveSearchDestinationConnector(BaseDestinationConnector):
             local_path = doc._output_filename
             with open(local_path) as json_file:
                 json_content = json.load(json_file)
-                for content in json_content:
-                    self.conform_dict(data=content)
                 logger.info(
                     f"appending {len(json_content)} json elements from content in {local_path}",
                 )


### PR DESCRIPTION
This PR changes where `conform_dict` gets applied in Azure Cognitive Search connector for better compatibility.