### PR TITLE
fix: docker-publish build test missing key error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
-      UNSTRUCTURED_HF_TOKEN: ${{ secrets.HF_TOKEN }}
     needs: [setup, lint]
     steps:
     - uses: actions/checkout@v3
@@ -216,7 +215,6 @@ jobs:
     - name: Test
       env:
         UNS_API_KEY: ${{ secrets.UNS_API_KEY }}
-        UNSTRUCTURED_HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
         source .venv-${{ matrix.extra }}/bin/activate
         # NOTE(newelh) - determine what needs to be installed here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
+      UNSTRUCTURED_HF_TOKEN: ${{ secrets.HF_TOKEN }}
     needs: [setup, lint]
     steps:
     - uses: actions/checkout@v3
@@ -215,6 +216,7 @@ jobs:
     - name: Test
       env:
         UNS_API_KEY: ${{ secrets.UNS_API_KEY }}
+        UNSTRUCTURED_HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
         source .venv-${{ matrix.extra }}/bin/activate
         # NOTE(newelh) - determine what needs to be installed here

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -68,46 +68,46 @@ jobs:
           DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
             make docker-test CI=true TEST_FILE=test_unstructured/partition/test_text.py
         fi
-  #       DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
-  #   - name: Push images
-  #     run: |
-  #       # write to the build repository to cache for the publish-images job
-  #       ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-  #       docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  # publish-images:
-  #   runs-on: ubuntu-latest-m
-  #   needs: [set-short-sha, build-images]
-  #   env:
-  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-  #   steps:
-  #   - uses: docker/setup-buildx-action@v1
-  #   - name: Checkout code
-  #     uses: actions/checkout@v3
-  #   - name: Login to Quay.io
-  #     uses: docker/login-action@v1
-  #     with:
-  #       registry: quay.io
-  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-  #   - name: Pull AMD image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-  #   - name: Pull ARM image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-  #   - name: Push latest build tags for AMD and ARM
-  #     run: |
-  #       # these are used to construct the final manifest but also cache-from in subsequent runs
-  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
-  #   - name: Push multiarch manifest
-  #     run: |
-  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:latest
-  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
+        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
+    - name: Push images
+      run: |
+        # write to the build repository to cache for the publish-images job
+        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+        docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
+  publish-images:
+    runs-on: ubuntu-latest-m
+    needs: [set-short-sha, build-images]
+    env:
+      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+    steps:
+    - uses: docker/setup-buildx-action@v1
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+    - name: Pull AMD image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+    - name: Pull ARM image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+    - name: Push latest build tags for AMD and ARM
+      run: |
+        # these are used to construct the final manifest but also cache-from in subsequent runs
+        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+        docker push $DOCKER_BUILD_REPOSITORY:amd64
+        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+        docker push $DOCKER_BUILD_REPOSITORY:arm64
+    - name: Push multiarch manifest
+      run: |
+        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:latest
+        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -59,54 +59,55 @@ jobs:
     - name: Test images
       run: |
         echo "UNS_API_KEY=${{ secrets.UNS_API_KEY }}" > uns_test_env_file
-        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-        if [ "$ARCH" = "amd64" ]; then
-        DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-          make docker-test CI=true
-        else
-          DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-            make docker-test CI=true TEST_FILE=test_unstructured/partition/test_text.py
-        fi
-        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
-    - name: Push images
-      run: |
-        # write to the build repository to cache for the publish-images job
-        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-        docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  publish-images:
-    runs-on: ubuntu-latest-m
-    needs: [set-short-sha, build-images]
-    env:
-      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-    steps:
-    - uses: docker/setup-buildx-action@v1
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Login to Quay.io
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-    - name: Pull AMD image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-    - name: Pull ARM image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-    - name: Push latest build tags for AMD and ARM
-      run: |
-        # these are used to construct the final manifest but also cache-from in subsequent runs
-        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-        docker push $DOCKER_BUILD_REPOSITORY:amd64
-        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-        docker push $DOCKER_BUILD_REPOSITORY:arm64
-    - name: Push multiarch manifest
-      run: |
-        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:latest
-        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$VERSION
+        echo "UNSTRUCTURED_HF_TOKEN=${{ secrets.HF_TOKEN }}" >> uns_test_env_file
+  #       ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+  #       if [ "$ARCH" = "amd64" ]; then
+  #       DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
+  #         make docker-test CI=true
+  #       else
+  #         DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
+  #           make docker-test CI=true TEST_FILE=test_unstructured/partition/test_text.py
+  #       fi
+  #       DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
+  #   - name: Push images
+  #     run: |
+  #       # write to the build repository to cache for the publish-images job
+  #       ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+  #       docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
+  # publish-images:
+  #   runs-on: ubuntu-latest-m
+  #   needs: [set-short-sha, build-images]
+  #   env:
+  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+  #   steps:
+  #   - uses: docker/setup-buildx-action@v1
+  #   - name: Checkout code
+  #     uses: actions/checkout@v3
+  #   - name: Login to Quay.io
+  #     uses: docker/login-action@v1
+  #     with:
+  #       registry: quay.io
+  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+  #   - name: Pull AMD image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+  #   - name: Pull ARM image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+  #   - name: Push latest build tags for AMD and ARM
+  #     run: |
+  #       # these are used to construct the final manifest but also cache-from in subsequent runs
+  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
+  #   - name: Push multiarch manifest
+  #     run: |
+  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:latest
+  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -60,54 +60,54 @@ jobs:
       run: |
         echo "UNS_API_KEY=${{ secrets.UNS_API_KEY }}" > uns_test_env_file
         echo "UNSTRUCTURED_HF_TOKEN=${{ secrets.HF_TOKEN }}" >> uns_test_env_file
