### PR TITLE
fix: handling of varied SharePoint date formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixes
 
-* **Fix SharePoint dates with inconsistent formatting** Adds logic to conditionally support dates returned by office365 that may vary in date formatting or may be a datetime rather than string.
+* **Fix SharePoint dates with inconsistent formatting** Adds logic to conditionally support dates returned by office365 that may vary in date formatting or may be a datetime rather than a string.
 
 ## 0.12.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.12.6-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* **Fix SharePoint dates with inconsistent formatting** Adds logic to conditionally support dates returned by office365 that may vary in date formatting or may be a datetime rather than string.
+
 ## 0.12.5
 
 ### Enhancements

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/fake-text.txt.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/fake-text.txt.json
@@ -3,8 +3,8 @@
     "element_id": "1df8eeb8be847c3a1a7411e3be3e0396",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [],
@@ -125,8 +125,8 @@
     "element_id": "a9d4657034aa3fdb5177f1325e912362",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [],
@@ -247,8 +247,8 @@
     "element_id": "9c218520320f238595f1fde74bdd137d",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [],
@@ -369,8 +369,8 @@
     "element_id": "39a3ae572581d0f1fe7511fd7b3aa414",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [],
@@ -491,8 +491,8 @@
     "element_id": "fc1adcb8eaceac694e500a103f9f698f",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [],
@@ -613,8 +613,8 @@
     "element_id": "0b61e826b1c4ab05750184da72b89f83",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [],

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/ideas-page.html.json
@@ -3,8 +3,8 @@
     "element_id": "8088fbcca4eb780b8a4b8efe4b018860",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:47",
