### PR TITLE
fix: chroma destination connector serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.1-dev15
+## 0.12.1-dev17
 
 ### Enhancements
 
@@ -27,6 +27,7 @@
 * **Fix the serialization of the Elasticsearch destination connector.** Presence of the _client object breaks serialization due to TypeError: cannot pickle '_thread.lock' object. This removes that object before serialization.
 * **Fix the serialization of the Postgres destination connector.** Presence of the _client object breaks serialization due to TypeError: cannot pickle '_thread.lock' object. This removes that object before serialization.
 * **Fix documentation and sample code for Chroma.** Was pointing to wrong examples..
+* **Fix the serialization of the Chroma destination connector.** Presence of the ChromaCollection object breaks serialization due to TypeError: cannot pickle 'module' object. This removes that object before serialization.
 
 ## 0.12.0
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.1-dev15"  # pragma: no cover
+__version__ = "0.12.1-dev17"  # pragma: no cover

--- a/unstructured/ingest/connector/chroma.py
+++ b/unstructured/ingest/connector/chroma.py
@@ -65,8 +65,8 @@ class ChromaDestinationConnector(BaseDestinationConnector):
     def to_dict(self, **kwargs):
         """
         The _collection variable in this dataclass breaks deepcopy due to:
-        TypeError: cannot pickle '_thread.lock' object
-        When serializing, remove it, meaning client data will need to be reinitialized
+        TypeError: cannot pickle 'module' object
+        When serializing, remove it, meaning collection data will need to be reinitialized
         when deserialized
         """
         self_cp = copy.copy(self)

--- a/unstructured/ingest/connector/chroma.py
+++ b/unstructured/ingest/connector/chroma.py
@@ -1,7 +1,9 @@
+import copy
 import typing as t
 import uuid
 from dataclasses import dataclass
 
+from unstructured.ingest.enhanced_dataclass.core import _asdict
 from unstructured.ingest.error import DestinationConnectionError
 from unstructured.ingest.interfaces import (
     AccessConfig,
@@ -59,6 +61,18 @@ class ChromaDestinationConnector(BaseDestinationConnector):
     @DestinationConnectionError.wrap
     def check_connection(self):
         _ = self.chroma_collection
+
+    def to_dict(self, **kwargs):
+        """
+        The _collection variable in this dataclass breaks deepcopy due to:
+        TypeError: cannot pickle '_thread.lock' object
+        When serializing, remove it, meaning client data will need to be reinitialized
+        when deserialized
+        """
+        self_cp = copy.copy(self)
+        if hasattr(self_cp, "_collection"):
+            setattr(self_cp, "_collection", None)
+        return _asdict(self_cp, **kwargs)
 
     @requires_dependencies(["chromadb"], extras="chroma")
     def create_collection(self) -> "ChromaCollection":


### PR DESCRIPTION
This fixes the serialization of the ChromaDB destination connector. Presence of the _collection object breaks serialization due to TypeError: cannot pickle 'module' object. This removes that object before serialization.