-  #       ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-  #       if [ "$ARCH" = "amd64" ]; then
-  #       DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-  #         make docker-test CI=true
-  #       else
-  #         DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
-  #           make docker-test CI=true TEST_FILE=test_unstructured/partition/test_text.py
-  #       fi
-  #       DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
-  #   - name: Push images
-  #     run: |
-  #       # write to the build repository to cache for the publish-images job
-  #       ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-  #       docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  # publish-images:
-  #   runs-on: ubuntu-latest-m
-  #   needs: [set-short-sha, build-images]
-  #   env:
-  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-  #   steps:
-  #   - uses: docker/setup-buildx-action@v1
-  #   - name: Checkout code
-  #     uses: actions/checkout@v3
-  #   - name: Login to Quay.io
-  #     uses: docker/login-action@v1
-  #     with:
-  #       registry: quay.io
-  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-  #   - name: Pull AMD image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-  #   - name: Pull ARM image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-  #   - name: Push latest build tags for AMD and ARM
-  #     run: |
-  #       # these are used to construct the final manifest but also cache-from in subsequent runs
-  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
-  #   - name: Push multiarch manifest
-  #     run: |
-  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:latest
-  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
+        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+        if [ "$ARCH" = "amd64" ]; then
+        DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
+          make docker-test CI=true
+        else
+          DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
+            make docker-test CI=true TEST_FILE=test_unstructured/partition/test_text.py
+        fi
+        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
+    - name: Push images
+      run: |
+        # write to the build repository to cache for the publish-images job
+        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+        docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
+  publish-images:
+    runs-on: ubuntu-latest-m
+    needs: [set-short-sha, build-images]
+    env:
+      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+    steps:
+    - uses: docker/setup-buildx-action@v1
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+    - name: Pull AMD image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+    - name: Pull ARM image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+    - name: Push latest build tags for AMD and ARM
+      run: |
+        # these are used to construct the final manifest but also cache-from in subsequent runs
+        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+        docker push $DOCKER_BUILD_REPOSITORY:amd64
+        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+        docker push $DOCKER_BUILD_REPOSITORY:arm64
+    - name: Push multiarch manifest
+      run: |
+        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:latest
+        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -67,46 +67,46 @@ jobs:
           DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
             make docker-test CI=true TEST_FILE=test_unstructured/partition/test_text.py
         fi
