### PR TITLE
feat(chunking): add include_orig_elements chunking option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.7-dev4
+## 0.12.7-dev5
 
 ### Enhancements
 

--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ tidy-shell:
 
 .PHONY: tidy-python
 tidy-python:
-	ruff . --select C4,COM,E,F,I,PLR0402,PT,SIM,UP015,UP018,UP032,UP034 --fix-only --ignore COM812,PT011,PT012,SIM117 || true
+	ruff . --fix-only || true
 	autoflake --in-place .
 	black  .
 

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import pytest
 
@@ -77,6 +77,20 @@ class DescribeChunkingOptions:
         """
         opts = ChunkingOptions(combine_text_under_n_chars=combine_text_under_n_chars)
         assert opts.combine_text_under_n_chars == expected_value
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected_value"),
+        [
+            ({"include_orig_elements": True}, True),
+            ({"include_orig_elements": False}, False),
+            ({"include_orig_elements": None}, True),
+            ({}, True),
+        ],
+    )
+    def it_knows_whether_to_include_orig_elements_in_the_chunk_metadata(
+        self, kwargs: dict[str, Any], expected_value: bool
+    ):
+        assert ChunkingOptions(**kwargs).include_orig_elements is expected_value
 
     @pytest.mark.parametrize("n_chars", [-1, -42])
     def it_rejects_new_after_n_chars_for_n_less_than_zero(self, n_chars: int):

--- a/test_unstructured/chunking/test_basic.py
+++ b/test_unstructured/chunking/test_basic.py
@@ -6,6 +6,11 @@ shared by all chunking strategies and no extra rules like perserve section or pa
 
 from __future__ import annotations
 
+from typing import Any
+
+import pytest
+
+from test_unstructured.unit_utils import FixtureRequest, Mock, function_mock
 from unstructured.chunking.basic import chunk_elements
 from unstructured.documents.elements import CompositeElement, Text, Title
 from unstructured.partition.docx import partition_docx
@@ -106,3 +111,37 @@ def test_it_chunks_elements_when_the_user_already_has_them():
         CompositeElement("Lorem ipsum dolor sit amet consectetur adipiscing elit. In"),
         CompositeElement("rhoncus ipsum sed lectus porta volutpat."),
     ]
+
+
+# ------------------------------------------------------------------------------------------------
+# UNIT TESTS
+# ------------------------------------------------------------------------------------------------
+
+
+class Describe_chunk_elements:
+    """Unit-test suite for `unstructured.chunking.basic.chunk_elements()` function."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected_value"),
+        [
+            ({"include_orig_elements": True}, True),
+            ({"include_orig_elements": False}, False),
+            ({"include_orig_elements": None}, True),
+            ({}, True),
+        ],
+    )
+    def it_supports_the_include_orig_elements_option(
+        self, kwargs: dict[str, Any], expected_value: bool, _chunk_elements_: Mock
+    ):
+        # -- this line would raise if "include_orig_elements" was not an available parameter on
+        # -- `chunk_elements()`.
+        chunk_elements([], **kwargs)
+
+        _, opts = _chunk_elements_.call_args.args
+        assert opts.include_orig_elements is expected_value
+
+    # -- fixtures --------------------------------------------------------------------------------
+
+    @pytest.fixture()
+    def _chunk_elements_(self, request: FixtureRequest):
+        return function_mock(request, "unstructured.chunking.basic._chunk_elements")

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
+from test_unstructured.unit_utils import FixtureRequest, Mock, function_mock
 from unstructured.chunking.base import (
     CHUNK_MULTI_PAGE_DEFAULT,
     PreChunker,
@@ -566,6 +567,35 @@ def test_it_considers_separator_length_when_pre_chunking():
 # These test individual components in isolation so can exercise all edge cases while still
 # performing well.
 # ================================================================================================
+
+
+class Describe_chunk_by_title:
+    """Unit-test suite for `unstructured.chunking.title.chunk_by_title()` function."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected_value"),
+        [
+            ({"include_orig_elements": True}, True),
+            ({"include_orig_elements": False}, False),
+            ({"include_orig_elements": None}, True),
+            ({}, True),
+        ],
+    )
+    def it_supports_the_include_orig_elements_option(
+        self, kwargs: dict[str, Any], expected_value: bool, _chunk_by_title_: Mock
+    ):
+        # -- this line would raise if "include_orig_elements" was not an available parameter on
+        # -- `chunk_by_title()`.
+        chunk_by_title([], **kwargs)
+
+        _, opts = _chunk_by_title_.call_args.args
+        assert opts.include_orig_elements is expected_value
+
+    # -- fixtures --------------------------------------------------------------------------------
+
+    @pytest.fixture()
+    def _chunk_by_title_(self, request: FixtureRequest):
+        return function_mock(request, "unstructured.chunking.title._chunk_by_title")
 
 
 class Describe_ByTitleChunkingOptions:

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.7-dev4"  # pragma: no cover
+__version__ = "0.12.7-dev5"  # pragma: no cover

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -136,6 +136,15 @@ class ChunkingOptions:
         return arg_value if arg_value is not None else CHUNK_MAX_CHARS_DEFAULT
 
     @lazyproperty
+    def include_orig_elements(self) -> bool:
+        """When True, add original elements from pre-chunk to `.metadata.orig_elements` of chunk.
+
+        Default value is `True`.
+        """
+        arg_value = self._kwargs.get("include_orig_elements")
+        return True if arg_value is None else bool(arg_value)
+
+    @lazyproperty
     def inter_chunk_overlap(self) -> int:
         """Characters of overlap to add between chunks.
 

--- a/unstructured/chunking/basic.py
+++ b/unstructured/chunking/basic.py
@@ -24,6 +24,7 @@ from unstructured.documents.elements import Element
 def chunk_elements(
     elements: Iterable[Element],
     *,
+    include_orig_elements: Optional[bool] = None,
     max_characters: Optional[int] = None,
     new_after_n_chars: Optional[int] = None,
     overlap: Optional[int] = None,
@@ -37,6 +38,11 @@ def chunk_elements(
     ----------
     elements
         A list of unstructured elements. Usually the output of a partition function.
+    include_orig_elements
+        When `True` (default), add elements from pre-chunk to the `.metadata.orig_elements` field
+        of the chunk(s) formed from that pre-chunk. Among other things, this allows access to
+        original-element metadata that cannot be consolidated and is dropped in the course of
+        chunking.
     max_characters
         Hard maximum chunk length. No chunk will exceed this length. A single element that exceeds
         this length will be divided into two or more chunks using text-splitting.
@@ -60,6 +66,7 @@ def chunk_elements(
     """
     # -- raises ValueError on invalid parameters --
     opts = _BasicChunkingOptions.new(
+        include_orig_elements=include_orig_elements,
         max_characters=max_characters,
         new_after_n_chars=new_after_n_chars,
         overlap=overlap,

--- a/unstructured/chunking/title.py
+++ b/unstructured/chunking/title.py
@@ -24,9 +24,10 @@ from unstructured.utils import lazyproperty
 def chunk_by_title(
     elements: Iterable[Element],
     *,
+    combine_text_under_n_chars: Optional[int] = None,
+    include_orig_elements: Optional[bool] = None,
     max_characters: Optional[int] = None,
     multipage_sections: Optional[bool] = None,
-    combine_text_under_n_chars: Optional[int] = None,
     new_after_n_chars: Optional[int] = None,
     overlap: Optional[int] = None,
     overlap_all: Optional[bool] = None,
@@ -41,23 +42,28 @@ def chunk_by_title(
     ----------
     elements
         A list of unstructured elements. Usually the output of a partition function.
-    multipage_sections
-        If True, sections can span multiple pages. Defaults to True.
     combine_text_under_n_chars
         Combines elements (for example a series of titles) until a section reaches a length of
         n characters. Defaults to `max_characters` which combines chunks whenever space allows.
         Specifying 0 for this argument suppresses combining of small chunks. Note this value is
         "capped" at the `new_after_n_chars` value since a value higher than that would not change
         this parameter's effect.
+    include_orig_elements
+        When `True` (default), add elements from pre-chunk to the `.metadata.orig_elements` field
+        of the chunk(s) formed from that pre-chunk. Among other things, this allows access to
+        original-element metadata that cannot be consolidated and is dropped in the course of
+        chunking.
+    max_characters
+        Chunks elements text and text_as_html (if present) into chunks of length
+        n characters (hard max)
+    multipage_sections
+        If True, sections can span multiple pages. Defaults to True.
     new_after_n_chars
         Cuts off new sections once they reach a length of n characters (soft max). Defaults to
         `max_characters` when not specified, which effectively disables any soft window.
         Specifying 0 for this argument causes each element to appear in a chunk by itself (although
         an element with text longer than `max_characters` will be still be split into two or more
         chunks).
-    max_characters
-        Chunks elements text and text_as_html (if present) into chunks of length
-        n characters (hard max)
     overlap
         Specifies the length of a string ("tail") to be drawn from each chunk and prefixed to the
         next chunk as a context-preserving mechanism. By default, this only applies to split-chunks
@@ -69,6 +75,7 @@ def chunk_by_title(
     """
     opts = _ByTitleChunkingOptions.new(
         combine_text_under_n_chars=combine_text_under_n_chars,
+        include_orig_elements=include_orig_elements,
         max_characters=max_characters,
         multipage_sections=multipage_sections,
         new_after_n_chars=new_after_n_chars,

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -158,9 +158,9 @@ class ElementMetadata:
     # - Add the field declaration with type here at the top. This makes it a "known" field and
     #   enables type-checking and completion.
     # - Add a parameter with default for field in __init__() and assign it in __init__() body.
-    # - Add a consolidation strategy for the field below in `ConsolidationStrategy`
-    #   `.field_consolidation_strategies()` to be used when consolidating metadata fields of a
-    #   section's elements during chunking.
+    # - Add a consolidation strategy for the new field in
+    #   `ConsolidationStrategy.field_consolidation_strategies()` below. This strategy will be used
+    #   to consolidate this new metadata field from each pre-chunk element during chunking.
     # - Add field-name to DEBUG_FIELD_NAMES if it shouldn't appear in dict/JSON or participate in
     #   equality comparison.
 
@@ -189,6 +189,8 @@ class ElementMetadata:
     link_texts: Optional[list[str]]
     link_urls: Optional[list[str]]
     links: Optional[list[Link]]
+    # -- used in chunks only, allowing access to element(s) chunk was formed from when enabled --
+    orig_elements: Optional[list[Element]]
     # -- the worksheet name in XLXS documents --
     page_name: Optional[str]
     # -- page numbers currently supported for DOCX, HTML, PDF, and PPTX documents --
@@ -234,6 +236,7 @@ class ElementMetadata:
         link_texts: Optional[list[str]] = None,
         link_urls: Optional[list[str]] = None,
         links: Optional[list[Link]] = None,
+        orig_elements: Optional[list[Element]] = None,
         page_name: Optional[str] = None,
         page_number: Optional[int] = None,
         parent_id: Optional[str | uuid.UUID | NoID | UUID] = None,
@@ -272,6 +275,7 @@ class ElementMetadata:
         self.link_texts = link_texts
         self.link_urls = link_urls
         self.links = links
+        self.orig_elements = orig_elements
         self.page_name = page_name
         self.page_number = page_number
         self.parent_id = parent_id
@@ -475,6 +479,7 @@ class ConsolidationStrategy(enum.Enum):
             "link_urls": cls.LIST_CONCATENATE,
             "links": cls.DROP,  # -- deprecated field --
             "max_characters": cls.DROP,  # -- unused, remove from ElementMetadata --
+            "orig_elements": cls.DROP,  # -- not expected, added by chunking, not before --
             "page_name": cls.FIRST,
             "page_number": cls.FIRST,
             "parent_id": cls.DROP,

--- a/unstructured/staging/weaviate.py
+++ b/unstructured/staging/weaviate.py
@@ -9,13 +9,14 @@ class Properties(TypedDict):
 
 
 exclude_metadata_keys = (
-    "data_source",
     "coordinates",
-    "links",
-    "regex_metadata",
-    "emphasized_texts",
+    "data_source",
     "detection_class_prob",
+    "emphasized_texts",
     "is_continuation",
+    "links",
+    "orig_elements",
+    "regex_metadata",
 )
 
 


### PR DESCRIPTION
**Summary**
Add `include_orig_elements: bool = True` as a new chunking option. This PR does not implement _adding_ original elements to chunks, only accepting this parameter as a chunking option and assigning `True` to it as a default value when it is omitted as a keyword argument.

Note this will need to be added in other repositories as well in order to fully support this new option by all access methods. In particular it will need to be added in `unstructured-api` in order to become available via the SDKs.