### PR TITLE
build(ci): skip `python 3.11` in CI ingest jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
   setup_ingest:
     strategy:
       matrix:
-        python-version: [ "3.9","3.10","3.11" ]
+        python-version: [ "3.9","3.10" ]
     runs-on: ubuntu-latest
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
@@ -254,7 +254,7 @@ jobs:
   test_ingest_unit:
     strategy:
       matrix:
-        python-version: [ "3.9","3.10","3.11" ]
+        python-version: [ "3.9","3.10" ]
     runs-on: ubuntu-latest
     needs: [ setup_ingest, lint ]
     steps:
@@ -280,7 +280,7 @@ jobs:
   test_ingest_src:
     strategy:
       matrix:
-        python-version: ["3.9","3.10","3.11"]
+        python-version: ["3.9","3.10"]
     runs-on: ubuntu-latest-m
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
@@ -364,7 +364,7 @@ jobs:
     environment: ci
     strategy:
       matrix:
-        python-version: ["3.9","3.10","3.11"]
+        python-version: ["3.9","3.10"]
     runs-on: ubuntu-latest-m
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data


### PR DESCRIPTION
CI fails every time on test_ingest_src (3.11) and test_ingest_dst (3.11) on what looks like a pip-install problem `(ModuleNotFoundError: No module named 'click')`. The error is exactly the same place every time.
- https://github.com/Unstructured-IO/unstructured/actions/runs/8622028071/job/23632669423
- https://github.com/Unstructured-IO/unstructured/actions/runs/8623541446
- https://github.com/Unstructured-IO/unstructured/actions/runs/8623056382
...

This PR skips the Python `3.11` ingest tests since the most important one is `3.10` anyway.