### PR TITLE
bug: fix pip-compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.3-dev8
+## 0.13.3-dev9
 
 ### Enhancements
 
@@ -15,6 +15,7 @@
 
 * **Add support for extracting text from tag tails in HTML**. This fix adds ability to generate separate elements using tag tails.
 * **Add support for extracting text from `<b>` tags in HTML** Now `partition_html()` can extract text from `<b>` tags inside container tags (like `<div>`, `<pre>`).
+* **Fix pip-compile make target** Missing base.in dependency missing from requirments make file added
 
 ## 0.13.2
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -30,7 +30,7 @@ docutils==0.18.1
     #   sphinx-tabs
 furo==2023.7.26
     # via -r ./build.in
-idna==3.6
+idna==3.7
     # via
     #   -c ./base.txt
     #   requests

--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -8,7 +8,7 @@ INGEST_REQUIREMENTSTXT := $(patsubst %.in,%.txt,$(INGEST_REQUIREMENTS))
 
 
 .PHONY: all
-all: compile-base compile-ingest
+all: compile-all-base compile-ingest
 
 .PHONY: compile-test
 compile-test:
@@ -19,7 +19,11 @@ compile-dev:
 	pip-compile --upgrade dev.in
 
 .PHONY: compile-base
-compile-base: compile-test compile-dev
+compile-base:
+	pip-compile --upgrade base.in
+
+.PHONY: compile-all-base
+compile-all-base: compile-base compile-test compile-dev
 	@$(foreach file,$(BASE_REQUIREMENTS),echo "compiling: $(file)" && pip-compile --upgrade $(file);)
 
 .PHONY: compile-ingest

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,11 +29,11 @@ emoji==2.11.0
     # via -r ./base.in
 filetype==1.2.0
     # via -r ./base.in
-idna==3.6
+idna==3.7
     # via
     #   requests
     #   unstructured-client
-joblib==1.3.2
+joblib==1.4.0
     # via nltk
 jsonpath-python==1.0.6
     # via unstructured-client
@@ -67,7 +67,7 @@ python-iso639==2024.2.7
     # via -r ./base.in
 python-magic==0.4.27
     # via -r ./base.in
-rapidfuzz==3.7.0
+rapidfuzz==3.8.1
     # via -r ./base.in
 regex==2023.12.25
     # via nltk

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -30,7 +30,7 @@ docutils==0.18.1
     #   sphinx-tabs
 furo==2023.7.26
     # via -r ./build.in
-idna==3.6
+idna==3.7
     # via
     #   -c ./base.txt
     #   requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -81,7 +81,7 @@ executing==2.0.1
     # via stack-data
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.3
+filelock==3.13.4
     # via virtualenv
 fqdn==1.5.1
     # via jsonschema
@@ -93,7 +93,7 @@ httpx==0.27.0
     # via jupyterlab
 identify==2.5.35
     # via pre-commit
-idna==3.6
+idna==3.7
     # via
     #   -c ./base.txt
     #   -c ./test.txt
@@ -134,7 +134,7 @@ jinja2==3.1.3
     #   jupyterlab
     #   jupyterlab-server
     #   nbconvert
-json5==0.9.24
+json5==0.9.25
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
@@ -170,9 +170,9 @@ jupyter-core==5.7.2
     #   qtconsole
 jupyter-events==0.10.0
     # via jupyter-server
-jupyter-lsp==2.2.4
+jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.13.0
+jupyter-server==2.14.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -181,11 +181,11 @@ jupyter-server==2.13.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.1.5
+jupyterlab==4.1.6
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.25.4
+jupyterlab-server==2.26.0
     # via
     #   jupyterlab
     #   notebook
@@ -327,7 +327,7 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-send2trash==1.8.2
+send2trash==1.8.3
     # via jupyter-server
 six==1.16.0
     # via

