### PR TITLE
bug: weaviate serialization broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.12.1-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+
 ## 0.12.0
 
 ### Enhancements

--- a/test_unstructured_ingest/dest/weaviate.sh
+++ b/test_unstructured_ingest/dest/weaviate.sh
@@ -45,6 +45,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
   --embedding-provider "langchain-huggingface" \
   weaviate \
   --host-url http://localhost:8080 \
-  --class-name elements
+  --class-name elements \
+  --anonymous
 
 "$SCRIPT_DIR"/python/test-ingest-weaviate-output.py

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.0"  # pragma: no cover
+__version__ = "0.12.1-dev0"  # pragma: no cover

--- a/unstructured/ingest/cli/cmds/weaviate.py
+++ b/unstructured/ingest/cli/cmds/weaviate.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 import click
 
-from unstructured.ingest.cli.interfaces import CliConfig, Dict
+from unstructured.ingest.cli.interfaces import CliConfig, DelimitedString
 from unstructured.ingest.connector.weaviate import SimpleWeaviateConfig, WeaviateWriteConfig
 
 CMD_NAME = "weaviate"
@@ -26,18 +26,46 @@ class WeaviateCliConfig(SimpleWeaviateConfig, CliConfig):
                 help="Name of the class to push the records into, e.g: Pdf-elements",
             ),
             click.Option(
-                ["--auth-keys"],
-                required=False,
-                type=Dict(),
-                help=(
-                    "String representing a JSON-like dict with key,value containing "
-                    "the required parameters to create an authentication object. "
-                    'example: \'{"api_key":"123abc!"}\' '
-                    "The connector resolves the authentication object from the parameters. "
-                    "See https://weaviate.io/developers/weaviate/client-libraries/python_v3"
-                    "#api-key-authentication "
-                    "for more information."
-                ),
+                ["--access-token"], default=None, type=str, help="Used to create the bearer token."
+            ),
+            click.Option(
+                ["--refresh-token"],
+                default=None,
+                type=str,
+                help="Will tie this value to the bearer token. If not provided, "
+                "the authentication will expire once the lifetime of the access token is up.",
+            ),
+            click.Option(
+                ["--api-key"],
+                default=None,
+                type=str,
+            ),
+            click.Option(
+                ["--client-secret"],
+                default=None,
+                type=str,
+            ),
+            click.Option(
+                ["--scope"],
+                default=None,
+                type=DelimitedString(),
+            ),
+            click.Option(
+                ["--username"],
+                default=None,
+                type=str,
+            ),
+            click.Option(
+                ["--password"],
+                default=None,
+                type=str,
+            ),
+            click.Option(
+                ["--anonymous"],
+                is_flag=True,
+                default=False,
+                type=bool,
+                help="if set, all auth values will be ignored",
             ),
         ]
         return options


### PR DESCRIPTION
### Description
This PR handles two things:
* Fixes the serialization of the weaviate destination connector since the client content breaks serialization when present due to `TypeError: cannot pickle '_thread.lock' object`.
* Set finer auth control rather than generic dictionary on the CLI and access config. 