### PR TITLE
feat(chunking): composite text gets is_continuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.12.7-dev0
+## 0.12.7-dev1
 
 ### Enhancements
+
+* **Add `.metadata.is_continuation` to text-split chunks.** `.metadata.is_continuation=True` is added to second-and-later chunks formed by text-splitting an oversized `Table` element but not to their counterpart `Text` element splits. Add this indicator for `CompositeElement` to allow text-split continuation chunks to be identified for downstream processes that may wish to skip intentionally redundant metadata values in continuation chunks.
 
 ### Features
 

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -634,10 +634,29 @@ class DescribeTextPreChunk:
         # --
         chunk = next(chunk_iter)
         assert chunk == CompositeElement("aliquip ex ea commodo consequat.")
-        assert chunk.metadata is pre_chunk._consolidated_metadata
+        assert chunk.metadata is pre_chunk._continuation_metadata
         # --
         with pytest.raises(StopIteration):
             next(chunk_iter)
+
+    def and_it_adds_the_is_continuation_flag_for_second_and_later_text_split_chunks(self):
+        metadata = ElementMetadata(
+            category_depth=0,
+            filename="foo.docx",
+            languages=["lat"],
+            parent_id="f87731e0",
+        )
+
+        pre_chunk = TextPreChunk(
+            # --   |--------------------- 48 ---------------------|
+            [Text("'Lorem ipsum dolor' means 'Thank you very much'.", metadata=metadata)],
+            overlap_prefix="",
+            opts=ChunkingOptions(max_characters=20),
+        )
+
+        chunk_iter = pre_chunk.iter_chunks()
+
+        assert [c.metadata.is_continuation for c in chunk_iter] == [None, True, True]
 
     @pytest.mark.parametrize(
         ("text", "expected_value"),

--- a/test_unstructured_ingest/expected-structured-output/local-single-file-basic-chunking/handbook-1p.docx.json
+++ b/test_unstructured_ingest/expected-structured-output/local-single-file-basic-chunking/handbook-1p.docx.json
@@ -64,7 +64,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -84,7 +85,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -104,7 +106,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -124,7 +127,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -144,7 +148,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -164,7 +169,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -184,7 +190,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -224,7 +231,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -244,7 +252,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -264,7 +273,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -284,7 +294,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1
+      "page_number": 1,
+      "is_continuation": true
     }
   },
   {
@@ -364,7 +375,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {
@@ -384,7 +396,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {
@@ -404,7 +417,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {
@@ -444,7 +458,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {
@@ -464,7 +479,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {
@@ -524,7 +540,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {
@@ -544,7 +561,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {
@@ -564,7 +582,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {
@@ -604,7 +623,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {
@@ -624,7 +644,8 @@
       "languages": [
         "eng"
       ],
-      "page_number": 2
+      "page_number": 2,
+      "is_continuation": true
     }
   },
   {

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.7-dev0"  # pragma: no cover
+__version__ = "0.12.7-dev1"  # pragma: no cover


### PR DESCRIPTION
**Summary**
Add `metadata.is_continuation = True` to metadata of second-and-later text-split chunks formed from an oversized non-table element. Previously this metadata was only present on text-split `TableChunk` elements.

This enables downstream filtering of intentionally redundant metadata on chunk elements that may not be desired for all purposes.