### PR TITLE
feat: allows for reorientation of pdf pages when strategy=HI_RES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Features
 * **MongoDB Source Connector.** New source connector added to all CLI ingest commands to support downloading/partitioning files from MongoDB.
 
+* **Add a capability to reorient pages.** Now, when using the HI\_RES strategy for PDF partitioning, and when the PDF appears to be a scanned one (single image per page, no native text), the file can have its pages individually reoriented through the setting of reorientation_strategy (currently, =NONE by default).
+
 ### Fixes
 
 * **Fix GCS connector converting JSON to string with single quotes.** FSSpec serialization caused conversion of JSON token to string with single quotes. GCS requires token in form of dict so this format is now assured.

--- a/test_unstructured/partition/pdf_image/test_reorientation.py
+++ b/test_unstructured/partition/pdf_image/test_reorientation.py
@@ -1,0 +1,131 @@
+import io
+from typing import List
+
+import pypdf
+import pytest
+from PIL import Image as PILImage
+from rapidfuzz.distance import Levenshtein
+
+from test_unstructured.unit_utils import example_doc_path
+from unstructured.documents.elements import Element, Text
+from unstructured.partition import pdf
+from unstructured.partition.pdf_image import orientation_and_rotation
+from unstructured.partition.pdf_image.orientation_and_rotation import Orientation
+from unstructured.partition.utils.constants import PartitionStrategy, ReorientationStrategy
+
+
+def test_do_not_reorient_when_strategy_none(
+    filename=example_doc_path("layout-parser-paper-fast.pdf"),
+):
+    pdf_doc = pypdf.PdfReader(filename)
+    for page in pdf_doc.pages:
+        assert orientation_and_rotation._find_orientation(page, ReorientationStrategy.NONE) == 0
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        ReorientationStrategy.NONE,
+        ReorientationStrategy.CNN,
+        ReorientationStrategy.TESSEROCR,
+        ReorientationStrategy.PYTESSERACT,
+    ],
+)
+def test_do_not_reorient_when_not_scan(
+    strategy: str,
+    filename=example_doc_path("embedded-images.pdf"),
+):
+    pdf_doc = pypdf.PdfReader(filename)
+    for page in pdf_doc.pages:
+        assert orientation_and_rotation._find_orientation(page.rotate(90), strategy) == 0
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        ReorientationStrategy.PYTESSERACT,
+    ],
+)
+@pytest.mark.parametrize("rotation", [0, 90, 180, 270])
+def test_reorient_when_rotated(
+    strategy: str,
+    rotation: Orientation,
+    filename=example_doc_path("loremipsum-flat.pdf"),
+):
+    pdf_doc = pypdf.PdfReader(filename)
+    for page in pdf_doc.pages:
+        assert (
+            orientation_and_rotation._find_orientation(page.rotate(rotation), strategy) == rotation
+        )
+
+
+@pytest.mark.parametrize("strategy", [ReorientationStrategy.PYTESSERACT])
+def test_reorient_when_natively_rotated(
+    strategy: str,
+    filename=example_doc_path("loremipsum-flat.pdf"),
+):
+    test_done = False
+
+    pdf_doc = pypdf.PdfReader(filename)
+    for page in pdf_doc.pages:
+        if len(page.images) == 1:
+            image = PILImage.open(io.BytesIO(page.images[0].data))
+            new_image = image.rotate(90)
+            new_pdf = io.BytesIO()
+            new_image.save(new_pdf, "pdf")
+            (new_page,) = pypdf.PdfReader(new_pdf).pages
+            assert orientation_and_rotation._find_orientation(new_page, strategy) == 90
+            test_done = True
+
+    assert test_done
+
+
+def test_same_ocr_result(
+    monkeypatch,
+    strategy: str = ReorientationStrategy.PYTESSERACT,
+    filename=example_doc_path("loremipsum-flat.pdf"),
+):
+    test_done = False
+    monkeypatch.setattr(orientation_and_rotation, "_find_orientation", lambda *args, **kwargs: 180)
+
+    pdf_doc = pypdf.PdfReader(filename)
+    for page in pdf_doc.pages:
+        if len(page.images) == 1:
+            image = PILImage.open(io.BytesIO(page.images[0].data))
+            new_image = image.rotate(180)
+            new_pdf_orig = io.BytesIO()
+            new_pdf_rotated = io.BytesIO()
+
+            image.save(new_pdf_orig, "pdf")
+            new_image.save(new_pdf_rotated, "pdf")
+            original_result = pdf.partition_pdf(
+                file=new_pdf_orig,
+                strategy=PartitionStrategy.HI_RES,
+                hi_res_reorientation_strategy="",
+            )
+            rotated_no_reorientation_result = pdf.partition_pdf(
+                file=new_pdf_rotated,
+                strategy=PartitionStrategy.HI_RES,
+                hi_res_reorientation_strategy="",
+            )
+            rotated_reoriented_result = pdf.partition_pdf(
+                file=new_pdf_rotated,
+                strategy=PartitionStrategy.HI_RES,
+                hi_res_reorientation_strategy=strategy,
+            )
+
+            def get_text(results: List[Element]) -> str:
+                return "".join([result.text for result in results if isinstance(result, Text)])
+
+            def similar(text1: str, text2: str) -> bool:
+                return Levenshtein.normalized_similarity(text1, text2) > 0.99
+
+            original_text = get_text(original_result)
+            rotated_no_reorientation_text = get_text(rotated_no_reorientation_result)
+            rotated_reoriented_text = get_text(rotated_reoriented_result)
+
+            assert similar(original_text, rotated_reoriented_text)
+            assert not similar(original_text, rotated_no_reorientation_text)
+            test_done = True
+
+    assert test_done

