### PR TITLE
rfctr(chunking): simplify chunking opts construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.7-dev1
+## 0.12.7-dev2
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.7-dev1"  # pragma: no cover
+__version__ = "0.12.7-dev2"  # pragma: no cover

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import collections
 import copy
-from typing import Any, Callable, DefaultDict, Iterable, Iterator, Optional, Sequence, cast
+from typing import Any, Callable, DefaultDict, Iterable, Iterator, Optional, cast
 
 import regex
-from typing_extensions import TypeAlias
+from typing_extensions import Self, TypeAlias
 
 from unstructured.documents.elements import (
     CompositeElement,
@@ -96,22 +96,15 @@ class ChunkingOptions:
         whitespace character sequences are suitable.
     """
 
-    def __init__(
-        self,
-        *,
-        combine_text_under_n_chars: Optional[int] = None,
-        max_characters: Optional[int] = None,
-        new_after_n_chars: Optional[int] = None,
-        overlap: Optional[int] = None,
-        overlap_all: Optional[bool] = None,
-        text_splitting_separators: Sequence[str] = ("\n", " "),
-    ):
-        self._combine_text_under_n_chars_arg = combine_text_under_n_chars
-        self._max_characters_arg = max_characters
-        self._new_after_n_chars_arg = new_after_n_chars
-        self._overlap_arg = overlap
-        self._overlap_all_arg = overlap_all
-        self._text_splitting_separators = text_splitting_separators
+    def __init__(self, **kwargs: Any):
+        self._kwargs = kwargs
+
+    @classmethod
+    def new(cls, **kwargs: Any) -> Self:
+        """Return instance or raises `ValueError` on invalid arguments like overlap > max_chars."""
+        self = cls(**kwargs)
+        self._validate()
+        return self
 
     @lazyproperty
     def boundary_predicates(self) -> tuple[BoundaryPredicate, ...]:
@@ -128,7 +121,7 @@ class ChunkingOptions:
         Default applied here is `0` which essentially disables chunk combining. Must be overridden
         by subclass where combining behavior is supported.
         """
-        arg_value = self._combine_text_under_n_chars_arg
+        arg_value = self._kwargs.get("combine_text_under_n_chars")
         return arg_value if arg_value is not None else 0
 
     @lazyproperty
@@ -139,7 +132,7 @@ class ChunkingOptions:
         exceeds this size. Such a pre-chunk is subject to mid-text splitting later in the chunking
         process.
         """
-        arg_value = self._max_characters_arg
+        arg_value = self._kwargs.get("max_characters")
         return arg_value if arg_value is not None else CHUNK_MAX_CHARS_DEFAULT
 
     @lazyproperty
@@ -149,7 +142,8 @@ class ChunkingOptions:
         This applies only to boundaries between chunks formed from whole elements and not to
         text-splitting boundaries that arise from splitting an oversized element.
         """
-        return self.overlap if self._overlap_all_arg else 0
+        overlap_all_arg = self._kwargs.get("overlap_all")
+        return self.overlap if overlap_all_arg else 0
 
     @lazyproperty
     def overlap(self) -> int:
@@ -158,7 +152,8 @@ class ChunkingOptions:
         The actual overlap will not exceed this number of characters but may be less as required to
         respect splitting-character boundaries.
         """
-        return self._overlap_arg or 0
+        overlap_arg = self._kwargs.get("overlap")
+        return overlap_arg or 0
 
     @lazyproperty
     def soft_max(self) -> int:
@@ -168,14 +163,10 @@ class ChunkingOptions:
         each element into its own chunk.
         """
         hard_max = self.hard_max
-        new_after_n_chars_arg = self._new_after_n_chars_arg
+        new_after_n_chars_arg = self._kwargs.get("new_after_n_chars")
 
         # -- default value is == max_characters --
         if new_after_n_chars_arg is None:
-            return hard_max
-
-        # -- we silently fix an invalid value, maybe we shouldn't --
-        if new_after_n_chars_arg < 0:
             return hard_max
 
         # -- new_after_n_chars > max_characters behaves the same as ==max_characters --
@@ -207,7 +198,12 @@ class ChunkingOptions:
     @lazyproperty
     def text_splitting_separators(self) -> tuple[str, ...]:
         """Sequence of text-splitting target strings to be used in order of preference."""
-        return tuple(self._text_splitting_separators)
+        text_splitting_separators_arg = self._kwargs.get("text_splitting_separators")
+        return (
+            ("\n", " ")
+            if text_splitting_separators_arg is None
+            else tuple(text_splitting_separators_arg)
+        )
 
     def _validate(self) -> None:
         """Raise ValueError if requestion option-set is invalid."""
@@ -218,7 +214,7 @@ class ChunkingOptions:
 
         # -- a negative value for `new_after_n_chars` is assumed to be a mistake the caller will
         # -- want to know about
-        new_after_n_chars = self._new_after_n_chars_arg
+        new_after_n_chars = self._kwargs.get("new_after_n_chars")
         if new_after_n_chars is not None and new_after_n_chars < 0:
             raise ValueError(
                 f"'new_after_n_chars' argument must be >= 0," f" got {new_after_n_chars}"

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 
 from typing import Iterable, Optional
 
-from typing_extensions import Self
-
 from unstructured.chunking.base import ChunkingOptions, PreChunker
 from unstructured.documents.elements import Element
 
@@ -68,6 +66,13 @@ def chunk_elements(
         overlap_all=overlap_all,
     )
 
+    return _chunk_elements(elements, opts)
+
+
+def _chunk_elements(elements: Iterable[Element], opts: _BasicChunkingOptions) -> list[Element]:
+    """Implementation of actual basic chunking."""
+    # -- Note(scanny): it might seem like over-abstraction for this to be a separate function but
+    # -- it eases overriding or adding individual chunking options when customizing a stock chunker.
     return [
         chunk
         for pre_chunk in PreChunker.iter_pre_chunks(elements, opts)
@@ -77,25 +82,3 @@ def chunk_elements(
 
 class _BasicChunkingOptions(ChunkingOptions):
     """Options for `basic` chunking."""
-
-    @classmethod
-    def new(
-        cls,
-        *,
-        max_characters: Optional[int] = None,
-        new_after_n_chars: Optional[int] = None,
-        overlap: Optional[int] = None,
-        overlap_all: Optional[bool] = None,
-    ) -> Self:
-        """Construct validated instance.
-
-        Raises `ValueError` on invalid arguments like overlap > max_chars.
-        """
-        self = cls(
-            max_characters=max_characters,
-            new_after_n_chars=new_after_n_chars,
-            overlap=overlap,
-            overlap_all=overlap_all,
-        )
-        self._validate()
-        return self


### PR DESCRIPTION
**Summary**
Use omnibus `kwargs` dict for `ChunkingOptions` state rather than explicit option parameters.

**Additional Context**
While articulating explicit options for `ChunkingOptions` and its (now several) sub-classes provides some type-safety, it induces a large amount of redundancy which complicates updates to the base class and especially patches to the base class from client code that adds custom chunkers.

In particular, it makes custom chunkers brittle to any new attributes added to `ChunkingOptions` (the base class).

Use a single omnibus `kwargs` argument to `ChunkingOptions` and its subclasses allowing each to pull out the options it is interested in and happily ignore the rest.

The type safety provided by explicit parameters and types is only afforded to the single place the options item is called from which is the custom chunker itself. Because this is "internal" code and not part of the public interface, this is a manageably small loss in type-safety.