### PR TITLE
fix(json): partition_json() does not chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.5-dev6
+## 0.12.5-dev7
 
 ### Enhancements
 
@@ -13,6 +13,7 @@
 * **Fix cluster of bugs in `partition_xlsx()` that dropped content.** Algorithm for detecting "subtables" within a worksheet dropped table elements for certain patterns of populated cells such as when a trailing single-cell row appeared in a contiguous block of populated cells.
 * **Improved documentation**. Fixed broken links and improved readability on `Key Concepts` page.
 * **Rename `OpenAiEmbeddingConfig` to `OpenAIEmbeddingConfig`.
+* **Fix partition_json() doesn't chunk.** The `@add_chunking_strategy` decorator was missing from `partition_json()` such that pre-partitioned documents serialized to JSON did not chunk when a chunking-strategy was specified.
 
 ## 0.12.4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,15 @@
 [tool.black]
 line-length = 100
 
+[tool.pyright]
+pythonPlatform = "Linux"
+pythonVersion = "3.8"
+reportUnnecessaryCast = true
+reportUnnecessaryTypeIgnoreComment = true
+stubPath = "./typings"
+typeCheckingMode = "strict"
+verboseOutput = true
+
 [tool.ruff]
 line-length = 100
 

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -9,6 +9,7 @@ import tempfile
 import pytest
 from pytest_mock import MockFixture
 
+from unstructured.documents.elements import CompositeElement
 from unstructured.file_utils.filetype import FileType, detect_filetype
 from unstructured.partition.email import partition_email
 from unstructured.partition.html import partition_html
@@ -28,6 +29,15 @@ test_files = [
 ]
 
 is_in_docker = os.path.exists("/.dockerenv")
+
+
+def test_it_chunks_elements_when_a_chunking_strategy_is_specified():
+    chunks = partition_json(
+        "example-docs/spring-weather.html.json", chunking_strategy="basic", max_characters=1500
+    )
+
+    assert len(chunks) == 10
+    assert all(isinstance(ch, CompositeElement) for ch in chunks)
 
 
 @pytest.mark.parametrize("filename", test_files)

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -1,8 +1,13 @@
+"""Test-suite for `unstructured.partition.json` module."""
+
+from __future__ import annotations
+
 import os
 import pathlib
 import tempfile
 
 import pytest
+from pytest_mock import MockFixture
 
 from unstructured.file_utils.filetype import FileType, detect_filetype
 from unstructured.partition.email import partition_email
@@ -28,9 +33,8 @@ is_in_docker = os.path.exists("/.dockerenv")
 @pytest.mark.parametrize("filename", test_files)
 def test_partition_json_from_filename(filename: str):
     path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-
+    elements = []
     filetype = detect_filetype(filename=path)
-
     if filetype == FileType.TXT:
         elements = partition_text(filename=path)
     if filetype == FileType.HTML:
@@ -58,9 +62,8 @@ def test_partition_json_from_filename(filename: str):
 @pytest.mark.parametrize("filename", test_files)
 def test_partition_json_from_filename_with_metadata_filename(filename: str):
     path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-
+    elements = []
     filetype = detect_filetype(filename=path)
-
     if filetype == FileType.TXT:
         elements = partition_text(filename=path)
     if filetype == FileType.HTML:
@@ -84,9 +87,8 @@ def test_partition_json_from_filename_with_metadata_filename(filename: str):
 @pytest.mark.parametrize("filename", test_files)
 def test_partition_json_from_file(filename: str):
     path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-
+    elements = []
     filetype = detect_filetype(filename=path)
-
     if filetype == FileType.TXT:
         elements = partition_text(filename=path)
     if filetype == FileType.HTML:
@@ -100,7 +102,7 @@ def test_partition_json_from_file(filename: str):
         _filename = os.path.basename(filename)
         test_path = os.path.join(tmpdir, _filename + ".json")
         elements_to_json(elements, filename=test_path, indent=2)
-        with open(test_path) as f:
+        with open(test_path, "rb") as f:
             test_elements = partition_json(file=f)
 
     assert len(elements) > 0
