### PR TITLE
fix: elasticsearch serialization issue 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.1-dev5
+## 0.12.1-dev6
 
 ### Enhancements
 
@@ -13,6 +13,7 @@
 
 * **Fix GCS connector converting JSON to string with single quotes.** FSSpec serialization caused conversion of JSON token to string with single quotes. GCS requires token in form of dict so this format is now assured.
 * **Fix the serialization of the Pinecone destination connector.** Presence of the PineconeIndex object breaks serialization due to TypeError: cannot pickle '_thread.lock' object. This removes that object before serialization.
+* **Fix the serialization of the Elasticsearch destination connector.** Presence of the _client object breaks serialization due to TypeError: cannot pickle '_thread.lock' object. This removes that object before serialization.
 
 ## 0.12.0
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.1-dev5"  # pragma: no cover
+__version__ = "0.12.1-dev6"  # pragma: no cover

--- a/unstructured/ingest/connector/elasticsearch.py
+++ b/unstructured/ingest/connector/elasticsearch.py
@@ -1,3 +1,4 @@
+import copy
 import hashlib
 import typing as t
 import uuid
@@ -7,6 +8,7 @@ from pathlib import Path
 from dataclasses_json.core import Json
 
 from unstructured.ingest.enhanced_dataclass import enhanced_field
+from unstructured.ingest.enhanced_dataclass.core import _asdict
 from unstructured.ingest.error import DestinationConnectionError, SourceConnectionError
 from unstructured.ingest.interfaces import (
     AccessConfig,
@@ -317,6 +319,18 @@ class ElasticsearchDestinationConnector(BaseDestinationConnector):
     write_config: ElasticsearchWriteConfig
     connector_config: SimpleElasticsearchConfig
     _client: t.Optional["Elasticsearch"] = field(init=False, default=None)
+
+    def to_dict(self, **kwargs):
+        """
+        The _client variable in this dataclass breaks deepcopy due to:
+        TypeError: cannot pickle '_thread.lock' object
+        When serializing, remove it, meaning client data will need to be reinitialized
+        when deserialized
+        """
+        self_cp = copy.copy(self)
+        if hasattr(self_cp, "_client"):
+            setattr(self_cp, "_client", None)
+        return _asdict(self_cp, **kwargs)
 
     @DestinationConnectionError.wrap
     @requires_dependencies(["elasticsearch"], extras="elasticsearch")


### PR DESCRIPTION
This fixes the serialization of the Elasticsearch destination connector. Presence of the _client object breaks serialization due to TypeError: cannot pickle '_thread.lock' object. This removes that object before serialization.