### PR TITLE
Fix the table of contents warning message on transforming html into a…

### DIFF
--- a/docs/source/examples/chroma.rst
+++ b/docs/source/examples/chroma.rst
@@ -2,7 +2,7 @@ Transforming HTML into Vector Database
 ======================================
 
 .. contents::
-   :local:
+   :class: this-will-duplicate-information-and-it-is-still-useful-here
    :depth: 2
 
 Introduction


### PR DESCRIPTION
There's a warning message on this page in the documentation: https://unstructured-io.github.io/unstructured/examples/chroma.html

This is the patch as advised in the chroma doc to remove the error message if you're inserting a TOC at the top.
