### PR TITLE
rfctr(chunking): preparation for plug-in chunkers, Part I

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.5-dev7
+## 0.12.5-dev8
 
 ### Enhancements
 

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import List, Sequence
+from typing import Sequence
 
 import pytest
 
@@ -836,7 +836,7 @@ class DescribeTextPreChunk:
         ],
     )
     def it_knows_the_concatenated_text_of_the_pre_chunk_to_help(
-        self, elements: List[Text], overlap_prefix: str, expected_value: str
+        self, elements: list[Text], overlap_prefix: str, expected_value: str
     ):
         """._text is the "joined" text of the pre-chunk elements.
 

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -1,6 +1,8 @@
 # pyright: reportPrivateUsage=false
 
-from typing import List
+"""Unit-test suite for the `unstructured.chunking.title` module."""
+
+from __future__ import annotations
 
 import pytest
 
@@ -23,7 +25,7 @@ from unstructured.partition.html import partition_html
 
 
 def test_it_splits_a_large_element_into_multiple_chunks():
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title("Introduction"),
         Text(
             "Lorem ipsum dolor sit amet consectetur adipiscing elit. In rhoncus ipsum sed lectus"
@@ -41,7 +43,7 @@ def test_it_splits_a_large_element_into_multiple_chunks():
 
 
 def test_split_elements_by_title_and_table():
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title("A Great Day"),
         Text("Today is a great day."),
         Text("It is sunny outside."),
@@ -91,7 +93,7 @@ def test_split_elements_by_title_and_table():
 
 
 def test_chunk_by_title():
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title("A Great Day", metadata=ElementMetadata(emphasized_text_contents=["Day"])),
         Text("Today is a great day.", metadata=ElementMetadata(emphasized_text_contents=["day"])),
         Text("It is sunny outside."),
@@ -129,7 +131,7 @@ def test_chunk_by_title():
 
 
 def test_chunk_by_title_respects_section_change():
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title("A Great Day", metadata=ElementMetadata(section="first")),
         Text("Today is a great day.", metadata=ElementMetadata(section="second")),
         Text("It is sunny outside.", metadata=ElementMetadata(section="second")),
@@ -166,7 +168,7 @@ def test_chunk_by_title_respects_section_change():
 
 
 def test_chunk_by_title_separates_by_page_number():
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title("A Great Day", metadata=ElementMetadata(page_number=1)),
         Text("Today is a great day.", metadata=ElementMetadata(page_number=2)),
         Text("It is sunny outside.", metadata=ElementMetadata(page_number=2)),
@@ -207,7 +209,7 @@ def test_chunk_by_title_does_not_break_on_regex_metadata_change():
     A regex-metadata match in an element does not signify a semantic boundary and a pre-chunk should
     not be split based on such a difference.
     """
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title(
             "Lorem Ipsum",
             metadata=ElementMetadata(
@@ -244,7 +246,7 @@ def test_chunk_by_title_consolidates_and_adjusts_offsets_of_regex_metadata():
     The `start` and `end` offsets of each regex-match are adjusted to reflect their new position in
     the chunk after element text has been concatenated.
     """
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title(
             "Lorem Ipsum",
             metadata=ElementMetadata(
@@ -286,7 +288,7 @@ def test_chunk_by_title_consolidates_and_adjusts_offsets_of_regex_metadata():
 
 
 def test_chunk_by_title_groups_across_pages():
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title("A Great Day", metadata=ElementMetadata(page_number=1)),
         Text("Today is a great day.", metadata=ElementMetadata(page_number=2)),
         Text("It is sunny outside.", metadata=ElementMetadata(page_number=2)),
@@ -401,7 +403,7 @@ def test_add_chunking_strategy_on_partition_html_respects_multipage():
 
 
 def test_chunk_by_title_drops_detection_class_prob():
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title(
             "A Great Day",
             metadata=ElementMetadata(
@@ -441,7 +443,7 @@ def test_chunk_by_title_drops_detection_class_prob():
 
 
 def test_chunk_by_title_drops_extra_metadata():
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title(
             "A Great Day",
             metadata=ElementMetadata(
@@ -525,7 +527,7 @@ def test_chunk_by_title_drops_extra_metadata():
 
 def test_it_considers_separator_length_when_pre_chunking():
     """PreChunker includes length of separators when computing remaining space."""
-    elements: List[Element] = [
+    elements: list[Element] = [
         Title("Chunking Priorities"),  # 19 chars
         ListItem("Divide text into manageable chunks"),  # 34 chars
         ListItem("Preserve semantic boundaries"),  # 28 chars

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.5-dev7"  # pragma: no cover
+__version__ = "0.12.5-dev8"  # pragma: no cover

--- a/unstructured/chunking/__init__.py
+++ b/unstructured/chunking/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import functools
 import inspect
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 from typing_extensions import ParamSpec
 
@@ -19,14 +19,14 @@ from unstructured.documents.elements import Element
 _P = ParamSpec("_P")
 
 
-def add_chunking_strategy() -> Callable[[Callable[_P, List[Element]]], Callable[_P, List[Element]]]:
+def add_chunking_strategy() -> Callable[[Callable[_P, list[Element]]], Callable[_P, list[Element]]]:
     """Decorator for chunking text.
 
     Chunks the element sequence produced by the partitioner it decorates when a `chunking_strategy`
     argument is present in the partitioner call and it names an available chunking strategy.
     """
 
-    def decorator(func: Callable[_P, List[Element]]) -> Callable[_P, List[Element]]:
+    def decorator(func: Callable[_P, list[Element]]) -> Callable[_P, list[Element]]:
         # -- Patch the docstring of the decorated function to add chunking strategy and
         # -- chunking-related argument documentation. This only applies when `chunking_strategy`
         # -- is an explicit argument of the decorated function and "chunking_strategy" is not
@@ -53,13 +53,13 @@ def add_chunking_strategy() -> Callable[[Callable[_P, List[Element]]], Callable[
             )
 
         @functools.wraps(func)
-        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> List[Element]:
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> list[Element]:
             """The decorated function is replaced with this one."""
 
-            def get_call_args_applying_defaults() -> Dict[str, Any]:
+            def get_call_args_applying_defaults() -> dict[str, Any]:
                 """Map both explicit and default arguments of decorated func call by param name."""
                 sig = inspect.signature(func)
-                call_args: Dict[str, Any] = dict(**dict(zip(sig.parameters, args)), **kwargs)
+                call_args: dict[str, Any] = dict(**dict(zip(sig.parameters, args)), **kwargs)
                 for param in sig.parameters.values():
                     if param.name not in call_args and param.default is not param.empty:
                         call_args[param.name] = param.default

--- a/unstructured/chunking/__init__.py
+++ b/unstructured/chunking/__init__.py
@@ -16,6 +16,8 @@ from unstructured.chunking.basic import chunk_elements
 from unstructured.chunking.title import chunk_by_title
 from unstructured.documents.elements import Element
 
+__all__ = ["CHUNK_MAX_CHARS_DEFAULT", "CHUNK_MULTI_PAGE_DEFAULT", "add_chunking_strategy"]
+
 _P = ParamSpec("_P")
 
 
@@ -74,23 +76,21 @@ def add_chunking_strategy() -> Callable[[Callable[_P, list[Element]]], Callable[
             if call_args.get("chunking_strategy") == "by_title":
                 return chunk_by_title(
                     elements,
-                    combine_text_under_n_chars=call_args.get("combine_text_under_n_chars", None),
-                    max_characters=call_args.get("max_characters", CHUNK_MAX_CHARS_DEFAULT),
-                    multipage_sections=call_args.get(
-                        "multipage_sections", CHUNK_MULTI_PAGE_DEFAULT
-                    ),
-                    new_after_n_chars=call_args.get("new_after_n_chars", None),
-                    overlap=call_args.get("overlap", 0),
-                    overlap_all=call_args.get("overlap_all", False),
+                    combine_text_under_n_chars=call_args.get("combine_text_under_n_chars"),
+                    max_characters=call_args.get("max_characters"),
+                    multipage_sections=call_args.get("multipage_sections"),
+                    new_after_n_chars=call_args.get("new_after_n_chars"),
+                    overlap=call_args.get("overlap"),
+                    overlap_all=call_args.get("overlap_all"),
                 )
 
             if call_args.get("chunking_strategy") == "basic":
                 return chunk_elements(
                     elements,
-                    max_characters=call_args.get("max_characters", CHUNK_MAX_CHARS_DEFAULT),
-                    new_after_n_chars=call_args.get("new_after_n_chars", None),
-                    overlap=call_args.get("overlap", 0),
-                    overlap_all=call_args.get("overlap_all", False),
+                    max_characters=call_args.get("max_characters"),
+                    new_after_n_chars=call_args.get("new_after_n_chars"),
+                    overlap=call_args.get("overlap"),
+                    overlap_all=call_args.get("overlap_all"),
                 )
 
             return elements

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -279,7 +279,10 @@ class ChunkingOptions:
         # otherwise there could be corner cases leading to an infinite
         # loop (I think).
         if self.overlap >= max_characters:
-            raise ValueError(f"'overlap' must be less than max_characters," f" got {self.overlap}")
+            raise ValueError(
+                f"'overlap' argument must be less than `max_characters`,"
+                f" got {self.overlap} >= {max_characters}"
+            )
 
 
 class _TextSplitter:
@@ -731,7 +734,7 @@ class TextPreChunk:
                     yield field_name, self._consolidated_regex_meta
                 elif strategy is CS.DROP:
                     continue
-                else:
+                else:  # pragma: no cover
                     # -- not likely to hit this since we have a test in `text_elements.py` that
                     # -- ensures every ElementMetadata fields has an assigned strategy.
                     raise NotImplementedError(

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -24,13 +24,19 @@ from unstructured.utils import lazyproperty
 # -- CONSTANTS -----------------------------------
 
 CHUNK_MAX_CHARS_DEFAULT: int = 500
-"""Hard-max chunk-length when no explicit value specified in `max_characters` argument."""
+"""Hard-max chunk-length when no explicit value specified in `max_characters` argument.
+
+Provided for reference only, for example so the ingest CLI can advertise the default value in its
+UI. External chunking-related functions (e.g. in ingest or decorators) should use
+`max_characters: Optional[int] = None` and not apply this default themselves. Only
+`ChunkingOptions.max_characters` should apply a default value.
+"""
 
 CHUNK_MULTI_PAGE_DEFAULT: bool = True
 """When False, respect page-boundaries (no two elements from different page in same chunk).
 
 Only operative for "by_title" chunking strategy.
-w"""
+"""
 
 
 # -- TYPES ---------------------------------------
@@ -115,11 +121,11 @@ class ChunkingOptions:
     def new(
         cls,
         combine_text_under_n_chars: Optional[int] = None,
-        max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
-        multipage_sections: bool = CHUNK_MULTI_PAGE_DEFAULT,
+        max_characters: Optional[int] = None,
+        multipage_sections: Optional[bool] = None,
         new_after_n_chars: Optional[int] = None,
-        overlap: int = 0,
-        overlap_all: bool = False,
+        overlap: Optional[int] = None,
+        overlap_all: Optional[bool] = None,
         text_splitting_separators: Sequence[str] = ("\n", " "),
     ) -> Self:
         """Construct validated instance.

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -17,16 +17,16 @@ from __future__ import annotations
 
 from typing import Iterable, Optional
 
-from unstructured.chunking.base import CHUNK_MAX_CHARS_DEFAULT, BasePreChunker, ChunkingOptions
+from unstructured.chunking.base import BasePreChunker, ChunkingOptions
 from unstructured.documents.elements import Element
 
 
 def chunk_elements(
     elements: Iterable[Element],
+    max_characters: Optional[int] = None,
     new_after_n_chars: Optional[int] = None,
-    max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
-    overlap: int = 0,
-    overlap_all: bool = False,
+    overlap: Optional[int] = None,
+    overlap_all: Optional[bool] = None,
 ) -> list[Element]:
     """Combine sequential `elements` into chunks, respecting specified text-length limits.
 

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -15,14 +15,14 @@ started.
 
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Iterable, Optional
 
 from unstructured.chunking.base import CHUNK_MAX_CHARS_DEFAULT, BasePreChunker, ChunkingOptions
 from unstructured.documents.elements import Element
 
 
 def chunk_elements(
-    elements: Sequence[Element],
+    elements: Iterable[Element],
     new_after_n_chars: Optional[int] = None,
     max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
     overlap: int = 0,

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -15,7 +15,7 @@ started.
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence
+from typing import Optional, Sequence
 
 from unstructured.chunking.base import CHUNK_MAX_CHARS_DEFAULT, BasePreChunker, ChunkingOptions
 from unstructured.documents.elements import Element
@@ -27,7 +27,7 @@ def chunk_elements(
     max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
     overlap: int = 0,
     overlap_all: bool = False,
-) -> List[Element]:
+) -> list[Element]:
     """Combine sequential `elements` into chunks, respecting specified text-length limits.
 
     Produces a sequence of `CompositeElement`, `Table`, and `TableChunk` elements (chunks).

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -5,7 +5,7 @@ Main entry point is the `@add_chunking_strategy()` decorator.
 
 from __future__ import annotations
 
-from typing import Iterator, Optional
+from typing import Iterable, Iterator, Optional
 
 from unstructured.chunking.base import (
     CHUNK_MAX_CHARS_DEFAULT,
@@ -23,7 +23,7 @@ from unstructured.utils import lazyproperty
 
 
 def chunk_by_title(
-    elements: list[Element],
+    elements: Iterable[Element],
     multipage_sections: bool = CHUNK_MULTI_PAGE_DEFAULT,
     combine_text_under_n_chars: Optional[int] = None,
     new_after_n_chars: Optional[int] = None,

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 from typing import Iterable, Iterator, Optional
 
 from unstructured.chunking.base import (
-    CHUNK_MAX_CHARS_DEFAULT,
-    CHUNK_MULTI_PAGE_DEFAULT,
     BasePreChunker,
     BoundaryPredicate,
     ChunkingOptions,
@@ -24,12 +22,12 @@ from unstructured.utils import lazyproperty
 
 def chunk_by_title(
     elements: Iterable[Element],
-    multipage_sections: bool = CHUNK_MULTI_PAGE_DEFAULT,
+    max_characters: Optional[int] = None,
+    multipage_sections: Optional[bool] = None,
     combine_text_under_n_chars: Optional[int] = None,
     new_after_n_chars: Optional[int] = None,
-    max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
-    overlap: int = 0,
-    overlap_all: bool = False,
+    overlap: Optional[int] = None,
+    overlap_all: Optional[bool] = None,
 ) -> list[Element]:
     """Uses title elements to identify sections within the document for chunking.
 

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -5,7 +5,7 @@ Main entry point is the `@add_chunking_strategy()` decorator.
 
 from __future__ import annotations
 
-from typing import Iterator, List, Optional, Tuple
+from typing import Iterator, Optional
 
 from unstructured.chunking.base import (
     CHUNK_MAX_CHARS_DEFAULT,
@@ -23,14 +23,14 @@ from unstructured.utils import lazyproperty
 
 
 def chunk_by_title(
-    elements: List[Element],
+    elements: list[Element],
     multipage_sections: bool = CHUNK_MULTI_PAGE_DEFAULT,
     combine_text_under_n_chars: Optional[int] = None,
     new_after_n_chars: Optional[int] = None,
     max_characters: int = CHUNK_MAX_CHARS_DEFAULT,
     overlap: int = 0,
     overlap_all: bool = False,
-) -> List[Element]:
+) -> list[Element]:
     """Uses title elements to identify sections within the document for chunking.
 
     Splits off into a new CompositeElement when a title is detected or if metadata changes, which
@@ -91,7 +91,7 @@ class _ByTitlePreChunker(BasePreChunker):
     """
 
     @lazyproperty
-    def _boundary_predicates(self) -> Tuple[BoundaryPredicate, ...]:
+    def _boundary_predicates(self) -> tuple[BoundaryPredicate, ...]:
         """The semantic-boundary detectors to be applied to break pre-chunks."""
 
         def iter_boundary_predicates() -> Iterator[BoundaryPredicate]:

--- a/unstructured/ingest/cli/interfaces.py
+++ b/unstructured/ingest/cli/interfaces.py
@@ -12,7 +12,7 @@ import click
 from dataclasses_json.core import Json
 from typing_extensions import Self
 
-from unstructured.chunking.base import CHUNK_MAX_CHARS_DEFAULT, CHUNK_MULTI_PAGE_DEFAULT
+from unstructured.chunking import CHUNK_MAX_CHARS_DEFAULT, CHUNK_MULTI_PAGE_DEFAULT
 from unstructured.ingest.interfaces import (
     BaseConfig,
     ChunkingConfig,

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from dataclasses_json import DataClassJsonMixin
 from dataclasses_json.core import Json, _decode_dataclass
 
-from unstructured.chunking.base import CHUNK_MAX_CHARS_DEFAULT, CHUNK_MULTI_PAGE_DEFAULT
 from unstructured.chunking.basic import chunk_elements
 from unstructured.chunking.title import chunk_by_title
 from unstructured.documents.elements import DataSourceMetadata
@@ -219,11 +218,11 @@ class ChunkingConfig(BaseConfig):
     chunk_elements: bool = False
     chunking_strategy: t.Optional[str] = None
     combine_text_under_n_chars: t.Optional[int] = None
-    max_characters: int = CHUNK_MAX_CHARS_DEFAULT
-    multipage_sections: bool = CHUNK_MULTI_PAGE_DEFAULT
+    max_characters: t.Optional[int] = None
+    multipage_sections: t.Optional[bool] = None
     new_after_n_chars: t.Optional[int] = None
-    overlap: int = 0
-    overlap_all: bool = False
+    overlap: t.Optional[int] = None
+    overlap_all: t.Optional[bool] = None
 
     def chunk(self, elements: t.List[Element]) -> t.List[Element]:
         chunking_strategy = (


### PR DESCRIPTION
**Summary**
In order to accommodate customized chunkers other than those directly provided by `unstructured`, some further modularization is necessary such that a new chunker can be added as a "plug-in" without modifying the `unstructured` library code.

This PR is the straightforward refactoring required for this process like typing changes. There are also some other small changes we've been meaning to make like making all chunking options accept `None` to represent their default value so the broad field of callers (e.g. ingest, unstructured-api, SDK) don't need to determine and set default values for chunking arguments leading to diverging defaults.

Isolating these "noisy" but easy to accept changes in this preparatory PR reduces the noise in the more substantive changes to follow. 