### PR TITLE
feat: introduce `date_from_file_object` parameter to partitions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.230"
+    rev: "v0.2.1"
     hooks:
       - id: ruff
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 ### Features
+* Add `date_from_file_object` parameter to partition. If True and if file is provided via `file` parameter it will cause partition to infer last modified date from `file`'s content. If False, last modified metadata will be `None`.
 
 ### Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ line-length = 100
 line-length = 100
 
 # -- changes made here should also be made in `.pre-commit-config.yaml` and `Makefile` --
-[tool.ruff.lint]
-select = [
+lint.select = [
     "C4",       # -- flake8-comprehensions --
     "COM",      # -- flake8-commas --
     "E",        # -- pycodestyle errors --
@@ -20,7 +19,7 @@ select = [
     "UP032",    # -- Use f-string instead of `.format()` call --
     "UP034",    # -- Avoid extraneous parentheses --
 ]
-ignore = [
+lint.ignore = [
     "COM812",   # -- over aggressively insists on trailing commas where not desireable --
     "PT011",    # -- pytest.raises({exc}) too broad, use match param or more specific exception --
     "PT012",    # -- pytest.raises() block should contain a single simple statement --

--- a/test_unstructured/partition/csv/test_csv.py
+++ b/test_unstructured/partition/csv/test_csv.py
@@ -160,6 +160,25 @@ def test_partition_csv_from_file_metadata_date(
 
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
     assert isinstance(elements[0], Table)
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_csv_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.csv",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.csv.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_csv(file=f, include_header=False, date_from_file_object=True)
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert isinstance(elements[0], Table)
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -177,7 +196,10 @@ def test_partition_csv_from_file_custom_metadata_date(
 
     with open(filename, "rb") as f:
         elements = partition_csv(
-            file=f, metadata_last_modified=expected_last_modification_date, include_header=False
+            file=f,
+            metadata_last_modified=expected_last_modification_date,
+            include_header=False,
+            date_from_file_object=True,
         )
 
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
@@ -195,7 +217,7 @@ def test_partition_csv_from_file_without_metadata(
         sf = SpooledTemporaryFile()
         sf.write(f.read())
         sf.seek(0)
-        elements = partition_csv(file=sf)
+        elements = partition_csv(file=sf, date_from_file_object=True)
 
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
     assert isinstance(elements[0], Table)

--- a/test_unstructured/partition/csv/test_tsv.py
+++ b/test_unstructured/partition/csv/test_tsv.py
@@ -1,3 +1,5 @@
+from tempfile import SpooledTemporaryFile
+
 import pytest
 
 from test_unstructured.partition.test_constants import (
@@ -154,6 +156,27 @@ def test_partition_tsv_from_file_metadata_date(
             include_header=False,
         )
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_tsv_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/stanley-cups.tsv",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.tsv.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_tsv(
+            file=f,
+            include_header=False,
+            date_from_file_object=True,
+        )
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -175,6 +198,20 @@ def test_partition_tsv_from_file_with_custom_metadata_date(
         )
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
+def test_partition_docx_from_file_without_metadata_date(
+    filename="example-docs/stanley-cups.tsv",
+):
+    """Test partition_tsv() with file that are not possible to get last modified date"""
+
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_tsv(file=sf, include_header=False, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified is None
 
 
 @pytest.mark.parametrize("filename", ["stanley-cups.tsv", "stanley-cups-with-emoji.tsv"])

--- a/test_unstructured/partition/csv/test_tsv.py
+++ b/test_unstructured/partition/csv/test_tsv.py
@@ -200,7 +200,7 @@ def test_partition_tsv_from_file_with_custom_metadata_date(
     assert elements[0].metadata.last_modified == expected_last_modification_date
 
 
-def test_partition_docx_from_file_without_metadata_date(
+def test_partition_tsv_from_file_without_metadata_date(
     filename="example-docs/stanley-cups.tsv",
 ):
     """Test partition_tsv() with file that are not possible to get last modified date"""

--- a/test_unstructured/partition/docx/test_doc.py
+++ b/test_unstructured/partition/docx/test_doc.py
@@ -237,6 +237,23 @@ def test_partition_doc_from_file_metadata_date(
     with open(filename, "rb") as f:
         elements = partition_doc(file=f)
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_doc_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/fake.doc",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.doc.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_doc(file=f, date_from_file_object=True)
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -252,24 +269,24 @@ def test_partition_doc_from_file_metadata_date_with_custom_metadata(
         return_value=mocked_last_modification_date,
     )
     with open(filename, "rb") as f:
-        elements = partition_doc(file=f, metadata_last_modified=expected_last_modified_date)
+        elements = partition_doc(
+            file=f, metadata_last_modified=expected_last_modified_date, date_from_file_object=True
+        )
 
     assert elements[0].metadata.last_modified == expected_last_modified_date
 
 
-@pytest.mark.xfail(reason="handling of last_modified for file vs. filename to be refined later")
 def test_partition_doc_from_file_without_metadata_date(
     filename="example-docs/fake.doc",
 ):
     """Test partition_doc() with file that are not possible to get last modified date"""
-
     with open(filename, "rb") as f:
         sf = SpooledTemporaryFile()
         sf.write(f.read())
         sf.seek(0)
-        elements = partition_doc(file=sf, metadata_date="2020-07-05")
+        elements = partition_doc(file=sf, date_from_file_object=True)
 
-    assert elements[0].metadata.date == "2020-07-05"
+    assert elements[0].metadata.last_modified is None
 
 
 def test_partition_doc_grabs_emphasized_texts():

--- a/test_unstructured/partition/docx/test_docx.py
+++ b/test_unstructured/partition/docx/test_docx.py
@@ -444,6 +444,18 @@ def test_partition_docx_from_file_metadata_date(mocker: MockFixture):
     with open(example_doc_path("fake.docx"), "rb") as f:
         elements = partition_docx(file=f)
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_docx_from_file_explicit_get_metadata_date(mocker: MockFixture):
+    mocker.patch(
+        "unstructured.partition.docx.get_last_modified_date_from_file",
+        return_value="2029-07-05T09:24:28",
+    )
+
+    with open(example_doc_path("fake.docx"), "rb") as f:
+        elements = partition_docx(file=f, date_from_file_object=True)
+
     assert elements[0].metadata.last_modified == "2029-07-05T09:24:28"
 
 
@@ -465,7 +477,7 @@ def test_partition_docx_from_file_without_metadata_date():
         sf = SpooledTemporaryFile()
         sf.write(f.read())
         sf.seek(0)
-        elements = partition_docx(file=sf)
+        elements = partition_docx(file=sf, date_from_file_object=True)
 
     assert elements[0].metadata.last_modified is None
 

--- a/test_unstructured/partition/epub/test_epub.py
+++ b/test_unstructured/partition/epub/test_epub.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from tempfile import SpooledTemporaryFile
 
 from test_unstructured.unit_utils import assert_round_trips_through_JSON
 from unstructured.chunking.title import chunk_by_title
@@ -137,6 +138,23 @@ def test_partition_epub_from_file_metadata_date(
     with open(filename, "rb") as f:
         elements = partition_epub(file=f)
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_epub_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/winter-sports.epub",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_epub(file=f, date_from_file_object=True)
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -156,6 +174,20 @@ def test_partition_epub_from_file_custom_metadata_date(
         elements = partition_epub(file=f, metadata_last_modified=expected_last_modification_date)
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
+def test_partition_docx_from_file_without_metadata_date(
+    filename="example-docs/winter-sports.epub",
+):
+    """Test partition_epub() with file that are not possible to get last modified date"""
+
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_epub(file=sf, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified is None
 
 
 def test_partition_epub_with_json():

--- a/test_unstructured/partition/epub/test_epub.py
+++ b/test_unstructured/partition/epub/test_epub.py
@@ -176,7 +176,7 @@ def test_partition_epub_from_file_custom_metadata_date(
     assert elements[0].metadata.last_modified == expected_last_modification_date
 
 
-def test_partition_docx_from_file_without_metadata_date(
+def test_partition_epub_from_file_without_metadata_date(
     filename="example-docs/winter-sports.epub",
 ):
     """Test partition_epub() with file that are not possible to get last modified date"""

--- a/test_unstructured/partition/markdown/test_md.py
+++ b/test_unstructured/partition/markdown/test_md.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from tempfile import SpooledTemporaryFile
 from unittest.mock import patch
 
 import pytest
@@ -214,6 +215,23 @@ def test_partition_md_from_file_metadata_date(
             file=f,
         )
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_md_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/README.md",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.md.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_md(file=f, date_from_file_object=True)
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -259,6 +277,19 @@ def test_partition_md_from_text_with_custom_metadata_date(
     elements = partition_md(text=text, metadata_last_modified=expected_last_modification_date)
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
+def test_partition_doc_from_file_without_metadata_date(
+    filename="example-docs/README.md",
+):
+    """Test partition_md() with file that are not possible to get last modified date"""
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_md(file=sf, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified is None
 
 
 def test_partition_md_with_json():

--- a/test_unstructured/partition/markdown/test_md.py
+++ b/test_unstructured/partition/markdown/test_md.py
@@ -279,7 +279,7 @@ def test_partition_md_from_text_with_custom_metadata_date(
     assert elements[0].metadata.last_modified == expected_last_modification_date
 
 
-def test_partition_doc_from_file_without_metadata_date(
+def test_partition_md_from_file_without_metadata_date(
     filename="example-docs/README.md",
 ):
     """Test partition_md() with file that are not possible to get last modified date"""

--- a/test_unstructured/partition/msg/test_msg.py
+++ b/test_unstructured/partition/msg/test_msg.py
@@ -239,6 +239,26 @@ def test_partition_msg_raises_with_no_partitioner(
         partition_msg(filename=filename, process_attachments=True)
 
 
+def test_partition_msg_metadata_date_from_header(
+    mocker,
+    filename="example-docs/fake-email.msg",
+):
+    expected_last_modification_date = "2022-12-16T17:04:16-05:00"
+
+    mocker.patch(
+        "unstructured.partition.msg.get_last_modified_date",
+        return_value=None,
+    )
+    mocker.patch(
+        "unstructured.partition.msg.get_last_modified_date_from_file",
+        return_value=None,
+    )
+
+    elements = partition_msg(filename=filename)
+
+    assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
 def test_partition_msg_from_file_custom_metadata_date(
     filename="example-docs/fake-email.msg",
 ):

--- a/test_unstructured/partition/odt/test_odt.py
+++ b/test_unstructured/partition/odt/test_odt.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from tempfile import SpooledTemporaryFile
 
 import pytest
 
@@ -155,6 +156,23 @@ def test_partition_odt_from_file_metadata_date(
             file=f,
         )
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_odt_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/fake.odt",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.odt.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_odt(file=f, date_from_file_object=True)
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -174,6 +192,19 @@ def test_partition_odt_from_file_with_custom_metadata_date(
         elements = partition_odt(file=f, metadata_last_modified=expected_last_modification_date)
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
+def test_partition_doc_from_file_without_metadata_date(
+    filename="example-docs/fake.odt",
+):
+    """Test partition_odt() with file that are not possible to get last modified date"""
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_odt(file=sf, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified is None
 
 
 def test_partition_odt_with_json():

--- a/test_unstructured/partition/odt/test_odt.py
+++ b/test_unstructured/partition/odt/test_odt.py
@@ -194,7 +194,7 @@ def test_partition_odt_from_file_with_custom_metadata_date(
     assert elements[0].metadata.last_modified == expected_last_modification_date
 
 
-def test_partition_doc_from_file_without_metadata_date(
+def test_partition_odt_from_file_without_metadata_date(
     filename="example-docs/fake.odt",
 ):
     """Test partition_odt() with file that are not possible to get last modified date"""

--- a/test_unstructured/partition/pdf_image/test_image.py
+++ b/test_unstructured/partition/pdf_image/test_image.py
@@ -397,6 +397,21 @@ def test_partition_image_from_file_metadata_date(
     with open(filename, "rb") as f:
         elements = image.partition_image(file=f)
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_image_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/english-and-korean.png",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+    with open(filename, "rb") as f:
+        elements = image.partition_image(file=f, date_from_file_object=True)
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -412,6 +427,24 @@ def test_partition_image_from_file_with_hi_res_strategy_metadata_date(
 
     with open(filename, "rb") as f:
         elements = image.partition_image(file=f, strategy=PartitionStrategy.HI_RES)
+
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_image_from_file_with_hi_res_strategy_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/english-and-korean.png",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+    mocker.patch(
+        "unstructured.partition.pdf.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = image.partition_image(
+            file=f, strategy=PartitionStrategy.HI_RES, date_from_file_object=True
+        )
 
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
@@ -455,6 +488,19 @@ def test_partition_image_from_file_with_hi_res_strategy_metadata_date_custom_met
         )
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
+def test_partition_image_from_file_without_metadata_date(
+    filename="example-docs/english-and-korean.png",
+):
+    """Test partition_image() with file that are not possible to get last modified date"""
+    with open(filename, "rb") as f:
+        sf = tempfile.SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = image.partition_image(file=sf, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified is None
 
 
 def test_partition_msg_with_json():

--- a/test_unstructured/partition/pdf_image/test_image.py
+++ b/test_unstructured/partition/pdf_image/test_image.py
@@ -341,7 +341,7 @@ def test_partition_image_with_hi_res_strategy_metadata_date(
         "unstructured.partition.pdf.get_last_modified_date",
         return_value=mocked_last_modification_date,
     )
-    elements = image.partition_image(filename=filename, stratefy=PartitionStrategy.HI_RES)
+    elements = image.partition_image(filename=filename, strategy=PartitionStrategy.HI_RES)
 
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
@@ -378,7 +378,7 @@ def test_partition_image_with_hi_res_strategy_metadata_date_custom_metadata_date
     )
     elements = image.partition_image(
         filename=filename,
-        stratefy=PartitionStrategy.HI_RES,
+        strategy=PartitionStrategy.HI_RES,
         metadata_last_modified=expected_last_modification_date,
     )
 
@@ -411,7 +411,7 @@ def test_partition_image_from_file_with_hi_res_strategy_metadata_date(
     )
 
     with open(filename, "rb") as f:
-        elements = image.partition_image(file=f, stratefy=PartitionStrategy.HI_RES)
+        elements = image.partition_image(file=f, strategy=PartitionStrategy.HI_RES)
 
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
@@ -451,7 +451,7 @@ def test_partition_image_from_file_with_hi_res_strategy_metadata_date_custom_met
         elements = image.partition_image(
             file=f,
             metadata_last_modified=expected_last_modification_date,
-            stratefy=PartitionStrategy.HI_RES,
+            strategy=PartitionStrategy.HI_RES,
         )
 
     assert elements[0].metadata.last_modified == expected_last_modification_date

--- a/test_unstructured/partition/pypandoc/test_org.py
+++ b/test_unstructured/partition/pypandoc/test_org.py
@@ -143,7 +143,7 @@ def test_partition_org_from_file_with_custom_metadata_date(
     assert elements[0].metadata.last_modified == expected_last_modification_date
 
 
-def test_partition_docx_from_file_without_metadata_date(
+def test_partition_org_from_file_without_metadata_date(
     filename="example-docs/README.org",
 ):
     """Test partition_org() with file that are not possible to get last modified date"""

--- a/test_unstructured/partition/pypandoc/test_org.py
+++ b/test_unstructured/partition/pypandoc/test_org.py
@@ -1,3 +1,5 @@
+from tempfile import SpooledTemporaryFile
+
 from test_unstructured.unit_utils import assert_round_trips_through_JSON, example_doc_path
 from unstructured.chunking.title import chunk_by_title
 from unstructured.documents.elements import Title
@@ -103,6 +105,23 @@ def test_partition_org_from_file_metadata_date(
             file=f,
         )
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_org_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/README.org",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_org(file=f, date_from_file_object=True)
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -122,6 +141,20 @@ def test_partition_org_from_file_with_custom_metadata_date(
         elements = partition_org(file=f, metadata_last_modified=expected_last_modification_date)
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
+def test_partition_docx_from_file_without_metadata_date(
+    filename="example-docs/README.org",
+):
+    """Test partition_org() with file that are not possible to get last modified date"""
+
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_org(file=sf, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified is None
 
 
 def test_partition_org_with_json():

--- a/test_unstructured/partition/pypandoc/test_rst.py
+++ b/test_unstructured/partition/pypandoc/test_rst.py
@@ -154,7 +154,7 @@ def test_partition_rst_from_file_with_custom_metadata_date(
     assert elements[0].metadata.last_modified == expected_last_modification_date
 
 
-def test_partition_docx_from_file_without_metadata_date(
+def test_partition_rst_from_file_without_metadata_date(
     filename="example-docs/README.rst",
 ):
     """Test partition_rst() with file that are not possible to get last modified date"""

--- a/test_unstructured/partition/pypandoc/test_rst.py
+++ b/test_unstructured/partition/pypandoc/test_rst.py
@@ -1,3 +1,5 @@
+from tempfile import SpooledTemporaryFile
+
 from test_unstructured.unit_utils import assert_round_trips_through_JSON, example_doc_path
 from unstructured.chunking.title import chunk_by_title
 from unstructured.documents.elements import Title
@@ -114,6 +116,23 @@ def test_partition_rst_from_file_metadata_date(
             file=f,
         )
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_rst_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/README.rst",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.html.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_rst(file=f, date_from_file_object=True)
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -133,6 +152,20 @@ def test_partition_rst_from_file_with_custom_metadata_date(
         elements = partition_rst(file=f, metadata_last_modified=expected_last_modification_date)
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
+def test_partition_docx_from_file_without_metadata_date(
+    filename="example-docs/README.rst",
+):
+    """Test partition_rst() with file that are not possible to get last modified date"""
+
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_rst(file=sf, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified is None
 
 
 def test_partition_rst_with_json():

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -362,6 +362,7 @@ def test_auto_partition_pdf_with_fast_strategy(monkeypatch):
         extract_image_block_output_dir=None,
         extract_image_block_to_payload=False,
         hi_res_model_name=None,
+        date_from_file_object=False,
     )
 
 

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -535,6 +535,26 @@ def test_partition_msg_raises_with_no_partitioner(
         partition_email(filename=filename, process_attachments=True)
 
 
+def test_partition_email_metadata_date_from_header(
+    mocker,
+    filename="example-docs/eml/fake-email-attachment.eml",
+):
+    expected_last_modification_date = "2022-12-23T12:08:48-06:00"
+
+    mocker.patch(
+        "unstructured.partition.email.get_last_modified_date",
+        return_value=None,
+    )
+    mocker.patch(
+        "unstructured.partition.email.get_last_modified_date_from_file",
+        return_value=None,
+    )
+
+    elements = partition_email(filename=filename)
+
+    assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
 def test_partition_email_from_file_custom_metadata_date(
     filename="example-docs/eml/fake-email-attachment.eml",
 ):

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -344,6 +344,26 @@ def test_partition_json_from_file_metadata_date(
             file=f,
         )
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_json_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/spring-weather.html.json",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.json.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_json(
+            file=f,
+            date_from_file_object=True,
+        )
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -389,6 +409,19 @@ def test_partition_json_from_text_with_custom_metadata_date(
     elements = partition_json(text=text, metadata_last_modified=expected_last_modification_date)
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
+def test_partition_json_from_file_without_metadata_date(
+    filename="example-docs/spring-weather.html.json",
+):
+    """Test partition_json() with file that are not possible to get last modified date"""
+    with open(filename, "rb") as f:
+        sf = tempfile.SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_json(file=sf, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified is None
 
 
 def test_partition_json_raises_with_unprocessable_json():

--- a/test_unstructured/partition/test_xml_partition.py
+++ b/test_unstructured/partition/test_xml_partition.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+from tempfile import SpooledTemporaryFile
 
 import pytest
 
@@ -228,6 +229,23 @@ def test_partition_xml_from_file_metadata_date(
             file=f,
         )
 
+    assert elements[0].metadata.last_modified is None
+
+
+def test_partition_xml_from_file_explicit_get_metadata_date(
+    mocker,
+    filename="example-docs/factbook.xml",
+):
+    mocked_last_modification_date = "2029-07-05T09:24:28"
+
+    mocker.patch(
+        "unstructured.partition.xml.get_last_modified_date_from_file",
+        return_value=mocked_last_modification_date,
+    )
+
+    with open(filename, "rb") as f:
+        elements = partition_xml(file=f, date_from_file_object=True)
+
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
@@ -247,6 +265,19 @@ def test_partition_xml_from_file_with_custom_metadata_date(
         elements = partition_xml(file=f, metadata_last_modified=expected_last_modification_date)
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
+
+
+def test_partition_xml_from_file_without_metadata_date(
+    filename="example-docs/factbook.xml",
+):
+    """Test partition_xml() with file that are not possible to get last modified date"""
+    with open(filename, "rb") as f:
+        sf = SpooledTemporaryFile()
+        sf.write(f.read())
+        sf.seek(0)
+        elements = partition_xml(file=sf, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified is None
 
 
 @pytest.mark.parametrize(

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -155,6 +155,7 @@ def partition(
     request_timeout: Optional[int] = None,
     hi_res_model_name: Optional[str] = None,
     model_name: Optional[str] = None,  # to be deprecated
+    date_from_file_object: bool = False,
     **kwargs,
 ):
     """Partitions a document into its constituent elements. Will use libmagic to determine
@@ -236,6 +237,10 @@ def partition(
     model_name
         The layout detection model used when partitioning strategy is set to `hi_res`. To be
         deprecated in favor of `hi_res_model_name`.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True and inference
+        from message header failed, attempt to infer last_modified metadata from bytes,
+        otherwise set it to None.
     """
     exactly_one(file=file, filename=filename, url=url)
 
@@ -252,6 +257,7 @@ def partition(
             "Please use metadata_filename instead.",
         )
     kwargs.setdefault("metadata_filename", metadata_filename)
+    kwargs.setdefault("date_from_file_object", date_from_file_object)
 
     languages = check_language_args(languages or [], ocr_languages)
 

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -38,6 +38,7 @@ def partition_csv(
     languages: Optional[List[str]] = ["auto"],
     # NOTE (jennings) partition_csv generates a single TableElement
     # so detect_language_per_element is not included as a param
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Partitions Microsoft Excel Documents in .csv format into its document elements.
@@ -66,6 +67,9 @@ def partition_csv(
         User defined value for `metadata.languages` if provided. Otherwise language is detected
         using naive Bayesian filter via `langdetect`. Multiple languages indicates text could be
         in either language.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     exactly_one(filename=filename, file=file)
 
@@ -77,7 +81,9 @@ def partition_csv(
         last_modification_date = get_last_modified_date(filename)
 
     elif file:
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
         f = spooled_to_bytes_io_if_needed(
             cast(Union[BinaryIO, SpooledTemporaryFile], file),
         )

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -28,6 +28,7 @@ def partition_doc(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
     **kwargs: Any,
 ) -> List[Element]:
     """Partitions Microsoft Word Documents in .doc format into its document elements.
@@ -51,6 +52,9 @@ def partition_doc(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     # Verify that only one of the arguments was provided
     if filename is None:
@@ -73,7 +77,9 @@ def partition_doc(
         _, filename_no_path = os.path.split(os.path.abspath(tmp.name))
         base_filename, _ = os.path.splitext(filename_no_path)
 
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
 
     with tempfile.TemporaryDirectory() as tmpdir:
         convert_office_doc(

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -19,6 +19,8 @@ from unstructured.logger import logger
 from unstructured.partition.common import (
     convert_to_bytes,
     exactly_one,
+    get_last_modified_date,
+    get_last_modified_date_from_file,
 )
 from unstructured.partition.lang import apply_lang_metadata
 
@@ -129,6 +131,7 @@ def build_email_metadata(
     msg: Message,
     filename: Optional[str],
     metadata_last_modified: Optional[str] = None,
+    last_modification_date: Optional[str] = None,
 ) -> ElementMetadata:
     """Creates an ElementMetadata object from the header information in the email."""
     signature = find_signature(msg)
@@ -151,7 +154,7 @@ def build_email_metadata(
         sent_from=sent_from,
         subject=header_dict.get("Subject"),
         signature=signature,
-        last_modified=metadata_last_modified or email_date,
+        last_modified=metadata_last_modified or email_date or last_modification_date,
         filename=filename,
     )
     element_metadata.detection_origin = DETECTION_ORIGIN
@@ -280,6 +283,7 @@ def partition_email(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Partitions an .eml documents into its constituent elements.
@@ -318,6 +322,10 @@ def partition_email(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True and inference
+        from message header failed, attempt to infer last_modified metadata from bytes,
+        otherwise set it to None.
     """
     if content_source not in VALID_CONTENT_SOURCES:
         raise ValueError(
@@ -473,10 +481,19 @@ def partition_email(
         header = partition_email_header(msg)
     all_elements = header + elements
 
+    last_modification_date = None
+    if filename is not None:
+        last_modification_date = get_last_modified_date(filename)
+    elif file is not None:
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
+
     metadata = build_email_metadata(
         msg,
         filename=metadata_filename or filename,
         metadata_last_modified=metadata_last_modified,
+        last_modification_date=last_modification_date,
     )
     for element in all_elements:
         element.metadata = copy.deepcopy(metadata)

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -22,6 +22,7 @@ def partition_epub(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
     **kwargs: Any,
 ) -> List[Element]:
     """Partitions an EPUB document. The document is first converted to HTML and then
@@ -44,6 +45,9 @@ def partition_epub(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
 
     elements = convert_and_partition_html(
@@ -54,6 +58,7 @@ def partition_epub(
         metadata_last_modified=metadata_last_modified,
         source_format="epub",
         detection_origin=DETECTION_ORIGIN,
+        date_from_file_object=date_from_file_object,
     )
 
     elements = list(

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -47,6 +47,7 @@ def partition_html(
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
     detection_origin: Optional[str] = None,
+    date_from_file_object: bool = False,
     **kwargs: Any,
 ) -> List[Element]:
     """Partitions an HTML document into its constituent elements.
@@ -89,6 +90,9 @@ def partition_html(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     if text is not None and text.strip() == "" and not file and not filename and not url:
         return []
@@ -106,7 +110,9 @@ def partition_html(
         )
 
     elif file is not None:
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
         _, file_text = read_txt_file(file=file, encoding=encoding)
         document = HTMLDocument.from_string(
             file_text,
@@ -163,6 +169,7 @@ def convert_and_partition_html(
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
     detection_origin: Optional[str] = None,
+    date_from_file_object: bool = False,
 ) -> List[Element]:
     """Converts a document to HTML and then partitions it using partition_html. Works with
     any file format support by pandoc.
@@ -188,13 +195,18 @@ def convert_and_partition_html(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
 
     last_modification_date = None
     if filename:
         last_modification_date = get_last_modified_date(filename)
     elif file:
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
     html_text = convert_file_to_html_text(
         source_format=source_format,
         filename=filename,

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -29,6 +29,7 @@ def partition_image(
     extract_image_block_types: Optional[List[str]] = None,
     extract_image_block_output_dir: Optional[str] = None,
     extract_image_block_to_payload: bool = False,
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Parses an image into a list of interpreted elements.
@@ -83,6 +84,9 @@ def partition_image(
         Only applicable if `strategy=hi_res` and `extract_image_block_to_payload=False`.
         The filesystem path for saving images of the element type(s)
         specified in 'extract_image_block_types'.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     exactly_one(filename=filename, file=file)
 
@@ -102,5 +106,6 @@ def partition_image(
         extract_image_block_types=extract_image_block_types,
         extract_image_block_output_dir=extract_image_block_output_dir,
         extract_image_block_to_payload=extract_image_block_to_payload,
+        date_from_file_object=date_from_file_object,
         **kwargs,
     )

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -24,6 +24,7 @@ def partition_json(
     include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
+    date_from_file_object: bool = False,
     **kwargs: Any,
 ) -> List[Element]:
     """Partitions serialized Unstructured output into its constituent elements.
@@ -38,6 +39,9 @@ def partition_json(
         The string representation of the .json document.
     metadata_last_modified
         The last modified date for the document.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     if text is not None and text.strip() == "" and not file and not filename:
         return []
@@ -51,7 +55,9 @@ def partition_json(
             file_text = f.read()
 
     elif file is not None:
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
 
         file_content = file.read()
         file_text = file_content if isinstance(file_content, str) else file_content.decode()

--- a/unstructured/partition/md.py
+++ b/unstructured/partition/md.py
@@ -40,6 +40,7 @@ def partition_md(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Partitions a markdown file into its constituent elements
@@ -69,6 +70,9 @@ def partition_md(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     # Verify that only one of the arguments was provided
     if text is None:
@@ -83,7 +87,9 @@ def partition_md(
             text = optional_decode(f.read())
 
     elif file is not None:
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
         text = optional_decode(file.read())
 
     elif url is not None:

--- a/unstructured/partition/msg.py
+++ b/unstructured/partition/msg.py
@@ -8,7 +8,11 @@ from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, ElementMetadata, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.logger import logger
-from unstructured.partition.common import exactly_one
+from unstructured.partition.common import (
+    exactly_one,
+    get_last_modified_date,
+    get_last_modified_date_from_file,
+)
 from unstructured.partition.email import convert_to_iso_8601
 from unstructured.partition.html import partition_html
 from unstructured.partition.lang import apply_lang_metadata
@@ -31,6 +35,7 @@ def partition_msg(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Partitions a MSFT Outlook .msg file
@@ -63,6 +68,10 @@ def partition_msg(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True and inference
+        from message header failed, attempt to infer last_modified metadata from bytes,
+        otherwise set it to None.
     """
     exactly_one(filename=filename, file=file)
 
@@ -104,10 +113,18 @@ def partition_msg(
             detection_origin="msg",
         )
 
+    last_modification_date = None
+    if filename is not None:
+        last_modification_date = get_last_modified_date(filename)
+    elif file is not None:
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
     metadata = build_msg_metadata(
         msg_obj,
         metadata_filename or filename,
         metadata_last_modified=metadata_last_modified,
+        last_modification_date=last_modification_date,
     )
     for element in elements:
         element.metadata = metadata
@@ -148,6 +165,7 @@ def build_msg_metadata(
     msg_obj: msg_parser.MsOxMessage,
     filename: Optional[str],
     metadata_last_modified: Optional[str],
+    last_modification_date: Optional[str],
     languages: Optional[List[str]] = ["auto"],
 ) -> ElementMetadata:
     """Creates an ElementMetadata object from the header information in the email."""
@@ -167,7 +185,7 @@ def build_msg_metadata(
         sent_to=sent_to,
         sent_from=sent_from,
         subject=getattr(msg_obj, "subject", None),
-        last_modified=metadata_last_modified or email_date,
+        last_modified=metadata_last_modified or email_date or last_modification_date,
         filename=filename,
         languages=languages,
     )

--- a/unstructured/partition/odt.py
+++ b/unstructured/partition/odt.py
@@ -23,6 +23,7 @@ def partition_odt(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
     **kwargs: Any,
 ) -> List[Element]:
     """Partitions Open Office Documents in .odt format into its document elements.
@@ -48,13 +49,18 @@ def partition_odt(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
 
     last_modification_date = None
     if filename:
         last_modification_date = get_last_modified_date(filename)
     elif file:
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
 
     return convert_and_partition_docx(
         source_format="odt",

--- a/unstructured/partition/org.py
+++ b/unstructured/partition/org.py
@@ -20,6 +20,7 @@ def partition_org(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
 ) -> List[Element]:
     """Partitions an org document. The document is first converted to HTML and then
     partitioned using partition_html.
@@ -41,6 +42,9 @@ def partition_org(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
 
     return convert_and_partition_html(
@@ -53,4 +57,5 @@ def partition_org(
         languages=languages,
         detect_language_per_element=detect_language_per_element,
         detection_origin=DETECTION_ORIGIN,
+        date_from_file_object=date_from_file_object,
     )

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -151,6 +151,7 @@ def partition_pdf(
     extract_image_block_types: Optional[List[str]] = None,
     extract_image_block_output_dir: Optional[str] = None,
     extract_image_block_to_payload: bool = False,
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Parses a pdf document into a list of interpreted elements.
@@ -204,6 +205,9 @@ def partition_pdf(
         Only applicable if `strategy=hi_res` and `extract_image_block_to_payload=False`.
         The filesystem path for saving images of the element type(s)
         specified in 'extract_image_block_types'.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
 
     exactly_one(filename=filename, file=file)
@@ -223,6 +227,7 @@ def partition_pdf(
         extract_image_block_types=extract_image_block_types,
         extract_image_block_output_dir=extract_image_block_output_dir,
         extract_image_block_to_payload=extract_image_block_to_payload,
+        date_from_file_object=date_from_file_object,
         **kwargs,
     )
 
@@ -242,6 +247,7 @@ def partition_pdf_or_image(
     extract_image_block_types: Optional[List[str]] = None,
     extract_image_block_output_dir: Optional[str] = None,
     extract_image_block_to_payload: bool = False,
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Parses a pdf or image document into a list of interpreted elements."""
@@ -258,6 +264,7 @@ def partition_pdf_or_image(
     last_modification_date = get_the_last_modification_date_pdf_or_img(
         file=file,
         filename=filename,
+        date_from_file_object=date_from_file_object,
     )
 
     extracted_elements = []
@@ -356,12 +363,15 @@ def extractable_elements(
 def get_the_last_modification_date_pdf_or_img(
     file: Optional[Union[bytes, BinaryIO, SpooledTemporaryFile]] = None,
     filename: Optional[str] = "",
+    date_from_file_object: bool = False,
 ) -> Union[str, None]:
     last_modification_date = None
     if not file and filename:
         last_modification_date = get_last_modified_date(filename=filename)
     elif not filename and file:
-        last_modification_date = get_last_modified_date_from_file(file=file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
     return last_modification_date
 
 

--- a/unstructured/partition/ppt.py
+++ b/unstructured/partition/ppt.py
@@ -28,6 +28,7 @@ def partition_ppt(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Partitions Microsoft PowerPoint Documents in .ppt format into their document elements.
@@ -55,6 +56,9 @@ def partition_ppt(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     # Verify that only one of the arguments was provided
     if filename is None:
@@ -70,7 +74,9 @@ def partition_ppt(
         last_modification_date = get_last_modified_date(filename)
 
     elif file is not None:
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
         tmp = tempfile.NamedTemporaryFile(delete=False)
         tmp.write(file.read())
         tmp.close()

--- a/unstructured/partition/rst.py
+++ b/unstructured/partition/rst.py
@@ -21,6 +21,7 @@ def partition_rst(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Partitions an RST document. The document is first converted to HTML and then
@@ -43,6 +44,9 @@ def partition_rst(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
 
     return convert_and_partition_html(
@@ -55,4 +59,5 @@ def partition_rst(
         languages=languages,
         detect_language_per_element=detect_language_per_element,
         detection_origin=DETECTION_ORIGIN,
+        date_from_file_object=date_from_file_object,
     )

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -55,6 +55,7 @@ def partition_text(
     chunking_strategy: Optional[str] = None,
     detect_language_per_element: bool = False,
     detection_origin: Optional[str] = "text",
+    date_from_file_object: bool = False,
     **kwargs: Any,
 ) -> List[Element]:
     """Partitions an .txt documents into its constituent paragraph elements.
@@ -89,6 +90,9 @@ def partition_text(
         The minimum number of characters to include in a partition.
     metadata_last_modified
         The day of the last modification
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     return _partition_text(
         filename=filename,
@@ -105,6 +109,7 @@ def partition_text(
         chunking_strategy=chunking_strategy,
         detect_language_per_element=detect_language_per_element,
         detection_origin=detection_origin,
+        date_from_file_object=date_from_file_object,
         **kwargs,
     )
 
@@ -127,6 +132,7 @@ def _partition_text(
     chunking_strategy: Optional[str] = None,
     detect_language_per_element: bool = False,
     detection_origin: Optional[str] = "text",
+    date_from_file_object: bool = False,
     **kwargs: Any,
 ) -> List[Element]:
     """internal API for `partition_text`"""
@@ -151,8 +157,9 @@ def _partition_text(
 
     elif file is not None:
         encoding, file_text = read_txt_file(file=file, encoding=encoding)
-        last_modification_date = get_last_modified_date_from_file(file)
-
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
     elif text is not None:
         file_text = str(text)
 

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -34,6 +34,7 @@ def partition_tsv(
     languages: Optional[List[str]] = ["auto"],
     # NOTE (jennings) partition_tsv generates a single TableElement
     # so detect_language_per_element is not included as a param
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Partitions TSV files into document elements.
@@ -54,6 +55,9 @@ def partition_tsv(
         User defined value for `metadata.languages` if provided. Otherwise language is detected
         using naive Bayesian filter via `langdetect`. Multiple languages indicates text could be
         in either language.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     exactly_one(filename=filename, file=file)
 
@@ -68,7 +72,9 @@ def partition_tsv(
             cast(Union[BinaryIO, SpooledTemporaryFile], file),
         )
         table = pd.read_csv(f, sep="\t", header=header)
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
 
     html_text = table.to_html(index=False, header=include_header, na_rep="")
     text = soupparser_fromstring(html_text).text_content()

--- a/unstructured/partition/xlsx.py
+++ b/unstructured/partition/xlsx.py
@@ -54,6 +54,7 @@ def partition_xlsx(
     metadata_last_modified: Optional[str] = None,
     include_header: bool = False,
     find_subtable: bool = True,
+    date_from_file_object: bool = False,
     **kwargs: Any,
 ) -> list[Element]:
     """Partitions Microsoft Excel Documents in .xlsx format into its document elements.
@@ -83,6 +84,9 @@ def partition_xlsx(
         The day of the last modification
     include_header
         Determines whether or not header info is included in text and medatada.text_as_html
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     last_modification_date = None
     header = 0 if include_header else None
@@ -103,7 +107,9 @@ def partition_xlsx(
         sheets = pd.read_excel(  # pyright: ignore[reportUnknownMemberType]
             f, sheet_name=None, header=header
         )
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
     else:
         raise ValueError("Either 'filename' or 'file' argument must be specified")
 

--- a/unstructured/partition/xml.py
+++ b/unstructured/partition/xml.py
@@ -95,6 +95,7 @@ def partition_xml(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
+    date_from_file_object: bool = False,
     **kwargs,
 ) -> List[Element]:
     """Partitions an XML document into its document elements.
@@ -126,6 +127,9 @@ def partition_xml(
         Additional Parameters:
             detect_language_per_element
                 Detect language per element instead of at the document level.
+    date_from_file_object
+        Applies only when providing file via `file` parameter. If this option is True, attempt
+        infer last_modified metadata from bytes, otherwise set it to None.
     """
     exactly_one(filename=filename, file=file, text=text)
 
@@ -135,7 +139,9 @@ def partition_xml(
     if filename:
         last_modification_date = get_last_modified_date(filename)
     elif file:
-        last_modification_date = get_last_modified_date_from_file(file)
+        last_modification_date = (
+            get_last_modified_date_from_file(file) if date_from_file_object else None
+        )
 
     if include_metadata:
         metadata = ElementMetadata(


### PR DESCRIPTION
Introduce `date_from_file_object` to `partition*` functions, by default set to `False`.
If set to `True` and file is provided via `file` parameter, partition will attempt to infer last modified date from `file`'s contents otherwise last modified metadata will be set to `None`.