### PR TITLE
rfctr(chunking): add chunking arg constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.1-dev7
+## 0.12.1-dev8
 
 ### Enhancements
 

--- a/test_unstructured_ingest/dest/chroma.sh
+++ b/test_unstructured_ingest/dest/chroma.sh
@@ -46,6 +46,7 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
   --input-path example-docs/book-war-and-peace-1p.txt \
   --work-dir "$WORK_DIR" \
   --chunk-elements \
+  --chunk-max-characters 1500 \
   --chunk-multipage-sections \
   --embedding-provider "langchain-huggingface" \
   chroma \

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.1-dev7"  # pragma: no cover
+__version__ = "0.12.1-dev8"  # pragma: no cover

--- a/unstructured/chunking/__init__.py
+++ b/unstructured/chunking/__init__.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List
 
 from typing_extensions import ParamSpec
 
+from unstructured.chunking.base import CHUNK_MAX_CHARS_DEFAULT, CHUNK_MULTI_PAGE_DEFAULT
 from unstructured.chunking.basic import chunk_elements
 from unstructured.chunking.title import chunk_by_title
 from unstructured.documents.elements import Element
@@ -73,10 +74,12 @@ def add_chunking_strategy() -> Callable[[Callable[_P, List[Element]]], Callable[
             if call_args.get("chunking_strategy") == "by_title":
                 return chunk_by_title(
                     elements,
-                    combine_text_under_n_chars=call_args.get("combine_text_under_n_chars", 500),
-                    max_characters=call_args.get("max_characters", 500),
-                    multipage_sections=call_args.get("multipage_sections", True),
-                    new_after_n_chars=call_args.get("new_after_n_chars", 500),
+                    combine_text_under_n_chars=call_args.get("combine_text_under_n_chars", None),
+                    max_characters=call_args.get("max_characters", CHUNK_MAX_CHARS_DEFAULT),
+                    multipage_sections=call_args.get(
+                        "multipage_sections", CHUNK_MULTI_PAGE_DEFAULT
+                    ),
+                    new_after_n_chars=call_args.get("new_after_n_chars", None),
                     overlap=call_args.get("overlap", 0),
                     overlap_all=call_args.get("overlap_all", False),
                 )
@@ -84,8 +87,8 @@ def add_chunking_strategy() -> Callable[[Callable[_P, List[Element]]], Callable[
             if call_args.get("chunking_strategy") == "basic":
                 return chunk_elements(
                     elements,
-                    max_characters=call_args.get("max_characters", 500),
-                    new_after_n_chars=call_args.get("new_after_n_chars", 500),
+                    max_characters=call_args.get("max_characters", CHUNK_MAX_CHARS_DEFAULT),
+                    new_after_n_chars=call_args.get("new_after_n_chars", None),
                     overlap=call_args.get("overlap", 0),
                     overlap_all=call_args.get("overlap_all", False),
                 )

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -33,6 +33,20 @@ from unstructured.documents.elements import (
 )
 from unstructured.utils import lazyproperty
 
+# -- CONSTANTS -----------------------------------
+
+CHUNK_MAX_CHARS_DEFAULT: int = 500
+"""Hard-max chunk-length when no explicit value specified in `max_characters` argument."""
+
+CHUNK_MULTI_PAGE_DEFAULT: bool = True
+"""When False, respect page-boundaries (no two elements from different page in same chunk).
+
+Only operative for "by_title" chunking strategy.
+w"""
+
+
+# -- TYPES ---------------------------------------
+
 BoundaryPredicate: TypeAlias = Callable[[Element], bool]
 """Detects when element represents crossing a semantic boundary like section or page."""
 
@@ -94,8 +108,8 @@ class ChunkingOptions:
     def __init__(
         self,
         combine_text_under_n_chars: Optional[int] = None,
-        max_characters: int = 500,
-        multipage_sections: bool = True,
+        max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
+        multipage_sections: bool = CHUNK_MULTI_PAGE_DEFAULT,
         new_after_n_chars: Optional[int] = None,
         overlap: int = 0,
         overlap_all: bool = False,
@@ -113,8 +127,8 @@ class ChunkingOptions:
     def new(
         cls,
         combine_text_under_n_chars: Optional[int] = None,
-        max_characters: int = 500,
-        multipage_sections: bool = True,
+        max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
+        multipage_sections: bool = CHUNK_MULTI_PAGE_DEFAULT,
         new_after_n_chars: Optional[int] = None,
         overlap: int = 0,
         overlap_all: bool = False,

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -17,14 +17,14 @@ from __future__ import annotations
 
 from typing import List, Optional, Sequence
 
-from unstructured.chunking.base import BasePreChunker, ChunkingOptions
+from unstructured.chunking.base import CHUNK_MAX_CHARS_DEFAULT, BasePreChunker, ChunkingOptions
 from unstructured.documents.elements import Element
 
 
 def chunk_elements(
     elements: Sequence[Element],
     new_after_n_chars: Optional[int] = None,
-    max_characters: int = 500,
+    max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
     overlap: int = 0,
     overlap_all: bool = False,
 ) -> List[Element]:

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from typing import Iterator, List, Optional, Tuple
 
 from unstructured.chunking.base import (
+    CHUNK_MAX_CHARS_DEFAULT,
+    CHUNK_MULTI_PAGE_DEFAULT,
     BasePreChunker,
     BoundaryPredicate,
     ChunkingOptions,
@@ -22,10 +24,10 @@ from unstructured.utils import lazyproperty
 
 def chunk_by_title(
     elements: List[Element],
-    multipage_sections: bool = True,
+    multipage_sections: bool = CHUNK_MULTI_PAGE_DEFAULT,
     combine_text_under_n_chars: Optional[int] = None,
     new_after_n_chars: Optional[int] = None,
-    max_characters: int = 500,
+    max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
     overlap: int = 0,
     overlap_all: bool = False,
 ) -> List[Element]:

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -12,6 +12,7 @@ import click
 from dataclasses_json.core import Json
 from typing_extensions import Self
 
+from unstructured.chunking.base import CHUNK_MAX_CHARS_DEFAULT, CHUNK_MULTI_PAGE_DEFAULT
 from unstructured.ingest.interfaces import (
     BaseConfig,
     ChunkingConfig,
@@ -475,7 +476,7 @@ class CliChunkingConfig(ChunkingConfig, CliMixin):
             click.Option(
                 ["--chunk-multipage-sections"],
                 is_flag=True,
-                default=False,
+                default=CHUNK_MULTI_PAGE_DEFAULT,
                 help=(
                     "Ignore page boundaries when chunking such that elements from two different"
                     " pages can appear in the same chunk. Only operative for 'by_title'"
@@ -485,8 +486,6 @@ class CliChunkingConfig(ChunkingConfig, CliMixin):
             click.Option(
                 ["--chunk-combine-text-under-n-chars"],
                 type=int,
-                default=500,
-                show_default=True,
                 help=(
                     "Combine consecutive chunks when the first does not exceed this length and"
                     " the second will fit without exceeding the hard-maximum length. Only"
@@ -496,8 +495,6 @@ class CliChunkingConfig(ChunkingConfig, CliMixin):
             click.Option(
                 ["--chunk-new-after-n-chars"],
                 type=int,
-                default=1500,
-                show_default=True,
                 help=(
                     "Soft-maximum chunk length. Another element will not be added to a chunk of"
                     " this length even when it would fit without exceeding the hard-maximum"
@@ -507,7 +504,7 @@ class CliChunkingConfig(ChunkingConfig, CliMixin):
             click.Option(
                 ["--chunk-max-characters"],
                 type=int,
-                default=1500,
+                default=CHUNK_MAX_CHARS_DEFAULT,
                 show_default=True,
                 help=(
                     "Hard maximum chunk length. No chunk will exceed this length. An oversized"

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from dataclasses_json import DataClassJsonMixin
 from dataclasses_json.core import Json, _decode_dataclass
 
+from unstructured.chunking.base import CHUNK_MAX_CHARS_DEFAULT, CHUNK_MULTI_PAGE_DEFAULT
 from unstructured.chunking.basic import chunk_elements
 from unstructured.chunking.title import chunk_by_title
 from unstructured.documents.elements import DataSourceMetadata
@@ -215,9 +216,9 @@ class EmbeddingConfig(BaseConfig):
 class ChunkingConfig(BaseConfig):
     chunk_elements: bool = False
     chunking_strategy: t.Optional[str] = None
-    multipage_sections: bool = True
-    combine_text_under_n_chars: int = 500
-    max_characters: int = 1500
+    combine_text_under_n_chars: t.Optional[int] = None
+    max_characters: int = CHUNK_MAX_CHARS_DEFAULT
+    multipage_sections: bool = CHUNK_MULTI_PAGE_DEFAULT
     new_after_n_chars: t.Optional[int] = None
     overlap: int = 0
     overlap_all: bool = False


### PR DESCRIPTION
There are several public interface points for chunking and they all provide a default for arguments like `max_charactes`. These defaults are provided by literal values. Keeping these synchronized has become a problem.

Declare constant values for chunking argument default values and use those wherever a non-trivial default is used in an end-user facing API function.