### PR TITLE
feat: `partition_pdf()` add an environment variable to control the capture of embedded links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Features
 
-* **Add a `PDF_ANNOTATION_THRESHOLD` environment variable to control the capture of embedded links in `partition_pdf()` for `fast` strategy**. Previously, a threshold value that affects the capture of embedded links was passed as a parameter. This allows users to configure this threshold value via an environment variable.
+* **Add a `PDF_ANNOTATION_THRESHOLD` environment variable to control the capture of embedded links in `partition_pdf()` for `fast` strategy**.
 * **Add integration with the Google Cloud Vision API**. Adds a third OCR provider, alongside Tesseract and Paddle: the Google Cloud Vision API.
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Features
 
-* ** Add a `PDF_ANNOTATION_THRESHOLD` environment variable to control annotations extraction on PDF documents**
+* **Add a `PDF_ANNOTATION_THRESHOLD` environment variable to control the capture of embedded links in `partition_pdf()` for `fast` strategy**. Previously, a threshold value that affects the capture of embedded links was passed as a parameter. This allows users to configure this threshold value via an environment variable.
 * **Add integration with the Google Cloud Vision API**. Adds a third OCR provider, alongside Tesseract and Paddle: the Google Cloud Vision API.
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.13.4-dev3
+## 0.13.4-dev4
 
 ### Enhancements
+
 * **Unique and deterministic hash IDs for elements** Element IDs produced by any partitioning
   function are now deterministic and unique at the document level by default. Before, hashes were
   based only on text; however, they now also take into account the element's sequence number on a
@@ -12,6 +13,7 @@
 
 ### Features
 
+* ** Add a `PDF_ANNOTATION_THRESHOLD` environment variable to control annotations extraction on PDF documents**
 * **Add integration with the Google Cloud Vision API**. Adds a third OCR provider, alongside Tesseract and Paddle: the Google Cloud Vision API.
 
 ### Fixes

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.4-dev3"  # pragma: no cover
+__version__ = "0.13.4-dev4"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -90,6 +90,7 @@ from unstructured.partition.pdf_image.pdfminer_utils import (
 )
 from unstructured.partition.strategies import determine_pdf_or_image_strategy, validate_strategy
 from unstructured.partition.text import element_from_text
+from unstructured.partition.utils.config import env_config
 from unstructured.partition.utils.constants import (
     SORT_MODE_BASIC,
     SORT_MODE_DONT,
@@ -705,7 +706,7 @@ def _process_pdfminer_pages(
     languages: List[str],
     metadata_last_modified: Optional[str],
     sort_mode: str = SORT_MODE_XY_CUT,
-    annotation_threshold: Optional[float] = 0.9,
+    annotation_threshold: Optional[float] = env_config.PDF_ANNOTATION_THRESHOLD,
     starting_page_number: int = 1,
     **kwargs,
 ):

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -90,6 +90,7 @@ from unstructured.partition.pdf_image.pdfminer_utils import (
 )
 from unstructured.partition.strategies import determine_pdf_or_image_strategy, validate_strategy
 from unstructured.partition.text import element_from_text
+from unstructured.partition.utils.config import env_config
 from unstructured.partition.utils.constants import (
     SORT_MODE_BASIC,
     SORT_MODE_DONT,
@@ -705,7 +706,6 @@ def _process_pdfminer_pages(
     languages: List[str],
     metadata_last_modified: Optional[str],
     sort_mode: str = SORT_MODE_XY_CUT,
-    annotation_threshold: Optional[float] = 0.9,
     starting_page_number: int = 1,
     **kwargs,
 ):
@@ -739,7 +739,6 @@ def _process_pdfminer_pages(
                     annotation_list,
                     bbox,
                     page_number,
-                    annotation_threshold,
                 )
                 _, words = get_word_bounding_box_from_element(obj, height)
                 for annot in annotations_within_element:
@@ -1210,7 +1209,6 @@ def check_annotations_within_element(
     annotation_list: List[Dict[str, Any]],
     element_bbox: Tuple[float, float, float, float],
     page_number: int,
-    annotation_threshold: float,
 ) -> List[Dict[str, Any]]:
     """
     Filter annotations that are within or highly overlap with a specified element on a page.
@@ -1221,9 +1219,6 @@ def check_annotations_within_element(
         element_bbox (Tuple[float, float, float, float]): The bounding box coordinates of the
             specified element in the bbox format (x1, y1, x2, y2).
         page_number (int): The page number to which the annotations and element belong.
-        annotation_threshold (float, optional): The threshold value (between 0.0 and 1.0)
-            that determines the minimum overlap required for an annotation to be considered
-            within the element. Default is 0.9.
 
     Returns:
         List[Dict[str,Any]]: A list of dictionaries containing information about annotations
@@ -1236,7 +1231,7 @@ def check_annotations_within_element(
             annotation_bbox_size = calculate_bbox_area(annotation["bbox"])
             if annotation_bbox_size and (
                 calculate_intersection_area(element_bbox, annotation["bbox"]) / annotation_bbox_size
-                > annotation_threshold
+                > env_config.PDF_ANNOTATION_THRESHOLD
             ):
                 annotations_within_element.append(annotation)
     return annotations_within_element

--- a/unstructured/partition/utils/config.py
+++ b/unstructured/partition/utils/config.py
@@ -109,5 +109,12 @@ class ENVConfig:
         """threshold to consider the bounding boxes of two embedded images as the same region"""
         return self._get_float("EMBEDDED_IMAGE_SAME_REGION_THRESHOLD", 0.6)
 
+    def PDF_ANNOTATION_THRESHOLD(self) -> float:
+        """The threshold value (between 0.0 and 1.0) that determines the minimum overlap required
+        for an annotation to be considered within the element.
+        """
+
+        return self._get_float("PDF_ANNOTATION_THRESHOLD", 0.9)
+
 
 env_config = ENVConfig()

--- a/unstructured/partition/utils/config.py
+++ b/unstructured/partition/utils/config.py
@@ -109,6 +109,7 @@ class ENVConfig:
         """threshold to consider the bounding boxes of two embedded images as the same region"""
         return self._get_float("EMBEDDED_IMAGE_SAME_REGION_THRESHOLD", 0.6)
 
+    @property
     def PDF_ANNOTATION_THRESHOLD(self) -> float:
         """The threshold value (between 0.0 and 1.0) that determines the minimum overlap required
         for an annotation to be considered within the element.


### PR DESCRIPTION
This PR aims to add an environment variable to control the capture of embedded links in `partition_pdf()` for `fast` strategy.

Related PR: https://github.com/Unstructured-IO/unstructured/pull/2537