### PR TITLE
fix: `partition_pdf()` not working when using chipper model with file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.4-dev1
+## 0.12.4-dev2
 
 ### Enhancements
 
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+* **Fix `partition_pdf()` not working when using chipper model with `file`**
 * **Handle common incorrect arguments for `languages` and `ocr_languages`** Users are regularly receiving errors on the API because they are defining `ocr_languages` or `languages` with additional quotationmarks, brackets, and similar mistakes. This update handles common incorrect arguments and raises an appropriate warning.
 * **Default `hi_res_model_name` now relies on `unstructured-inference`** When no explicit `hi_res_model_name` is passed into `partition` or `partition_pdf_or_image` the default model is picked by `unstructured-inference`'s settings or os env variable `UNSTRUCTURED_HI_RES_MODEL_NAME`; it now returns the same model name regardless of `infer_table_structure`'s value; this function will be deprecated in the future and the default model name will simply rely on `unstructured-inference` and will not consider os env in a future release.
 

--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -202,8 +202,10 @@ def test_partition_pdf_with_model_name_env_var(
         assert mock_process.call_args[1]["model_name"] == "checkbox"
 
 
+@pytest.mark.parametrize("model_name", ["checkbox", "yolox", "chipper"])
 def test_partition_pdf_with_model_name(
     monkeypatch,
+    model_name,
     filename=example_doc_path("layout-parser-paper-fast.pdf"),
 ):
     monkeypatch.setattr(pdf, "extractable_elements", lambda *args, **kwargs: [])
@@ -213,9 +215,24 @@ def test_partition_pdf_with_model_name(
         mock.MagicMock(),
     ) as mock_process:
         pdf.partition_pdf(
-            filename=filename, strategy=PartitionStrategy.HI_RES, model_name="checkbox"
+            filename=filename,
+            strategy=PartitionStrategy.HI_RES,
+            model_name=model_name,
         )
-        assert mock_process.call_args[1]["model_name"] == "checkbox"
+        assert mock_process.call_args[1]["model_name"] == model_name
+
+    with mock.patch.object(
+        layout,
+        "process_data_with_model",
+        mock.MagicMock(),
+    ) as mock_process:
+        with open(filename, "rb") as f:
+            pdf.partition_pdf(
+                file=f,
+                strategy=PartitionStrategy.HI_RES,
+                model_name=model_name,
+            )
+            assert mock_process.call_args[1]["model_name"] == model_name
 
 
 def test_partition_pdf_with_hi_res_model_name(

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.4-dev1"  # pragma: no cover
+__version__ = "0.12.4-dev2"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -366,7 +366,7 @@ def _partition_pdf_or_image_local(
         if hi_res_model_name.startswith("chipper"):
             # NOTE(alan): We shouldn't do OCR with chipper
             # NOTE(antonio): We shouldn't do PDFMiner with chipper
-            final_document_layout = merged_document_layout
+            final_document_layout = inferred_document_layout
         else:
             if hasattr(file, "seek"):
                 file.seek(0)


### PR DESCRIPTION
Closes #2480.
 
### Summary
- fixed an error introduced by PR [#2347](https://github.com/Unstructured-IO/unstructured/pull/2347) - https://github.com/Unstructured-IO/unstructured/pull/2347/files#diff-cefa2d296ae7ffcf5c28b5734d5c7d506fbdb225c05a0bc27c6b755d5424ffdaL373
- updated `test_partition_pdf_with_model_name()` to test more model names

### Testing
The updated test function `test_partition_pdf_with_model_name()` should work on this branch, but fails on the `main` branch.