-        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
-    - name: Push images
-      run: |
-        # write to the build repository to cache for the publish-images job
-        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-        docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  publish-images:
-    runs-on: ubuntu-latest-m
-    needs: [set-short-sha, build-images]
-    env:
-      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-    steps:
-    - uses: docker/setup-buildx-action@v1
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Login to Quay.io
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-    - name: Pull AMD image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-    - name: Pull ARM image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-    - name: Push latest build tags for AMD and ARM
-      run: |
-        # these are used to construct the final manifest but also cache-from in subsequent runs
-        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-        docker push $DOCKER_BUILD_REPOSITORY:amd64
-        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-        docker push $DOCKER_BUILD_REPOSITORY:arm64
-    - name: Push multiarch manifest
-      run: |
-        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:latest
-        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$VERSION
+  #       DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
+  #   - name: Push images
+  #     run: |
+  #       # write to the build repository to cache for the publish-images job
+  #       ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+  #       docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
+  # publish-images:
+  #   runs-on: ubuntu-latest-m
+  #   needs: [set-short-sha, build-images]
+  #   env:
+  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+  #   steps:
+  #   - uses: docker/setup-buildx-action@v1
+  #   - name: Checkout code
+  #     uses: actions/checkout@v3
+  #   - name: Login to Quay.io
+  #     uses: docker/login-action@v1
+  #     with:
+  #       registry: quay.io
+  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+  #   - name: Pull AMD image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+  #   - name: Pull ARM image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+  #   - name: Push latest build tags for AMD and ARM
+  #     run: |
+  #       # these are used to construct the final manifest but also cache-from in subsequent runs
+  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
+  #   - name: Push multiarch manifest
+  #     run: |
+  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:latest
+  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -67,46 +67,46 @@ jobs:
           DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
             make docker-test CI=true TEST_FILE=test_unstructured/partition/test_text.py
         fi
-  #       DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
-  #   - name: Push images
-  #     run: |
-  #       # write to the build repository to cache for the publish-images job
-  #       ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-  #       docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  # publish-images:
-  #   runs-on: ubuntu-latest-m
-  #   needs: [set-short-sha, build-images]
-  #   env:
-  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-  #   steps:
-  #   - uses: docker/setup-buildx-action@v1
-  #   - name: Checkout code
-  #     uses: actions/checkout@v3
-  #   - name: Login to Quay.io
-  #     uses: docker/login-action@v1
-  #     with:
-  #       registry: quay.io
-  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-  #   - name: Pull AMD image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-  #   - name: Pull ARM image
-  #     run: |
-  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-  #   - name: Push latest build tags for AMD and ARM
-  #     run: |
-  #       # these are used to construct the final manifest but also cache-from in subsequent runs
-  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
-  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
-  #   - name: Push multiarch manifest
-  #     run: |
-  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:latest
-  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-  #       docker manifest push $DOCKER_REPOSITORY:$VERSION
+        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
+    - name: Push images
+      run: |
+        # write to the build repository to cache for the publish-images job
+        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+        docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
+  publish-images:
+    runs-on: ubuntu-latest-m
+    needs: [set-short-sha, build-images]
+    env:
+      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+    steps:
+    - uses: docker/setup-buildx-action@v1
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to Quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+    - name: Pull AMD image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+    - name: Pull ARM image
+      run: |
+        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+    - name: Push latest build tags for AMD and ARM
+      run: |
+        # these are used to construct the final manifest but also cache-from in subsequent runs
+        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+        docker push $DOCKER_BUILD_REPOSITORY:amd64
+        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+        docker push $DOCKER_BUILD_REPOSITORY:arm64
+    - name: Push multiarch manifest
+      run: |
+        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:latest
+        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+        docker manifest push $DOCKER_REPOSITORY:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,8 @@ name: Build And Push Docker Image
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 env:
   DOCKER_REPOSITORY: quay.io/unstructured-io/unstructured
@@ -68,46 +68,46 @@ jobs:
           DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \
             make docker-test CI=true TEST_FILE=test_unstructured/partition/test_text.py
         fi
