### PR TITLE
rfctr(chunking): extract strategy-specific chunking options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.5-dev8
+## 0.12.5-dev9
 
 ### Enhancements
 

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -9,10 +9,10 @@ from typing import Optional, Sequence
 import pytest
 
 from unstructured.chunking.base import (
-    BasePreChunker,
     ChunkingOptions,
     PreChunkBuilder,
     PreChunkCombiner,
+    PreChunker,
     TablePreChunk,
     TextPreChunk,
     TextPreChunkAccumulator,
@@ -242,12 +242,12 @@ class Describe_TextSplitter:
 
 
 # ================================================================================================
-# BASE PRE-CHUNKER
+# PRE-CHUNKER
 # ================================================================================================
 
 
-class DescribeBasePreChunker:
-    """Unit-test suite for `unstructured.chunking.base.BasePreChunker` objects."""
+class DescribePreChunker:
+    """Unit-test suite for `unstructured.chunking.base.PreChunker` objects."""
 
     def it_gathers_elements_into_pre_chunks_respecting_the_specified_chunk_size(self):
         elements = [
@@ -262,7 +262,7 @@ class DescribeBasePreChunker:
 
         opts = ChunkingOptions(max_characters=150, new_after_n_chars=65)
 
-        pre_chunk_iter = BasePreChunker.iter_pre_chunks(elements, opts=opts)
+        pre_chunk_iter = PreChunker.iter_pre_chunks(elements, opts=opts)
 
         pre_chunk = next(pre_chunk_iter)
         assert isinstance(pre_chunk, TextPreChunk)

--- a/test_unstructured/chunking/test_basic.py
+++ b/test_unstructured/chunking/test_basic.py
@@ -1,4 +1,4 @@
-"""Unit-test suite for the `unstructured.chunking.basic` module.
+"""Test suite for the `unstructured.chunking.basic` module.
 
 That module implements the baseline chunking strategy. The baseline strategy has all behaviors
 shared by all chunking strategies and no extra rules like perserve section or page boundaries.

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -1,13 +1,15 @@
 # pyright: reportPrivateUsage=false
 
-"""Unit-test suite for the `unstructured.chunking.title` module."""
+"""Test suite for the `unstructured.chunking.title` module."""
 
 from __future__ import annotations
+
+from typing import Optional
 
 import pytest
 
 from unstructured.chunking.base import ChunkingOptions, TablePreChunk, TextPreChunk
-from unstructured.chunking.title import _ByTitlePreChunker, chunk_by_title
+from unstructured.chunking.title import _ByTitleChunkingOptions, _ByTitlePreChunker, chunk_by_title
 from unstructured.documents.coordinates import CoordinateSystem
 from unstructured.documents.elements import (
     CheckBox,
@@ -22,6 +24,13 @@ from unstructured.documents.elements import (
     Title,
 )
 from unstructured.partition.html import partition_html
+
+# ================================================================================================
+# INTEGRATION-TESTS
+# ================================================================================================
+# These test `chunk_by_title()` as an integrated whole, calling `chunk_by_title()` and inspecting
+# the outputs.
+# ================================================================================================
 
 
 def test_it_splits_a_large_element_into_multiple_chunks():
@@ -544,3 +553,76 @@ def test_it_considers_separator_length_when_pre_chunking():
         ),
         CompositeElement("Minimize mid-text chunk-splitting"),
     ]
+
+
+# ================================================================================================
+# UNIT-TESTS
+# ================================================================================================
+# These test individual components in isolation so can exercise all edge cases while still
+# performing well.
+# ================================================================================================
+
+
+class Describe_ByTitleChunkingOptions:
+    """Unit-test suite for `unstructured.chunking.title._ByTitleChunkingOptions` objects."""
+
+    @pytest.mark.parametrize("n_chars", [-1, -42])
+    def it_rejects_combine_text_under_n_chars_for_n_less_than_zero(self, n_chars: int):
+        with pytest.raises(
+            ValueError,
+            match=f"'combine_text_under_n_chars' argument must be >= 0, got {n_chars}",
+        ):
+            _ByTitleChunkingOptions.new(combine_text_under_n_chars=n_chars)
+
+    def it_accepts_0_for_combine_text_under_n_chars_to_disable_chunk_combining(self):
+        """Specifying `combine_text_under_n_chars=0` is how a caller disables chunk-combining."""
+        opts = _ByTitleChunkingOptions(combine_text_under_n_chars=0)
+        assert opts.combine_text_under_n_chars == 0
+
+    def it_does_not_complain_when_specifying_combine_text_under_n_chars_by_itself(self):
+        """Caller can specify `combine_text_under_n_chars` arg without specifying other options."""
+        try:
+            opts = _ByTitleChunkingOptions(combine_text_under_n_chars=50)
+        except ValueError:
+            pytest.fail("did not accept `combine_text_under_n_chars` as option by itself")
+
+        assert opts.combine_text_under_n_chars == 50
+
+    @pytest.mark.parametrize(
+        ("combine_text_under_n_chars", "max_characters", "expected_hard_max"),
+        [(600, None, 500), (600, 450, 450)],
+    )
+    def it_rejects_combine_text_under_n_chars_greater_than_maxchars(
+        self, combine_text_under_n_chars: int, max_characters: Optional[int], expected_hard_max: int
+    ):
+        """`combine_text_under_n_chars` > `max_characters` can produce behavior confusing to users.
+
+        The behavior is no different from `combine_text_under_n_chars == max_characters`, but if
+        `max_characters` is left to default (500) and `combine_text_under_n_chars` is set to a
+        larger number like 1500 then it can look like chunk-combining isn't working.
+        """
+        with pytest.raises(
+            ValueError,
+            match=(
+                "'combine_text_under_n_chars' argument must not exceed `max_characters` value,"
+                f" got {combine_text_under_n_chars} > {expected_hard_max}"
+            ),
+        ):
+            _ByTitleChunkingOptions.new(
+                max_characters=max_characters, combine_text_under_n_chars=combine_text_under_n_chars
+            )
+
+    def it_does_not_complain_when_specifying_new_after_n_chars_by_itself(self):
+        """Caller can specify `new_after_n_chars` arg without specifying any other options.
+
+        In particular, `combine_text_under_n_chars` value is adjusted down to the
+        `new_after_n_chars` value when the default for `combine_text_under_n_chars` exceeds the
+        value of `new_after_n_chars`.
+        """
+        try:
+            opts = _ByTitleChunkingOptions(new_after_n_chars=200)
+        except ValueError:
+            pytest.fail("did not accept `new_after_n_chars` as option by itself")
+
+        assert opts.soft_max == 200
+        assert opts.combine_text_under_n_chars == 200

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import pytest
 
-from unstructured.chunking.base import ChunkingOptions, TablePreChunk, TextPreChunk
+from unstructured.chunking.base import CHUNK_MULTI_PAGE_DEFAULT, TablePreChunk, TextPreChunk
 from unstructured.chunking.title import _ByTitleChunkingOptions, _ByTitlePreChunker, chunk_by_title
 from unstructured.documents.coordinates import CoordinateSystem
 from unstructured.documents.elements import (
@@ -66,7 +66,7 @@ def test_split_elements_by_title_and_table():
         CheckBox(),
     ]
 
-    pre_chunks = _ByTitlePreChunker.iter_pre_chunks(elements, opts=ChunkingOptions.new())
+    pre_chunks = _ByTitlePreChunker.iter_pre_chunks(elements, opts=_ByTitleChunkingOptions.new())
 
     pre_chunk = next(pre_chunks)
     assert isinstance(pre_chunk, TextPreChunk)
@@ -626,3 +626,13 @@ class Describe_ByTitleChunkingOptions:
 
         assert opts.soft_max == 200
         assert opts.combine_text_under_n_chars == 200
+
+    @pytest.mark.parametrize(
+        ("multipage_sections", "expected_value"),
+        [(True, True), (False, False), (None, CHUNK_MULTI_PAGE_DEFAULT)],
+    )
+    def it_knows_whether_to_break_chunks_on_page_boundaries(
+        self, multipage_sections: bool, expected_value: bool
+    ):
+        opts = _ByTitleChunkingOptions(multipage_sections=multipage_sections)
+        assert opts.multipage_sections is expected_value

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -10,7 +10,7 @@ import pytest
 
 from unstructured.chunking.base import (
     CHUNK_MULTI_PAGE_DEFAULT,
-    BasePreChunker,
+    PreChunker,
     TablePreChunk,
     TextPreChunk,
 )
@@ -71,7 +71,7 @@ def test_split_elements_by_title_and_table():
         CheckBox(),
     ]
 
