### PR TITLE
feature: add octoai for embeddings (#2538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 0.12.5-dev1
+## 0.12.5-dev2
 
 ### Enhancements
 
 ### Features
+
+* **Add OctoAI embedder** Adds support for embeddings via OctoAI.
 
 ### Fixes
 

--- a/docs/source/core/embedding.rst
+++ b/docs/source/core/embedding.rst
@@ -43,10 +43,10 @@ To obtain an api key, visit: https://platform.openai.com/account/api-keys
     import os
 
     from unstructured.documents.elements import Text
-    from unstructured.embed.openai import OpenAIEmbeddingEncoder
+    from unstructured.embed.openai import OpenAiEmbeddingConfig, OpenAIEmbeddingEncoder
 
     # Initialize the encoder with OpenAI credentials
-    embedding_encoder = OpenAIEmbeddingEncoder(api_key=os.environ["OPENAI_API_KEY"])
+    embedding_encoder = OpenAIEmbeddingEncoder(config=OpenAiEmbeddingConfig(api_key=os.environ["OPENAI_API_KEY"]))
 
     # Embed a list of Elements
     elements = embedding_encoder.embed_documents(
@@ -130,3 +130,47 @@ To create an instance of the `BedrockEmbeddingEncoder`, AWS credentials and the 
 
 Dependencies:
 This class relies on several dependencies which include boto3, numpy, and langchain. Ensure these are installed and available in the environment where this class is utilized.
+
+``OctoAIEmbeddingEncoder``
+--------------------------
+
+The ``OctoAIEmbeddingEncoder`` class connects to the OctoAI Text&Embedding API to obtain embeddings for pieces of text.
+
+``embed_documents`` will receive a list of Elements, and return an updated list which
+includes the ``embeddings`` attribute for each Element.
+
+``embed_query`` will receive a query as a string, and return a list of floats which is the
+embedding vector for the given query string.
+
+``num_of_dimensions`` is a metadata property that denotes the number of dimensions in any
+embedding vector obtained via this class.
+
+``is_unit_vector`` is a metadata property that denotes if embedding vectors obtained via
+this class are unit vectors.
+
+The following code block shows an example of how to use ``OctoAIEmbeddingEncoder``. You will
+see the updated elements list (with the ``embeddings`` attribute included for each element),
+the embedding vector for the query string, and some metadata properties about the embedding model.
+You will need to set an environment variable named ``OCTOAI_API_KEY`` to be able to run this example.
+To obtain an api key, visit: https://octo.ai/docs/getting-started/how-to-create-an-octoai-access-token
+
+.. code:: python
+
+    import os
+
+    from unstructured.documents.elements import Text
+    from unstructured.embed.octoai import OctoAiEmbeddingConfig, OctoAIEmbeddingEncoder
+
+    embedding_encoder = OctoAIEmbeddingEncoder(
+        config=OctoAiEmbeddingConfig(api_key=os.environ["OCTOAI_API_KEY"])
+    )
+    elements = embedding_encoder.embed_documents(
+        elements=[Text("This is sentence 1"), Text("This is sentence 2")],
+    )
+
+    query = "This is the query"
+    query_embedding = embedding_encoder.embed_query(query=query)
+
+    [print(e.embeddings, e) for e in elements]
+    print(query_embedding, query)
+    print(embedding_encoder.is_unit_vector(), embedding_encoder.num_of_dimensions())

--- a/examples/embed/example_octoai.py
+++ b/examples/embed/example_octoai.py
@@ -1,0 +1,18 @@
+import os
+
+from unstructured.documents.elements import Text
+from unstructured.embed.octoai import OctoAiEmbeddingConfig, OctoAIEmbeddingEncoder
+
+embedding_encoder = OctoAIEmbeddingEncoder(
+    config=OctoAiEmbeddingConfig(api_key=os.environ["OCTOAI_API_KEY"])
+)
+elements = embedding_encoder.embed_documents(
+    elements=[Text("This is sentence 1"), Text("This is sentence 2")],
+)
+
+query = "This is the query"
+query_embedding = embedding_encoder.embed_query(query=query)
+
+[print(e.embeddings, e) for e in elements]
+print(query_embedding, query)
+print(embedding_encoder.is_unit_vector(), embedding_encoder.num_of_dimensions())

--- a/examples/embed/example_openai.py
+++ b/examples/embed/example_openai.py
@@ -1,9 +1,11 @@
 import os
 
 from unstructured.documents.elements import Text
-from unstructured.embed.openai import OpenAIEmbeddingEncoder
+from unstructured.embed.openai import OpenAiEmbeddingConfig, OpenAIEmbeddingEncoder
 
-embedding_encoder = OpenAIEmbeddingEncoder(api_key=os.environ["OPENAI_API_KEY"])
+embedding_encoder = OpenAIEmbeddingEncoder(
+    config=OpenAiEmbeddingConfig(api_key=os.environ["OPENAI_API_KEY"])
+)
 elements = embedding_encoder.embed_documents(
     elements=[Text("This is sentence 1"), Text("This is sentence 2")],
 )

--- a/test_unstructured/embed/test_octoai.py
+++ b/test_unstructured/embed/test_octoai.py
@@ -1,0 +1,19 @@
+from unstructured.documents.elements import Text
+from unstructured.embed.octoai import OctoAiEmbeddingConfig, OctoAIEmbeddingEncoder
+
+
+def test_embed_documents_does_not_break_element_to_dict(mocker):
+    # Mocked client with the desired behavior for embed_documents
+    mock_client = mocker.MagicMock()
+    mock_client.embed_documents.return_value = [1, 2]
+
+    # Mock create_client to return our mock_client
+    mocker.patch.object(OctoAIEmbeddingEncoder, "create_client", return_value=mock_client)
+
+    encoder = OctoAIEmbeddingEncoder(config=OctoAiEmbeddingConfig(api_key="api_key"))
+    elements = encoder.embed_documents(
+        elements=[Text("This is sentence 1"), Text("This is sentence 2")],
+    )
+    assert len(elements) == 2
+    assert elements[0].to_dict()["text"] == "This is sentence 1"
+    assert elements[1].to_dict()["text"] == "This is sentence 2"

--- a/test_unstructured/test_utils.py
+++ b/test_unstructured/test_utils.py
@@ -105,7 +105,7 @@ def test_only_gives_only(iterator):
 @pytest.mark.parametrize("iterator", [[0, 1], (0, 1), range(10)])
 def test_only_raises_when_len_more_than_1(iterator):
     with pytest.raises(ValueError):
-        utils.only(iterator) == 0
+        utils.only(iterator)
 
 
 @pytest.mark.parametrize("iterator", [[], ()])
@@ -115,7 +115,7 @@ def test_only_raises_if_empty(iterator):
 
 
 @pytest.mark.parametrize(
-    ("elements", "nested_error_tolerance_px", "sm_overlap_threshold", "expectation"),
+    ("elements", "nested_error_tolerance_px", "expectation"),
     [
         (
             [
@@ -133,7 +133,6 @@ def test_only_raises_if_empty(iterator):
                 ),
             ],
             5,
-            10.0,
             (
                 True,
                 [
@@ -168,7 +167,6 @@ def test_only_raises_if_empty(iterator):
                 ),
             ],
             1,
-            10.0,
             (
                 True,
                 [
@@ -204,13 +202,82 @@ def test_only_raises_if_empty(iterator):
                 ),
             ],
             1,
-            10.0,
             (
                 True,
                 [
                     {
                         "overlapping_elements": ["0. Title(ix=0)", "1. NarrativeText(ix=1)"],
                         "overlapping_case": "partial overlap with duplicate text",
+                        "overlap_percentage": "11.11%",
+                        "metadata": {
+                            "largest_ngram_percentage": None,
+                            "overlap_percentage_total": "5.88%",
+                            "max_area": "9pxˆ2",
+                            "min_area": "9pxˆ2",
+                            "total_area": "18pxˆ2",
+                        },
+                    },
+                ],
+            ),
+        ),
+        (
+            [
+                Title(
+                    text="Some lovely title",
+                    coordinates=((4, 5), (4, 8), (7, 8), (7, 5)),
+                    coordinate_system=PixelSpace(width=20, height=20),
+                    metadata=ElementMetadata(page_number=1),
+                ),
+                NarrativeText(
+                    text="",
+                    coordinates=((2, 3), (2, 6), (5, 6), (5, 3)),
+                    coordinate_system=PixelSpace(width=20, height=20),
+                    metadata=ElementMetadata(page_number=1),
+                ),
+            ],
+            1,
+            (
+                True,
+                [
+                    {
+                        "overlapping_elements": ["1. NarrativeText(ix=1)", "0. Title(ix=0)"],
+                        "overlapping_case": (
+                            "partial overlap with empty content in 1. NarrativeText"
+                        ),
+                        "overlap_percentage": "11.11%",
+                        "metadata": {
+                            "largest_ngram_percentage": None,
+                            "overlap_percentage_total": "5.88%",
+                            "max_area": "9pxˆ2",
+                            "min_area": "9pxˆ2",
+                            "total_area": "18pxˆ2",
+                        },
+                    },
+                ],
+            ),
+        ),
+        (
+            [
+                Title(
+                    text="",
+                    coordinates=((4, 5), (4, 8), (7, 8), (7, 5)),
+                    coordinate_system=PixelSpace(width=20, height=20),
+                    metadata=ElementMetadata(page_number=1),
+                ),
+                NarrativeText(
+                    text="Some lovely title",
+                    coordinates=((2, 3), (2, 6), (5, 6), (5, 3)),
+                    coordinate_system=PixelSpace(width=20, height=20),
+                    metadata=ElementMetadata(page_number=1),
+                ),
+            ],
+            1,
+            (
+                True,
+                [
+                    {
+                        "overlapping_elements": ["0. Title(ix=0)", "1. NarrativeText(ix=1)"],
+                        "overlapping_case": "partial overlap with empty content in 0. Title",
                         "overlap_percentage": "11.11%",
                         "metadata": {
                             "largest_ngram_percentage": None,
@@ -239,7 +306,6 @@ def test_only_raises_if_empty(iterator):
                 ),
             ],
             1,
-            10.0,
             (
                 True,
                 [
@@ -274,7 +340,6 @@ def test_only_raises_if_empty(iterator):
                 ),
             ],
             1,
-            10.0,
             (
                 True,
                 [
@@ -309,7 +374,6 @@ def test_only_raises_if_empty(iterator):
                 ),
             ],
             1,
-            10.0,
             (False, []),
         ),
     ],
@@ -318,12 +382,65 @@ def test_catch_overlapping_and_nested_bboxes(
     elements,
     expectation,
     nested_error_tolerance_px,
-    sm_overlap_threshold,
 ):
     overlapping_flag, overlapping_cases = utils.catch_overlapping_and_nested_bboxes(
         elements,
         nested_error_tolerance_px,
-        sm_overlap_threshold,
+        sm_overlap_threshold=10.0,
     )
     assert overlapping_flag == expectation[0]
     assert overlapping_cases == expectation[1]
+
+
+def test_validate_date_args_accepts_standard_formats():
+    assert utils.validate_date_args("1990-12-01")
+    assert utils.validate_date_args("2050-01-01T00:00:00")
+    assert utils.validate_date_args("2050-01-01+00:00:00")
+    assert utils.validate_date_args("2022-02-12T14:30:00-0500")
+
+
+def test_validate_date_args_raises_for_invalid_formats():
+    with pytest.raises(ValueError):
+        assert utils.validate_date_args(None)
+        assert utils.validate_date_args("not a date")
+        assert utils.validate_date_args("1990-12-33")
+        assert utils.validate_date_args("2022-02-12T14:30:00-2000")
+
+
+def test_htmlify_matrix_handles_empty_cells():
+    matrix = [["cell1", "", "cell3"], ["", "cell5", ""]]
+    expected_html = (
+        "<table><tr><td>cell1</td><td></td><td>cell3</td></tr>"
+        "<tr><td></td><td>cell5</td><td></td></tr></table>"
+    )
+    assert utils.htmlify_matrix_of_cell_texts(matrix) == expected_html
+
+
+def test_htmlify_matrix_handles_special_characters():
+    matrix = [['<>&"', "newline\n"]]
+    expected_html = "<table><tr><td>&lt;&gt;&amp;&quot;</td><td>newline<br/></td></tr></table>"
+    assert utils.htmlify_matrix_of_cell_texts(matrix) == expected_html
+
+
+def test_htmlify_matrix_handles_multiple_rows_and_cells():
+    matrix = [["cell1", "cell2"], ["cell3", "cell4"]]
+    expected_html = (
+        "<table><tr><td>cell1</td><td>cell2</td></tr><tr><td>cell3</td><td>cell4</td></tr></table>"
+    )
+    assert utils.htmlify_matrix_of_cell_texts(matrix) == expected_html
+
+
+def test_htmlify_matrix_handles_empty_matrix():
+    assert utils.htmlify_matrix_of_cell_texts([]) == ""
+
+
+def test_only_returns_singleton_iterable():
+    singleton_iterable = [42]
+    result = utils.only(singleton_iterable)
+    assert result == 42
+
+
+def test_only_raises_on_non_singleton_iterable():
+    singleton_iterable = [42, 0]
+    with pytest.raises(ValueError):
+        utils.only(singleton_iterable)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.5-dev1"  # pragma: no cover
+__version__ = "0.12.5-dev2"  # pragma: no cover

--- a/unstructured/embed/__init__.py
+++ b/unstructured/embed/__init__.py
@@ -1,9 +1,11 @@
 from unstructured.embed.bedrock import BedrockEmbeddingEncoder
 from unstructured.embed.huggingface import HuggingFaceEmbeddingEncoder
+from unstructured.embed.octoai import OctoAIEmbeddingEncoder
 from unstructured.embed.openai import OpenAIEmbeddingEncoder
 
 EMBEDDING_PROVIDER_TO_CLASS_MAP = {
     "langchain-openai": OpenAIEmbeddingEncoder,
     "langchain-huggingface": HuggingFaceEmbeddingEncoder,
     "langchain-aws-bedrock": BedrockEmbeddingEncoder,
+    "octoai": OctoAIEmbeddingEncoder,
 }

--- a/unstructured/embed/octoai.py
+++ b/unstructured/embed/octoai.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional
+
+import numpy as np
+
+from unstructured.documents.elements import (
+    Element,
+)
+from unstructured.embed.interfaces import BaseEmbeddingEncoder, EmbeddingConfig
+from unstructured.ingest.error import EmbeddingEncoderConnectionError
+from unstructured.utils import requires_dependencies
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+
+OCTOAI_BASE_URL = "https://text.octoai.run/v1"
+
+
+@dataclass
+class OctoAiEmbeddingConfig(EmbeddingConfig):
+    api_key: str
+    model_name: str = "thenlper/gte-large"
+
+
+@dataclass
+class OctoAIEmbeddingEncoder(BaseEmbeddingEncoder):
+    config: OctoAiEmbeddingConfig
+    # Uses the OpenAI SDK
+    _client: Optional["OpenAI"] = field(init=False, default=None)
+    _exemplary_embedding: Optional[List[float]] = field(init=False, default=None)
+
+    @property
+    def client(self) -> "OpenAI":
+        if self._client is None:
+            self._client = self.create_client()
+        return self._client
+
+    @property
+    def exemplary_embedding(self) -> List[float]:
+        if self._exemplary_embedding is None:
+            self._exemplary_embedding = self.embed_query("Q")
+        return self._exemplary_embedding
+
+    def initialize(self):
+        pass
+
+    def num_of_dimensions(self):
+        return np.shape(self.exemplary_embedding)
+
+    def is_unit_vector(self):
+        return np.isclose(np.linalg.norm(self.exemplary_embedding), 1.0)
+
+    def embed_query(self, query):
+        response = self.client.embeddings.create(input=str(query), model=self.config.model_name)
+        return response.data[0].embedding
+
+    def embed_documents(self, elements: List[Element]) -> List[Element]:
+        embeddings = [self.embed_query(e) for e in elements]
+        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
+        return elements_with_embeddings
+
+    def _add_embeddings_to_elements(self, elements, embeddings) -> List[Element]:
+        assert len(elements) == len(embeddings)
+        elements_w_embedding = []
+        for i, element in enumerate(elements):
+            element.embeddings = embeddings[i]
+            elements_w_embedding.append(element)
+        return elements
+
+    @EmbeddingEncoderConnectionError.wrap
+    @requires_dependencies(
+        ["openai", "tiktoken"],
+        extras="embed-openai",
+    )
+    def create_client(self) -> "OpenAI":
+        """Creates an OpenAI python client to embed elements. Uses the OpenAI SDK."""
+        from openai import OpenAI
+
+        return OpenAI(api_key=self.config.api_key, base_url=OCTOAI_BASE_URL)

--- a/unstructured/ingest/interfaces.py
+++ b/unstructured/ingest/interfaces.py
@@ -206,6 +206,10 @@ class EmbeddingConfig(BaseConfig):
             )
 
             return HuggingFaceEmbeddingEncoder(config=HuggingFaceEmbeddingConfig(**kwargs))
+        elif self.provider == "octoai":
+            from unstructured.embed.octoai import OctoAiEmbeddingConfig, OctoAIEmbeddingEncoder
+
+            return OctoAIEmbeddingEncoder(config=OctoAiEmbeddingConfig(**kwargs))
         else:
             raise ValueError(f"{self.provider} not a recognized encoder")
 

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -228,8 +228,19 @@ def dependency_exists(dependency: str):
     return True
 
 
-# Copied from unstructured/ingest/connector/biomed.py
-def validate_date_args(date: Optional[str] = None):
+def validate_date_args(date: Optional[str] = None) -> bool:
+    """Validate whether the provided date string satisfies any of the supported date formats.
+    Used by unstructured/ingest/connector/biomed.py
+
+    Returns `True` if the date string satisfies any of the supported formats, otherwise raises
+    `ValueError`.
+
+    Supported Date Formats:
+        - 'YYYY-MM-DD'
+        - 'YYYY-MM-DDTHH:MM:SS'
+        - 'YYYY-MM-DD+HH:MM:SS'
+        - 'YYYY-MM-DDTHH:MM:SS±HHMM'
+    """
     if not date:
         raise ValueError("The argument date is None.")
 
@@ -241,8 +252,8 @@ def validate_date_args(date: Optional[str] = None):
             pass
 
     raise ValueError(
-        f"The argument {date} does not satisfy the format: "
-        "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD+HH:MM:SS or YYYY-MM-DDTHH:MM:SStz",
+        f"The argument {date} does not satisfy the format:"
+        " YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS or YYYY-MM-DD+HH:MM:SS or YYYY-MM-DDTHH:MM:SS±HHMM",
     )
 
 
@@ -647,7 +658,7 @@ def catch_overlapping_and_nested_bboxes(
     elements: List["Text"],
     nested_error_tolerance_px: int = 5,
     sm_overlap_threshold: float = 10.0,
-) -> (bool, List[Dict]):
+) -> tuple[bool, List[Dict]]:
     """Catch overlapping and nested bounding boxes cases across a list of elements."""
 
     num_pages = elements[-1].metadata.page_number


### PR DESCRIPTION
Thanks to Pedro at OctoAI we have a new embedding option.

The following PR adds support for the use of OctoAI embeddings.

Forked from the original OpenAI embeddings class. We removed the use of the LangChain adaptor, and use OpenAI's SDK directly instead.

Also updated out-of-date example script.

Including new test file for OctoAI.

# Testing
Get a token from our platform at: https://www.octoai.cloud/ For testing one can do the following:
```
export OCTOAI_TOKEN=<your octo token>
python3 examples/embed/example_octoai.py
```

## Testing done
Validated running the above script from within a locally built container via `make docker-start-dev`

---------