### PR TITLE
fix documentation html links example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-## 0.12.6-dev0
+## 0.12.6-dev1
 
 ### Enhancements
 
 ### Features
 
 ### Fixes
- 
+
 * **Fix SharePoint dates with inconsistent formatting** Adds logic to conditionally support dates returned by office365 that may vary in date formatting or may be a datetime rather than a string.
 
 ## 0.12.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=build.txt build.in
 #
-alabaster==0.7.16
+alabaster==0.7.13
     # via sphinx
 babel==2.14.0
     # via sphinx

--- a/docs/source/examples/chroma.rst
+++ b/docs/source/examples/chroma.rst
@@ -20,9 +20,9 @@ First, we gather links from the CNN Lite homepage using the `partition_html` fun
     links = []
 
     for element in elements:
-        if element.metadata.links is not None:
-            relative_link = element.metadata.links[0]["url"][1:]
-            if relative_link.startswith("2023"):
+        if element.metadata.link_urls:
+            relative_link = element.metadata.link_urls[0][1:]
+            if relative_link.startswith("2024"):
                 links.append(f"{cnn_lite_url}{relative_link}")
 
 Ingest Individual Articles with UnstructuredURLLoader

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=build.txt build.in
 #
-alabaster==0.7.16
+alabaster==0.7.13
     # via sphinx
 babel==2.14.0
     # via sphinx

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.6-dev0"  # pragma: no cover
+__version__ = "0.12.6-dev1"  # pragma: no cover


### PR DESCRIPTION
Closes  #2577

Testing:
```
from unstructured.partition.html import partition_html

cnn_lite_url = "https://lite.cnn.com/"
elements = partition_html(url=cnn_lite_url)
links = []

for element in elements:
    if element.metadata.link_urls:
        relative_link = element.metadata.link_urls[0][1:]
        if relative_link.startswith("2024"):
            links.append(f"{cnn_lite_url}{relative_link}")
            
print(links)
```