-    pre_chunks = BasePreChunker.iter_pre_chunks(elements, opts=_ByTitleChunkingOptions.new())
+    pre_chunks = PreChunker.iter_pre_chunks(elements, opts=_ByTitleChunkingOptions.new())
 
     pre_chunk = next(pre_chunks)
     assert isinstance(pre_chunk, TextPreChunk)

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -8,8 +8,13 @@ from typing import Optional
 
 import pytest
 
-from unstructured.chunking.base import CHUNK_MULTI_PAGE_DEFAULT, TablePreChunk, TextPreChunk
-from unstructured.chunking.title import _ByTitleChunkingOptions, _ByTitlePreChunker, chunk_by_title
+from unstructured.chunking.base import (
+    CHUNK_MULTI_PAGE_DEFAULT,
+    BasePreChunker,
+    TablePreChunk,
+    TextPreChunk,
+)
+from unstructured.chunking.title import _ByTitleChunkingOptions, chunk_by_title
 from unstructured.documents.coordinates import CoordinateSystem
 from unstructured.documents.elements import (
     CheckBox,
@@ -66,7 +71,7 @@ def test_split_elements_by_title_and_table():
         CheckBox(),
     ]
 
-    pre_chunks = _ByTitlePreChunker.iter_pre_chunks(elements, opts=_ByTitleChunkingOptions.new())
+    pre_chunks = BasePreChunker.iter_pre_chunks(elements, opts=_ByTitleChunkingOptions.new())
 
     pre_chunk = next(pre_chunks)
     assert isinstance(pre_chunk, TextPreChunk)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.5-dev8"  # pragma: no cover