@@ -114,9 +116,8 @@ def test_partition_json_from_file(filename: str):
 @pytest.mark.parametrize("filename", test_files)
 def test_partition_json_from_file_with_metadata_filename(filename: str):
     path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-
+    elements = []
     filetype = detect_filetype(filename=path)
-
     if filetype == FileType.TXT:
         elements = partition_text(filename=path)
     if filetype == FileType.HTML:
@@ -129,7 +130,7 @@ def test_partition_json_from_file_with_metadata_filename(filename: str):
         _filename = os.path.basename(filename)
         test_path = os.path.join(tmpdir, _filename + ".json")
         elements_to_json(elements, filename=test_path, indent=2)
-        with open(test_path) as f:
+        with open(test_path, "rb") as f:
             test_elements = partition_json(file=f, metadata_filename="test")
 
     for i in range(len(test_elements)):
@@ -139,9 +140,8 @@ def test_partition_json_from_file_with_metadata_filename(filename: str):
 @pytest.mark.parametrize("filename", test_files)
 def test_partition_json_from_text(filename: str):
     path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-
+    elements = []
     filetype = detect_filetype(filename=path)
-
     if filetype == FileType.TXT:
         elements = partition_text(filename=path)
     if filetype == FileType.HTML:
@@ -182,9 +182,8 @@ def test_partition_json_works_with_empty_list():
 
 def test_partition_json_raises_with_too_many_specified():
     path = os.path.join(DIRECTORY, "..", "..", "example-docs", "fake-text.txt")
-
+    elements = []
     filetype = detect_filetype(filename=path)
-
     if filetype == FileType.TXT:
         elements = partition_text(filename=path)
     if filetype == FileType.HTML:
@@ -197,8 +196,8 @@ def test_partition_json_raises_with_too_many_specified():
     with tempfile.TemporaryDirectory() as tmpdir:
         test_path = os.path.join(tmpdir, "fake-text.txt.json")
         elements_to_json(elements, filename=test_path, indent=2)
-        with open(test_path) as f:
-            text = f.read()
+        with open(test_path, "rb") as f:
+            text = f.read().decode("utf-8")
 
     with pytest.raises(ValueError):
         partition_json(filename=test_path, file=f)
@@ -216,9 +215,8 @@ def test_partition_json_raises_with_too_many_specified():
 @pytest.mark.parametrize("filename", test_files)
 def test_partition_json_from_filename_exclude_metadata(filename: str):
     path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-
+    elements = []
     filetype = detect_filetype(filename=path)
-
     if filetype == FileType.TXT:
         elements = partition_text(filename=path)
     if filetype == FileType.HTML:
@@ -241,9 +239,8 @@ def test_partition_json_from_filename_exclude_metadata(filename: str):
 @pytest.mark.parametrize("filename", test_files)
 def test_partition_json_from_file_exclude_metadata(filename: str):
     path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-
+    elements = []
     filetype = detect_filetype(filename=path)
-
     if filetype == FileType.TXT:
         elements = partition_text(filename=path)
     if filetype == FileType.HTML:
@@ -257,7 +254,7 @@ def test_partition_json_from_file_exclude_metadata(filename: str):
         _filename = os.path.basename(filename)
         test_path = os.path.join(tmpdir, _filename + ".json")
         elements_to_json(elements, filename=test_path, indent=2)
-        with open(test_path) as f:
+        with open(test_path, "rb") as f:
             test_elements = partition_json(file=f, include_metadata=False)
 
     for i in range(len(test_elements)):
@@ -267,9 +264,8 @@ def test_partition_json_from_file_exclude_metadata(filename: str):
 @pytest.mark.parametrize("filename", test_files)
 def test_partition_json_from_text_exclude_metadata(filename: str):
     path = os.path.join(DIRECTORY, "..", "..", "example-docs", filename)
-
+    elements = []
     filetype = detect_filetype(filename=path)
-
     if filetype == FileType.TXT:
         elements = partition_text(filename=path)
     if filetype == FileType.HTML:
