### PR TITLE
AstraDB Fix: Add usage tracking

### DIFF
--- a/requirements/ingest/astra.txt
+++ b/requirements/ingest/astra.txt
@@ -8,7 +8,7 @@ anyio==3.7.1
     # via
     #   -c ingest/../constraints.in
     #   httpx
-astrapy==0.7.6
+astrapy==0.7.7
     # via -r ingest/astra.in
 cassandra-driver==3.29.0
     # via cassio

--- a/unstructured/ingest/connector/astra.py
+++ b/unstructured/ingest/connector/astra.py
@@ -16,6 +16,11 @@ from unstructured.ingest.utils.data_prep import chunk_generator
 from unstructured.staging.base import flatten_dict
 from unstructured.utils import requires_dependencies
 
+# For version tracking
+from unstructured import __name__ as integration_name
+from unstructured.__version__ import __version__ as integration_version
+
+
 if t.TYPE_CHECKING:
     from astrapy.db import AstraDB, AstraDBCollection
 
@@ -71,6 +76,8 @@ class AstraDestinationConnector(BaseDestinationConnector):
             self._astra_db = AstraDB(
                 api_endpoint=self.connector_config.access_config.api_endpoint,
                 token=self.connector_config.access_config.token,
+                caller_name=integration_name,
+                caller_version=integration_version,
             )
 
             # Create and connect to the newly created collection


### PR DESCRIPTION
This pull request passes the name (`unstructured`) and the version of the package to the Astra DB client, in order to help us track the usage of the integration on the Astra DB side. It requires the latest `astrapy==0.7.7` release.