### PR TITLE
chore(ingest): update pinecone index creation specifications

### DIFF
--- a/test_unstructured_ingest/dest/pinecone.sh
+++ b/test_unstructured_ingest/dest/pinecone.sh
@@ -71,7 +71,6 @@ response_code=$(curl \
   "dimension": 384,
   "metric": "cosine",
   "pods": 1,
-  "replicas": 1,
   "pod_type": "p1.x1"
 }
 ')


### PR DESCRIPTION
This PR updates Pinecone index creation in the ingest test due to a recent update in Pinecone API.

Due to a change in Pinecone API, it is not allowed anymore to specify both number of replicas and number of pods:
`Cannot specify both replicas and pods`

We solve it by removing the replica specification while sending the index creation request.

```
Creating index ingest-test-28418
Index creation success: 201
```