@@ -278,6 +274,7 @@ def test_partition_json_from_text_exclude_metadata(filename: str):
         elements = partition_xml(filename=path)
     if filetype == FileType.EML:
         elements = partition_email(filename=path)
+
     with tempfile.TemporaryDirectory() as tmpdir:
         _filename = os.path.basename(filename)
         test_path = os.path.join(tmpdir, _filename + ".json")
@@ -290,100 +287,73 @@ def test_partition_json_from_text_exclude_metadata(filename: str):
         assert any(test_elements[i].metadata.to_dict()) is False
 
 
-def test_partition_json_metadata_date(
-    mocker,
-    filename="example-docs/spring-weather.html.json",
-):
+def test_partition_json_metadata_date(mocker: MockFixture):
     mocked_last_modification_date = "2029-07-05T09:24:28"
-
     mocker.patch(
         "unstructured.partition.json.get_last_modified_date",
         return_value=mocked_last_modification_date,
     )
 
-    elements = partition_json(
-        filename=filename,
-    )
+    elements = partition_json("example-docs/spring-weather.html.json")
 
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
-def test_partition_json_with_custom_metadata_date(
-    mocker,
-    filename="example-docs/spring-weather.html.json",
-):
+def test_partition_json_with_custom_metadata_date(mocker: MockFixture):
     mocked_last_modification_date = "2029-07-05T09:24:28"
     expected_last_modification_date = "2020-07-05T09:24:28"
-
     mocker.patch(
         "unstructured.partition.json.get_last_modified_date",
         return_value=mocked_last_modification_date,
     )
 
     elements = partition_json(
-        filename=filename,
+        "example-docs/spring-weather.html.json",
         metadata_last_modified=expected_last_modification_date,
     )
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
 
 
-def test_partition_json_from_file_metadata_date(
-    mocker,
-    filename="example-docs/spring-weather.html.json",
-):
+def test_partition_json_from_file_metadata_date(mocker: MockFixture):
     mocked_last_modification_date = "2029-07-05T09:24:28"
-
     mocker.patch(
         "unstructured.partition.json.get_last_modified_date_from_file",
         return_value=mocked_last_modification_date,
     )
 
-    with open(filename, "rb") as f:
-        elements = partition_json(
-            file=f,
-        )
+    with open("example-docs/spring-weather.html.json", "rb") as f:
+        elements = partition_json(file=f)
 
     assert elements[0].metadata.last_modified == mocked_last_modification_date
 
 
-def test_partition_json_from_file_with_custom_metadata_date(
-    mocker,
-    filename="example-docs/spring-weather.html.json",
-):
+def test_partition_json_from_file_with_custom_metadata_date(mocker: MockFixture):
     mocked_last_modification_date = "2029-07-05T09:24:28"
     expected_last_modification_date = "2020-07-05T09:24:28"
-
     mocker.patch(
         "unstructured.partition.json.get_last_modified_date_from_file",
         return_value=mocked_last_modification_date,
     )
 
-    with open(filename, "rb") as f:
+    with open("example-docs/spring-weather.html.json", "rb") as f:
         elements = partition_json(file=f, metadata_last_modified=expected_last_modification_date)
 
     assert elements[0].metadata.last_modified == expected_last_modification_date
 
 
-def test_partition_json_from_text_metadata_date(
-    filename="example-docs/spring-weather.html.json",
-):
-    with open(filename) as f:
+def test_partition_json_from_text_metadata_date():
+    with open("example-docs/spring-weather.html.json") as f:
         text = f.read()
 
-    elements = partition_json(
-        text=text,
-    )
+    elements = partition_json(text=text)
 
     assert elements[0].metadata.last_modified is None
 
 
-def test_partition_json_from_text_with_custom_metadata_date(
-    filename="example-docs/spring-weather.html.json",
-):
+def test_partition_json_from_text_with_custom_metadata_date():
     expected_last_modification_date = "2020-07-05T09:24:28"
-
-    with open(filename) as f:
+    with open("example-docs/spring-weather.html.json") as f:
         text = f.read()
 
     elements = partition_json(text=text, metadata_last_modified=expected_last_modification_date)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.5-dev6"  # pragma: no cover
