### PR TITLE
bug: remove vectara requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.4-dev4
+## 0.12.4-dev5
 
 ### Enhancements
 
@@ -15,6 +15,8 @@
 * **Fix `partition_pdf()` not working when using chipper model with `file`** 
 * **Handle common incorrect arguments for `languages` and `ocr_languages`** Users are regularly receiving errors on the API because they are defining `ocr_languages` or `languages` with additional quotationmarks, brackets, and similar mistakes. This update handles common incorrect arguments and raises an appropriate warning.
 * **Default `hi_res_model_name` now relies on `unstructured-inference`** When no explicit `hi_res_model_name` is passed into `partition` or `partition_pdf_or_image` the default model is picked by `unstructured-inference`'s settings or os env variable `UNSTRUCTURED_HI_RES_MODEL_NAME`; it now returns the same model name regardless of `infer_table_structure`'s value; this function will be deprecated in the future and the default model name will simply rely on `unstructured-inference` and will not consider os env in a future release.
+* **Fix remove Vectara requirements from setup.py - there are no dependencies ** 
+
 
 ## 0.12.3
 

--- a/Makefile
+++ b/Makefile
@@ -227,10 +227,6 @@ install-ingest-sftp:
 install-ingest-pinecone:
 	python3 -m pip install -r requirements/ingest/pinecone.txt
 
-.PHONY: install-ingest-vectara
-install-ingest-vectara:
-	python3 -m pip install -r requirements/ingest/vectara.txt
-
 .PHONY: install-ingest-qdrant
 install-ingest-qdrant:
 	python3 -m pip install -r requirements/ingest/qdrant.txt

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,6 @@ setup(
         "salesforce": load_requirements("requirements/ingest/salesforce.in"),
         "sftp": load_requirements("requirements/ingest/sftp.in"),
         "slack": load_requirements("requirements/ingest/slack.in"),
-        "vectara": load_requirements("requirements/ingest/vectara.in"),
         "wikipedia": load_requirements("requirements/ingest/wikipedia.in"),
         "weaviate": load_requirements("requirements/ingest/weaviate.in"),
         # Legacy extra requirements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.4-dev4"  # pragma: no cover
+__version__ = "0.12.4-dev5"  # pragma: no cover


### PR DESCRIPTION
I accidentally added Vectara to setup and makefile. But there are no dependencies for Vectara

This removes Vectara from those files.