+__version__ = "0.12.5-dev9"  # pragma: no cover

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -7,7 +7,7 @@ import copy
 from typing import Any, Callable, DefaultDict, Iterable, Iterator, Optional, Sequence, cast
 
 import regex
-from typing_extensions import Self, TypeAlias
+from typing_extensions import TypeAlias
 
 from unstructured.documents.elements import (
     CompositeElement,
@@ -112,30 +112,6 @@ class ChunkingOptions:
         self._overlap_arg = overlap
         self._overlap_all_arg = overlap_all
         self._text_splitting_separators = text_splitting_separators
-
-    @classmethod
-    def new(
-        cls,
-        *,
-        max_characters: Optional[int] = None,
-        new_after_n_chars: Optional[int] = None,
-        overlap: Optional[int] = None,
-        overlap_all: Optional[bool] = None,
-        text_splitting_separators: Sequence[str] = ("\n", " "),
-    ) -> Self:
-        """Construct validated instance.
-
-        Raises `ValueError` on invalid arguments like overlap > max_chars.
-        """
-        self = cls(
-            max_characters=max_characters,
-            new_after_n_chars=new_after_n_chars,
-            overlap=overlap,
-            overlap_all=overlap_all,
-            text_splitting_separators=text_splitting_separators,
-        )
-        self._validate()
-        return self
 
     @lazyproperty
     def boundary_predicates(self) -> tuple[BoundaryPredicate, ...]:

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -349,12 +349,12 @@ class _TextSplitter:
 
 
 # ================================================================================================
-# BASE PRE-CHUNKER
+# PRE-CHUNKER
 # ================================================================================================
 
 
-class BasePreChunker:
-    """Base-class for per-strategy pre-chunkers.
+class PreChunker:
+    """Gathers sequential elements into pre-chunks as length constraints allow.
 
     The pre-chunker's responsibilities are:
 

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -68,9 +68,6 @@ class ChunkingOptions:
         when not specified, which effectively disables this behavior. Specifying 0 for this
         argument causes each element to appear in a chunk by itself (although an element with text
         longer than `max_characters` will be still be split into two or more chunks).
-    multipage_sections
-        Indicates that page-boundaries should not be respected while chunking, i.e. elements
-        appearing on two different pages can appear in the same chunk.
     combine_text_under_n_chars
         Provides a way to "recombine" small chunks formed by breaking on a semantic boundary. Only
         relevant for a chunking strategy that specifies higher-level semantic boundaries to be
@@ -104,7 +101,6 @@ class ChunkingOptions:
         *,
         combine_text_under_n_chars: Optional[int] = None,
         max_characters: Optional[int] = None,
-        multipage_sections: Optional[bool] = None,
         new_after_n_chars: Optional[int] = None,
         overlap: Optional[int] = None,
         overlap_all: Optional[bool] = None,
@@ -112,7 +108,6 @@ class ChunkingOptions:
     ):
         self._combine_text_under_n_chars_arg = combine_text_under_n_chars
         self._max_characters_arg = max_characters
-        self._multipage_sections_arg = multipage_sections
         self._new_after_n_chars_arg = new_after_n_chars
         self._overlap_arg = overlap
         self._overlap_all_arg = overlap_all
@@ -123,7 +118,6 @@ class ChunkingOptions:
         cls,
         *,
         max_characters: Optional[int] = None,
-        multipage_sections: Optional[bool] = None,
         new_after_n_chars: Optional[int] = None,
         overlap: Optional[int] = None,
         overlap_all: Optional[bool] = None,