-        "date_modified": "2023-06-16T05:04:47",
+        "date_created": "2023-06-16T05:04:47+00:00",
+        "date_modified": "2023-06-16T05:04:47+00:00",
         "permissions_data": [
           {
             "grantedTo": {

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/permissions-fake-text.docx.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/permissions-fake-text.docx.json
@@ -3,8 +3,8 @@
     "element_id": "d0cbb64f401635d84108950595cd2a19",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [
@@ -169,8 +169,8 @@
     "element_id": "a9d4657034aa3fdb5177f1325e912362",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [
@@ -335,8 +335,8 @@
     "element_id": "9c218520320f238595f1fde74bdd137d",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [
@@ -501,8 +501,8 @@
     "element_id": "13cb11be3e999b5fa22144d1e7334bea",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [
@@ -667,8 +667,8 @@
     "element_id": "ecc0621109605092d5cb0166734d86fe",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [
@@ -833,8 +833,8 @@
     "element_id": "f57013da02d00faf64e01c67fab8058f",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "permissions_data": [
           {
             "grantedToIdentities": [

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/stanley-cups.xlsx.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/stanley-cups.xlsx.json
@@ -3,8 +3,8 @@
     "element_id": "c37e2cb941a2e20a9f728fbea5f9e400",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:05:05",
-        "date_modified": "2023-06-16T05:05:05",
+        "date_created": "2023-06-16T05:05:05+00:00",
+        "date_modified": "2023-06-16T05:05:05+00:00",
         "permissions_data": [
           {
             "grantedTo": {
@@ -115,8 +115,8 @@
     "element_id": "c00fc0e5ac303c40f9089791e5e485b1",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:05:05",
-        "date_modified": "2023-06-16T05:05:05",
+        "date_created": "2023-06-16T05:05:05+00:00",
+        "date_modified": "2023-06-16T05:05:05+00:00",
         "permissions_data": [
           {
             "grantedTo": {
@@ -227,8 +227,8 @@
     "element_id": "98656277bdadc9ef7d1a9e1bc969579b",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:05:05",
-        "date_modified": "2023-06-16T05:05:05",
+        "date_created": "2023-06-16T05:05:05+00:00",
+        "date_modified": "2023-06-16T05:05:05+00:00",
         "permissions_data": [
           {
             "grantedTo": {
@@ -339,8 +339,8 @@
     "element_id": "31421b5cd94fedb10dc82738503b4505",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:05:05",
-        "date_modified": "2023-06-16T05:05:05",
+        "date_created": "2023-06-16T05:05:05+00:00",
+        "date_modified": "2023-06-16T05:05:05+00:00",
         "permissions_data": [
           {
             "grantedTo": {

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/fake-text.txt.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/fake-text.txt.json
@@ -3,8 +3,8 @@
     "element_id": "1df8eeb8be847c3a1a7411e3be3e0396",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/fake-text.txt",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -25,8 +25,8 @@
     "element_id": "a9d4657034aa3fdb5177f1325e912362",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/fake-text.txt",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -47,8 +47,8 @@
     "element_id": "9c218520320f238595f1fde74bdd137d",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/fake-text.txt",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -69,8 +69,8 @@
     "element_id": "39a3ae572581d0f1fe7511fd7b3aa414",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/fake-text.txt",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -91,8 +91,8 @@
     "element_id": "fc1adcb8eaceac694e500a103f9f698f",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/fake-text.txt",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -113,8 +113,8 @@
     "element_id": "0b61e826b1c4ab05750184da72b89f83",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:55",
-        "date_modified": "2023-06-16T05:04:55",
+        "date_created": "2023-06-16T05:04:55+00:00",
+        "date_modified": "2023-06-16T05:04:55+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/fake-text.txt",
           "site_url": "https://unstructuredio.sharepoint.com"

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/ideas-page.html.json
@@ -3,8 +3,8 @@
     "element_id": "8088fbcca4eb780b8a4b8efe4b018860",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:04:47",
-        "date_modified": "2023-06-16T05:04:47",
+        "date_created": "2023-06-16T05:04:47+00:00",
+        "date_modified": "2023-06-16T05:04:47+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/ideas-page.html",
           "site_url": "https://unstructuredio.sharepoint.com"

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/permissions-fake-text.docx.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/permissions-fake-text.docx.json
@@ -3,8 +3,8 @@
     "element_id": "d0cbb64f401635d84108950595cd2a19",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/permissions-fake-text.docx",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -25,8 +25,8 @@
     "element_id": "a9d4657034aa3fdb5177f1325e912362",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/permissions-fake-text.docx",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -47,8 +47,8 @@
     "element_id": "9c218520320f238595f1fde74bdd137d",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/permissions-fake-text.docx",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -69,8 +69,8 @@
     "element_id": "13cb11be3e999b5fa22144d1e7334bea",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/permissions-fake-text.docx",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -91,8 +91,8 @@
     "element_id": "ecc0621109605092d5cb0166734d86fe",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/permissions-fake-text.docx",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -113,8 +113,8 @@
     "element_id": "f57013da02d00faf64e01c67fab8058f",
     "metadata": {
       "data_source": {
-        "date_created": "2023-10-27T11:06:24",
-        "date_modified": "2023-10-27T11:07:34",
+        "date_created": "2023-10-27T11:06:24+00:00",
+        "date_modified": "2023-10-27T11:07:34+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/permissions-fake-text.docx",
           "site_url": "https://unstructuredio.sharepoint.com"

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/stanley-cups.xlsx.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/stanley-cups.xlsx.json
@@ -3,8 +3,8 @@
     "element_id": "c37e2cb941a2e20a9f728fbea5f9e400",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:05:05",
-        "date_modified": "2023-06-16T05:05:05",
+        "date_created": "2023-06-16T05:05:05+00:00",
+        "date_modified": "2023-06-16T05:05:05+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/stanley-cups.xlsx",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -27,8 +27,8 @@
     "element_id": "c00fc0e5ac303c40f9089791e5e485b1",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:05:05",
-        "date_modified": "2023-06-16T05:05:05",
+        "date_created": "2023-06-16T05:05:05+00:00",
+        "date_modified": "2023-06-16T05:05:05+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/stanley-cups.xlsx",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -51,8 +51,8 @@
     "element_id": "98656277bdadc9ef7d1a9e1bc969579b",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:05:05",
-        "date_modified": "2023-06-16T05:05:05",
+        "date_created": "2023-06-16T05:05:05+00:00",
+        "date_modified": "2023-06-16T05:05:05+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/stanley-cups.xlsx",
           "site_url": "https://unstructuredio.sharepoint.com"
@@ -75,8 +75,8 @@
     "element_id": "31421b5cd94fedb10dc82738503b4505",
     "metadata": {
       "data_source": {
-        "date_created": "2023-06-16T05:05:05",
-        "date_modified": "2023-06-16T05:05:05",
+        "date_created": "2023-06-16T05:05:05+00:00",
+        "date_modified": "2023-06-16T05:05:05+00:00",
         "record_locator": {
           "server_path": "/Shared Documents/stanley-cups.xlsx",
           "site_url": "https://unstructuredio.sharepoint.com"

--- a/test_unstructured_ingest/unit/test_sharepoint.py
+++ b/test_unstructured_ingest/unit/test_sharepoint.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from unstructured.ingest.connector.sharepoint import SharepointIngestDoc
+from unstructured.ingest.interfaces import ProcessorConfig, ReadConfig
+
+
+@pytest.mark.parametrize(
+    "time_created,time_last_modified,expected_created,expected_modified",
+    [
+        (
+            "2023-06-16T05:05:05+00:00",
+            datetime(2023, 6, 16, 5, 5, 5),
+            "2023-06-16T05:05:05+00:00",
+            "2023-06-16T05:05:05",
+        ),
+        ("2023-06-16 05:05:05", "2023-06-16", "2023-06-16T05:05:05", "2023-06-16T00:00:00"),
+        # Add more pairs of input strings and their expected ISO format results here
+    ],
+)
+def test_datetime_handling_in_update_source_metadata(
+    mocker, time_created, time_last_modified, expected_created, expected_modified
+):
+    """Test the handling of various datetime formats in update_source_metadata."""
+    # Create a mock SharePoint response directly in the test
+    mock_sharepoint_response = mocker.MagicMock()
+    mock_sharepoint_response.time_created = time_created
+    mock_sharepoint_response.time_last_modified = time_last_modified
+
+    # Patch the SharePoint interaction methods to use the mock response
+    mocker.patch(
+        "unstructured.ingest.connector.sharepoint.SharepointIngestDoc._fetch_file",
+        return_value=mock_sharepoint_response,
+    )
+    mocker.patch(
+        "unstructured.ingest.connector.sharepoint.SharepointIngestDoc._fetch_page",
+        return_value=None,
+    )
+
+    # Instantiate your document with dummy data
+    ingest_doc = SharepointIngestDoc(
+        connector_config=MagicMock(),
+        site_url="dummy_url",
+        server_path="dummy_path",
+        is_page=False,
+        file_path="dummy_path.html",
+        processor_config=ProcessorConfig(),
+        read_config=ReadConfig(),
+    )
+
+    # Execute the method under test
+    ingest_doc.update_source_metadata()
+
+    # Assertions to verify the datetime handling against expected results
+    assert ingest_doc.source_metadata is not None
+    assert ingest_doc.source_metadata.date_created.startswith(expected_created)
+    assert ingest_doc.source_metadata.date_modified.startswith(expected_modified)

--- a/test_unstructured_ingest/unit/test_sharepoint.py
+++ b/test_unstructured_ingest/unit/test_sharepoint.py
@@ -8,7 +8,7 @@ from unstructured.ingest.interfaces import ProcessorConfig, ReadConfig
 
 
 @pytest.mark.parametrize(
-    "time_created,time_last_modified,expected_created,expected_modified",
+    ("time_created", "time_last_modified", "expected_created", "expected_modified"),
     [
         (
             "2023-06-16T05:05:05+00:00",

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.5"  # pragma: no cover
+__version__ = "0.12.6-dev0"  # pragma: no cover

--- a/unstructured/ingest/connector/sharepoint.py
+++ b/unstructured/ingest/connector/sharepoint.py
@@ -3,6 +3,8 @@ import os
 import typing as t
 from dataclasses import dataclass
 from datetime import datetime
+from dateutil import parser
+
 from html import unescape
 from pathlib import Path
 from urllib.parse import urlparse
@@ -202,6 +204,27 @@ class SharepointIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
 
         return permissions_data
 
+
+    def _ensure_isoformat_datetime(self, timestamp: t.Union[datetime, str]) -> str:
+        """
+        Ensures that the input value is converted to an ISO format datetime string.
+        Handles both datetime objects and strings.
+        """
+        if isinstance(timestamp, datetime):
+            return timestamp.isoformat()
+        elif isinstance(timestamp, str):
+            try:
+                # Parse the datetime string in various formats
+                dt = parser.parse(timestamp)
+                return dt.isoformat()
+            except ValueError as e:
+                raise ValueError(
+                    f"String '{timestamp}' could not be parsed as a datetime."
+                ) from e
+        else:
+            raise TypeError(f"Expected input type datetime or str, but got {type(timestamp)}.")
+
+
     def update_source_metadata(self, **kwargs):
         if self.is_page:
             page = self._fetch_page()
@@ -231,11 +254,8 @@ class SharepointIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
             )
             return
         self.source_metadata = SourceMetadata(
-            date_created=datetime.strptime(file.time_created, "%Y-%m-%dT%H:%M:%SZ").isoformat(),
-            date_modified=datetime.strptime(
-                file.time_last_modified,
-                "%Y-%m-%dT%H:%M:%SZ",
-            ).isoformat(),
+            date_created=self._ensure_isoformat_datetime(timestamp=file.time_created),
+            date_modified=self._ensure_isoformat_datetime(timestamp=file.time_last_modified),
             version=file.major_version,
             source_url=file.properties.get("LinkingUrl", None),
             exists=True,

--- a/unstructured/ingest/connector/sharepoint.py
+++ b/unstructured/ingest/connector/sharepoint.py
@@ -3,11 +3,11 @@ import os
 import typing as t
 from dataclasses import dataclass
 from datetime import datetime
-from dateutil import parser
-
 from html import unescape
 from pathlib import Path
 from urllib.parse import urlparse
+
+from dateutil import parser
 
 from unstructured.file_utils.filetype import EXT_TO_FILETYPE
 from unstructured.ingest.enhanced_dataclass import enhanced_field
@@ -204,7 +204,6 @@ class SharepointIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
 
         return permissions_data
 
-
     def _ensure_isoformat_datetime(self, timestamp: t.Union[datetime, str]) -> str:
         """
         Ensures that the input value is converted to an ISO format datetime string.
@@ -218,12 +217,9 @@ class SharepointIngestDoc(IngestDocCleanupMixin, BaseSingleIngestDoc):
                 dt = parser.parse(timestamp)
                 return dt.isoformat()
             except ValueError as e:
-                raise ValueError(
-                    f"String '{timestamp}' could not be parsed as a datetime."
-                ) from e
+                raise ValueError(f"String '{timestamp}' could not be parsed as a datetime.") from e
         else:
             raise TypeError(f"Expected input type datetime or str, but got {type(timestamp)}.")
-
 
     def update_source_metadata(self, **kwargs):
         if self.is_page:


### PR DESCRIPTION
We are seeing occurrences of inconsistency in the timestamps returned by office365.sharepoint when fetching created and modified dates. Furthermore, in future versions of this library, a datetime object will be returned rather than a string. 

## Changes

- This adds logic to guarantee SharePoint dates will be properly formatted as ISO, regardless of the format provided by the sharepoint library.
- Bumps timestamp format output to include timezone offset (as we do with others)

## Testing

Unit test added to validate this datetime handling across various formats.