+__version__ = "0.12.5-dev7"  # pragma: no cover

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -7,7 +7,7 @@ import sys
 from email.message import Message
 from functools import partial
 from tempfile import NamedTemporaryFile, SpooledTemporaryFile, TemporaryDirectory
-from typing import IO, Callable, Dict, List, Optional, Tuple, Union
+from typing import IO, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from unstructured.file_utils.encoding import (
     COMMON_ENCODINGS,
@@ -265,7 +265,7 @@ def parse_email(
 @add_chunking_strategy()
 def partition_email(
     filename: Optional[str] = None,
-    file: Optional[Union[IO[bytes], SpooledTemporaryFile]] = None,
+    file: Optional[Union[IO[bytes], SpooledTemporaryFile[bytes]]] = None,
     text: Optional[str] = None,
     content_source: str = "text/html",
     encoding: Optional[str] = None,
@@ -275,12 +275,12 @@ def partition_email(
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     process_attachments: bool = False,
-    attachment_partitioner: Optional[Callable] = None,
+    attachment_partitioner: Optional[Callable[..., List[Element]]] = None,
     min_partition: Optional[int] = 0,
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> List[Element]:
     """Partitions an .eml documents into its constituent elements.
     Parameters

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 from typing import IO, Any, Optional
 
+from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import (
     FileType,
@@ -28,6 +29,7 @@ from unstructured.staging.base import dict_to_elements
 
 @process_metadata()
 @add_metadata_with_filetype(FileType.JSON)
+@add_chunking_strategy()
 def partition_json(
     filename: Optional[str] = None,
     file: Optional[IO[bytes]] = None,

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -1,5 +1,16 @@
+"""Provides `partition_json()`.
+
+Note this does not partition arbitrary JSON. Its only use-case is to "rehydrate" unstructured
+document elements serialized to JSON, essentially the same function as `elements_from_json()`, but
+this allows a document of already-partitioned elements to be combined transparently with other
+documents in a partitioning run. It also allows multiple (low-cost) chunking runs to be performed on
+a document while only incurring partitioning cost once.
+"""
+
+from __future__ import annotations
+
 import json
-from typing import IO, Any, List, Optional
+from typing import IO, Any, Optional
 
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import (
@@ -25,7 +36,7 @@ def partition_json(
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions serialized Unstructured output into its constituent elements.
 
     Parameters
@@ -45,6 +56,7 @@ def partition_json(
     exactly_one(filename=filename, file=file, text=text)
 
     last_modification_date = None
+    file_text = ""
     if filename is not None:
         last_modification_date = get_last_modified_date(filename)
         with open(filename, encoding="utf8") as f:

--- a/unstructured/partition/xml.py
+++ b/unstructured/partition/xml.py
@@ -1,7 +1,7 @@
 import copy
 from io import BytesIO
 from tempfile import SpooledTemporaryFile
-from typing import IO, BinaryIO, Iterator, List, Optional, Union, cast
+from typing import IO, Any, BinaryIO, Iterator, List, Optional, Union, cast
 
 from lxml import etree
 
@@ -84,7 +84,7 @@ def _get_leaf_elements(
 @add_chunking_strategy()
 def partition_xml(
     filename: Optional[str] = None,
-    file: Optional[Union[IO[bytes], SpooledTemporaryFile]] = None,
+    file: Optional[Union[IO[bytes], SpooledTemporaryFile[bytes]]] = None,
     text: Optional[str] = None,
     xml_keep_tags: bool = False,
     xml_path: Optional[str] = None,
@@ -95,7 +95,7 @@ def partition_xml(
     chunking_strategy: Optional[str] = None,
     languages: Optional[List[str]] = ["auto"],
     detect_language_per_element: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> List[Element]:
     """Partitions an XML document into its document elements.
 


### PR DESCRIPTION
**Summary**
For whatever reason, the `@add_chunking_strategy` decorator was not present on `partition_json()`. This broke the only way to accomplish a "chunking-only" workflow using the REST API. This PR remedies that problem.