### PR TITLE
refactor: get_mean_grouping command takes in export_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.12.7-dev8
 
-### Enhancements
+### Enhancements 
 
 * **Add `.metadata.is_continuation` to text-split chunks.** `.metadata.is_continuation=True` is added to second-and-later chunks formed by text-splitting an oversized `Table` element but not to their counterpart `Text` element splits. Add this indicator for `CompositeElement` to allow text-split continuation chunks to be identified for downstream processes that may wish to skip intentionally redundant metadata values in continuation chunks.
 * **Add `compound_structure_acc` metric to table eval.** Add a new property to `unstructured.metrics.table_eval.TableEvaluation`: `composite_structure_acc`, which is computed from the element level row and column index and content accuracy scores

--- a/unstructured/ingest/evaluate.py
+++ b/unstructured/ingest/evaluate.py
@@ -42,7 +42,7 @@ def main():
     help="Directory to save the output evaluation metrics to. Default to \
         your/working/dir/metrics/",
 )
-@click.option("--grouping", type=str, help="Input field for aggregration, or leave blank if none.")
+@click.option("--group_by", type=str, help="Input field for aggregration, or leave blank if none.")
 @click.option(
     "--weights",
     type=(int, int, int),
@@ -74,7 +74,7 @@ def measure_text_extraction_accuracy_command(
     output_type: str,
     output_list: Optional[List[str]] = None,
     source_list: Optional[List[str]] = None,
-    grouping: Optional[str] = None,
+    group_by: Optional[str] = None,
 ):
     return measure_text_extraction_accuracy(
         output_dir,
@@ -82,7 +82,7 @@ def measure_text_extraction_accuracy_command(
         output_list,
         source_list,
         export_dir,
-        grouping,
+        group_by,
         weights,
         visualize,
         output_type,

--- a/unstructured/ingest/evaluate.py
+++ b/unstructured/ingest/evaluate.py
@@ -159,11 +159,11 @@ def measure_element_type_accuracy_command(
     help="Evaluated metric. Expecting one of 'text_extraction' or 'element_type'",
 )
 @click.option(
-    "--export_name",
-    type=str,
-    help="Optional. Define your file name for the output here."
+    "--export_name", type=str, help="Optional. Define your file name for the output here."
 )
-def get_mean_grouping_command(group_by: str, data_input: str, export_dir: str, eval_name: str, export_name: str):
+def get_mean_grouping_command(
+    group_by: str, data_input: str, export_dir: str, eval_name: str, export_name: str
+):
     return get_mean_grouping(group_by, data_input, export_dir, eval_name, export_name)
 
 

--- a/unstructured/ingest/evaluate.py
+++ b/unstructured/ingest/evaluate.py
@@ -158,8 +158,13 @@ def measure_element_type_accuracy_command(
     type=str,
     help="Evaluated metric. Expecting one of 'text_extraction' or 'element_type'",
 )
-def get_mean_grouping_command(group_by: str, data_input: str, export_dir: str, eval_name: str):
-    return get_mean_grouping(group_by, data_input, export_dir, eval_name)
+@click.option(
+    "--export_name",
+    type=str,
+    help="Optional. Define your file name for the output here."
+)
+def get_mean_grouping_command(group_by: str, data_input: str, export_dir: str, eval_name: str, export_name: str):
+    return get_mean_grouping(group_by, data_input, export_dir, eval_name, export_name)
 
 
 @main.command()


### PR DESCRIPTION
The `get_mean_grouping_command` currently does not take `export_name` as param. Add the param for better naming use case.