### PR TITLE
test: update test Elasticsearch mappings to validate embedding search

### DIFF
--- a/docs/source/ingest/destination_connectors/data/elasticsearch_elements_mappings.json
+++ b/docs/source/ingest/destination_connectors/data/elasticsearch_elements_mappings.json
@@ -11,7 +11,8 @@
          "type": "keyword"
       },
       "embeddings": {
-         "type": "float"
+         "type": "dense_vector",
+         "dims": 384
       },
       "metadata": {
          "type": "object",

--- a/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
+++ b/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
@@ -10,6 +10,7 @@ from es_cluster_config import (
     PASSWORD,
     USER,
 )
+
 from unstructured.embed.huggingface import HuggingFaceEmbeddingConfig, HuggingFaceEmbeddingEncoder
 
 N_ELEMENTS = 1404
@@ -31,8 +32,8 @@ def query(client: Elasticsearch, search_text: str):
                 "query": {"match_all": {}},
                 "script": {
                     "source": "cosineSimilarity(params.query_vector, 'embeddings') + 1.0",
-                    "params": {"query_vector": search_vector}
-                }
+                    "params": {"query_vector": search_vector},
+                },
             }
         }
     }
@@ -59,6 +60,9 @@ if __name__ == "__main__":
     # Query the index using the appropriate embedding vector for given query text
     # Verify that the top 1 result matches the expected chunk by checking the start text
     print("Testing query to the embedded index.")
-    query_response = query(client, "A gathering of Russian nobility and merchants in historic uniforms, discussing the Emperor's manifesto with a mix of solemn anticipation and everyday concerns, while Pierre, dressed in a tight nobleman's uniform, ponders the French Revolution and social contracts amidst the crowd.")
-    assert query_response['hits']['hits'][0]['_source']['text'].startswith("CHAPTER XXII")
+    query_response = query(
+        client,
+        "A gathering of Russian nobility and merchants in historic uniforms, discussing the Emperor's manifesto with a mix of solemn anticipation and everyday concerns, while Pierre, dressed in a tight nobleman's uniform, ponders the French Revolution and social contracts amidst the crowd.",
+    )
+    assert query_response["hits"]["hits"][0]["_source"]["text"].startswith("CHAPTER XXII")
     print("Query to the embedded index was successful and returned the expected result.")

--- a/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
+++ b/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+from typing import List
 
 from elasticsearch import Elasticsearch
 from es_cluster_config import (
@@ -9,8 +10,35 @@ from es_cluster_config import (
     PASSWORD,
     USER,
 )
+from unstructured.embed.huggingface import HuggingFaceEmbeddingConfig, HuggingFaceEmbeddingEncoder
 
 N_ELEMENTS = 1404
+
+
+def embeddings_for_text(text: str) -> List[float]:
+    embedding_encoder = HuggingFaceEmbeddingEncoder(config=HuggingFaceEmbeddingConfig())
+    return embedding_encoder.embed_query(text)
+
+
+def query(client: Elasticsearch, search_text: str):
+    # Query the index using the appropriate embedding vector for given query text
+    # Return the top 1 result
+    search_vector = embeddings_for_text(search_text)
+    print(search_vector)
+    # Constructing the search query
+    query = {
+        "query": {
+            "script_score": {
+                "query": {"match_all": {}},
+                "script": {
+                    "source": "cosineSimilarity(params.query_vector, 'embeddings') + 1.0",
+                    "params": {"query_vector": search_vector}
+                }
+            }
+        }
+    }
+    return client.search(index=INDEX_NAME, body=query)
+
 
 if __name__ == "__main__":
     print(f"Checking contents of index" f"{INDEX_NAME} at {CLUSTER_URL}")
@@ -28,3 +56,10 @@ if __name__ == "__main__":
             f"got {count} items in index, expected {N_ELEMENTS} items in index."
         )
     print(f"Elasticsearch destination test was successful with {count} items being uploaded.")
+
+    # Query the index using the appropriate embedding vector for given query text
+    # Verify that the top 1 result matches the expected chunk by checking the start text
+    print("Testing query to the embedded index.")
+    query_response = query(client, "A gathering of Russian nobility and merchants in historic uniforms, discussing the Emperor's manifesto with a mix of solemn anticipation and everyday concerns, while Pierre, dressed in a tight nobleman's uniform, ponders the French Revolution and social contracts amidst the crowd.")
+    assert query_response['hits']['hits'][0]['_source']['text'].startswith("CHAPTER XXII")
+    print("Query to the embedded index was successful and returned the expected result.")

--- a/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
+++ b/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
@@ -60,9 +60,12 @@ if __name__ == "__main__":
     # Query the index using the appropriate embedding vector for given query text
     # Verify that the top 1 result matches the expected chunk by checking the start text
     print("Testing query to the embedded index.")
-    query_response = query(
-        client,
-        "A gathering of Russian nobility and merchants in historic uniforms, discussing the Emperor's manifesto with a mix of solemn anticipation and everyday concerns, while Pierre, dressed in a tight nobleman's uniform, ponders the French Revolution and social contracts amidst the crowd.",
+    query_text = (
+        "A gathering of Russian nobility and merchants in historic uniforms, "
+        "discussing the Emperor's manifesto with a mix of solemn anticipation "
+        "and everyday concerns, while Pierre, dressed in a tight nobleman's uniform, "
+        "ponders the French Revolution and social contracts amidst the crowd."
     )
+    query_response = query(client, query_text)
     assert query_response["hits"]["hits"][0]["_source"]["text"].startswith("CHAPTER XXII")
     print("Query to the embedded index was successful and returned the expected result.")

--- a/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
+++ b/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
@@ -22,7 +22,6 @@ def embeddings_for_text(text: str) -> List[float]:
 
 def query(client: Elasticsearch, search_text: str):
     # Query the index using the appropriate embedding vector for given query text
-    # Return the top 1 result
     search_vector = embeddings_for_text(search_text)
     print(search_vector)
     # Constructing the search query

--- a/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
+++ b/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
@@ -24,7 +24,6 @@ def embeddings_for_text(text: str) -> List[float]:
 def query(client: Elasticsearch, search_text: str):
     # Query the index using the appropriate embedding vector for given query text
     search_vector = embeddings_for_text(search_text)
-    print(search_vector)
     # Constructing the search query
     query = {
         "query": {

--- a/test_unstructured_ingest/dest/elasticsearch.sh
+++ b/test_unstructured_ingest/dest/elasticsearch.sh
@@ -59,4 +59,4 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
   --batch-size-bytes 15000000 \
   --num-processes "$max_processes"
 
-scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
+PYTHONPATH=. scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py


### PR DESCRIPTION
Currently in the Elasticsearch Destination ingest test we are writing the embeddings to a "float" type field. In order to leverage this field for similarity search it should be mapped as "dense_vector" with the respective dimensions assigned.

This PR updates that mapping and adds a test query to validate that this works as expected. 