### PR TITLE
Fix a parameter name in the js-client example usage

### DIFF
--- a/docs/source/apis/api_sdks.rst
+++ b/docs/source/apis/api_sdks.rst
@@ -91,7 +91,7 @@ Below is a basic example of how to use the JavaScript SDK:
         # Note that this currently only supports a single file
         files: {
             content: data,
-            files: filename,
+            fileName: filename,
         },
         # Other partition params
         strategy: "fast",


### PR DESCRIPTION
`files` should be `fileName` as noted in https://github.com/Unstructured-IO/unstructured-js-client/issues/24