### PR TITLE
fix: declare -i [SC2324 shellcheck]

### DIFF
--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -20,8 +20,8 @@ function getopts-extra() {
   # if the next argument is not an option, then append it to array OPTARG
   while [[ ${OPTIND} -le $# && ${!OPTIND:0:1} != '-' ]]; do
     OPTARG[i]=${!OPTIND}
-    i+=1
-    OPTIND+=1
+    (( i+=1 ))
+    (( OPTIND+=1 ))
   done
 }
 

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -16,7 +16,7 @@ function usage {
 }
 
 function getopts-extra() {
-  declare i=1
+  declare -i i=1
   # if the next argument is not an option, then append it to array OPTARG
   while [[ ${OPTIND} -le $# && ${!OPTIND:0:1} != '-' ]]; do
     OPTARG[i]=${!OPTIND}

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -20,8 +20,8 @@ function getopts-extra() {
   # if the next argument is not an option, then append it to array OPTARG
   while [[ ${OPTIND} -le $# && ${!OPTIND:0:1} != '-' ]]; do
     OPTARG[i]=${!OPTIND}
-    ((i+=1))
-    ((OPTIND+=1))
+    ((i += 1))
+    ((OPTIND += 1))
   done
 }
 

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -20,8 +20,8 @@ function getopts-extra() {
   # if the next argument is not an option, then append it to array OPTARG
   while [[ ${OPTIND} -le $# && ${!OPTIND:0:1} != '-' ]]; do
     OPTARG[i]=${!OPTIND}
-    (( i+=1 ))
-    (( OPTIND+=1 ))
+    ((i+=1))
+    ((OPTIND+=1))
   done
 }
 


### PR DESCRIPTION
Fix SC2324 shellcheck warning by adding -i to indicate var type of integer and tidy up the formatting.