--- a/requirements/extra-csv.txt
+++ b/requirements/extra-csv.txt
@@ -8,7 +8,7 @@ numpy==1.26.4
     # via
     #   -c ./base.txt
     #   pandas
-pandas==2.2.1
+pandas==2.2.2
     # via -r ./extra-csv.in
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/extra-paddleocr.txt
+++ b/requirements/extra-paddleocr.txt
@@ -39,7 +39,7 @@ cython==3.0.10
     # via unstructured-paddleocr
 et-xmlfile==1.1.0
     # via openpyxl
-flask==3.0.2
+flask==3.0.3
     # via
     #   flask-babel
     #   visualdl
@@ -49,7 +49,7 @@ fonttools==4.51.0
     # via matplotlib
 future==1.0.0
     # via bce-python-sdk
-idna==3.6
+idna==3.7
     # via
     #   -c ./base.txt
     #   requests
@@ -129,7 +129,7 @@ packaging==23.2
     #   matplotlib
     #   scikit-image
     #   visualdl
-pandas==2.2.1
+pandas==2.2.2
     # via visualdl
 pdf2image==1.17.0
     # via unstructured-paddleocr
@@ -168,7 +168,7 @@ pytz==2024.1
     # via
     #   flask-babel
     #   pandas
-rapidfuzz==3.7.0
+rapidfuzz==3.8.1
     # via
     #   -c ./base.txt
     #   unstructured-paddleocr

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -30,7 +30,7 @@ deprecated==1.2.14
     # via pikepdf
 effdet==0.4.1
     # via layoutparser
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   huggingface-hub
     #   torch
@@ -51,7 +51,7 @@ huggingface-hub==0.22.2
     #   unstructured-inference
 humanfriendly==10.0
     # via coloredlogs
-idna==3.6
+idna==3.7
     # via
     #   -c ./base.txt
     #   requests
@@ -120,7 +120,7 @@ packaging==23.2
     #   pytesseract
     #   transformers
     #   unstructured-pytesseract
-pandas==2.2.1
+pandas==2.2.2
     # via layoutparser
 pdf2image==1.17.0
     # via
@@ -132,7 +132,7 @@ pdfminer-six==20231228
     #   pdfplumber
 pdfplumber==0.11.0
     # via layoutparser
-pikepdf==8.14.0
+pikepdf==8.15.0
     # via -r ./extra-pdf-image.in
 pillow==10.3.0
     # via
@@ -164,9 +164,9 @@ pyparsing==3.0.9
     # via
     #   -c ././deps/constraints.txt
     #   matplotlib
-pypdf==4.1.0
+pypdf==4.2.0
     # via -r ./extra-pdf-image.in
-pypdfium2==4.28.0
+pypdfium2==4.29.0
     # via pdfplumber
 pytesseract==0.3.10
     # via layoutparser
@@ -186,7 +186,7 @@ pyyaml==6.0.1
     #   omegaconf
     #   timm
     #   transformers
-rapidfuzz==3.7.0
+rapidfuzz==3.8.1
     # via
     #   -c ./base.txt
     #   unstructured-inference

--- a/requirements/extra-xlsx.txt
+++ b/requirements/extra-xlsx.txt
@@ -14,7 +14,7 @@ numpy==1.26.4
     #   pandas
 openpyxl==3.1.2
     # via -r ./extra-xlsx.in
-pandas==2.2.1
+pandas==2.2.2
     # via -r ./extra-xlsx.in
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -17,7 +17,7 @@ click==8.1.7
     # via
     #   -c ./base.txt
     #   sacremoses
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   huggingface-hub
     #   torch
@@ -30,13 +30,13 @@ huggingface-hub==0.22.2
     # via
     #   tokenizers
     #   transformers
-idna==3.6
+idna==3.7
     # via
     #   -c ./base.txt
     #   requests
 jinja2==3.1.3
     # via torch
-joblib==1.3.2
+joblib==1.4.0
     # via
     #   -c ./base.txt
     #   sacremoses

