### PR TITLE
chore CORE-4775: remove html page number metadata field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.7
+## 0.13.7-dev0
 
 ### Enhancements
 * **Remove `page_number` metadata fields** for HTML partition until we have a better strategy to decide page counting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.13.6
+
+### Enhancements
+* Remove `page_number` metadata fields for HTML partition until we have a better strategy to decide page counting.
+
+### Features
+
+### Fixes
+
 ## 0.13.5
 
 ### Enhancements

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -360,52 +360,6 @@ def test_add_chunking_strategy_respects_max_characters():
     assert chunk_elements == chunks
 
 
-def test_add_chunking_strategy_on_partition_html_respects_multipage():
-    filename = "example-docs/example-10k-1p.html"
-    partitioned_elements_multipage_false_combine_chars_0 = partition_html(
-        filename,
-        chunking_strategy="by_title",
-        multipage_sections=False,
-        combine_text_under_n_chars=0,
-        new_after_n_chars=300,
-        max_characters=400,
-    )
-    partitioned_elements_multipage_true_combine_chars_0 = partition_html(
-        filename,
-        chunking_strategy="by_title",
-        multipage_sections=True,
-        combine_text_under_n_chars=0,
-        new_after_n_chars=300,
-        max_characters=400,
-    )
-    elements = partition_html(filename)
-    cleaned_elements_multipage_false_combine_chars_0 = chunk_by_title(
-        elements,
-        multipage_sections=False,
-        combine_text_under_n_chars=0,
-        new_after_n_chars=300,
-        max_characters=400,
-    )
-    cleaned_elements_multipage_true_combine_chars_0 = chunk_by_title(
-        elements,
-        multipage_sections=True,
-        combine_text_under_n_chars=0,
-        new_after_n_chars=300,
-        max_characters=400,
-    )
-    assert (
-        partitioned_elements_multipage_false_combine_chars_0
-        == cleaned_elements_multipage_false_combine_chars_0
-    )
-    assert (
-        partitioned_elements_multipage_true_combine_chars_0
-        == cleaned_elements_multipage_true_combine_chars_0
-    )
-    assert len(partitioned_elements_multipage_true_combine_chars_0) != len(
-        partitioned_elements_multipage_false_combine_chars_0,
-    )
-
-
 def test_chunk_by_title_drops_detection_class_prob():
     elements: list[Element] = [
         Title(

--- a/test_unstructured/chunking/test_title.py
+++ b/test_unstructured/chunking/test_title.py
@@ -175,6 +175,38 @@ def test_chunk_by_title_separates_by_page_number():
     ]
 
 
+def test_chuck_by_title_respects_multipage():
+    elements: list[Element] = [
+        Title("A Great Day", metadata=ElementMetadata(page_number=1)),
+        Text("Today is a great day.", metadata=ElementMetadata(page_number=2)),
+        Text("It is sunny outside.", metadata=ElementMetadata(page_number=2)),
+        Table("Heading\nCell text"),
+        Title("An Okay Day"),
+        Text("Today is an okay day."),
+        Text("It is rainy outside."),
+        Title("A Bad Day"),
+        Text(
+            "Today is a bad day.",
+            metadata=ElementMetadata(
+                regex_metadata={"a": [RegexMetadata(text="A", start=0, end=1)]},
+            ),
+        ),
+        Text("It is storming outside."),
+        CheckBox(),
+    ]
+    chunks = chunk_by_title(elements, multipage_sections=True, combine_text_under_n_chars=0)
+    assert chunks == [
+        CompositeElement(
+            "A Great Day\n\nToday is a great day.\n\nIt is sunny outside.",
+        ),
+        Table("Heading\nCell text"),
+        CompositeElement("An Okay Day\n\nToday is an okay day.\n\nIt is rainy outside."),
+        CompositeElement(
+            "A Bad Day\n\nToday is a bad day.\n\nIt is storming outside.",
+        ),
+    ]
+
+
 def test_chunk_by_title_does_not_break_on_regex_metadata_change():
     """PreChunker is insensitive to regex-metadata changes.
 

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -1081,52 +1081,6 @@ def test_add_chunking_strategy_on_partition_auto():
     assert chunk_elements == chunks
 
 
-def test_add_chunking_strategy_title_on_partition_auto_respects_multipage():
-    filename = "example-docs/example-10k-1p.html"
-    partitioned_elements_multipage_false_combine_chars_0 = partition(
-        filename,
-        chunking_strategy="by_title",
-        multipage_sections=False,
-        combine_text_under_n_chars=0,
-        new_after_n_chars=300,
-        max_characters=400,
-    )
-    partitioned_elements_multipage_true_combine_chars_0 = partition(
-        filename,
-        chunking_strategy="by_title",
-        multipage_sections=True,
-        combine_text_under_n_chars=0,
-        new_after_n_chars=300,
-        max_characters=400,
-    )
-    elements = partition(filename)
-    cleaned_elements_multipage_false_combine_chars_0 = chunk_by_title(
-        elements,
-        multipage_sections=False,
-        combine_text_under_n_chars=0,
-        new_after_n_chars=300,
-        max_characters=400,
-    )
-    cleaned_elements_multipage_true_combine_chars_0 = chunk_by_title(
-        elements,
-        multipage_sections=True,
-        combine_text_under_n_chars=0,
-        new_after_n_chars=300,
-        max_characters=400,
-    )
-    assert (
-        partitioned_elements_multipage_false_combine_chars_0
-        == cleaned_elements_multipage_false_combine_chars_0
-    )
-    assert (
-        partitioned_elements_multipage_true_combine_chars_0
-        == cleaned_elements_multipage_true_combine_chars_0
-    )
-    assert len(partitioned_elements_multipage_true_combine_chars_0) != len(
-        partitioned_elements_multipage_false_combine_chars_0,
-    )
-
-
 def test_add_chunking_strategy_on_partition_auto_respects_max_chars():
     filename = "example-docs/example-10k-1p.html"
 

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -733,12 +733,12 @@ def test_all_element_ids_are_unique():
 def test_element_ids_are_deterministic():
     ids = [e.id for e in partition_html("example-docs/fake-html-with-duplicate-elements.html")]
     assert ids == [
-        "cba9e551ed975e0f8a1956095894e92a",
-        "f540ea3b6569aafeb433df6616e79971",
-        "f4a34ee0fac26589fffdb53d0dfedbaf",
-        "15168aeddbd19da60791109a5a45af65",
-        "0c027f66120dd96271489dd0bb69bff5",
-        "abe89090c2e46dda8fff81053cc79f17",
+        "5899179e882d799d869a1d98fe7c7e77",
+        "88e47a42516af650afdcedfe098c3e6c",
+        "884be260a86bbdf265c248d5fff5ea00",
+        "0a23b3ae6bd812b3d90e47fec1df9fe0",
+        "1e9e5be33c99f7bbf2e569b2430e16cf",
+        "333e32df62a0ec81a8df07d52dd73c99",
     ]
 
 

--- a/test_unstructured/partition/test_html_partition.py
+++ b/test_unstructured/partition/test_html_partition.py
@@ -731,15 +731,13 @@ def test_all_element_ids_are_unique():
 
 
 def test_element_ids_are_deterministic():
-    ids = [e.id for e in partition_html("example-docs/fake-html-with-duplicate-elements.html")]
-    assert ids == [
-        "5899179e882d799d869a1d98fe7c7e77",
-        "88e47a42516af650afdcedfe098c3e6c",
-        "884be260a86bbdf265c248d5fff5ea00",
-        "0a23b3ae6bd812b3d90e47fec1df9fe0",
-        "1e9e5be33c99f7bbf2e569b2430e16cf",
-        "333e32df62a0ec81a8df07d52dd73c99",
+    ids_first_partition = [
+        e.id for e in partition_html("example-docs/fake-html-with-duplicate-elements.html")
     ]
+    ids_second_partition = [
+        e.id for e in partition_html("example-docs/fake-html-with-duplicate-elements.html")
+    ]
+    assert ids_first_partition == ids_second_partition
 
 
 def test_partition_html_b_tag_parsing():

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/Shared Documents/ideas-page.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "b7b1c359c06495bd6fe8e174b2a9908f",
+    "element_id": "32bc8af17151389d3e80f65036f8e65b",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-16T05:04:47+00:00",
@@ -17,7 +17,6 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>"
     },
     "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/SitePages/Home.html.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/SitePages/Home.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "8d15e7cb1bbb2bf4bab95dcd20a79f29",
+    "element_id": "f346c0d677012f9d4265678f9626c829",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -16,14 +16,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Documents",
     "type": "Title"
   },
   {
-    "element_id": "2ef8cded92afdc398b5757e488f5d53d",
+    "element_id": "fea3bac751e7273dfe57b271fe9dd22b",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -39,8 +38,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Events",
     "type": "Title"

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/SitePages/This-is-a-title.html.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint-with-permissions/SitePages/This-is-a-title.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "a227bc5e1e168472aa02c7ddeac6023b",
+    "element_id": "fe9e95d69e2fe6e0fcf74f630e24f11f",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -17,14 +17,13 @@
       "languages": [
         "cat",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "This is a plain text site page for testing purposes",
     "type": "ListItem"
   },
   {
-    "element_id": "110e27269e69e01c41db4faf9a31d770",
+    "element_id": "bf2f616265a06fa30e74df2cf6291c40",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -41,14 +40,13 @@
       "languages": [
         "cat",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "These are bullet points meant for testing",
     "type": "ListItem"
   },
   {
-    "element_id": "c398848281e72db6061cf211b7c211d9",
+    "element_id": "f59e42aff8f1b1ad83f8280a0686eabe",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -65,14 +63,13 @@
       "languages": [
         "cat",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ex tellus, sodales non nulla et, sodales consequat turpis. Etiam vestibulum nisl placerat risus elementum, a sodales purus rhoncus. Sed eget velit pharetra, pretium nisi nec, laoreet ligula. Duis luctus mi in ligula cursus, vel lacinia tortor ultricies. Aenean sit amet sodales odio, a maximus elit. Pellentesque vehicula diam sit amet leo placerat placerat. Integer varius elementum accumsan. Donec posuere elit mauris, eget efficitur nisl viverra vitae.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "8a67276048c91e45cae58a087eba44cc",
+    "element_id": "9fa12141ac0e9ad3d09fe51dc393ad59",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -89,8 +86,7 @@
       "languages": [
         "cat",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Integer at dictum nisi. Cras venenatis non velit in posuere. Curabitur tristique, eros eget tristique pellentesque, neque metus ullamcorper ligula, nec posuere neque lacus nec felis. Nulla a libero eget eros consectetur hendrerit. Pellentesque interdum, diam eget tristique pretium, quam lorem pulvinar lorem, a eleifend nisl lectus at ex. Praesent pulvinar ex ut consequat condimentum. Sed rutrum, erat a hendrerit blandit, urna mauris posuere est, at porttitor risus diam non leo. Nullam rutrum vehicula dolor, quis venenatis ligula rutrum sit amet. Nam massa justo, fermentum in dui lacinia, tincidunt imperdiet nunc. Nam posuere tortor ac lectus elementum, non mollis urna consequat. In interdum non tellus sed pellentesque.",
     "type": "NarrativeText"

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint/Shared Documents/ideas-page.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "b7b1c359c06495bd6fe8e174b2a9908f",
+    "element_id": "32bc8af17151389d3e80f65036f8e65b",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-16T05:04:47+00:00",
@@ -17,7 +17,6 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>"
     },
     "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint/SitePages/Home.html.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint/SitePages/Home.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "8d15e7cb1bbb2bf4bab95dcd20a79f29",
+    "element_id": "f346c0d677012f9d4265678f9626c829",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -16,14 +16,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Documents",
     "type": "Title"
   },
   {
-    "element_id": "2ef8cded92afdc398b5757e488f5d53d",
+    "element_id": "fea3bac751e7273dfe57b271fe9dd22b",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -39,8 +38,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Events",
     "type": "Title"

--- a/test_unstructured_ingest/expected-structured-output/Sharepoint/SitePages/This-is-a-title.html.json
+++ b/test_unstructured_ingest/expected-structured-output/Sharepoint/SitePages/This-is-a-title.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "a227bc5e1e168472aa02c7ddeac6023b",
+    "element_id": "fe9e95d69e2fe6e0fcf74f630e24f11f",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -17,14 +17,13 @@
       "languages": [
         "cat",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "This is a plain text site page for testing purposes",
     "type": "ListItem"
   },
   {
-    "element_id": "110e27269e69e01c41db4faf9a31d770",
+    "element_id": "bf2f616265a06fa30e74df2cf6291c40",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -41,14 +40,13 @@
       "languages": [
         "cat",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "These are bullet points meant for testing",
     "type": "ListItem"
   },
   {
-    "element_id": "c398848281e72db6061cf211b7c211d9",
+    "element_id": "f59e42aff8f1b1ad83f8280a0686eabe",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -65,14 +63,13 @@
       "languages": [
         "cat",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ex tellus, sodales non nulla et, sodales consequat turpis. Etiam vestibulum nisl placerat risus elementum, a sodales purus rhoncus. Sed eget velit pharetra, pretium nisi nec, laoreet ligula. Duis luctus mi in ligula cursus, vel lacinia tortor ultricies. Aenean sit amet sodales odio, a maximus elit. Pellentesque vehicula diam sit amet leo placerat placerat. Integer varius elementum accumsan. Donec posuere elit mauris, eget efficitur nisl viverra vitae.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "8a67276048c91e45cae58a087eba44cc",
+    "element_id": "9fa12141ac0e9ad3d09fe51dc393ad59",
     "metadata": {
       "data_source": {
         "date_created": "0001-01-01T08:00:00Z",
@@ -89,8 +86,7 @@
       "languages": [
         "cat",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Integer at dictum nisi. Cras venenatis non velit in posuere. Curabitur tristique, eros eget tristique pellentesque, neque metus ullamcorper ligula, nec posuere neque lacus nec felis. Nulla a libero eget eros consectetur hendrerit. Pellentesque interdum, diam eget tristique pretium, quam lorem pulvinar lorem, a eleifend nisl lectus at ex. Praesent pulvinar ex ut consequat condimentum. Sed rutrum, erat a hendrerit blandit, urna mauris posuere est, at porttitor risus diam non leo. Nullam rutrum vehicula dolor, quis venenatis ligula rutrum sit amet. Nam massa justo, fermentum in dui lacinia, tincidunt imperdiet nunc. Nam posuere tortor ac lectus elementum, non mollis urna consequat. In interdum non tellus sed pellentesque.",
     "type": "NarrativeText"

--- a/test_unstructured_ingest/expected-structured-output/azure/spring-weather.html.json
+++ b/test_unstructured_ingest/expected-structured-output/azure/spring-weather.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "4a50d579fc8026cc680291defb92a868",
+    "element_id": "fb902c5b26b38e2d35a70a55d43a5de6",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -15,14 +15,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "News Around NOAA",
     "type": "Title"
   },
   {
-    "element_id": "84cb87b83a4935828cd9798cf08ab3fd",
+    "element_id": "100233c72890df3d216e2bc2c36f7153",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -37,14 +36,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "National Program",
     "type": "Title"
   },
   {
-    "element_id": "8a346377084655e022a251f887f72074",
+    "element_id": "88f0bebe7a9cca77675bd8a5db823092",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -59,14 +57,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Are You Weather-Ready for the Spring?",
     "type": "Title"
   },
   {
-    "element_id": "63c7370ce5267041b69018008347a784",
+    "element_id": "568c824acda361cfc270a75e2eca7a23",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -90,14 +87,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Weather.gov >",
     "type": "Title"
   },
   {
-    "element_id": "5bc8a82f208fa597bc1bb454a1b1e0d6",
+    "element_id": "767e68cdb3d891322eb8b65489f53b4c",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -121,14 +117,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov/news"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "News Around NOAA > Are You Weather-Ready for the Spring?",
     "type": "Title"
   },
   {
-    "element_id": "a36cdf114f8098ad8049ed2b701a7991",
+    "element_id": "79fb885317b2666481d0a1c31970400d",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -212,14 +207,13 @@
         "https://www.weather.gov/safety/wildfire",
         "https://www.weather.gov/safety/wind",
         "https://www.weather.gov/safety/winter "
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Weather Safety                                                                                                        Air Quality                                                                            Beach Hazards                                                                            Cold                                                                            Cold Water                                                                            Drought                                                                            Floods                                                                            Fog                                                                            Heat                                                                             Hurricanes                                                                             Lightning Safety                                                                            Rip Currents                                                                            Safe Boating                                                                            Space Weather                                                                            Sun (Ultraviolet Radiation)                                                                             Thunderstorms & Tornadoes                                                                            Tornado                                                                            Tsunami                                                                            Wildfire                                                                            Wind                                                                            Winter",
     "type": "ListItem"
   },
   {
-    "element_id": "bc44ce5164889bee3e50e0046bc3f30e",
+    "element_id": "512e6a00cacb0ab139ede6b0145f441d",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -261,14 +255,13 @@
         "https://www.weather.gov/wrn/intellectualdisabilities",
         "https://www.weather.gov/wrn/fall2020-espanol-sm",
         "https://www.noaa.gov/explainers/great-outdoors-weather-safety"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Safety Campaigns                                                                                                        Seasonal Safety Campaigns                                                                            #SafePlaceSelfie                                                                            Deaf & Hard of Hearing                                                                            Intellectual Disabilities                                                                            Spanish-language Content                                                                            The Great Outdoors",
     "type": "ListItem"
   },
   {
-    "element_id": "7aeb230a1715f02bf6b0e6df620c2cf1",
+    "element_id": "d4145282089e41261300a9bcf440edb9",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -328,14 +321,13 @@
         " http://www.weather.gov/wrn/current-ambassadors",
         "http://www.weather.gov/media/wrn/WRN_Ambassador_Flyer.pdf",
         "https://www.weather.gov/wrn/en-espanol"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Ambassador                                                                                                        About WRN Ambassadors                                                                            Become an Ambassador                                                                            Ambassadors of Excellence                                                                            People of WRN                                                                             FAQS                                                                            Tell Your Success Story                                                                             Success Stories                                                                            Tri-fold                                                                            Aviation                                                                             Current Ambassadors                                                                            Brochure                                                                            En Español",
     "type": "ListItem"
   },
   {
-    "element_id": "fd30298fbaae5847d3f8c96ae2b0005e",
+    "element_id": "aeee9b1d3904eda123d21c851ce4747d",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -389,14 +381,13 @@
         "https://www.weather.gov/wrn/hourly-weather-graph",
         "http://www.weather.gov/media/wrn/citizen_science_page.pdf",
         "https://www.weather.gov/wrn/intellectualdisabilities"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Education                                                                                                        NWS Education Home                                                                            Be A Force Of Nature                                                                            WRN Kids Flyer                                                                            Wireless Emergency Alerts                                                                            NOAA Weather Radio                                                                            Mobile Weather                                                                            Brochures                                                                            Hourly Weather Forecast                                                                            Citizen Science                                                                            Intellectual Disabilities",
     "type": "ListItem"
   },
   {
-    "element_id": "0d387704dfc9f817d53b599d6337ba08",
+    "element_id": "752f5b846e4a24df6d62d9dc014e5aec",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -447,14 +438,13 @@
         "https://nwschat.weather.gov/",
         "https://inws.ncep.noaa.gov/",
         "https://www.weather.gov/SKYWARN"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Collaboration                                                                                                        Get Involved                                                                             Social Media                                                                            WRN Ambassadors ​                                                                            Enterprise Resources                                                                            StormReady                                                                            TsunamiReady                                                                            NWSChat (core partners only)                                                                            InteractiveNWS (iNWS) (core partners only)​                                                                            SKYWARN",
     "type": "ListItem"
   },
   {
-    "element_id": "a1bffb371b3a2e0becf16b0c179a3705",
+    "element_id": "8729b5380b0f442c0512948bd18de66b",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -490,14 +480,13 @@
         "https://www.weather.gov/wrn/calendar",
         " https://www.weather.gov/wrn/workshops",
         "https://www.weather.gov/publications/aware"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "News & Events                                                                                                        Latest News                                                                            Calendar                                                                            Meetings & Workshops                                                                            NWS Aware Newsletter",
     "type": "ListItem"
   },
   {
-    "element_id": "db416c28f174208d27679569a8babb1d",
+    "element_id": "ec0f9efa0e7de0d7bbf11f3b8fb2a1ca",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -521,14 +510,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov/wrn/wrns"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "International",
     "type": "ListItem"
   },
   {
-    "element_id": "61497de07daa899cd6a211f90aff38c9",
+    "element_id": "f17da617a620de011003a204ecf48752",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -582,14 +570,13 @@
         "https://www.weather.gov/media/wrn/NWS_Weather-Ready-Nation_Strategic_Plan_2019-2022.pdf",
         " https://www.weather.gov/wrn/international",
         "https://vlab.noaa.gov/web/nws-social-science"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "About                                                                                                        Contact Us                                                                             What is WRN?                                                                             WRN FAQ                                                                            WRN Brochure                                                                            Hazard Simplification                                                                            IDSS Brochure                                                                            Roadmap                                                                            Strategic Plan                                                                            WRN International                                                                            Social Science",
     "type": "ListItem"
   },
   {
-    "element_id": "be7fac8bf613c5a2c20b28b85a63abf8",
+    "element_id": "623c25f2247b125d6df5138a7c5ee153",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -604,14 +591,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "The spring season is all about change – a rebirth both literally and figuratively. Even though the spring season doesn’t officially (astronomically, that is) begin until March 20 this year, climatologically, it starts March 1.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "d4238acb6a370cbe65908c77123a1c8a",
+    "element_id": "c8c953bd87e4571df8e6486e9c467861",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -626,14 +612,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "As cold winter nights are replaced by the warmth of longer daylight hours, the National Weather Service invites you to do two important things that may save your life or the life of a loved one.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "ae017cbfc4d30ec372adbd524993cf33",
+    "element_id": "b6553aef4dc61e5d31e2e28426e56f0b",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -654,14 +639,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "First, take steps to better prepare for the seasonal hazards weather can throw at you.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "3e76b95ade58da32e846d182164ab3c0",
+    "element_id": "ac246c4693669d08d274f628c3293a78",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -676,14 +660,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "This could include a spring cleaning of your storm shelter or ensuring your emergency kit is fully stocked. Take a look at our infographics and social media posts to help you become “weather-ready.”",
     "type": "NarrativeText"
   },
   {
-    "element_id": "b458277b70135cce8e2b20933551f878",
+    "element_id": "d1fa2a66a4df9759bdf01f6f1ec51d8e",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -713,14 +696,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov/wrn/spring-safety"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Second, encourage others to become Weather-Ready as well. Share the message by taking advantage of our vast array of weather safety content – everything posted on our Spring Safety website is freely available, and we encourage sharing on social media networks. Also remember those who are most vulnerable, like an elderly family member or neighbor who might have limited mobility or is isolated. Reach out to those who are at higher risk of being impacted by extreme weather, and help them get prepared. This simple act of caring could become heroic.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "370d6aaa463de1a32cebe1df6aaf6ff6",
+    "element_id": "996f1b86d1cb5a02028bd3816f5790f1",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -744,14 +726,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov/wrn/spring-infographics"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "This spring, the campaign is focused on heat dangers. Heat illness and death can occur even in spring’s moderately warm weather. The majority of all heat-related deaths occur outside of heat waves and roughly a third of child hot car deaths occur outside of the summer months. Learn more by viewing the infographics that are now available.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "8f880f3256e3874a6ebad0d5f27fc28c",
+    "element_id": "90b31790a9b5fd903e6dbaea50e05f45",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -766,14 +747,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Stay safe this spring, and every season, by being informed, prepared, and Weather-Ready.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "149e5482b9f74315683cd32b2da85d9a",
+    "element_id": "9dcf311a7e6225af9333100c709b7f23",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -797,14 +777,13 @@
       ],
       "link_urls": [
         "http://www.commerce.gov"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "US Dept of Commerce",
     "type": "Title"
   },
   {
-    "element_id": "cdcf589e9682c6b97f484d0d09b858ff",
+    "element_id": "60711b68cb732ecb10f4c05f0f784647",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -828,14 +807,13 @@
       ],
       "link_urls": [
         "http://www.noaa.gov"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "National Oceanic and Atmospheric Administration",
     "type": "Title"
   },
   {
-    "element_id": "c9f610a88296ac9e0458c19c39f9888d",
+    "element_id": "55ca4bf03b04ffacb8ea8cb528c22a6f",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -859,14 +837,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "National Weather Service",
     "type": "Title"
   },
   {
-    "element_id": "b7d320e07264f693666d474ecb6c3f75",
+    "element_id": "3ebaebb5791662dfa6d2e2b8af436f9d",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -881,14 +858,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "News Around NOAA",
     "type": "Title"
   },
   {
-    "element_id": "b9059fa8c53169cdb1d8d97d6e573662",
+    "element_id": "ccf5cdb2984d2ac2d934010960d32aca",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -903,14 +879,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "1325 East West Highway",
     "type": "Title"
   },
   {
-    "element_id": "813fa3b4d01cd241e0fa340b22f1158a",
+    "element_id": "64a081cb854ff90dbc668c2b334d0ae8",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -925,14 +900,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Silver Spring, MD 20910",
     "type": "Address"
   },
   {
-    "element_id": "070df83566389b04c0cb017264974742",
+    "element_id": "6af532045e3aa6fe3764590594dc0dd7",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -956,14 +930,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov/news/contact"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Comments? Questions? Please Contact Us.",
     "type": "Title"
   },
   {
-    "element_id": "1d1c1ffaf7ac020e1552331b6be405aa",
+    "element_id": "a63c69dcc655b1b32bc6157427e9ca8e",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -987,14 +960,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov/disclaimer"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Disclaimer",
     "type": "Title"
   },
   {
-    "element_id": "04ddc82328a758f26a13414ba0aa9778",
+    "element_id": "95054785187bcc0cf98cdb17c135ca1d",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -1018,14 +990,13 @@
       ],
       "link_urls": [
         "http://www.cio.noaa.gov/services_programs/info_quality.html"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Information Quality",
     "type": "Title"
   },
   {
-    "element_id": "4ca996b97fb264856e901f4a72f1ca8a",
+    "element_id": "800d660faa52732cd4d361b187bbd6e2",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -1049,14 +1020,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov/help"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Help",
     "type": "Title"
   },
   {
-    "element_id": "beb2f602d83b8ca30bd1bfe8d2c71371",
+    "element_id": "718284e0cdf275514b6aa8fb8976a7cc",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -1080,14 +1050,13 @@
       ],
       "link_urls": [
         "http://www.weather.gov/glossary"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Glossary",
     "type": "Title"
   },
   {
-    "element_id": "2ae858be1e88c00e351ed0d4ccbe53b6",
+    "element_id": "678ef3e5cd635ba851d2dfd7f6f20d0f",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -1111,14 +1080,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov/privacy"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Privacy Policy",
     "type": "Title"
   },
   {
-    "element_id": "99f5dc3b635f3d914cd9401788b78c7c",
+    "element_id": "f66ad83bfffccef0afe60d0aaba55b54",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -1142,14 +1110,13 @@
       ],
       "link_urls": [
         "https://www.noaa.gov/foia-freedom-of-information-act"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Freedom of Information Act (FOIA)",
     "type": "Title"
   },
   {
-    "element_id": "367ea82ddbb15a01b08a575fa266c1f8",
+    "element_id": "f50c4a988c7336b9d1100227fa7f03a3",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -1173,14 +1140,13 @@
       ],
       "link_urls": [
         "https://www.weather.gov/about"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "About Us",
     "type": "Title"
   },
   {
-    "element_id": "20312c2fb87e22e1a2e18244d85b0525",
+    "element_id": "a9a5f8ac29adb68999173b4e65a189bd",
     "metadata": {
       "data_source": {
         "date_created": "2023-03-10T09:40:16+00:00",
@@ -1204,8 +1170,7 @@
       ],
       "link_urls": [
         "https://www.weather.gov/careers"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Career Opportunities",
     "type": "Title"

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1540126.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1540126.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "5c545823b155a2a0c7dc1aa0a72948f0",
+    "element_id": "87d54efb69679f52b8c22f98f5ee6008",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -16,14 +16,13 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td>Driver</td><td></td></tr><tr><td>Approver</td><td></td></tr><tr><td>Contributors</td><td></td></tr><tr><td>Informed</td><td></td></tr><tr><td>Objective</td><td></td></tr><tr><td>Due date</td><td></td></tr><tr><td>Key outcomes</td><td></td></tr><tr><td>Status</td><td>NOT STARTED / IN PROGRESS / COMPLETE</td></tr></table>"
     },
     "text": "Driver Approver Contributors Informed Objective Due date Key outcomes Status NOT STARTED / IN PROGRESS / COMPLETE",
     "type": "Table"
   },
   {
-    "element_id": "21b228d181137322486b756fc687ae1e",
+    "element_id": "c5528cff9dc4266b252f172314e2221c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -38,14 +37,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "\\uD83E\\uDD14 Problem Statement",
     "type": "Title"
   },
   {
-    "element_id": "d4f83dc1a0a584a5932708603abf0514",
+    "element_id": "7745f8f335c0d63ac895f39209fa50bf",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -60,14 +58,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "🎯 Scope",
     "type": "Title"
   },
   {
-    "element_id": "14349f6e73577f168f836ae1fe026111",
+    "element_id": "a67a84caf3e93f9d3c6ee9462f6ac7bb",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -83,14 +80,13 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td>Must have:</td><td></td></tr><tr><td>Nice to have:</td><td></td></tr><tr><td>Not in scope:</td><td></td></tr></table>"
     },
     "text": "Must have: Nice to have: Not in scope:",
     "type": "Table"
   },
   {
-    "element_id": "db468e20be81cbe2eb7eef33d152760a",
+    "element_id": "eb8b47b67216ffd84479631af63b656a",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -105,14 +101,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "\\uD83D\\uDDD3 Timeline",
     "type": "Title"
   },
   {
-    "element_id": "592434711a6b7166c444ec138eab980b",
+    "element_id": "7aa58f6123e145d68b491d3e735060f8",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -127,14 +122,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Lane 1",
     "type": "Title"
   },
   {
-    "element_id": "a3766b5d3a33512577f1d848c1666829",
+    "element_id": "21354bac4c070eaa9722a971e6bdbfea",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -149,14 +143,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Lane 2",
     "type": "Title"
   },
   {
-    "element_id": "fa58e80377497584b5abea7770dba17d",
+    "element_id": "2fac077cc411e658746e76d86ea1ec37",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -171,14 +164,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Feature 1",
     "type": "Title"
   },
   {
-    "element_id": "e4e495e40974bbb18a13c05b98da42c5",
+    "element_id": "ff8497516144be25a4c0922f14c6ee28",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -193,14 +185,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Feature 2",
     "type": "Title"
   },
   {
-    "element_id": "19a3999a616933fcbb45f9b594a4f9f2",
+    "element_id": "0f701ee7f075b9b83ca75e844ab8184a",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -215,14 +206,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Feature 3",
     "type": "Title"
   },
   {
-    "element_id": "3da9dc78a285cd946d1f0a996c7c3957",
+    "element_id": "edf428e92bdb9e94ac17f876cdf7c058",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -237,14 +227,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Feature 4",
     "type": "Title"
   },
   {
-    "element_id": "4ae65b5ab9979438d86b294d7960c19d",
+    "element_id": "4d846dbdfa5783f976e41e1852ffb179",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -259,14 +248,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "iOS app",
     "type": "Title"
   },
   {
-    "element_id": "193219c9b1efb9d49360dd1354888cf0",
+    "element_id": "4fb022f234174c8dc5df55dd0c677833",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -281,14 +269,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Android app",
     "type": "Title"
   },
   {
-    "element_id": "c4706690b3acb61a903dd0f14fe46899",
+    "element_id": "a70dd893a3b6bd5c641812c25763f01a",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -303,14 +290,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "\\uD83D\\uDEA9 Milestones and deadlines",
     "type": "Title"
   },
   {
-    "element_id": "66e5e0b6ce51e04a0e37094cab772c32",
+    "element_id": "15b3d2fa95017389c5c47d1c5fc64b4d",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -326,14 +312,13 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td>Milestone</td><td>Owner</td><td>Deadline</td><td>Status</td></tr><tr><td></td><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td><td></td></tr></table>"
     },
     "text": "Milestone Owner Deadline Status",
     "type": "Table"
   },
   {
-    "element_id": "a7297ae69af4956865d668d076da911a",
+    "element_id": "edd10b45a03a9b9dac237354faa55251",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:55:50.911000",
@@ -348,8 +333,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "\\uD83D\\uDD17 Reference materials",
     "type": "Title"

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1605928.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1605928.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "fff28f1810e9e7fadc4cee805265466e",
+    "element_id": "ad87ce21734cf59c34b5a62cc0798c2f",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -15,14 +15,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "\\uD83D\\uDDD3 Date",
     "type": "Title"
   },
   {
-    "element_id": "6b5975666ff11ded81460bd163889869",
+    "element_id": "1c52504ada107bf7ccef5f78b58a2083",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -37,14 +36,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "\\uD83D\\uDC65 Participants",
     "type": "Title"
   },
   {
-    "element_id": "efdb80f487530df5dedbd40d0ccaa885",
+    "element_id": "8d5c737a91fb0e10371805abc1f89c79",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -59,14 +57,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "4ac682eab89d8495a7cd07466757029f",
+    "element_id": "1a46f51535f943b6dfa8746cd0f281ff",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -81,14 +78,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "5fa89c297204b53023cb3e19ce4385f9",
+    "element_id": "36b6c4ece8174d6fb3e516b7242f3c6c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -103,14 +99,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "\\uD83E\\uDD45 Goals",
     "type": "Title"
   },
   {
-    "element_id": "c8ef6f62fd82a1be88733eddb3fa7c75",
+    "element_id": "1cc1de2b35cec6a4adfe184157d2eb8e",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -125,14 +120,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "3cb7984bcb4433a53358aa980beef286",
+    "element_id": "b0293c68400b43db9bc8d5ef33be43df",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -147,14 +141,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "\\uD83D\\uDDE3 Discussion topics",
     "type": "Title"
   },
   {
-    "element_id": "c114a47ef12aa1eaa55603c3f4dd87e0",
+    "element_id": "29654ae71d95e217350645e33e219bb3",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -170,14 +163,13 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td>Time</td><td>Item</td><td>Presenter</td><td>Notes</td></tr><tr><td></td><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td><td></td></tr></table>"
     },
     "text": "Time Item Presenter Notes",
     "type": "Table"
   },
   {
-    "element_id": "2473ced77e8610dbbdb2e1a09e36e376",
+    "element_id": "0f8fa6214fd823bf85c04e6395bac656",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -192,14 +184,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "✅ Action items",
     "type": "Title"
   },
   {
-    "element_id": "d8f05203bd43f4b13777aca609718e3d",
+    "element_id": "01776c72263f5080b363440bfa4501a2",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -214,14 +205,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "81400b25b68a00ad60090b2b5e4bd744",
+    "element_id": "92f7acca41806b5beb8bc39eea59ac21",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.162000",
@@ -236,8 +226,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "⤴ Decisions",
     "type": "Title"

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1605942.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1605942.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "375de74537bbe1fd31021086d68769bf",
+    "element_id": "8cf6f327a51bcafbe61f759da949eae4",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -15,14 +15,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Copy and paste this section for each week.",
     "type": "Title"
   },
   {
-    "element_id": "cab64c08a463fe95a7fbd921fc640d21",
+    "element_id": "0e80063a2a29a298f8f761e73d131d6c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -43,14 +42,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Win",
     "type": "Title"
   },
   {
-    "element_id": "c2c9596ed6bee008aae3ce4db696ac24",
+    "element_id": "3fa457c99713dacee34a094ca844d369",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -65,14 +63,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "ae07661a728e59fbfef629ac4f428156",
+    "element_id": "f147aba8b007b4bd8208e4572f5b9deb",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -87,14 +84,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "d3c4f46e6a1e6e61eb2326e355a939fe",
+    "element_id": "6eb6112deae2548a83547e5ef9a21b88",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -109,14 +105,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "3af48952e1993daadd5ed991d577d0e8",
+    "element_id": "0ec9faddd7d36aa48091805f98e064a0",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -137,14 +132,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Needs input",
     "type": "Title"
   },
   {
-    "element_id": "7df2e781177efd8f71499e8c625822a4",
+    "element_id": "10d0eeb46296850b4d495368cd20f70f",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -159,14 +153,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "03bb9a55d87cb58486edb4d6489566ce",
+    "element_id": "70f82254d37a60cc5c83e07d98cce166",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -181,14 +174,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "c89bb55847e2ffad844e85a9669ab060",
+    "element_id": "93362aec18fca024916f21651c4fb019",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -203,14 +195,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "5425cdbf43e1a3479d7040c9652a8def",
+    "element_id": "2342f48f943338e6a30647e86ced5d81",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -231,14 +222,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Focus",
     "type": "Title"
   },
   {
-    "element_id": "3efe995111b5e90b3c048508acefb393",
+    "element_id": "e33fbc16d200926cce19fe943c3bbb62",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -253,14 +243,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "44d35bf5e10cef76e3cb4541988c7ad3",
+    "element_id": "1a2728decdac66085a26a43934e2c7cd",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -275,14 +264,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "53db392c4a0f76b2ade29aefe3ef9eca",
+    "element_id": "86e4984d57e4197d967dd0f0e866e9fd",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.226000",
@@ -298,7 +286,6 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td>Notes</td><td></td></tr><tr><td>Important Links</td><td></td></tr></table>"
     },
     "text": "Notes Important Links",

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1605956.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/1605956.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "907be3aeca1cb6daa23076499e8e5d9b",
+    "element_id": "d5576cc299d7d8417c136933f890831c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -15,14 +15,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Create a stellar overview",
     "type": "Title"
   },
   {
-    "element_id": "1ef50c655f5eb2d22f4626b0b5e55473",
+    "element_id": "d36113941235a14bdacafa399698ee71",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -37,14 +36,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "The overview is the first page visitors will see when they visit your space, so it helps to include some information on what the space is about and what your team is working on.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "de6999259f7ac654b672b2cba4703b7b",
+    "element_id": "21e1683c1bc71c40ea20081368bcc7f6",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -65,14 +63,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Add a header image. This gives your overview visual appeal and makes it welcoming for visitors.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "a31689180453d23e25391cf683296d19",
+    "element_id": "65f03aec0f3637db38c5a3741968eeff",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -93,14 +90,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Explain what the space is for. Start by summarizing the purpose of the space. This could be your team's mission statement or a brief description of the kind of work you do.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "68fd23c466a174c221dec12330e7d876",
+    "element_id": "e2522f792c3c5ef32bf1ba342a282fdd",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -136,14 +132,13 @@
         "https://www.atlassian.com/software/confluence/templates/okrs",
         "https://www.atlassian.com/software/confluence/templates/project-plan",
         "https://www.atlassian.com/software/confluence/templates/product-roadmap"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Share team goals. Add links to your team's OKRs, project plans, and product roadmaps so visitors can quickly get a sense of your team's goals.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "618c72ad36b013bd3b02d939418d0737",
+    "element_id": "bd058a2d2c45c92a3178e327564e135a",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -164,14 +159,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Tell people how to contact you. Share your timezone and links to Slack channels, email aliases, or other contact details your team uses so visitors can contact you with questions or feedback about your team's work.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "1ea4349c057f788b4815304b077f2256",
+    "element_id": "eab79997042ec6e273d0a13383347a57",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -186,14 +180,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Use shortcuts for easy access",
     "type": "Title"
   },
   {
-    "element_id": "e249ed17f1d4da02e04cc4356e0bc9d7",
+    "element_id": "29cdfa9dda669b1dac60890795ab526c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -208,14 +201,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Shortcuts are helpful for important pages that members of a space might need to get to often. These shortcuts are added and organized by the space administrator. Space admins can link to pages in the space, other related spaces, or relevant external web content as well as reorder the shortcuts as needed.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "42bc6a5b088633436273aaedfcd1fbb0",
+    "element_id": "3251fe353cdbb64ce5cf084aef00cd96",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -230,14 +222,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "💭Start discussions with inline comments",
     "type": "Title"
   },
   {
-    "element_id": "794cc3760fc4171ff60c9e7cdd5079ca",
+    "element_id": "29a93ef334092c2a12daf86b1c1b61fb",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -261,14 +252,13 @@
       ],
       "link_urls": [
         "https://support.atlassian.com/confluence-cloud/docs/comment-on-pages-and-blog-posts/"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Thoughtful responses can get lost and lose context as email replies pile up. And if you neglect to copy someone or want to add them later on, it's difficult for them to get up to speed. Inline comments allow anyone (or everyone) to huddle around an idea while referencing key information on the project page.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "e287cd8480984727045d2e1a3589676c",
+    "element_id": "15cc91b0ec273ab28ab202cd5e7836ea",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -283,14 +273,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "To leave an inline comment, highlight text on the page and the comment icon will appear.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "8ed2a507b6db6435d8d82efbdd3357b5",
+    "element_id": "c606d30a11f8686a33c4f5305ab878fa",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -305,14 +294,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team members with permission to access the page can respond to any comment. Plus, when a comment thread comes to its natural conclusion, comments can be resolved and cleared away.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "33cf669c7fe947a56558dc7c779d437d",
+    "element_id": "9cec5c4cb40b1424590a7d2255ba5d98",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -327,14 +315,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "👋Loop in team members with @mentions",
     "type": "Title"
   },
   {
-    "element_id": "c1028def152a4e0b5abf9044e852f84e",
+    "element_id": "158ce46e2f05121666d26652b44ce556",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -358,14 +345,13 @@
       ],
       "link_urls": [
         "https://support.atlassian.com/confluence-cloud/docs/mention-a-person-or-team/"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "@mentions on Confluence function like @mentions on social media platforms like Twitter, Instagram, and Slack. Type the @ symbol on a Confluence page or in a comment, begin spelling a team member's first name, and a list will appear. Select the individual to ask a question or assign a task.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "f42b02bccf88f7ad24f493aaecfa92a9",
+    "element_id": "aedbcb95b475418adc9e82fb50e1832f",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -380,14 +366,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "👏Endorse ideas with reactions",
     "type": "Title"
   },
   {
-    "element_id": "fc7dcd4f625da24adc10a406ace59fe5",
+    "element_id": "9dcf5a605331e2e0db925a329a727df8",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -402,14 +387,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Use reactions when you want to support a comment or acknowledge you've seen one without clogging up the thread with another comment.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "be7c586952844b0f04e593da9cdc3400",
+    "element_id": "a26e40b5555fb394e0844b7ae0118a90",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -424,14 +408,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "You can also use reactions on a page or blog post. The author of the content will be notified, and if enough team members react or add comments to the content, it'll be surfaced on Confluence home feed",
     "type": "NarrativeText"
   },
   {
-    "element_id": "d97b706ba50a6fe7b3654c6e39c70f25",
+    "element_id": "04dfe464a23b5192ca7465fca96e8a56",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -446,14 +429,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Take your Confluence space to the next level",
     "type": "Title"
   },
   {
-    "element_id": "d07b25dbed409a5dab1ec4209bbf1149",
+    "element_id": "0702e0badc70e2f3caa9d29e353e7983",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -468,14 +450,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Extend the capabilities of your Confluence pages by  adding extra functionality or including dynamic content.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "21d0d703939661862c87d7cd14f07c3c",
+    "element_id": "7d4a53bc8e11c662ba62212041b24cf6",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -496,14 +477,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "To add functionality:",
     "type": "NarrativeText"
   },
   {
-    "element_id": "0c62f091366d8a24816068226d13186d",
+    "element_id": "29eaf10632e9bd8a0f0c46ac3f6ff876",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -518,14 +498,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Type ' / ' to open the list of items available to use",
     "type": "ListItem"
   },
   {
-    "element_id": "16b9a39f18b130d91ea0b63dc210dcc2",
+    "element_id": "885e34b9230d70d0c3257eef2d3f6a0f",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -540,14 +519,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Find the item to be inserted and select it",
     "type": "ListItem"
   },
   {
-    "element_id": "ab160d300e507e1fd56e9dd79e6d1892",
+    "element_id": "258ee604863fd54e308f2925d07ebd79",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -568,14 +546,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Select Insert",
     "type": "ListItem"
   },
   {
-    "element_id": "910c4a3bbb543125d90cf48a64b65446",
+    "element_id": "04a5e0e0b40cb961c84088dcc67b26b7",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -590,14 +567,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Useful elements for Team space",
     "type": "Title"
   },
   {
-    "element_id": "8dce3e8d54e2dfa6b07ba55df73cda9f",
+    "element_id": "bd4f8d2535746efce21ce872c09ef973",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -618,14 +594,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Introduce the team",
     "type": "Title"
   },
   {
-    "element_id": "980b7486bfda841df67789c7f7eca121",
+    "element_id": "433789f2b20ca6275f62a944390e3c1d",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -649,14 +624,13 @@
       ],
       "link_urls": [
         "https://support.atlassian.com/confluence-cloud/docs/insert-the-user-profile-macro/"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Add user profiles to display a short summary of a given Confluence user's profile with their role, profile photo and contact details.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "e52c0c2554902087be57b5f924de82a6",
+    "element_id": "959ffe89453ca67c279ed576df24e196",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -677,14 +651,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Share news and announcements with your team",
     "type": "Title"
   },
   {
-    "element_id": "d97cd73e0d35053c463712c2b9f07b4f",
+    "element_id": "8b81b2db2cef191090cfa1d4204b8964",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -708,14 +681,13 @@
       ],
       "link_urls": [
         "https://support.atlassian.com/confluence-cloud/docs/insert-the-blog-posts-macro/"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Display a stream of latest blog posts so your team can easily see what's been going on.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "4aa6abf3a47a916bb1481276135abdb9",
+    "element_id": "3fd46bb09e57e95f1211f475c45b575b",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -736,14 +708,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Display a list of important pages",
     "type": "NarrativeText"
   },
   {
-    "element_id": "1fbd1b071e7aff555cadc6fdf0957734",
+    "element_id": "5cbfe913e369743f1f14830c0b6572ab",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:45.288000",
@@ -767,8 +738,7 @@
       ],
       "link_urls": [
         "https://support.atlassian.com/confluence-cloud/docs/insert-the-content-report-table-macro/"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Paste in page URLs to create smart links, or use the content report table to create a list of all the pages in the space.",
     "type": "NarrativeText"

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/229477.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/MFS/229477.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "d9e500a6e802884f5b83fba8dcecc49e",
+    "element_id": "af28136055ec3b58ec92da684eabe972",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -15,14 +15,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Welcome to your team space!",
     "type": "Title"
   },
   {
-    "element_id": "25a59cf1d4c40c6cd02236d933666c2c",
+    "element_id": "637226363ce2403ca3a797b8e400b470",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -37,14 +36,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "We've added some suggestions and placeholders. Everything is customizable.",
     "type": "ListItem"
   },
   {
-    "element_id": "23bacd7f54743e32a6dcafc05a716f24",
+    "element_id": "1827a210ba924c56e275c47f4dcc8680",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -74,14 +72,13 @@
         "/wiki/spaces/MFS/pages/1540126/Template+-+Project+plan",
         "/wiki/spaces/MFS/pages/1605928/Template+-+Meeting+notes",
         "/wiki/spaces/MFS/pages/1605942/Template+-+Weekly+status+report"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Get started with page templates:Template - Project planTemplate - Meeting notesTemplate - Weekly status report",
     "type": "ListItem"
   },
   {
-    "element_id": "5ce7656ba0ef50009f78e0317954be09",
+    "element_id": "74ac57479647bf966333f308343d489e",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -105,14 +102,13 @@
       ],
       "link_urls": [
         "/wiki/spaces/MFS/pages/1605956/Get+the+most+out+of+your+team+space"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Check out Get the most out of your team space for more tips.",
     "type": "ListItem"
   },
   {
-    "element_id": "cda80414ca0f2e335c3c72ec111e9a91",
+    "element_id": "42b26823e7d33c417844e3d9866cad89",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -127,14 +123,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "About",
     "type": "Title"
   },
   {
-    "element_id": "24013ff70e4940c9f0b77dd3d8b8ec9e",
+    "element_id": "cf2be0c50ea0ff66bb1dfb0497c453e7",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -157,14 +152,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "What is your team all about?",
     "type": "NarrativeText"
   },
   {
-    "element_id": "c8e6c8cc992272412585608ef094dd91",
+    "element_id": "53d259755e03050e0d88ddd6660a5e6c",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -179,14 +173,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Mission and vision",
     "type": "Title"
   },
   {
-    "element_id": "a8e3e30f65b9ad23b60ef3ebc2202537",
+    "element_id": "a725e33535aa3530fe16f61a8417afd7",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -209,14 +202,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "What is your team's mission? What is your vision?",
     "type": "NarrativeText"
   },
   {
-    "element_id": "a57d67ba594f3d4f8a9c1ffd6ab3ed3d",
+    "element_id": "885d987a2a3077b6d014c1db0fa59252",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -231,14 +223,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Meet the team",
     "type": "Title"
   },
   {
-    "element_id": "40fe67ee68eb99624930de7af54a8477",
+    "element_id": "b578d6f9d0e812f6130f14d79a2c9c97",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -261,14 +252,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Add team members to your space.",
     "type": "Title"
   },
   {
-    "element_id": "00c6d24871bc0d328014fe5676fc5a9a",
+    "element_id": "7428e6a9256f6030b2137d082c7ffd27",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -289,14 +279,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team member",
     "type": "Title"
   },
   {
-    "element_id": "b8e1449ef65afb6a5128d70cbdae8f87",
+    "element_id": "6aaa4f81530815729e63c057ee8606b5",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -317,14 +306,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Role",
     "type": "Title"
   },
   {
-    "element_id": "95d5088f0cc25f22178331dab1e595b7",
+    "element_id": "9c3c330b00ee89060e13303f5e02bcba",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -345,14 +333,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Responsibility",
     "type": "Title"
   },
   {
-    "element_id": "75808150fdb4d8f3b3e244537e92f6a1",
+    "element_id": "8e206800f74b037f87bc91ce09a66587",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -373,14 +360,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team member",
     "type": "Title"
   },
   {
-    "element_id": "a67c2f1a5b201e9dfbe01e1e21b200e3",
+    "element_id": "2c4cc93ed9393b0f05a3e564c436e13e",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -401,14 +387,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Role",
     "type": "Title"
   },
   {
-    "element_id": "8451c40b12ec20c35b10398a0b265b60",
+    "element_id": "554c2527470d9fea2aaf8cefd8aa8ffc",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -429,14 +414,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Responsibility",
     "type": "Title"
   },
   {
-    "element_id": "c5ff2a7f278dd30eacc616697e0fd3f7",
+    "element_id": "feb3b3be79c77e3d661dc3fa522de26f",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -457,14 +441,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team member",
     "type": "Title"
   },
   {
-    "element_id": "464a4ee936def1c064e15594b4389625",
+    "element_id": "5a73ff028549542468675768deee0430",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -485,14 +468,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Role",
     "type": "Title"
   },
   {
-    "element_id": "6ea6880df9c934cb0a1ab91a07b7616b",
+    "element_id": "94d211691238a7f3f74db151876c6734",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -513,14 +495,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Responsibility",
     "type": "Title"
   },
   {
-    "element_id": "52cd76a2d925992aac18b9e36906441a",
+    "element_id": "819971206479a68fc2c9b189efb456bc",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -535,14 +516,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Contact us",
     "type": "Title"
   },
   {
-    "element_id": "7e95e28526cea2ef1b963e0651ab8cbd",
+    "element_id": "c8a0d091f295537e075e91a05c5b9700",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -565,14 +545,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "How can someone reach out to your team?",
     "type": "NarrativeText"
   },
   {
-    "element_id": "25eac0501321e5b995c14824c90095d5",
+    "element_id": "55d2e1480c9b0daa291da9bb125ed991",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -602,14 +581,13 @@
       ],
       "link_urls": [
         "mailto:team@email.com"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "team@email.com",
     "type": "ListItem"
   },
   {
-    "element_id": "6544e3a323486295c7507d1ed9233573",
+    "element_id": "8cdf7c104c621a61684afb22e1a12ae6",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -630,14 +608,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Tickets",
     "type": "ListItem"
   },
   {
-    "element_id": "77013ea2d88478c056bc21321ba02275",
+    "element_id": "184e1ab78f1ad23cbd87e4051a2e44ba",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -658,14 +635,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Jira board",
     "type": "ListItem"
   },
   {
-    "element_id": "5a07d153a4c65b036a6204210b8b14c2",
+    "element_id": "b11108036b6d8a3c5beff0ba72018fbf",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -686,14 +662,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "#channel",
     "type": "ListItem"
   },
   {
-    "element_id": "1f4fc38715cf9ca3c3149c2ec1192a9e",
+    "element_id": "bec770c2e66ae2747664908931bc34bb",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -708,14 +683,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Important Pages",
     "type": "Title"
   },
   {
-    "element_id": "f8255069bc6370911a26b98ce3a1381f",
+    "element_id": "5c143a6e4a05107f68ef13d7da7cd3ed",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -738,14 +712,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "List them here",
     "type": "NarrativeText"
   },
   {
-    "element_id": "33ceff50e6f6ef818d66a8f8639cbbbb",
+    "element_id": "656e2cc40d11fdc4906f2dd580a19c6a",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -760,14 +733,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "8ae7dbeadd16a7528b2c6a81a4b96cd0",
+    "element_id": "618b555629238a470093892056791c8d",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -782,14 +754,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "c9fafc9bdf9cfbc66991059da1e6e455",
+    "element_id": "fb61fd8022c3b78d934d1407834e5409",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -804,14 +775,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "a22fc48a85b11e636b2e26fecff3f1ba",
+    "element_id": "68accd9d0365712f54b96da661cce03d",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -826,14 +796,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Onboarding FAQs",
     "type": "Title"
   },
   {
-    "element_id": "4ae5bf04328dd69fbacdf02ba5d4df0e",
+    "element_id": "35aa0d02a38ad72c0ca0534155dbdeb8",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -856,14 +825,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Add resources for new hires",
     "type": "Title"
   },
   {
-    "element_id": "1917058bf8ff843a3782195b4c4a9a11",
+    "element_id": "ea538f1ebdd2ced67e8c86dcf50bc164",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -878,14 +846,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Meeting notes",
     "type": "Title"
   },
   {
-    "element_id": "01b55b27ca4f59d385dc8c777c65e551",
+    "element_id": "6f4ae84a8d8a1d9005384f35e2ce793c",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -908,14 +875,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Add links to meeting notes",
     "type": "NarrativeText"
   },
   {
-    "element_id": "a932690e5e7d16afcf18cd955693fd64",
+    "element_id": "9616030a71ad0e0654b28e61578d0443",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -930,14 +896,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team goals",
     "type": "Title"
   },
   {
-    "element_id": "d82d6fa569c160b1731ba1ceb5430f5a",
+    "element_id": "d81cb76df56721595c0495e4f5e6094f",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -960,14 +925,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "List them here",
     "type": "NarrativeText"
   },
   {
-    "element_id": "a3ec6f91fa124b63f4d4a3711335db9c",
+    "element_id": "46c3bd98dbea47cb63923597c929b932",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -982,14 +946,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team news",
     "type": "Title"
   },
   {
-    "element_id": "62996282b16b1ba3ecb5c4c9431eb94f",
+    "element_id": "1558d5e9d97c1cbb5cbb5cb2b077f83d",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -1012,14 +975,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Create a blog post to share team news. It will automatically appear here once it's published.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "96a019409dbabbd15d1468d620ec8498",
+    "element_id": "c281ed85f2e1125c9aaf318fd5178d4d",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -1034,14 +996,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Blog stream",
     "type": "Title"
   },
   {
-    "element_id": "9d29edca8d3fe280aa77a46c9e593156",
+    "element_id": "4b401fd3bc190fce17f70000e0164772",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-30T17:25:25.504000",
@@ -1056,8 +1017,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Create a blog post to share news and announcements with your team and company.",
     "type": "NarrativeText"

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1605859.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1605859.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "b2dffab1e0fecc6795a48996eff8cfef",
+    "element_id": "e1f5fcc433282a2fa999a1dec593f59a",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -15,14 +15,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Welcome to your team space!",
     "type": "Title"
   },
   {
-    "element_id": "d00e448311988dfa06dd17d5d7cd5ea3",
+    "element_id": "c1a9308ef0747d4d4e4224516ecddb18",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -37,14 +36,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "We've added some suggestions and placeholders. Everything is customizable.",
     "type": "ListItem"
   },
   {
-    "element_id": "5071e324c3ae210cba58c3ae049a0e64",
+    "element_id": "0541e1bcde4e7efd6de89e8920ca8080",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -74,14 +72,13 @@
         "/wiki/spaces/MFS/pages/1540126/Template+-+Project+plan",
         "/wiki/spaces/MFS/pages/1605928/Template+-+Meeting+notes",
         "/wiki/spaces/MFS/pages/1605942/Template+-+Weekly+status+report"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Get started with page templates:Template - Project planTemplate - Meeting notesTemplate - Weekly status report",
     "type": "ListItem"
   },
   {
-    "element_id": "9d6d7d5fcebac894e9e1e321d45e6e08",
+    "element_id": "58d6e4f85d58b5d3e291326c1c5dafba",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -105,14 +102,13 @@
       ],
       "link_urls": [
         "/wiki/spaces/MFS/pages/1605956/Get+the+most+out+of+your+team+space"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Check out Get the most out of your team space for more tips.",
     "type": "ListItem"
   },
   {
-    "element_id": "406189fbaebe85d176b3dfe827add0a0",
+    "element_id": "171deecd78c76bbd89be75dd13342cc2",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -127,14 +123,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "About",
     "type": "Title"
   },
   {
-    "element_id": "84a078eb5765c238b9e6014cba8a4f53",
+    "element_id": "e3f9b4aabce922efda54bfce0ff29aaa",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -157,14 +152,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "What is your team all about?",
     "type": "NarrativeText"
   },
   {
-    "element_id": "36883fa2ff4ab8db6b5832d4368ee274",
+    "element_id": "feda90682ffacf43bb009fd562c1206c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -179,14 +173,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Mission and vision",
     "type": "Title"
   },
   {
-    "element_id": "1f7abb86c779c0e830750db832d48975",
+    "element_id": "da6021de78b8b943777414ff3ec94186",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -209,14 +202,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "What is your team's mission? What is your vision?",
     "type": "NarrativeText"
   },
   {
-    "element_id": "49e64efc81d07791f9d12d2dc06393b9",
+    "element_id": "5b801b2fbeafefe2b1f2f5e00356f214",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -231,14 +223,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Meet the team",
     "type": "Title"
   },
   {
-    "element_id": "c900c03252356b00917943d4641a8435",
+    "element_id": "baffb88089e750a4b1b1209aa55d1410",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -261,14 +252,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Add team members to your space.",
     "type": "Title"
   },
   {
-    "element_id": "71207fbb7b663d46649a6b3d274abe9a",
+    "element_id": "7a4fddccf630b618da314c2a2ee45491",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -289,14 +279,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team member",
     "type": "Title"
   },
   {
-    "element_id": "c4af1e80ef58874898e9aa3fc615b72b",
+    "element_id": "55bdf090c6dac121668ac65a9a7f2bf9",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -317,14 +306,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Role",
     "type": "Title"
   },
   {
-    "element_id": "e2e9e8ab04baeb7cad33d9c9161a7dcd",
+    "element_id": "f926f3cf69185b202f8f868f0e8577dc",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -345,14 +333,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Responsibility",
     "type": "Title"
   },
   {
-    "element_id": "b6bb95454f285842f2837d38aeefa24d",
+    "element_id": "93eecf0cb223bb9b38800c595a2c1ce2",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -373,14 +360,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team member",
     "type": "Title"
   },
   {
-    "element_id": "adbed78d36fb9ebf3d1918306e223a87",
+    "element_id": "75ee4a303fc5ab8639c7bca973f29e30",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -401,14 +387,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Role",
     "type": "Title"
   },
   {
-    "element_id": "3c25361ff2e99a02ad8c8dbf8c5971d6",
+    "element_id": "22731d9c17747fc4708fd7f418e9dd57",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -429,14 +414,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Responsibility",
     "type": "Title"
   },
   {
-    "element_id": "cc3939494b92e34cf282e50cf325c09f",
+    "element_id": "c4327bb8ec4ea8444a6307fcdf6928cd",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -457,14 +441,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team member",
     "type": "Title"
   },
   {
-    "element_id": "b89df8dccdb1336ad818b8d028a87473",
+    "element_id": "aa48062270f019242d68093284c4fa0c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -485,14 +468,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Role",
     "type": "Title"
   },
   {
-    "element_id": "97e782277feb65217df239a5e488762a",
+    "element_id": "4bdb6fa86fd59b0729ecb9b6dbbf1ba7",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -513,14 +495,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Responsibility",
     "type": "Title"
   },
   {
-    "element_id": "4a0b3cd3b5efd6e68f26f957777d3687",
+    "element_id": "2c7f4046974b76def589634ebe2c0c47",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -535,14 +516,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Contact us",
     "type": "Title"
   },
   {
-    "element_id": "90043dc56cbf8660d953bb9e33931944",
+    "element_id": "5939e388affdc9ab440c5c158478e6b5",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -565,14 +545,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "How can someone reach out to your team?",
     "type": "NarrativeText"
   },
   {
-    "element_id": "4b3fcda15d77fb4f40b56b1d6e58f053",
+    "element_id": "53e3a9c9214c1410cc0658cb871e8291",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -602,14 +581,13 @@
       ],
       "link_urls": [
         "mailto:team@email.com"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "team@email.com",
     "type": "ListItem"
   },
   {
-    "element_id": "31ade55eed8dbac1a510c95d0f739766",
+    "element_id": "1507ffa5704d588237bb94150d9cfd27",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -630,14 +608,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Tickets",
     "type": "ListItem"
   },
   {
-    "element_id": "26e61734f70ba1ae1b76a2f2997b7d3e",
+    "element_id": "ac32614a08d10f91199e9c6e1b3c4a20",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -658,14 +635,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Jira board",
     "type": "ListItem"
   },
   {
-    "element_id": "ab4ccfadb811bbc5b3872b85e07e8b69",
+    "element_id": "3c70a6c9abd4e0c53832503a04fd9772",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -686,14 +662,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "#channel",
     "type": "ListItem"
   },
   {
-    "element_id": "0d7f5df8cd97610090fdd5cf0ff734d9",
+    "element_id": "4f58203ca7333ae2f3ae45c62617425c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -708,14 +683,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Important Pages",
     "type": "Title"
   },
   {
-    "element_id": "bfc894ceb0f92f46afb0c709491f3dff",
+    "element_id": "548d2e7b200eed8688e8eeeb1915c5e5",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -738,14 +712,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "List them here",
     "type": "NarrativeText"
   },
   {
-    "element_id": "8e2293f468ec19a56e484b2ce330ff55",
+    "element_id": "cac81bd65cfc7098409c7a04ed50642b",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -760,14 +733,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "e00fe0f977dbf95e73d7ab0d04ded1c5",
+    "element_id": "3ccf13a948a19a1d2434fdd2fdd451ce",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -782,14 +754,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "9685d61cc2cd39b070726a8265346e65",
+    "element_id": "e38ebc13023b654efab1e71ca25aeec9",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -804,14 +775,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "",
     "type": "ListItem"
   },
   {
-    "element_id": "181f3e242ced439746d16f1b527d267e",
+    "element_id": "f4186b4e1cec5ef7009560d11cb74087",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -826,14 +796,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Onboarding FAQs",
     "type": "Title"
   },
   {
-    "element_id": "ffd31aadf3f7b64ec9dc3b2b2bdbc753",
+    "element_id": "a27a3099dea44c05dfea1e0e125abac5",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -856,14 +825,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Add resources for new hires",
     "type": "Title"
   },
   {
-    "element_id": "56eef85fcd4a2263c691071999f6429c",
+    "element_id": "44d083c5ce62947d874c568db0dbc01b",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -878,14 +846,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Meeting notes",
     "type": "Title"
   },
   {
-    "element_id": "6abd21fb6255e27160aef66ee7d36d96",
+    "element_id": "23d9d3b7eb1b506a1031e99b28243136",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -908,14 +875,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Add links to meeting notes",
     "type": "NarrativeText"
   },
   {
-    "element_id": "d2cee09477e088d84e74b08de5deff7a",
+    "element_id": "5d12aca2ca2b8aba5c9dee48f1475f55",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -930,14 +896,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team goals",
     "type": "Title"
   },
   {
-    "element_id": "a13f70938d824846645934a807d69905",
+    "element_id": "70182a5acbdac0041ee51b85dfca692f",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -960,14 +925,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "List them here",
     "type": "NarrativeText"
   },
   {
-    "element_id": "90cd734b8134a2357a8b465734d6ecd2",
+    "element_id": "243fc77b8eebdbcf00a6a108a8159b69",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -982,14 +946,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Team news",
     "type": "Title"
   },
   {
-    "element_id": "4ed278bf47e737b3703c69d7725190b7",
+    "element_id": "3014e5236eb14590a7c13e83c36b20ce",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -1012,14 +975,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Create a blog post to share team news. It will automatically appear here once it's published.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "e3d39efdb0e176646c9e1a32841bebb2",
+    "element_id": "800f984e0d3456624dce9630abfd873a",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -1034,14 +996,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Blog stream",
     "type": "Title"
   },
   {
-    "element_id": "2bb89f660ae31c6938db49f7b1cf8115",
+    "element_id": "800885acdda14ccb63621293f9a3aa2f",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:54:40.304000",
@@ -1056,8 +1017,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Create a blog post to share news and announcements with your team and company.",
     "type": "NarrativeText"

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1605989.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1605989.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "02490913ad4b7772ba5ab107c1797c58",
+    "element_id": "1672cd06afcef46532e0c1ac6d1ef3e4",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -16,14 +16,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "96bdd50eaa2bc6157763876e50a620c5",
+    "element_id": "ef1707e2cadf95400b688c2ea15f6657",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -39,14 +38,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "ca31d450b74205651e859ccf0586b016",
+    "element_id": "23332b5a74f166672eda00916897d09c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -62,14 +60,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "52621a70b2be3ba9d0c2bf7fa9873e4d",
+    "element_id": "00290c97c096654a5ad758c1aa963b8b",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -85,14 +82,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "c99ed4cb193a4a96c19fda6ffc52afba",
+    "element_id": "252751d6be961b05b423171e53612340",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -108,14 +104,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "c7615f07a590c799b7d84d9478a59a3f",
+    "element_id": "9d9ce8fac05e0a6064fc173f51f886b5",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -131,14 +126,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "3c1b5e3cca5dac10daecfc98be367ecf",
+    "element_id": "bcce1169cfd0d24990e5dcf9a1f4417c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -154,14 +148,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "c6cb5fafcc7be4f5b01f0ddd3e314bc8",
+    "element_id": "bef3930174a53244d9333aba98d6ef37",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -177,14 +170,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "53148e8de8af14658c0f63624d118cfb",
+    "element_id": "40aa9fc4d7bc2522da02123e07615fd1",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -200,14 +192,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "884b01ed278bac5525a680cd9852eb3b",
+    "element_id": "f284f9398e8b26287f59b01df3f87395",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -223,14 +214,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "2d7e40f15604f3a820b6ff77c4cc02ac",
+    "element_id": "6da438b97512b144f96de65bcb35c380",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -246,14 +236,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "7bc15b4bef508628eb3ed661c2c48c77",
+    "element_id": "a3d7fbfb7e7cb92f6c2c809be1aa6a67",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -269,14 +258,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "4f73209738ec0a21d57e96f827718e55",
+    "element_id": "6780aadfc4e2332b6da7302971e7744e",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -292,14 +280,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "9f2482aba7d582aa2130480a7cb56fdf",
+    "element_id": "ca6e8673360d0f9a946786edc086f26e",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -315,14 +302,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3 testtext3",
     "type": "Title"
   },
   {
-    "element_id": "465afd89bee91ce6cd30154a7827c64d",
+    "element_id": "9b3f13651bd9c76260e5af72a9178c15",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -338,14 +324,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 List Item 1Testdoc3 List Item 1 Nested Item ATestdoc3 List Item 1 Nested Item B",
     "type": "ListItem"
   },
   {
-    "element_id": "63534206e58487b7d800f3caf20fc924",
+    "element_id": "1d29a4258d918a1ef755a28e6ef99ae0",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -361,14 +346,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 List Item 2",
     "type": "ListItem"
   },
   {
-    "element_id": "2368beff3d5b1ed201162cda1d842d83",
+    "element_id": "4244e1b92dbb75ce777baf4fb75a17fd",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -384,14 +368,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 List Item 3",
     "type": "ListItem"
   },
   {
-    "element_id": "ab364ee16e2f9fd2c329c53f43d4f718",
+    "element_id": "5c9ab1d333c163c4e5974a1b6241f4db",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -407,14 +390,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 List Item 4",
     "type": "ListItem"
   },
   {
-    "element_id": "f7033441b476c1b5f1a7944c8403ab3b",
+    "element_id": "446567ab87e1207a1e90f68a7357ea69",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -430,14 +412,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 List Item 5",
     "type": "ListItem"
   },
   {
-    "element_id": "f7ed3170ef8efb97d62f9e619741c86d",
+    "element_id": "fceace3d21355835e0efab1220200754",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -462,14 +443,13 @@
       ],
       "link_urls": [
         "https://www.unstructured.io/"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "This is the link for unstructured . io.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "3326982014bf0313233602790631316e",
+    "element_id": "3103a93c0b7268907d5f12ec3919630f",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -491,14 +471,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 Checklist Item 1",
     "type": "ListItem"
   },
   {
-    "element_id": "00d7b6d81d9cab0b28fed5dd16d9ebf8",
+    "element_id": "49e02888ddebdfccb7c5d813d1cd8d80",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -520,14 +499,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 Checklist Item 2 (checked)",
     "type": "ListItem"
   },
   {
-    "element_id": "20caf6713a5d4e23be8c32b0932d15cd",
+    "element_id": "623205757930bf68f63245809ab88165",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -549,14 +527,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 Checklist Item 3",
     "type": "ListItem"
   },
   {
-    "element_id": "c4157a81ddc168a43207319d16889e70",
+    "element_id": "4878f87e35a0014ef3b7137a5eb3be37",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -572,14 +549,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "😃 😃 😃 😃 😃 😃 😃 😃 😃 😃 😃 😃",
     "type": "UncategorizedText"
   },
   {
-    "element_id": "79b31ebbae361f66505bc6e6549287c8",
+    "element_id": "f6d6c30b44ae2ef4a98631d6ab8daec3",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -601,14 +577,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 bold text",
     "type": "NarrativeText"
   },
   {
-    "element_id": "339d8e6e913d4412ad56dd80d9f32c93",
+    "element_id": "181c7bd23470228c174857aaa63ee8f8",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -630,14 +605,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 italic text",
     "type": "Title"
   },
   {
-    "element_id": "efaaef7d02ac5fce70a03f0431b20e80",
+    "element_id": "f8aba27556bcc7ec05baf554f302d7be",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -653,14 +627,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 Heading 1 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "1079d9be97789f3b516c651c41bed105",
+    "element_id": "7f33bffe06658936ae4a2db0c3475b09",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -676,14 +649,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 Heading 2 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "0a48339de930f49bad086287d3cd31a3",
+    "element_id": "ac020a7fd396847465e98ade9f72a2be",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -699,14 +671,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 Heading 3 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "157e05b1337bd4efb397cf2087e34617",
+    "element_id": "3c087dd347cfe41d03590ab09c2d5a0a",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -722,14 +693,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 Heading 4 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "3b42752e42a619b95070c3843aff2dbd",
+    "element_id": "32b6823ad80e7c1ba90f8a4285a1a080",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -745,14 +715,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc3 Heading 5 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "ee154b59fe5a84067195094b28a1ac86",
+    "element_id": "2c23de0ced97cc9bcf524905170df223",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-09T12:56:40.842000",
@@ -769,7 +738,6 @@
         "eng",
         "fra"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td>Testdoc3 Table: Column 1 Row 0</td><td>Testdoc3 Table: Column 2 Row 0</td><td>Testdoc3 Table: Column 3 Row 0</td></tr><tr><td>Testdoc3 Table: Column 1 Row 1</td><td>Testdoc3 Table: Column 2 Row 1</td><td>Testdoc3 Table: Column 3 Row 1</td></tr><tr><td>Testdoc3 Table: Column 1 Row 2</td><td>Testdoc3 Table: Column 2 Row 2</td><td>Testdoc3 Table: Column 3 Row 2</td></tr></table>"
     },
     "text": "Testdoc3 Table: Column 1 Row 0 Testdoc3 Table: Column 2 Row 0 Testdoc3 Table: Column 3 Row 0 Testdoc3 Table: Column 1 Row 1 Testdoc3 Table: Column 2 Row 1 Testdoc3 Table: Column 3 Row 1 Testdoc3 Table: Column 1 Row 2 Testdoc3 Table: Column 2 Row 2 Testdoc3 Table: Column 3 Row 2",

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1802252.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1802252.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "bbf79449efd468940e9d4dec0a1bd616",
+    "element_id": "1eba9da7f7ba3d80d060f638e240cc2c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -16,14 +16,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "a24a2601a0154646b662032959e18fcb",
+    "element_id": "74d66fc2066f7844294c8d162f443892",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -39,14 +38,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "48723ccd2d681ec7065ffe86f60d2eb1",
+    "element_id": "20c74c9c7e2f03ebdaa0cc475abc461e",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -62,14 +60,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "5681402f3d53987a356c23f900ee843f",
+    "element_id": "13be5a443b462adf06733ac5f3c3f821",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -85,14 +82,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "2677a40f217655faa8328d5172002cf6",
+    "element_id": "e3c59c23c9a8d3251fbe8c0b8bf06a4f",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -108,14 +104,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "63e0681ab46ba97fc9094da6c04bfb03",
+    "element_id": "a97244e416b60752f3071e465dd63d41",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -131,14 +126,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "74b84618bb90b661d60eef562242c09f",
+    "element_id": "dfd9cc8f70664dc0b785e1f2332a0993",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -154,14 +148,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "192b49818c9f63966481782cee6098ee",
+    "element_id": "d597dda3a2ba146bd314a4d3a92c4aac",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -177,14 +170,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "3152368b27dd71fd69107ed92b118095",
+    "element_id": "5e75c9860459e175f1087efd0dc40972",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -200,14 +192,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "379279d638c2311dd960c82ed43892d4",
+    "element_id": "c41a8ba74f19172536db4877b5e13f7e",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -223,14 +214,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "5e8a2c39eb484d18f982b3a972ac8e63",
+    "element_id": "29d99bc3b2a5fde6029ddfe8b1604f3a",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -246,14 +236,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "988151a26f5792af834d1ef75972a000",
+    "element_id": "589780ba10ade81f721303579ee9bce0",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -269,14 +258,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "efbed9a2ef407ce6f01f2c0b19649c61",
+    "element_id": "7bc5e9d84b41175c9ff8ad841394c2b3",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -292,14 +280,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "fbfa660cc333ebf76ea4e428d4f9b2c7",
+    "element_id": "caab6974e98b9e03c78191c02591775e",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -315,14 +302,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2 testtext2",
     "type": "Title"
   },
   {
-    "element_id": "c04cb8aec98e23a9d76ee495b1ee0cf3",
+    "element_id": "fb956c2b3b6bc34871a42881a9bb7b63",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -338,14 +324,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 List Item 1Testdoc2 List Item 1 Nested Item ATestdoc2 List Item 1 Nested Item B",
     "type": "ListItem"
   },
   {
-    "element_id": "ffeca29c21a76f85df30ba3c33934884",
+    "element_id": "3ca8684b5eaa058dfeba0ce29a0f71cd",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -361,14 +346,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 List Item 2",
     "type": "ListItem"
   },
   {
-    "element_id": "51da759c3236af8ba8db78bf3073eb48",
+    "element_id": "7d021a80087130e7ac662b4218b11fd0",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -384,14 +368,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 List Item 3",
     "type": "ListItem"
   },
   {
-    "element_id": "2debb77da92a8aed2b77daff6a1426f0",
+    "element_id": "550b644ec595cc8bf7e708d025d9cbfc",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -407,14 +390,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 List Item 4",
     "type": "ListItem"
   },
   {
-    "element_id": "420d0c6f47e22d2f00fd6ca7f204bb8c",
+    "element_id": "893e516f50218b5fcc974bfbbfa09e54",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -430,14 +412,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 List Item 5",
     "type": "ListItem"
   },
   {
-    "element_id": "1f1406229cf15df139a62c1298b92c4b",
+    "element_id": "34ca1c89586f687361d40323d1d1e089",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -462,14 +443,13 @@
       ],
       "link_urls": [
         "https://www.unstructured.io/"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "This is the link for unstructured . io.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "72fbf216913c586ac1285c07446e55e1",
+    "element_id": "cbcd197b1d044ea4b71da451273f6695",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -491,14 +471,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 Checklist Item 1",
     "type": "ListItem"
   },
   {
-    "element_id": "a095687b9b0c3eb008b40836f06c90a9",
+    "element_id": "cb303b5226d382a210692c8af82a209c",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -520,14 +499,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 Checklist Item 2 (checked)",
     "type": "ListItem"
   },
   {
-    "element_id": "311e476c48960b926b12a07222ee4b55",
+    "element_id": "74ce8c77f9e995b3a6a8f875b1c769a6",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -549,14 +527,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 Checklist Item 3",
     "type": "ListItem"
   },
   {
-    "element_id": "707db83e91a01d5406d7690ff64672a6",
+    "element_id": "7db875e9d61f74fe42dfd17feeaaa470",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -572,14 +549,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "😃 😃 😃 😃 😃 😃 😃 😃 😃 😃 😃 😃",
     "type": "UncategorizedText"
   },
   {
-    "element_id": "00a741394474c8951363eaac7d3c9c9a",
+    "element_id": "5b94af34bf8e667df31a179a4e9c4f57",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -601,14 +577,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 bold text",
     "type": "NarrativeText"
   },
   {
-    "element_id": "f513bfdce18c859eca131221854e8241",
+    "element_id": "86b950ab73fb5cff558bce55f97edad3",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -630,14 +605,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 italic text",
     "type": "Title"
   },
   {
-    "element_id": "ddd01d57e091c1b0c476c5474a761c0f",
+    "element_id": "6fd66af3449ab45ec24172d7004644af",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -653,14 +627,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 Heading 1 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "cb3c9031e973f35fcc6306ef80514c68",
+    "element_id": "d0c615e86d95ed2535c1da2591e60df6",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -676,14 +649,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 Heading 2 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "0009184908aef19595b65219a242eaea",
+    "element_id": "2f445fe2b559a79b9105cafbb6dc9e6d",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -699,14 +671,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 Heading 3 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "5402f9dd0ca7da2db3e2e75fd3bc2c72",
+    "element_id": "dc21ed2230310b97f88d2204e35e0a54",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -722,14 +693,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 Heading 4 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "0a17c30db07459d93002bdfea7fee6aa",
+    "element_id": "faebbfc5510e489bbab066d312c3b069",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -745,14 +715,13 @@
       "languages": [
         "eng",
         "fra"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc2 Heading 5 Sized Text",
     "type": "Title"
   },
   {
-    "element_id": "24a342664a77bae50ab8b4a58f37d21f",
+    "element_id": "5deb9304a24bd612feb118b3942d7d12",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:39.240000",
@@ -769,7 +738,6 @@
         "eng",
         "fra"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td>Testdoc2 Table: Column 1 Row 0</td><td>Testdoc2 Table: Column 2 Row 0</td><td>Testdoc2 Table: Column 3 Row 0</td></tr><tr><td>Testdoc2 Table: Column 1 Row 1</td><td>Testdoc2 Table: Column 2 Row 1</td><td>Testdoc2 Table: Column 3 Row 1</td></tr><tr><td>Testdoc2 Table: Column 1 Row 2</td><td>Testdoc2 Table: Column 2 Row 2</td><td>Testdoc2 Table: Column 3 Row 2</td></tr></table>"
     },
     "text": "Testdoc2 Table: Column 1 Row 0 Testdoc2 Table: Column 2 Row 0 Testdoc2 Table: Column 3 Row 0 Testdoc2 Table: Column 1 Row 1 Testdoc2 Table: Column 2 Row 1 Testdoc2 Table: Column 3 Row 1 Testdoc2 Table: Column 1 Row 2 Testdoc2 Table: Column 2 Row 2 Testdoc2 Table: Column 3 Row 2",

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1867777.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/1867777.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "9b56cbe96f509d43ba706a4faaf671f0",
+    "element_id": "05ef452e8c54005abc4c0666d8404dfd",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -15,14 +15,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 1",
     "type": "NarrativeText"
   },
   {
-    "element_id": "e89817ef5b10d7bd5cacc62083530114",
+    "element_id": "683293ea6931fb5021d4adaec2c4fce7",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -37,14 +36,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 2",
     "type": "NarrativeText"
   },
   {
-    "element_id": "e38e0e00f7fb8d4b32271530cfde5c3a",
+    "element_id": "54da27b49c6c112ed419e6b8895be2c4",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -59,14 +57,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 3",
     "type": "NarrativeText"
   },
   {
-    "element_id": "3885e42cbd9d0c4c9854475c75450b29",
+    "element_id": "1a9848c57a6d51bdc462e33fbc95602d",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -81,14 +78,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 4",
     "type": "NarrativeText"
   },
   {
-    "element_id": "69e8d160b997383de9ef07ede5fd0693",
+    "element_id": "a30c9fa2274f7308a14fec6454deb88d",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -103,14 +99,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 5",
     "type": "NarrativeText"
   },
   {
-    "element_id": "32bb7799e53f295ef8a92d93634fb753",
+    "element_id": "b030841bd2c052c02beffba231c16613",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -125,14 +120,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 6",
     "type": "NarrativeText"
   },
   {
-    "element_id": "9a2c033a0ae7cbe306a7032162911085",
+    "element_id": "cfc808c5bcc358e14b673d6202c2f09d",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -147,14 +141,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 7",
     "type": "NarrativeText"
   },
   {
-    "element_id": "529da18f70a29f756ffba75f10feefa0",
+    "element_id": "a51cb5b3992630d3bfffe014a285370f",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -169,14 +162,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 8",
     "type": "NarrativeText"
   },
   {
-    "element_id": "bc115408c67b2109fd0730d7fd013e12",
+    "element_id": "f05150f3d4675e976a42a5ea8055b1fe",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -191,14 +183,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 9",
     "type": "NarrativeText"
   },
   {
-    "element_id": "4714a0ee9493d579ec617bda1a900b45",
+    "element_id": "1ad195d0303ee0f0924b4f41b0335a56",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-11T17:01:19.072000",
@@ -213,8 +204,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Testdoc1 has only this text for 10 times: 10",
     "type": "NarrativeText"

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/2589690.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/2589690.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "78df45ee870bd758b1c748e1c593c6df",
+    "element_id": "273902edca72a67af1614267e617ea06",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-13T14:27:12.821000",
@@ -15,8 +15,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Test text",
     "type": "Title"

--- a/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/2589704.json
+++ b/test_unstructured_ingest/expected-structured-output/confluence-diff/testteamsp/2589704.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "f273c4bc5102c3e9b7463be8210ad7ab",
+    "element_id": "9c477a45b1db458b12a2a350ecb57a36",
     "metadata": {
       "data_source": {
         "date_created": "2023-07-13T14:28:06.310000",
@@ -15,8 +15,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Test text",
     "type": "Title"

--- a/test_unstructured_ingest/expected-structured-output/dropbox/nested-1/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/dropbox/nested-1/ideas-page.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "b7b1c359c06495bd6fe8e174b2a9908f",
+    "element_id": "32bc8af17151389d3e80f65036f8e65b",
     "metadata": {
       "data_source": {
         "record_locator": {
@@ -14,7 +14,6 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>"
     },
     "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",

--- a/test_unstructured_ingest/expected-structured-output/dropbox/nested-2/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/dropbox/nested-2/ideas-page.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "b7b1c359c06495bd6fe8e174b2a9908f",
+    "element_id": "32bc8af17151389d3e80f65036f8e65b",
     "metadata": {
       "data_source": {
         "record_locator": {
@@ -14,7 +14,6 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>"
     },
     "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",

--- a/test_unstructured_ingest/expected-structured-output/gcs/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/gcs/ideas-page.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "b7b1c359c06495bd6fe8e174b2a9908f",
+    "element_id": "32bc8af17151389d3e80f65036f8e65b",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-20T23:49:31.038000+00:00",
@@ -16,7 +16,6 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>"
     },
     "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",

--- a/test_unstructured_ingest/expected-structured-output/gcs/nested-1/nested/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/gcs/nested-1/nested/ideas-page.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "b7b1c359c06495bd6fe8e174b2a9908f",
+    "element_id": "32bc8af17151389d3e80f65036f8e65b",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-20T23:48:13.750000+00:00",
@@ -16,7 +16,6 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>"
     },
     "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",

--- a/test_unstructured_ingest/expected-structured-output/gcs/nested-2/nested/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/gcs/nested-2/nested/ideas-page.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "b7b1c359c06495bd6fe8e174b2a9908f",
+    "element_id": "32bc8af17151389d3e80f65036f8e65b",
     "metadata": {
       "data_source": {
         "date_created": "2023-06-20T23:48:24.586000+00:00",
@@ -16,7 +16,6 @@
       "languages": [
         "eng"
       ],
-      "page_number": 1,
       "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>"
     },
     "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",

--- a/test_unstructured_ingest/expected-structured-output/github/test.html.json
+++ b/test_unstructured_ingest/expected-structured-output/github/test.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "3223d6a33166a8c5c464b9726d609925",
+    "element_id": "218722ac66e142a570ab2053b430c6c4",
     "metadata": {
       "data_source": {
         "date_modified": "2010-01-23T23:18:40",
@@ -14,14 +14,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Downloadify Example",
     "type": "Title"
   },
   {
-    "element_id": "bc3bc4f4fcca56a055650a485a8cbb18",
+    "element_id": "bf0fab1925c4b2cbb23a53afce28ebd2",
     "metadata": {
       "data_source": {
         "date_modified": "2010-01-23T23:18:40",
@@ -44,14 +43,13 @@
       ],
       "link_urls": [
         "http://github.com/dcneiner/Downloadify"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "More info available at the Github Project Page",
     "type": "Title"
   },
   {
-    "element_id": "77c31f18a75cde83aee435615eebcc81",
+    "element_id": "d31b62e7e93ed0f7cdebc476a335b3b7",
     "metadata": {
       "data_source": {
         "date_modified": "2010-01-23T23:18:40",
@@ -65,14 +63,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Filename",
     "type": "Title"
   },
   {
-    "element_id": "5f70a0a170439dfafbb7fa107f37f4eb",
+    "element_id": "3cc4ede1735d2fe4f5e3f7e5aa29f277",
     "metadata": {
       "data_source": {
         "date_modified": "2010-01-23T23:18:40",
@@ -86,14 +83,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "File Contents",
     "type": "Title"
   },
   {
-    "element_id": "de83f06b2b2af045473b428b52ef037d",
+    "element_id": "4064323aa25900cf4cb136f665a2aa06",
     "metadata": {
       "data_source": {
         "date_modified": "2010-01-23T23:18:40",
@@ -107,14 +103,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Whatever you put in this text box will be downloaded and saved in the file. If you leave it blank, no file will be downloaded",
     "type": "NarrativeText"
   },
   {
-    "element_id": "f1b2d229355f02158e09d4b8c3c2cd69",
+    "element_id": "4a6c95c31bb76c1c7f818ca31ea6e0a6",
     "metadata": {
       "data_source": {
         "date_modified": "2010-01-23T23:18:40",
@@ -128,14 +123,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "You must have Flash 10 installed to download this file.",
     "type": "NarrativeText"
   },
   {
-    "element_id": "cc31bfb2c9233c850f7924fb3bc43f89",
+    "element_id": "6eeead38cfa3d4b7462eb9042aead2c4",
     "metadata": {
       "data_source": {
         "date_modified": "2010-01-23T23:18:40",
@@ -149,14 +143,13 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Downloadify Invoke Script For This Page",
     "type": "Title"
   },
   {
-    "element_id": "d89aec93c26ff28fb2cf35a8336cd856",
+    "element_id": "69aedad22d0d13473663cb65051284a0",
     "metadata": {
       "data_source": {
         "date_modified": "2010-01-23T23:18:40",
@@ -170,8 +163,7 @@
       "filetype": "text/html",
       "languages": [
         "eng"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Downloadify.create('downloadify',{\n  filename: function(){\n    return document.getElementById('filename').value;\n  },\n  data: function(){ \n    return document.getElementById('data').value;\n  },\n  onComplete: function(){ \n    alert('Your File Has Been Saved!'); \n  },\n  onCancel: function(){ \n    alert('You have cancelled the saving of this file.');\n  },\n  onError: function(){ \n    alert('You must put something in the File Contents or there will be nothing to save!'); \n  },\n  swf: 'media/downloadify.swf',\n  downloadImage: 'images/download.png',\n  width: 100,\n  height: 30,\n  transparent: true,\n  append: false\n});",
     "type": "NarrativeText"

--- a/test_unstructured_ingest/expected-structured-output/local-single-file-with-encoding/fake-html-cp1252.html.json
+++ b/test_unstructured_ingest/expected-structured-output/local-single-file-with-encoding/fake-html-cp1252.html.json
@@ -1,6 +1,6 @@
 [
   {
-    "element_id": "6d81b14abb68dd983ee32280d93c3e59",
+    "element_id": "a59f117741c76dca0bc8f5ee72e2010b",
     "metadata": {
       "data_source": {
         "permissions_data": [
@@ -16,14 +16,13 @@
         "cat",
         "eng",
         "vie"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "My First Heading",
     "type": "Title"
   },
   {
-    "element_id": "514c3b14e786d9a2ab43e7ec7b2f724b",
+    "element_id": "82eda2671c5ead903683b67b0f8e3f29",
     "metadata": {
       "data_source": {
         "permissions_data": [
@@ -39,14 +38,13 @@
         "cat",
         "eng",
         "vie"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "My first paragraph.",
     "type": "Title"
   },
   {
-    "element_id": "756f407ce499d5bebe8914e15f45049a",
+    "element_id": "9f76e487d5df3f6c4ce8ea2ece61057f",
     "metadata": {
       "data_source": {
         "permissions_data": [
@@ -62,14 +60,13 @@
         "cat",
         "eng",
         "vie"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "Some CP1252-specific characters:",
     "type": "Title"
   },
   {
-    "element_id": "218c8916f8db5ea8900d2101b37e2cbb",
+    "element_id": "a7394a14aa8bf2dae179420d96ac755c",
     "metadata": {
       "data_source": {
         "permissions_data": [
@@ -85,8 +82,7 @@
         "cat",
         "eng",
         "vie"
-      ],
-      "page_number": 1
+      ]
     },
     "text": "¡\t¢\t£\t¤\t¥\t¦\t§\t¨\t©\tª\t«\t¬\tSHY\t®\t¯\n°\t±\t²\t³\t´\tµ\t¶\t·\t¸\t¹\tº\t»\t¼\t½\t¾\t¿\nÀ\tÁ\tÂ\tÃ\tÄ\tÅ\tÆ\tÇ\tÈ\tÉ\tÊ\tË\tÌ\tÍ\tÎ\tÏ\nÐ\tÑ\tÒ\tÓ\tÔ\tÕ\tÖ\t×\tØ\tÙ\tÚ\tÛ\tÜ\tÝ\tÞ\tß\nà\tá\tâ\tã\tä\tå\tæ\tç\tè\té\tê\të\tì\tí\tî\tï\nð\tñ\tò\tó\tô\tõ\tö\t÷\tø\tù\tú\tû\tü\tý\tþ\tÿ",
     "type": "NarrativeText"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.5"  # pragma: no cover
+__version__ = "0.13.6"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.7"  # pragma: no cover
+__version__ = "0.13.7-dev0"  # pragma: no cover

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -142,7 +142,7 @@ def partition_html(
     if skip_headers_and_footers:
         document = filter_footer_and_header(document)
 
-    return list(
+    elements = list(
         apply_lang_metadata(
             document_to_element_list(
                 document,
@@ -157,6 +157,13 @@ def partition_html(
             detect_language_per_element=detect_language_per_element,
         ),
     )
+
+    # Note(yuming): Rip off page_number metadata fields here
+    # until we have a better way to handle page counting for html files
+    for element in elements:
+        if hasattr(element.metadata, "page_number"):
+            element.metadata.page_number = None
+    return elements
 
 
 def convert_and_partition_html(


### PR DESCRIPTION
### Summary

Rip off page_number metadata fields until we have page counting for all kinds of html files (not just limited to news articles with multiple `<article>` tag)

### Test
Unit tests `test_add_chunking_strategy_on_partition_html_respects_multipage` and `test_add_chunking_strategy_title_on_partition_auto_respects_multipage` removed since they relay on the `page_number` fields from the SEC html file - now test moved to mock test for chunk_by_title -> revisit those tests when we find test file for this

Also changed the element ids from partition outputs for html files - element id change due to page number change (in element id hashing) -> todo ticket: update other deterministic element id tests per crag's comment