@@ -135,7 +129,6 @@ class ChunkingOptions:
         """
         self = cls(
             max_characters=max_characters,
-            multipage_sections=multipage_sections,
             new_after_n_chars=new_after_n_chars,
             overlap=overlap,
             overlap_all=overlap_all,
@@ -173,12 +166,6 @@ class ChunkingOptions:
         text-splitting boundaries that arise from splitting an oversized element.
         """
         return self.overlap if self._overlap_all_arg else 0
-
-    @lazyproperty
-    def multipage_sections(self) -> bool:
-        """When False, break pre-chunks on page-boundaries."""
-        arg_value = self._multipage_sections_arg
-        return CHUNK_MULTI_PAGE_DEFAULT if arg_value is None else bool(arg_value)
 
     @lazyproperty
     def overlap(self) -> int:

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -138,6 +138,14 @@ class ChunkingOptions:
         return self
 
     @lazyproperty
+    def boundary_predicates(self) -> tuple[BoundaryPredicate, ...]:
+        """The semantic-boundary detectors to be applied to break pre-chunks.
+
+        Overridden by sub-typs to provide semantic-boundary isolation behaviors.
+        """
+        return ()
+
+    @lazyproperty
     def combine_text_under_n_chars(self) -> int:
         """Combine two consecutive text pre-chunks if first is smaller than this and both will fit.
 
@@ -428,7 +436,7 @@ class BasePreChunker:
     @lazyproperty
     def _boundary_predicates(self) -> tuple[BoundaryPredicate, ...]:
         """The semantic-boundary detectors to be applied to break pre-chunks."""
-        return ()
+        return self._opts.boundary_predicates
 
     def _is_in_new_semantic_unit(self, element: Element) -> bool:
         """True when `element` begins a new semantic unit such as a section or page."""

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -69,7 +69,7 @@ def chunk_elements(
 
     return [
         chunk
-        for pre_chunk in BasicPreChunker.iter_pre_chunks(elements, opts)
+        for pre_chunk in BasePreChunker.iter_pre_chunks(elements, opts)
         for chunk in pre_chunk.iter_chunks()
     ]
 
@@ -98,11 +98,3 @@ class _BasicChunkingOptions(ChunkingOptions):
         )
         self._validate()
         return self
-
-
-class BasicPreChunker(BasePreChunker):
-    """Produces pre-chunks from a sequence of document-elements using the "basic" rule-set.
-
-    The "basic" rule-set is essentially "no-rules" other than `Table` is segregated into its own
-    pre-chunk.
-    """

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -78,7 +78,7 @@ class _BasicChunkingOptions(ChunkingOptions):
     """Options for `basic` chunking."""
 
     @classmethod
-    def new(  # pyright: ignore[reportIncompatibleMethodOverride]
+    def new(
         cls,
         *,
         max_characters: Optional[int] = None,

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from typing import Iterable, Optional
 
+from typing_extensions import Self
+
 from unstructured.chunking.base import BasePreChunker, ChunkingOptions
 from unstructured.documents.elements import Element
 
@@ -58,7 +60,7 @@ def chunk_elements(
         level of "pollution" of otherwise clean semantic chunk boundaries.
     """
     # -- raises ValueError on invalid parameters --