--- a/requirements/ingest/airtable.txt
+++ b/requirements/ingest/airtable.txt
@@ -15,7 +15,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -23,9 +23,9 @@ inflection==0.5.1
     # via pyairtable
 pyairtable==2.3.3
     # via -r ./ingest/airtable.in
-pydantic==2.6.4
+pydantic==2.7.0
     # via pyairtable
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 requests==2.31.0
     # via

--- a/requirements/ingest/astra.txt
+++ b/requirements/ingest/astra.txt
@@ -8,8 +8,10 @@ anyio==3.7.1
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   httpx
-astrapy==0.7.7
+astrapy==1.0.0
     # via -r ./ingest/astra.in
+bson==0.5.10
+    # via astrapy
 cassandra-driver==3.29.1
     # via cassio
 cassio==0.1.5
@@ -47,7 +49,7 @@ httpx[http2]==0.27.0
     # via astrapy
 hyperframe==6.0.1
     # via h2
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -62,6 +64,10 @@ packaging==23.2
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   deprecation
+python-dateutil==2.9.0.post0
+    # via
+    #   -c ./ingest/../base.txt
+    #   bson
 requests==2.31.0
     # via
     #   -c ./ingest/../base.txt
@@ -69,7 +75,9 @@ requests==2.31.0
 six==1.16.0
     # via
     #   -c ./ingest/../base.txt
+    #   bson
     #   geomet
+    #   python-dateutil
 sniffio==1.3.1
     # via
     #   anyio
@@ -81,3 +89,5 @@ urllib3==1.26.18
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   requests
+uuid6==2024.1.12
+    # via astrapy

--- a/requirements/ingest/azure-cognitive-search.txt
+++ b/requirements/ingest/azure-cognitive-search.txt
@@ -19,7 +19,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/azure.txt
+++ b/requirements/ingest/azure.txt
@@ -6,7 +6,7 @@
 #
 adlfs==2024.2.0
     # via -r ./ingest/azure.in
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via adlfs
 aiosignal==1.3.1
     # via aiohttp
@@ -21,7 +21,7 @@ azure-core==1.30.1
     #   azure-storage-blob
 azure-datalake-store==0.0.53
     # via adlfs
-azure-identity==1.15.0
+azure-identity==1.16.0
     # via adlfs
 azure-storage-blob==12.19.1
     # via adlfs
@@ -52,7 +52,7 @@ fsspec==2024.3.1
     # via
     #   -r ./ingest/azure.in
     #   adlfs
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/box.txt
+++ b/requirements/ingest/box.txt
@@ -27,7 +27,7 @@ fsspec==2024.3.1
     # via
     #   -r ./ingest/box.in
     #   boxfs
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/chroma.txt
+++ b/requirements/ingest/chroma.txt
@@ -48,7 +48,7 @@ exceptiongroup==1.2.0
     # via anyio
 fastapi==0.110.1
     # via chromadb
-filelock==3.13.3
+filelock==3.13.4
     # via huggingface-hub
 flatbuffers==24.3.25
     # via onnxruntime
@@ -70,7 +70,7 @@ huggingface-hub==0.22.2
     # via tokenizers
 humanfriendly==10.0
     # via coloredlogs
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -139,11 +139,11 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   chromadb
     #   fastapi
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 pypika==0.48.9
     # via chromadb

--- a/requirements/ingest/clarifai.txt
+++ b/requirements/ingest/clarifai.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-clarifai==10.2.1
+clarifai==10.3.0
     # via -r ./ingest/clarifai.in
 clarifai-grpc==10.2.3
     # via clarifai