-        DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
-    - name: Push images
-      run: |
-        # write to the build repository to cache for the publish-images job
-        ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
-        docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
-  publish-images:
-    runs-on: ubuntu-latest-m
-    needs: [set-short-sha, build-images]
-    env:
-      SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
-    steps:
-    - uses: docker/setup-buildx-action@v1
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Login to Quay.io
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
-        password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
-    - name: Pull AMD image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
-    - name: Pull ARM image
-      run: |
-        docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
-    - name: Push latest build tags for AMD and ARM
-      run: |
-        # these are used to construct the final manifest but also cache-from in subsequent runs
-        docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
-        docker push $DOCKER_BUILD_REPOSITORY:amd64
-        docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
-        docker push $DOCKER_BUILD_REPOSITORY:arm64
-    - name: Push multiarch manifest
-      run: |
-        docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:latest
-        docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
-        VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
-        docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
-        docker manifest push $DOCKER_REPOSITORY:$VERSION
+  #       DOCKER_IMAGE=$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA make docker-smoke-test
+  #   - name: Push images
+  #     run: |
+  #       # write to the build repository to cache for the publish-images job
+  #       ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
+  #       docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
+  # publish-images:
+  #   runs-on: ubuntu-latest-m
+  #   needs: [set-short-sha, build-images]
+  #   env:
+  #     SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}
+  #   steps:
+  #   - uses: docker/setup-buildx-action@v1
+  #   - name: Checkout code
+  #     uses: actions/checkout@v3
+  #   - name: Login to Quay.io
+  #     uses: docker/login-action@v1
+  #     with:
+  #       registry: quay.io
+  #       username: ${{ secrets.QUAY_IO_ROBOT_USERNAME }}
+  #       password: ${{ secrets.QUAY_IO_ROBOT_TOKEN }}
+  #   - name: Pull AMD image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA
+  #   - name: Pull ARM image
+  #     run: |
+  #       docker pull $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA
+  #   - name: Push latest build tags for AMD and ARM
+  #     run: |
+  #       # these are used to construct the final manifest but also cache-from in subsequent runs
+  #       docker tag $DOCKER_BUILD_REPOSITORY:amd64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker push $DOCKER_BUILD_REPOSITORY:amd64
+  #       docker tag $DOCKER_BUILD_REPOSITORY:arm64-$SHORT_SHA $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker push $DOCKER_BUILD_REPOSITORY:arm64
+  #   - name: Push multiarch manifest
+  #     run: |
+  #       docker manifest create ${DOCKER_REPOSITORY}:latest $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:latest
+  #       docker manifest create ${DOCKER_REPOSITORY}:$SHORT_SHA $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$SHORT_SHA
+  #       VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' unstructured/__version__.py)
+  #       docker manifest create ${DOCKER_REPOSITORY}:$VERSION $DOCKER_BUILD_REPOSITORY:amd64 $DOCKER_BUILD_REPOSITORY:arm64
+  #       docker manifest push $DOCKER_REPOSITORY:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,6 @@ jobs:
     - name: Test images
       run: |
         echo "UNS_API_KEY=${{ secrets.UNS_API_KEY }}" > uns_test_env_file
-        echo "UNSTRUCTURED_HF_TOKEN=${{ secrets.HF_TOKEN }}" > uns_test_env_file
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         if [ "$ARCH" = "amd64" ]; then
         DOCKER_PLATFORM="${{ matrix.docker-platform }}" DOCKER_IMAGE="$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA" \

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -20,8 +20,8 @@ function getopts-extra() {
   # if the next argument is not an option, then append it to array OPTARG
   while [[ ${OPTIND} -le $# && ${!OPTIND:0:1} != '-' ]]; do
     OPTARG[i]=${!OPTIND}
-    i+=1
-    OPTIND+=1
+    (( i += 1 ))
+    (( OPTIND += 1 ))
   done
 }
 

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -20,8 +20,8 @@ function getopts-extra() {
   # if the next argument is not an option, then append it to array OPTARG
   while [[ ${OPTIND} -le $# && ${!OPTIND:0:1} != '-' ]]; do
     OPTARG[i]=${!OPTIND}
-    (( i += 1 ))
-    (( OPTIND += 1 ))
+    ((i += 1))
+    ((OPTIND += 1))
   done
 }
 


### PR DESCRIPTION
The docker-publish github actions workflow builds amd and arm images of the repository and tests them before publishing. These tests have been failing since [this commit](https://github.com/Unstructured-IO/unstructured/commit/ee8b0f93dcba5adb2e4e032346fbaafbe0f45e54) with an error `UNS_API_KEY environment variable not set`.

The issue is that [this line](https://github.com/Unstructured-IO/unstructured/blob/b27ad9b6aa4cb29d5d3194cb1f1a0bf1fbaab30b/.github/workflows/docker-publish.yml#L62) in the workflow is actually blowing away the value assigned to the file in the previous line

## Changes

* Update line that was overwriting the assignment of UNS_API_KEY to the uns_test_env_file in the docker-publish workflow to leverage the `>>` operator so that UNSTRUCTURED_HF_TOKEN assignment is only appended.
* [bonus]: arithmetic expansion in version-sync.sh to keep shell-check happy

## Testing

To validate, I edited the docker-publish workflow to trigger on push (and to run the test but not publish the workflow) in [this commit](https://github.com/Unstructured-IO/unstructured/pull/2623/commits/0f04f5f0f7912853822239d2c0ba43608e71509a). The successful test results can be reviewed [here](https://github.com/Unstructured-IO/unstructured/actions/runs/8199826803).

