### PR TITLE
Fixed sphinx-build error by pinning alabaster=-0.7.13

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=build.txt build.in
 #
-alabaster==0.7.16
+alabaster==0.7.13
     # via sphinx
 babel==2.14.0
     # via sphinx


### PR DESCRIPTION
Fix sphinx-build error
> ERROR: Could not find a version that satisfies the requirement alabaster==0.7.16 (from -r docs/requirements.txt (line 7)) (from versions: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 0.4.1, 0.5.0, 0.5.1, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.7.1, 0.7.2, 0.7.3, 0.7.4, 0.7.5, 0.7.6, 0.7.7, 0.7.8, 0.7.9, 0.7.10, 0.7.11, 0.7.12, 0.7.13)

Changelog: 
* pin alabaster version to 0.7.13