@@ -23,7 +23,7 @@ googleapis-common-protos==1.63.0
     # via clarifai-grpc
 grpcio==1.62.1
     # via clarifai-grpc
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/confluence.txt
+++ b/requirements/ingest/confluence.txt
@@ -21,7 +21,7 @@ charset-normalizer==3.3.2
     #   requests
 deprecated==1.2.14
     # via atlassian-python-api
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/databricks-volumes.txt
+++ b/requirements/ingest/databricks-volumes.txt
@@ -15,11 +15,11 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-databricks-sdk==0.24.0
+databricks-sdk==0.25.1
     # via -r ./ingest/databricks-volumes.in
 google-auth==2.29.0
     # via databricks-sdk
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/discord.txt
+++ b/requirements/ingest/discord.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/discord.in
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via discord-py
 aiosignal==1.3.1
     # via aiohttp
@@ -18,7 +18,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   yarl

--- a/requirements/ingest/dropbox.txt
+++ b/requirements/ingest/dropbox.txt
@@ -21,7 +21,7 @@ fsspec==2024.3.1
     # via
     #   -r ./ingest/dropbox.in
     #   dropboxdrivefs
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/embed-aws-bedrock.in
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via langchain-community
 aiosignal==1.3.1
     # via aiohttp
@@ -38,7 +38,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -51,11 +51,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==2.4
     # via jsonpatch
-langchain-community==0.0.31
+langchain-community==0.0.32
     # via -r ./ingest/embed-aws-bedrock.in
-langchain-core==0.1.40
+langchain-core==0.1.42
     # via langchain-community
-langsmith==0.1.40
+langsmith==0.1.46
     # via
     #   langchain-community
     #   langchain-core
@@ -83,11 +83,11 @@ packaging==23.2
     #   -c ./ingest/../deps/constraints.txt
     #   langchain-core
     #   marshmallow
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   langchain-core
     #   langsmith
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/embed-huggingface.in
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via langchain-community
 aiosignal==1.3.1
     # via aiohttp
@@ -27,7 +27,7 @@ dataclasses-json==0.6.4
     # via
     #   -c ./ingest/../base.txt
     #   langchain-community
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   huggingface-hub
     #   torch
@@ -47,14 +47,14 @@ huggingface-hub==0.22.2
     #   sentence-transformers
     #   tokenizers
     #   transformers
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests
     #   yarl
 jinja2==3.1.3
     # via torch
-joblib==1.3.2
+joblib==1.4.0
     # via
     #   -c ./ingest/../base.txt
     #   scikit-learn
@@ -62,11 +62,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==2.4
     # via jsonpatch
-langchain-community==0.0.31
+langchain-community==0.0.32
     # via -r ./ingest/embed-huggingface.in
-langchain-core==0.1.40
+langchain-core==0.1.42
     # via langchain-community
-langsmith==0.1.40
+langsmith==0.1.46
     # via
     #   langchain-community
     #   langchain-core
@@ -108,11 +108,11 @@ packaging==23.2
     #   transformers
 pillow==10.3.0
     # via sentence-transformers
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   langchain-core
     #   langsmith
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 pyyaml==6.0.1
     # via
@@ -135,7 +135,7 @@ safetensors==0.3.2
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   transformers
-scikit-learn==1.4.1.post1
+scikit-learn==1.4.2
     # via sentence-transformers
 scipy==1.10.1
     # via

--- a/requirements/ingest/embed-octoai.txt
+++ b/requirements/ingest/embed-octoai.txt
@@ -32,17 +32,17 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via openai
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   anyio
     #   httpx
     #   requests
-openai==1.16.2
+openai==1.17.0
     # via -r ./ingest/embed-octoai.in
-pydantic==2.6.4
+pydantic==2.7.0
     # via openai
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 regex==2023.12.25
     # via

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/embed-openai.in
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via langchain-community
 aiosignal==1.3.1
     # via aiohttp
@@ -48,7 +48,7 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via openai
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -59,11 +59,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==2.4
     # via jsonpatch
-langchain-community==0.0.31
+langchain-community==0.0.32
     # via -r ./ingest/embed-openai.in