-    opts = ChunkingOptions.new(
+    opts = _BasicChunkingOptions.new(
         max_characters=max_characters,
         new_after_n_chars=new_after_n_chars,
         overlap=overlap,
@@ -70,6 +72,32 @@ def chunk_elements(
         for pre_chunk in BasicPreChunker.iter_pre_chunks(elements, opts)
         for chunk in pre_chunk.iter_chunks()
     ]
+
+
+class _BasicChunkingOptions(ChunkingOptions):
+    """Options for `basic` chunking."""
+
+    @classmethod
+    def new(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls,
+        *,
+        max_characters: Optional[int] = None,
+        new_after_n_chars: Optional[int] = None,
+        overlap: Optional[int] = None,
+        overlap_all: Optional[bool] = None,
+    ) -> Self:
+        """Construct validated instance.
+
+        Raises `ValueError` on invalid arguments like overlap > max_chars.
+        """
+        self = cls(
+            max_characters=max_characters,
+            new_after_n_chars=new_after_n_chars,
+            overlap=overlap,
+            overlap_all=overlap_all,
+        )
+        self._validate()
+        return self
 
 
 class BasicPreChunker(BasePreChunker):

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -19,7 +19,7 @@ from typing import Iterable, Optional
 
 from typing_extensions import Self
 
-from unstructured.chunking.base import BasePreChunker, ChunkingOptions
+from unstructured.chunking.base import ChunkingOptions, PreChunker
 from unstructured.documents.elements import Element
 
 
@@ -69,7 +69,7 @@ def chunk_elements(
 
     return [
         chunk
-        for pre_chunk in BasePreChunker.iter_pre_chunks(elements, opts)
+        for pre_chunk in PreChunker.iter_pre_chunks(elements, opts)
         for chunk in pre_chunk.iter_chunks()
     ]
 

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Iterable, Iterator, Optional
 
+from typing_extensions import Self
+
 from unstructured.chunking.base import (
     BasePreChunker,
     BoundaryPredicate,
@@ -65,7 +67,7 @@ def chunk_by_title(
         elements and not subject to text-splitting. Use this with caution as it entails a certain
         level of "pollution" of otherwise clean semantic chunk boundaries.
     """
-    opts = ChunkingOptions.new(
+    opts = _ByTitleChunkingOptions.new(
         combine_text_under_n_chars=combine_text_under_n_chars,
         max_characters=max_characters,
         multipage_sections=multipage_sections,
@@ -79,6 +81,52 @@ def chunk_by_title(
     ).iter_combined_pre_chunks()
 
     return [chunk for pre_chunk in pre_chunks for chunk in pre_chunk.iter_chunks()]
+
+
+class _ByTitleChunkingOptions(ChunkingOptions):
+    """Adds the by-title-specific chunking options to the base case."""
+
+    def __init__(
+        self,
+        *,
+        max_characters: Optional[int] = None,
+        combine_text_under_n_chars: Optional[int] = None,
+        multipage_sections: Optional[bool] = None,
+        new_after_n_chars: Optional[int] = None,
+        overlap: Optional[int] = None,
+        overlap_all: Optional[bool] = None,
+    ):
+        super().__init__(
+            combine_text_under_n_chars=combine_text_under_n_chars,
+            max_characters=max_characters,
+            multipage_sections=multipage_sections,
+            new_after_n_chars=new_after_n_chars,
+            overlap=overlap,
+            overlap_all=overlap_all,
+        )
+
+    @classmethod
+    def new(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls,
+        *,
+        max_characters: Optional[int] = None,
+        combine_text_under_n_chars: Optional[int] = None,
+        multipage_sections: Optional[bool] = None,
+        new_after_n_chars: Optional[int] = None,
+        overlap: Optional[int] = None,
+        overlap_all: Optional[bool] = None,
+    ) -> Self:
+        """Return instance or raises `ValueError` on invalid arguments like overlap > max_chars."""
+        self = cls(
+            max_characters=max_characters,
+            combine_text_under_n_chars=combine_text_under_n_chars,
+            multipage_sections=multipage_sections,
+            new_after_n_chars=new_after_n_chars,
+            overlap=overlap,
+            overlap_all=overlap_all,
+        )
+        self._validate()
+        return self
 
 
 class _ByTitlePreChunker(BasePreChunker):

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -115,7 +115,7 @@ class _ByTitleChunkingOptions(ChunkingOptions):
         self._multipage_sections_arg = multipage_sections
 
     @classmethod
-    def new(  # pyright: ignore[reportIncompatibleMethodOverride]
+    def new(
         cls,
         *,
         max_characters: Optional[int] = None,

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -11,10 +11,10 @@ from typing_extensions import Self
 
 from unstructured.chunking.base import (
     CHUNK_MULTI_PAGE_DEFAULT,
-    BasePreChunker,
     BoundaryPredicate,
     ChunkingOptions,
     PreChunkCombiner,
+    PreChunker,
     is_in_next_section,
     is_on_next_page,
     is_title,
@@ -79,7 +79,7 @@ def chunk_by_title(
     )
 
     pre_chunks = PreChunkCombiner(
-        BasePreChunker.iter_pre_chunks(elements, opts), opts=opts
+        PreChunker.iter_pre_chunks(elements, opts), opts=opts
     ).iter_combined_pre_chunks()
 
     return [chunk for pre_chunk in pre_chunks for chunk in pre_chunk.iter_chunks()]


### PR DESCRIPTION
**Summary**
A pluggable chunking strategy needs its own local set of chunking options that subclasses a base-class in `unstructured`.

Extract distinct `_ByTitleChunkingOptions` and `_BasicChunkingOptions` for the existing two chunking strategies and move their strategy-specific option setting and validation to the respective subclass.

This was also a good opportunity for us to clean up a few odds and ends we'd been meaning to.

Might be worth looking at the commits individually as they are cohesive incremental steps toward the goal.