### PR TITLE
enhancement: process `.p7s` files with `partition_email`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-## 0.12.4-dev8
+## 0.12.4-dev9
 
 ### Enhancements
 
 * **Apply New Version of `black` formatting** The `black` library recently introduced a new major version that introduces new formatting conventions. This change brings code in the `unstructured` repo into compliance with the new conventions.
 * **Move ingest imports to local scopes** Moved ingest dependencies into local scopes to be able to import ingest connector classes without the need of installing imported external dependencies. This allows lightweight use of the classes (not the instances. to use the instances as intended you'll still need the dependencies).
+* **Add support for `.p7s` files** `partition_email` can now process `.p7s` files. The signature for
+  the signed message is extracted and added to metadata.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@
 
 * **Apply New Version of `black` formatting** The `black` library recently introduced a new major version that introduces new formatting conventions. This change brings code in the `unstructured` repo into compliance with the new conventions.
 * **Move ingest imports to local scopes** Moved ingest dependencies into local scopes to be able to import ingest connector classes without the need of installing imported external dependencies. This allows lightweight use of the classes (not the instances. to use the instances as intended you'll still need the dependencies).
-* **Add support for `.p7s` files** `partition_email` can now process `.p7s` files. The signature for
-  the signed message is extracted and added to metadata.
-* **Fallback to valid content types for emails** If the user selected content type does not exist on
-  the email message, `partition_email` now falls back to anoter valid content type if it's
-  available.
+* **Add support for `.p7s` files** `partition_email` can now process `.p7s` files. The signature for the signed message is extracted and added to metadata.
+* **Fallback to valid content types for emails** If the user selected content type does not exist on the email message, `partition_email` now falls back to anoter valid content type if it's available.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * **Move ingest imports to local scopes** Moved ingest dependencies into local scopes to be able to import ingest connector classes without the need of installing imported external dependencies. This allows lightweight use of the classes (not the instances. to use the instances as intended you'll still need the dependencies).
 * **Add support for `.p7s` files** `partition_email` can now process `.p7s` files. The signature for
   the signed message is extracted and added to metadata.
+* **Fallback to valid content types for emails** If the user selected content type does not exist on
+  the email message, `partition_email` now falls back to anoter valid content type if it's
+  available.
 
 ### Features
 

--- a/example-docs/eml/signed-doc.p7s
+++ b/example-docs/eml/signed-doc.p7s
@@ -1,0 +1,17 @@
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----DA7C0B64AB4D78BAFBED70C0FA340877"
+
+This is an S/MIME signed message
+
+------DA7C0B64AB4D78BAFBED70C0FA340877
+This is a test
+
+------DA7C0B64AB4D78BAFBED70C0FA340877
+Content-Type: application/x-pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+<SIGNATURE>
+
+------DA7C0B64AB4D78BAFBED70C0FA340877--
+

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -1282,3 +1282,10 @@ def test_partition_image_with_bmp_with_auto(
     table = [el.metadata.text_as_html for el in elements if el.metadata.text_as_html]
     assert len(table) == 1
     assert "<table><thead><th>" in table[0]
+
+
+def test_auto_partition_eml_add_signature_to_metadata(filename="example-docs/eml/signed-doc.p7s"):
+    elements = partition(filename=filename)
+    assert len(elements) == 1
+    assert elements[0].text == "This is a test"
+    assert elements[0].metadata.signature == "<SIGNATURE>\n"

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -1284,8 +1284,8 @@ def test_partition_image_with_bmp_with_auto(
     assert "<table><thead><th>" in table[0]
 
 
-def test_auto_partition_eml_add_signature_to_metadata(filename="example-docs/eml/signed-doc.p7s"):
-    elements = partition(filename=filename)
+def test_auto_partition_eml_add_signature_to_metadata():
+    elements = partition(filename="example-docs/eml/signed-doc.p7s")
     assert len(elements) == 1
     assert elements[0].text == "This is a test"
     assert elements[0].metadata.signature == "<SIGNATURE>\n"

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -635,8 +635,8 @@ def test_partition_eml_respects_detect_language_per_element():
     assert "spa" in langs
 
 
-def test_partition_eml_add_signature_to_metadata(filename="example-docs/eml/signed-doc.p7s"):
-    elements = partition_email(filename=filename)
+def test_partition_eml_add_signature_to_metadata():
+    elements = partition_email(filename="example-docs/eml/signed-doc.p7s")
     assert len(elements) == 1
     assert elements[0].text == "This is a test"
     assert elements[0].metadata.signature == "<SIGNATURE>\n"

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -406,10 +406,12 @@ def test_convert_to_iso_8601(time, expected):
     assert iso_time == expected
 
 
-def test_partition_email_still_works_with_no_content():
+def test_partition_email_still_works_with_no_content(caplog):
     filename = os.path.join(EXAMPLE_DOCS_DIRECTORY, "email-no-html-content-1.eml")
     elements = partition_email(filename=filename)
-    assert elements == []
+    assert len(elements) == 1
+    assert elements[0].text.startswith("Hey there")
+    assert "text/html was not found. Falling back to text/plain" in caplog.text
 
 
 def test_partition_email_from_filename_exclude_metadata():

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -633,3 +633,10 @@ def test_partition_eml_respects_detect_language_per_element():
     langs = {element.metadata.languages[0] for element in elements}
     assert "eng" in langs
     assert "spa" in langs
+
+
+def test_partition_eml_add_signature_to_metadata(filename="example-docs/eml/signed-doc.p7s"):
+    elements = partition_email(filename=filename)
+    assert len(elements) == 1
+    assert elements[0].text == "This is a test"
+    assert elements[0].metadata.signature == "<SIGNATURE>\n"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.4-dev8"  # pragma: no cover
+__version__ = "0.12.4-dev9"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -203,6 +203,7 @@ class ElementMetadata:
     sent_from: Optional[List[str]]
     sent_to: Optional[List[str]]
     subject: Optional[str]
+    signature: Optional[str]
 
     # -- used for Table elements to capture rows/col structure --
     text_as_html: Optional[str]
@@ -240,6 +241,7 @@ class ElementMetadata:
         section: Optional[str] = None,
         sent_from: Optional[List[str]] = None,
         sent_to: Optional[List[str]] = None,
+        signature: Optional[str] = None,
         subject: Optional[str] = None,
         text_as_html: Optional[str] = None,
         url: Optional[str] = None,
@@ -277,6 +279,7 @@ class ElementMetadata:
         self.section = section
         self.sent_from = sent_from
         self.sent_to = sent_to
+        self.signature = signature
         self.subject = subject
         self.text_as_html = text_as_html
         self.url = url
@@ -479,6 +482,7 @@ class ConsolidationStrategy(enum.Enum):
             "section": cls.FIRST,
             "sent_from": cls.FIRST,
             "sent_to": cls.FIRST,
+            "signature": cls.FIRST,
             "subject": cls.FIRST,
             "text_as_html": cls.DROP,  # -- not expected, only occurs in _TableSection --
             "url": cls.FIRST,

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -189,6 +189,7 @@ EXT_TO_FILETYPE = {
     ".rst": FileType.RST,
     ".xlsx": FileType.XLSX,
     ".pptx": FileType.PPTX,
+    ".p7s": FileType.EML,
     ".png": FileType.PNG,
     ".doc": FileType.DOC,
     ".zip": FileType.ZIP,
@@ -228,6 +229,7 @@ PLAIN_TEXT_EXTENSIONS = [
     ".txt",
     ".text",
     ".eml",
+    ".p7s",
     ".md",
     ".rtf",
     ".html",
@@ -329,6 +331,7 @@ def detect_filetype(
 
         if extension in [
             ".eml",
+            ".p7s",
             ".md",
             ".rtf",
             ".html",

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -385,7 +385,7 @@ def partition_email(
 
     if content_source in content_map:
         content = content_map.get(content_source)
-    # NOTE(robinson) - If a the chosen content source is not available and there is
+    # NOTE(robinson) - If the chosen content source is not available and there is
     # another valid content source, fall back to the other valid source
     else:
         for _content_source in VALID_CONTENT_SOURCES:

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -112,19 +112,26 @@ def partition_email_header(msg: Message) -> List[Element]:
     return elements
 
 
+def find_signature(msg: Message) -> Optional[str]:
+    """Extracts the signature from an email message, if it's available."""
+    payload = msg.get_payload()
+    if not isinstance(payload, list):
+        return None
+
+    for item in payload:
+        if item.get_content_type().endswith("signature"):
+            return item.get_payload()
+
+    return None
+
+
 def build_email_metadata(
     msg: Message,
     filename: Optional[str],
     metadata_last_modified: Optional[str] = None,
 ) -> ElementMetadata:
     """Creates an ElementMetadata object from the header information in the email."""
-    signature = None
-    payload = msg.get_payload()
-    if isinstance(payload, list):
-        for item in payload:
-            if item.get_content_type().endswith("signature"):
-                signature = item.get_payload()
-                break
+    signature = find_signature(msg)
 
     header_dict = dict(msg.raw_items())
     email_date = header_dict.get("Date")

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -375,8 +375,11 @@ def partition_email(
         for _content_source in VALID_CONTENT_SOURCES:
             content = content_map.get(_content_source, "")
             if content:
-                logger.warning(f"{content_source} was not found. Falling back to {_content_source}")
+                logger.warning(
+                    f"{content_source} was not found. Falling back to {_content_source}."
+                )
                 break
+
 
     elements: List[Element] = []
 

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -367,7 +367,16 @@ def partition_email(
         else:
             content_map[content_type] = part.get_payload()
 
-    content = content_map.get(content_source, "")
+    if content_source in content_map:
+        content = content_map.get(content_source)
+    # NOTE(robinson) - If a the chosen content source is not available and there is
+    # another valid content source, fall back to the other valid source
+    else:
+        for _content_source in VALID_CONTENT_SOURCES:
+            content = content_map.get(_content_source, "")
+            if content:
+                logger.warning(f"{content_source} was not found. Falling back to {_content_source}")
+                break
 
     elements: List[Element] = []
 

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -118,6 +118,14 @@ def build_email_metadata(
     metadata_last_modified: Optional[str] = None,
 ) -> ElementMetadata:
     """Creates an ElementMetadata object from the header information in the email."""
+    signature = None
+    payload = msg.get_payload()
+    if isinstance(payload, list):
+        for item in payload:
+            if item.get_content_type().endswith("signature"):
+                signature = item.get_payload()
+                break
+
     header_dict = dict(msg.raw_items())
     email_date = header_dict.get("Date")
     if email_date is not None:
@@ -135,6 +143,7 @@ def build_email_metadata(
         sent_to=sent_to,
         sent_from=sent_from,
         subject=header_dict.get("Subject"),
+        signature=signature,
         last_modified=metadata_last_modified or email_date,
         filename=filename,
     )

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -380,7 +380,6 @@ def partition_email(
                 )
                 break
 
-
     elements: List[Element] = []
 
     if is_encrypted:


### PR DESCRIPTION
### Summary

Closes #2489, which reported an inability to process `.p7s` files. PR implements two changes:

- If the user selected content type for the email is not available and there is another valid content type available, fall back to the other valid content type.
- For signed message, extract the signature and add it to the metadata


### Testing

```python
from unstructured.partition.auto import partition

filename = "example-docs/eml/signed-doc.p7s"
elements = partition(filename=filename) # should get a message about fall back logic
print(elements[0]) # "This is a test"
elements[0].metadata.to_dict() # Will see the signature
```