-langchain-core==0.1.40
+langchain-core==0.1.42
     # via langchain-community
-langsmith==0.1.40
+langsmith==0.1.46
     # via
     #   langchain-community
     #   langchain-core
@@ -83,7 +83,7 @@ numpy==1.26.4
     # via
     #   -c ./ingest/../base.txt
     #   langchain-community
-openai==1.16.2
+openai==1.17.0
     # via -r ./ingest/embed-openai.in
 orjson==3.10.0
     # via langsmith
@@ -93,12 +93,12 @@ packaging==23.2
     #   -c ./ingest/../deps/constraints.txt
     #   langchain-core
     #   marshmallow
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   langchain-core
     #   langsmith
     #   openai
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 pyyaml==6.0.1
     # via

--- a/requirements/ingest/embed-vertexai.txt
+++ b/requirements/ingest/embed-vertexai.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/embed-vertexai.in
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via
     #   langchain
     #   langchain-community
@@ -55,7 +55,7 @@ google-auth==2.29.0
     #   google-cloud-core
     #   google-cloud-resource-manager
     #   google-cloud-storage
-google-cloud-aiplatform==1.46.0
+google-cloud-aiplatform==1.47.0
     # via langchain-google-vertexai
 google-cloud-bigquery==3.20.1
     # via google-cloud-aiplatform
@@ -92,7 +92,7 @@ grpcio==1.62.1
     #   grpcio-status
 grpcio-status==1.62.1
     # via google-api-core
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -103,23 +103,23 @@ jsonpatch==1.33
     #   langchain-core
 jsonpointer==2.4
     # via jsonpatch
-langchain==0.1.14
+langchain==0.1.16
     # via -r ./ingest/embed-vertexai.in
-langchain-community==0.0.31
+langchain-community==0.0.32
     # via
     #   -r ./ingest/embed-vertexai.in
     #   langchain
-langchain-core==0.1.40
+langchain-core==0.1.42
     # via
     #   langchain
     #   langchain-community
     #   langchain-google-vertexai
     #   langchain-text-splitters
-langchain-google-vertexai==0.1.2
+langchain-google-vertexai==1.0.1
     # via -r ./ingest/embed-vertexai.in
 langchain-text-splitters==0.0.1
     # via langchain
-langsmith==0.1.40
+langsmith==0.1.46
     # via
     #   langchain
     #   langchain-community
@@ -173,13 +173,13 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   google-cloud-aiplatform
     #   langchain
     #   langchain-core
     #   langsmith
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 python-dateutil==2.9.0.post0
     # via
@@ -216,7 +216,7 @@ tenacity==8.2.3
     #   langchain
     #   langchain-community
     #   langchain-core
-types-protobuf==4.24.0.20240311
+types-protobuf==4.25.0.20240410
     # via langchain-google-vertexai
 types-requests==2.31.0.6
     # via langchain-google-vertexai

--- a/requirements/ingest/gcs.txt
+++ b/requirements/ingest/gcs.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/gcs.in
 #
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via gcsfs
 aiosignal==1.3.1
     # via aiohttp
@@ -66,7 +66,7 @@ google-resumable-media==2.7.0
     # via google-cloud-storage
 googleapis-common-protos==1.63.0
     # via google-api-core
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/github.txt
+++ b/requirements/ingest/github.txt
@@ -21,7 +21,7 @@ cryptography==42.0.5
     # via pyjwt
 deprecated==1.2.14
     # via pygithub
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/gitlab.txt
+++ b/requirements/ingest/gitlab.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/google-drive.txt
+++ b/requirements/ingest/google-drive.txt
@@ -32,7 +32,7 @@ httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/jira.txt
+++ b/requirements/ingest/jira.txt
@@ -21,7 +21,7 @@ charset-normalizer==3.3.2
     #   requests
 deprecated==1.2.14
     # via atlassian-python-api
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/notion.txt
+++ b/requirements/ingest/notion.txt
@@ -24,7 +24,7 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via notion-client
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   anyio

