### PR TITLE
bug: don't redact text when serialization if not value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.1-dev0
+## 0.12.1-dev1
 
 ### Enhancements
 
@@ -6,7 +6,10 @@
 
 ### Fixes
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> 154a77c10 (bump changelog)
 ## 0.12.0
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.1-dev0"  # pragma: no cover
+__version__ = "0.12.1-dev1"  # pragma: no cover

--- a/unstructured/ingest/enhanced_dataclass/core.py
+++ b/unstructured/ingest/enhanced_dataclass/core.py
@@ -48,9 +48,7 @@ def _asdict(
         result = []
         overrides = _user_overrides_or_exts(obj)
         for field in fields(obj):
-            if getattr(field, "sensitive", False) and redact_sensitive:
-                value = redacted_text
-            elif overrides[field.name].encoder:
+            if overrides[field.name].encoder:
                 value = getattr(obj, field.name)
             else:
                 value = _asdict(
@@ -59,6 +57,8 @@ def _asdict(
                     redact_sensitive=redact_sensitive,
                     redacted_text=redacted_text,
                 )
+            if getattr(field, "sensitive", False) and redact_sensitive and value:
+                value = redacted_text
             if getattr(field, "overload_name", None) and apply_name_overload:
                 overload_name = getattr(field, "overload_name")
                 result.append((overload_name, value))


### PR DESCRIPTION
### Description
The current approach injects the redacted text for all sensitive fields regardless of if they have a value or not. This updates the code to only replace the value with the redacted text if the value exists. 