### PR TITLE
pin unstructured-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.1-dev3
+## 0.12.1-dev4
 
 ### Enhancements
 
@@ -11,6 +11,7 @@
 ### Fixes
 
 * **Fix GCS connector converting JSON to string with single quotes.** FSSpec serialization caused conversion of JSON token to string with single quotes. GCS requires token in form of dict so this format is now assured.
+* **Pin version of unstructured-client** Set minimum version of unstructured-client to avoid raising a TypeError when passing `api_key_auth` to `UnstructuredClient`
 
 ## 0.12.0
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=build.txt build.in
 #
-alabaster==0.7.15
+alabaster==0.7.16
     # via sphinx
 babel==2.14.0
     # via sphinx
@@ -38,7 +38,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==7.0.1
     # via sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   myst-parser
     #   sphinx

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -15,5 +15,6 @@ numpy
 rapidfuzz
 backoff
 typing-extensions
-unstructured-client
+# NOTE(jennings): pinned due to later versions not supporting api_key_auth in UnstructuredClient
+unstructured-client>=0.15.1
 wrapt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -41,7 +41,7 @@ langdetect==1.0.9
     # via -r base.in
 lxml==5.1.0
     # via -r base.in
-marshmallow==3.20.1
+marshmallow==3.20.2
     # via
     #   dataclasses-json
     #   unstructured-client

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=build.txt build.in
 #
-alabaster==0.7.15
+alabaster==0.7.16
     # via sphinx
 babel==2.14.0
     # via sphinx
@@ -38,7 +38,7 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==7.0.1
     # via sphinx
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   myst-parser
     #   sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -118,7 +118,7 @@ isoduration==20.11.0
     # via jsonschema
 jedi==0.19.1
     # via ipython
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   jupyter-server
     #   jupyterlab
@@ -162,7 +162,7 @@ jupyter-events==0.9.0
     # via jupyter-server
 jupyter-lsp==2.2.1
     # via jupyterlab
-jupyter-server==2.12.2
+jupyter-server==2.12.4
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -193,7 +193,7 @@ mistune==3.0.2
     # via nbconvert
 nbclient==0.9.0
     # via nbconvert
-nbconvert==7.14.0
+nbconvert==7.14.1
     # via
     #   jupyter
     #   jupyter-server

--- a/requirements/extra-markdown.txt
+++ b/requirements/extra-markdown.txt
@@ -6,7 +6,7 @@
 #
 importlib-metadata==7.0.1
     # via markdown
-markdown==3.5.1
+markdown==3.5.2
     # via -r extra-markdown.in
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/extra-paddleocr.txt
+++ b/requirements/extra-paddleocr.txt
@@ -8,7 +8,7 @@ attrdict==2.0.1
     # via unstructured-paddleocr
 babel==2.14.0
     # via flask-babel
-bce-python-sdk==0.8.99
+bce-python-sdk==0.9.2
     # via visualdl
 blinker==1.7.0
     # via flask
@@ -35,7 +35,7 @@ cssutils==2.9.0
     # via premailer
 cycler==0.12.1
     # via matplotlib
-cython==3.0.7
+cython==3.0.8
     # via unstructured-paddleocr
 et-xmlfile==1.1.0
     # via openpyxl
@@ -45,7 +45,7 @@ flask==3.0.0
     #   visualdl
 flask-babel==4.0.0
     # via visualdl
-fonttools==4.47.0
+fonttools==4.47.2
     # via matplotlib
 future==0.18.3
     # via bce-python-sdk
@@ -65,7 +65,7 @@ importlib-resources==6.1.1
     # via matplotlib
 itsdangerous==2.1.2
     # via flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via
     #   flask
     #   flask-babel
@@ -151,7 +151,7 @@ psutil==5.9.7
     # via visualdl
 pyclipper==1.3.0.post5
     # via unstructured-paddleocr
-pycryptodome==3.19.1
+pycryptodome==3.20.0
     # via bce-python-sdk
 pyparsing==3.0.9
     # via

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -37,7 +37,7 @@ filelock==3.13.1
     #   transformers
 flatbuffers==23.5.26
     # via onnxruntime
-fonttools==4.47.0
+fonttools==4.47.2
     # via matplotlib
 fsspec==2023.12.2
     # via
@@ -59,7 +59,7 @@ importlib-resources==6.1.1
     # via matplotlib
 iopath==0.1.10
     # via layoutparser
-jinja2==3.1.2
+jinja2==3.1.3
     # via torch
 kiwisolver==1.4.5
     # via matplotlib
@@ -162,7 +162,7 @@ pyparsing==3.0.9
     #   matplotlib
 pypdf==3.17.4
     # via -r extra-pdf-image.in
-pypdfium2==4.25.0
+pypdfium2==4.26.0
     # via pdfplumber
 pytesseract==0.3.10
     # via layoutparser

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -34,7 +34,7 @@ idna==3.6
     # via
     #   -c base.txt
     #   requests
-jinja2==3.1.2
+jinja2==3.1.3
     # via torch
 joblib==1.3.2
     # via

