### PR TITLE
feat(pptx): partition_pptx() accepts strategy arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.13.3-dev2
+## 0.13.3-dev3
 
 ### Enhancements
+
+* **Add `strategy` arg value to `_PptxPartitionerOptions`.** This makes this paritioning option available for sub-partitioners to come that may optionally use inference or other expensive operations to improve the partitioning.
 
 ### Features
 

--- a/test_unstructured/partition/pptx/test_pptx.py
+++ b/test_unstructured/partition/pptx/test_pptx.py
@@ -261,7 +261,7 @@ def test_partition_pptx_malformed():
         assert element.metadata.filename == "fake-power-point-malformed.pptx"
 
 
-# == DescribePptxPartitionerMetadataBehaviors ====================================================
+# == metadata behaviors ==========================================================================
 
 
 def test_partition_pptx_metadata_date(mocker: MockFixture):
@@ -357,7 +357,7 @@ def test_partition_pptx_raises_TypeError_for_invalid_languages():
         partition_pptx(example_doc_path("fake-power-point.pptx"), languages="eng")  # type: ignore
 
 
-# == DescribePptxPartitionerDownstreamBehaviors ==================================================
+# == downstream behaviors ========================================================================
 
 
 def test_partition_pptx_with_json():
@@ -714,6 +714,17 @@ class Describe_PptxPartitionerOptions:
         with pytest.raises(ValueError, match="No PPTX document specified, either `filename` or "):
             opts.pptx_file
 
+    # -- .strategy -------------------------------
+
+    @pytest.mark.parametrize("arg_value", ["fast", "hi_res"])
+    def it_knows_which_partitioning_strategy_to_use(
+        self, arg_value: str, opts_args: dict[str, Any]
+    ):
+        opts_args["strategy"] = arg_value
+        opts = _PptxPartitionerOptions(**opts_args)
+
+        assert opts.strategy == arg_value
+
     # -- .table_metadata -------------------------
 
     def it_can_create_table_metadata(self, opts_args: dict[str, Any]):
@@ -776,4 +787,5 @@ class Describe_PptxPartitionerOptions:
             "infer_table_structure": True,
             "metadata_file_path": None,
             "metadata_last_modified": None,
+            "strategy": "fast",
         }

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.3-dev2"  # pragma: no cover
+__version__ = "0.13.3-dev3"  # pragma: no cover


### PR DESCRIPTION
**Summary**
As we move to adding pluggable sub-partitioners, `partition_pptx()` will need to become sensitive to the `strategy` argument, in particular when it is set to "hi_res". Up until now there were no expensive operations (inference, OCR, etc.) incurred while partitioning PPTX so this argument was ignored.

After this PR, `partition_pptx()` still won't do anything with that value, other than pass it along to `_PptxPartitionerOptions` for safe-keeping, but now its ready for use by a `PicturePartitioner` (to come in a subsequent PR).