### PR TITLE
chore: Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM quay.io/unstructured-io/base-images:rocky9.2-9@sha256:6c838b65b7e4b3b9a94d56ab92ba5d801f5a530709ffb2ef63ece267955d3140 as base
+FROM quay.io/unstructured-io/base-images:rocky9.2-9@sha256:73d8492452f086144d4b92b7931aa04719f085c74d16cae81e8826ef873729c9 as base
 
 # NOTE(crag): NB_USER ARG for mybinder.org compat:
 #             https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html


### PR DESCRIPTION
Propagating the openssl revert made in the base image: https://github.com/Unstructured-IO/base-images/pull/13

Note that I messed up and wrote over the existing 9.2-9 image. Any current prs will need to rebase in order to get a working dockerfile.