### PR TITLE
refactor: use _get_iso639_language_object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.1-dev15
+## 0.12.1-dev16
 
 ### Enhancements
 

--- a/test_unstructured/partition/test_lang.py
+++ b/test_unstructured/partition/test_lang.py
@@ -6,7 +6,6 @@ from unstructured.documents.elements import (
 )
 from unstructured.partition.lang import (
     _convert_language_code_to_pytesseract_lang_code,
-    _convert_to_standard_langcode,
     apply_lang_metadata,
     detect_languages,
     prepare_languages_for_tesseract,
@@ -127,5 +126,6 @@ def test_convert_language_code_to_pytesseract_lang_code(lang_in, expected_lang):
     assert expected_lang == _convert_language_code_to_pytesseract_lang_code(lang_in)
 
 
-def test_convert_to_standard_langcode_full_language():
-    assert _convert_to_standard_langcode("Spanish") == "spa"
+def test_detect_languages_handles_spelled_out_languages():
+    languages = detect_languages(text="Sample text longer than 5 words.", languages=["Spanish"])
+    assert languages == ["spa"]

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.1-dev15"  # pragma: no cover
+__version__ = "0.12.1-dev16"  # pragma: no cover

--- a/unstructured/partition/lang.py
+++ b/unstructured/partition/lang.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable, Iterator, List, Optional, Union
+from typing import Iterable, Iterator, List, Optional
 
 import iso639
 from langdetect import DetectorFactory, detect_langs, lang_detect_exception
@@ -243,13 +243,12 @@ def _convert_language_code_to_pytesseract_lang_code(lang: str) -> str:
     return ""
 
 
-def _get_iso639_language_object(lang: str) -> Union[iso639.Language, str]:
+def _get_iso639_language_object(lang: str) -> Optional[iso639.Language]:
     try:
-        lang_iso639 = iso639.Language.match(lang.lower())
+        return iso639.Language.match(lang.lower())
     except iso639.LanguageNotFoundError:
         logger.warning(f"{lang} is not a valid standard language code.")
         return None
-    return lang_iso639
 
 
 def _get_all_tesseract_langcodes_with_prefix(prefix: str):
@@ -257,19 +256,6 @@ def _get_all_tesseract_langcodes_with_prefix(prefix: str):
     Get all matching tesseract langcodes with this prefix (may be one or multiple variants).
     """
     return [langcode for langcode in PYTESSERACT_LANG_CODES if langcode.startswith(prefix)]
-
-
-def _convert_to_standard_langcode(lang: str) -> str:
-    """
-    Convert a single language or language code to the standard internal language code format.
-    """
-    if TESSERACT_LANGUAGES_AND_CODES.get(lang.lower()):
-        lang = TESSERACT_LANGUAGES_AND_CODES.get(lang.lower())
-    # convert to standard ISO 639-3 language code
-    lang_iso639 = _get_iso639_language_object(lang[:3])
-    if lang_iso639:
-        return lang_iso639.part3
-    return ""
 
 
 def detect_languages(
@@ -301,11 +287,17 @@ def detect_languages(
     # set seed for deterministic langdetect outputs
     DetectorFactory.seed = 0
 
+    doc_languages: list[str] = []
+
     # user inputted languages:
     # if "auto" is included in the list of inputs, language detection will be triggered
     # and the rest of the inputted languages will be ignored
     if languages and "auto" not in languages:
-        doc_languages = [_convert_to_standard_langcode(lang) for lang in languages]
+        for lang in languages:
+            str_lang = TESSERACT_LANGUAGES_AND_CODES.get(lang.lower(), lang)
+            language = _get_iso639_language_object(str_lang[:3])
+            if language:
+                doc_languages.append(language.part3)
 
     # language detection:
     else:
@@ -323,19 +315,21 @@ def detect_languages(
             logger.warning(e)
             return None  # None as default
 
+        langdetect_langs: list[str] = []
+
         # NOTE(robinson) - Chinese gets detected with codes zh-cn, zh-tw, zh-hk for various
         # Chinese variants. We normalizes these because there is a single model for Chinese
         # machine translation
         # TODO(shreya): decide how to maintain nonstandard chinese script information
-        langdetect_langs = [
-            _convert_to_standard_langcode("zh")
-            if langobj.lang.startswith("zh")
-            else _convert_to_standard_langcode(langobj.lang)
-            for langobj in langdetect_result
-        ]
+        for langobj in langdetect_result:
+            if str(langobj.lang).startswith("zh"):
+                langdetect_langs.append("zho")
+            else:
+                language = _get_iso639_language_object(langobj.lang[:3])
+                if language:
+                    langdetect_langs.append(language.part3)
 
         # remove duplicate chinese (if exists) without modifying order
-        doc_languages = []
         for lang in langdetect_langs:
             if lang not in doc_languages:
                 doc_languages.append(lang)


### PR DESCRIPTION
This refactor removes `_convert_to_standard_langcode` and replaces it with calling `_get_iso639_language_object` with a string slice.

Use of TESSERACT_LANGUAGES_AND_CODES, which was added to `_convert_to_standard_langcode` previously, is moved to the relevant part where `_convert_to_standard_langcode` was previously called.

If/else statements replace the list comprehension for readability and `langdetect_langs.append("zho")` replaces `_convert_to_standard_langcode("zh")` since that always returned `"zho"`.