--- a/requirements/ingest/chroma.txt
+++ b/requirements/ingest/chroma.txt
@@ -51,7 +51,7 @@ deprecated==1.2.14
     #   opentelemetry-exporter-otlp-proto-grpc
 exceptiongroup==1.2.0
     # via anyio
-fastapi==0.108.0
+fastapi==0.109.0
     # via chromadb
 filelock==3.13.1
     # via huggingface-hub
@@ -59,7 +59,7 @@ flatbuffers==23.5.26
     # via onnxruntime
 fsspec==2023.12.2
     # via huggingface-hub
-google-auth==2.26.1
+google-auth==2.26.2
     # via kubernetes
 googleapis-common-protos==1.62.0
     # via opentelemetry-exporter-otlp-proto-grpc
@@ -153,7 +153,7 @@ packaging==23.2
     #   build
     #   huggingface-hub
     #   onnxruntime
-posthog==3.3.0
+posthog==3.3.1
     # via chromadb
 protobuf==4.23.4
     # via
@@ -211,7 +211,7 @@ six==1.16.0
     #   python-dateutil
 sniffio==1.3.0
     # via anyio
-starlette==0.32.0.post1
+starlette==0.35.1
     # via fastapi
 sympy==1.12
     # via onnxruntime

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -67,18 +67,18 @@ jsonpointer==2.4
     # via jsonpatch
 langchain==0.1.0
     # via -r ingest/embed-aws-bedrock.in
-langchain-community==0.0.10
+langchain-community==0.0.11
     # via langchain
-langchain-core==0.1.8
+langchain-core==0.1.10
     # via
     #   langchain
     #   langchain-community
-langsmith==0.0.78
+langsmith==0.0.80
     # via
     #   langchain
     #   langchain-community
     #   langchain-core
-marshmallow==3.20.1
+marshmallow==3.20.2
     # via
     #   -c ingest/../base.txt
     #   dataclasses-json

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -66,7 +66,7 @@ idna==3.6
     #   anyio
     #   requests
     #   yarl
-jinja2==3.1.2
+jinja2==3.1.3
     # via torch
 joblib==1.3.2
     # via
@@ -81,20 +81,20 @@ jsonpointer==2.4
     # via jsonpatch
 langchain==0.1.0
     # via -r ingest/embed-huggingface.in
-langchain-community==0.0.10
+langchain-community==0.0.11
     # via langchain
-langchain-core==0.1.8
+langchain-core==0.1.10
     # via
     #   langchain
     #   langchain-community
-langsmith==0.0.78
+langsmith==0.0.80
     # via
     #   langchain
     #   langchain-community
     #   langchain-core
 markupsafe==2.1.3
     # via jinja2
-marshmallow==3.20.1
+marshmallow==3.20.2
     # via
     #   -c ingest/../base.txt
     #   dataclasses-json

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -67,18 +67,18 @@ jsonpointer==2.4
     # via jsonpatch
 langchain==0.1.0
     # via -r ingest/embed-openai.in
-langchain-community==0.0.10
+langchain-community==0.0.11
     # via langchain
-langchain-core==0.1.8
+langchain-core==0.1.10
     # via
     #   langchain
     #   langchain-community
-langsmith==0.0.78
+langsmith==0.0.80
     # via
     #   langchain
     #   langchain-community
     #   langchain-core
-marshmallow==3.20.1
+marshmallow==3.20.2
     # via
     #   -c ingest/../base.txt
     #   dataclasses-json
@@ -95,7 +95,7 @@ numpy==1.26.3
     #   -c ingest/../base.txt
     #   langchain
     #   langchain-community
-openai==1.7.0
+openai==1.7.2
     # via -r ingest/embed-openai.in
 packaging==23.2
     # via

--- a/requirements/ingest/gcs.txt
+++ b/requirements/ingest/gcs.txt
@@ -45,7 +45,7 @@ google-api-core==2.15.0
     # via
     #   google-cloud-core
     #   google-cloud-storage
-google-auth==2.26.1
+google-auth==2.26.2
     # via
     #   gcsfs
     #   google-api-core

--- a/requirements/ingest/google-drive.txt
+++ b/requirements/ingest/google-drive.txt
@@ -19,7 +19,7 @@ google-api-core==2.15.0
     # via google-api-python-client
 google-api-python-client==2.113.0
     # via -r ingest/google-drive.in
-google-auth==2.26.1
+google-auth==2.26.2
     # via
     #   google-api-core
     #   google-api-python-client

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -111,7 +111,7 @@ requests==2.31.0
     # via
     #   -c base.txt
     #   label-studio-sdk
-ruff==0.1.11
+ruff==0.1.13
     # via -r test.in
 six==1.16.0
     # via

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.1-dev3"  # pragma: no cover
+__version__ = "0.12.1-dev4"  # pragma: no cover


### PR DESCRIPTION
Replacement for #2311 since python 3.8 was dropped as a supported version.

Unstructured-client added `api_key_auth` as a param to `UnstructuredClient` in [version 0.9.0](https://github.com/Unstructured-IO/unstructured-python-client/commit/8c93115c926765efe95c4e2a4e6bdf739fce41ad).

This pins the version of `unstructured-client` so users do not receive `TypeError: UnstructuredClient.__init__() got an unexpected keyword argument 'api_key_auth'`