--- a/requirements/ingest/onedrive.txt
+++ b/requirements/ingest/onedrive.txt
@@ -25,7 +25,7 @@ cryptography==42.0.5
     # via
     #   msal
     #   pyjwt
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/opensearch.txt
+++ b/requirements/ingest/opensearch.txt
@@ -14,7 +14,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/outlook.txt
+++ b/requirements/ingest/outlook.txt
@@ -19,7 +19,7 @@ cryptography==42.0.5
     # via
     #   msal
     #   pyjwt
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/pinecone.txt
+++ b/requirements/ingest/pinecone.txt
@@ -15,7 +15,7 @@ charset-normalizer==3.3.2
     #   requests
 dnspython==2.6.1
     # via pinecone-client
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/qdrant.txt
+++ b/requirements/ingest/qdrant.txt
@@ -36,7 +36,7 @@ httpx[http2]==0.27.0
     # via qdrant-client
 hyperframe==6.0.1
     # via h2
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -51,9 +51,9 @@ protobuf==4.23.4
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   grpcio-tools
-pydantic==2.6.4
+pydantic==2.7.0
     # via qdrant-client
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 qdrant-client==1.8.2
     # via -r ./ingest/qdrant.in

--- a/requirements/ingest/reddit.txt
+++ b/requirements/ingest/reddit.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/s3.txt
+++ b/requirements/ingest/s3.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile ./ingest/s3.in
 #
-aiobotocore==2.12.2
+aiobotocore==2.12.3
     # via s3fs
-aiohttp==3.9.3
+aiohttp==3.9.4
     # via
     #   aiobotocore
     #   s3fs
@@ -30,7 +30,7 @@ fsspec==2024.3.1
     # via
     #   -r ./ingest/s3.in
     #   s3fs
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   yarl

--- a/requirements/ingest/salesforce.txt
+++ b/requirements/ingest/salesforce.txt
@@ -19,7 +19,7 @@ charset-normalizer==3.3.2
     #   requests
 cryptography==42.0.5
     # via simple-salesforce
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/sharepoint.txt
+++ b/requirements/ingest/sharepoint.txt
@@ -19,7 +19,7 @@ cryptography==42.0.5
     # via
     #   msal
     #   pyjwt
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/weaviate.txt
+++ b/requirements/ingest/weaviate.txt
@@ -44,7 +44,7 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via weaviate-client
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -57,9 +57,9 @@ protobuf==4.23.4
     #   grpcio-tools
 pycparser==2.22
     # via cffi
-pydantic==2.6.4
+pydantic==2.7.0
     # via weaviate-client
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 requests==2.31.0
     # via

--- a/requirements/ingest/wikipedia.txt
+++ b/requirements/ingest/wikipedia.txt
@@ -17,7 +17,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.6
+idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -41,7 +41,7 @@ freezegun==1.4.0
     # via -r ./test.in
 grpcio==1.62.1
     # via -r ./test.in
-idna==3.6
+idna==3.7
     # via
     #   -c ./base.txt
     #   requests
@@ -87,11 +87,11 @@ pycodestyle==2.11.1
     # via
     #   flake8
     #   flake8-print
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   -r ./test.in
     #   label-studio-sdk
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 pyflakes==3.2.0
     # via
@@ -115,7 +115,7 @@ requests==2.31.0
     # via
     #   -c ./base.txt
     #   label-studio-sdk
-ruff==0.3.5
+ruff==0.3.7
     # via -r ./test.in
 six==1.16.0
     # via

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.3-dev8"  # pragma: no cover
+__version__ = "0.13.3-dev9"  # pragma: no cover


### PR DESCRIPTION
### Description
Currently wasn't compiling `base.in` first, which is required because others use the generated `.txt` file as a constraint. 