### PR TITLE
fix: fsspec connectors returning data source version as integer

### DIFF
--- a/test_unstructured_ingest/unit/test_fsspec.py
+++ b/test_unstructured_ingest/unit/test_fsspec.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fsspec import AbstractFileSystem
+
+from unstructured.ingest.connector.fsspec.fsspec import FsspecIngestDoc, SimpleFsspecConfig
+from unstructured.ingest.interfaces import ProcessorConfig, ReadConfig
+
+
+class TestFsspecIngestDoc(unittest.TestCase):
+    @patch("fsspec.get_filesystem_class")
+    def test_version_is_string(self, mock_get_filesystem_class):
+        """
+        Test that the version is a string even when the filesystem checksum is an integer.
+        """
+        # Setup
+        mock_fs = MagicMock(spec=AbstractFileSystem)
+        mock_fs.checksum.return_value = 1234567890
+        mock_fs.info.return_value = {"etag": ""}
+        mock_get_filesystem_class.return_value = lambda **kwargs: mock_fs
+        config = SimpleFsspecConfig("s3://my-bucket", access_config={})
+        doc = FsspecIngestDoc(
+            processor_config=ProcessorConfig(),
+            read_config=ReadConfig(),
+            connector_config=config,
+            remote_file_path="test.txt",
+        )
+
+        # Check the version is a string
+        self.assertIsInstance(doc.source_metadata.version, str)

--- a/unstructured/ingest/connector/fsspec/fsspec.py
+++ b/unstructured/ingest/connector/fsspec/fsspec.py
@@ -134,7 +134,7 @@ class FsspecIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
         self.source_metadata = SourceMetadata(
             date_created=date_created,
             date_modified=date_modified,
-            version=version,
+            version=str(version),
             source_url=f"{self.connector_config.protocol}://{self.remote_file_path}",
             exists=file_exists,
         )


### PR DESCRIPTION
Connector data source versions should always be string values, however we were using the integer checksum value for the version for fsspec connectors. This casts that value to a string.

## Changes

* Cast the checksum value to a string when assigning the version value for fsspec connectors.
* Adds test to validate that these connectors will assign a string value when an integer checksum is fetched.

## Testing

Unit test added.