--- a/unstructured/partition/pdf_image/orientation_and_rotation.py
+++ b/unstructured/partition/pdf_image/orientation_and_rotation.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import io
+from typing import BinaryIO, Literal, Optional, Union, cast
+
+import pypdf
+from PIL import Image as PILImage
+
+from unstructured.partition.utils.constants import ReorientationStrategy
+from unstructured.utils import requires_dependencies
+
+FULL_CIRCLE = 360
+
+RIGHT_ORIENTATIONS = [0, 90, 180, 270]
+Orientation = Literal[0, 90, 180, 270]
+
+
+@requires_dependencies("unstructured_pytesseract")
+def _find_orientation_pytesseract(page: PILImage) -> Orientation:
+    from unstructured_pytesseract import TesseractError, image_to_osd
+
+    try:
+        osd_result = image_to_osd(page, output_type="dict")
+        rotation = osd_result["rotate"]
+        if rotation in RIGHT_ORIENTATIONS:
+            return rotation
+        return 0
+    except TesseractError:
+        return 0
+
+
+def _find_orientation_tesserocr(page: PILImage) -> Orientation:
+    raise NotImplementedError("tesserocr-based page reorientation is not yet implemented.")
+
+
+def _find_orientation_cnn(page: PILImage) -> Orientation:
+    raise NotImplementedError("CNN-based page reorientation is not yet implemented.")
+
+
+def _find_orientation(page: pypdf.PageObject, reorientation_strategy: str) -> Orientation:
+    if len(page.images) != 1:
+        # extremely unlikely to be a page scan, which is the only page type we want rotated
+        return 0
+    if reorientation_strategy == ReorientationStrategy.NONE:
+        return 0
+
+    image = PILImage.open(io.BytesIO(page.images[0].data))
+
+    strategies = {
+        ReorientationStrategy.PYTESSERACT: _find_orientation_pytesseract,
+        ReorientationStrategy.CNN: _find_orientation_cnn,
+        ReorientationStrategy.TESSEROCR: _find_orientation_tesserocr,
+    }
+
+    if reorientation_strategy not in strategies:
+        raise ValueError(f"Unknown reorientation strategy picked: {reorientation_strategy}")
+
+    image_orientation = strategies[reorientation_strategy](image)
+    return cast(Orientation, (page.rotation + image_orientation) % FULL_CIRCLE)
+
+
+def reorient_file_or_data(
+    filename: str,
+    file: Optional[Union[bytes, BinaryIO]],
+    reorientation_strategy: str,
+    target: str,
+) -> None:
+    """Opens the PDF, determines the orientation of individual pages,
+       rotates as needed and writes the result to target.
+    Parameters
+    ----------
+    filename
+        A string defining the target filename path.
+    file
+        A file-like object as bytes --> open(filename, "rb").
+    reorientation_strategy
+        The strategy to use for detecting orientation.
+        Valid strategies are governed by the ReorientationStrategy constant.
+    target
+        The writable (mode should be w+) file to save the converted pdf to.
+        Allows simple use within with temptile.TemporaryFile closures.
+
+    """
+    reader = pypdf.PdfReader(file if file is not None else filename)
+    with pypdf.PdfWriter() as writer:
+        for page in reader.pages:
+            orientation = _find_orientation(page, reorientation_strategy=reorientation_strategy)
+            page = page.rotate(-orientation)
+            writer.add_page(page)
+        writer.write(target)

--- a/unstructured/partition/pdf_image/orientation_and_rotation.py
+++ b/unstructured/partition/pdf_image/orientation_and_rotation.py
@@ -63,8 +63,7 @@ def reorient_file_or_data(
     filename: str,
     file: Optional[Union[bytes, BinaryIO]],
     reorientation_strategy: str,
-    target: str,
-) -> None:
+) -> io.BytesIO:
     """Opens the PDF, determines the orientation of individual pages,
        rotates as needed and writes the result to target.
     Parameters
@@ -82,9 +81,12 @@ def reorient_file_or_data(
 
     """
     reader = pypdf.PdfReader(file if file is not None else filename)
-    with pypdf.PdfWriter() as writer:
-        for page in reader.pages:
-            orientation = _find_orientation(page, reorientation_strategy=reorientation_strategy)
-            page = page.rotate(-orientation)
-            writer.add_page(page)
-        writer.write(target)
+    writer = pypdf.PdfWriter()
+    for page in reader.pages:
+        orientation = _find_orientation(page, reorientation_strategy=reorientation_strategy)
+        page = page.rotate(-orientation)
+        writer.add_page(page)
+    target = io.BytesIO()
+    writer.write(target)
+    target.seek(0)
+    return target

--- a/unstructured/partition/utils/constants.py
+++ b/unstructured/partition/utils/constants.py
@@ -20,6 +20,13 @@ class PartitionStrategy:
     HI_RES = "hi_res"
 
 
+class ReorientationStrategy:
+    NONE = ""
+    PYTESSERACT = "pytesseract"
+    TESSEROCR = "tesserocr"
+    CNN = "cnn"
+
+
 SORT_MODE_XY_CUT = "xy-cut"
 SORT_MODE_BASIC = "basic"
 SORT_MODE_DONT = "dont"


### PR DESCRIPTION
Some of the PDFs, especially the scanner-produced ones, contain pages that are oriented wrong. To combat this, I'm introducing a very crude step of detecting the orientation and rotating the pages.
The solution I used (creating a TemporaryFile and re-running partition) is very hacky, but avoids a complete refactor, which would likely be the other option.