### PR TITLE
chore: update python-docx version dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.13.7-dev0
+## 0.13.7-dev1
 
 ### Enhancements
+
 * **Remove `page_number` metadata fields** for HTML partition until we have a better strategy to decide page counting.
 
 ### Features

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -52,7 +52,7 @@ mdit-py-plugins==0.4.0
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-myst-parser==3.0.0
+myst-parser==3.0.1
     # via -r ./build.in
 packaging==23.2
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ charset-normalizer==3.3.2
     #   unstructured-client
 click==8.1.7
     # via nltk
-dataclasses-json==0.6.4
+dataclasses-json==0.6.5
     # via -r ./base.in
 dataclasses-json-speakeasy==0.5.11
     # via unstructured-client
@@ -39,10 +39,8 @@ jsonpath-python==1.0.6
     # via unstructured-client
 langdetect==1.0.9
     # via -r ./base.in
-lxml==4.9.4
-    # via
-    #   -c ././deps/constraints.txt
-    #   -r ./base.in
+lxml==5.2.1
+    # via -r ./base.in
 marshmallow==3.21.1
     # via
     #   dataclasses-json
@@ -63,13 +61,13 @@ packaging==23.2
     #   unstructured-client
 python-dateutil==2.9.0.post0
     # via unstructured-client
-python-iso639==2024.2.7
+python-iso639==2024.4.27
     # via -r ./base.in
 python-magic==0.4.27
     # via -r ./base.in
 rapidfuzz==3.8.1
     # via -r ./base.in
-regex==2024.4.16
+regex==2024.4.28
     # via nltk
 requests==2.31.0
     # via

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -52,7 +52,7 @@ mdit-py-plugins==0.4.0
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-myst-parser==3.0.0
+myst-parser==3.0.1
     # via -r ./build.in
 packaging==23.2
     # via

--- a/requirements/deps/constraints.txt
+++ b/requirements/deps/constraints.txt
@@ -38,6 +38,10 @@ opencv-python==4.8.0.76
 opencv-contrib-python==4.8.0.76
 platformdirs==3.10.0
 
+# Note(scanny): partition_docx() uses table features added in python-docx v1.1.2. Added here since
+# multiple formats have a python-docx dependency (docx, odt)
+python-docx>=1.1.2
+
 # TODO: Constraint due to langchain, remove when that gets updated:
 packaging<24.0
 
@@ -47,9 +51,6 @@ urllib3<1.27
 
 # TODO: Constriant due to aiobotocore, remove when that gets updates:
 botocore<1.34.52
-
-# TODO: constraint due to current release of pikepdf (v8.14.0), remove once next version releases since fix is on main
-lxml<5
 
 # NOTE(jennings): pinned due to later versions not supporting api_key_auth in UnstructuredClient
 unstructured-client<=0.18.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -81,7 +81,7 @@ executing==2.0.1
     # via stack-data
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.4
+filelock==3.14.0
     # via virtualenv
 fqdn==1.5.1
     # via jsonschema
@@ -138,7 +138,7 @@ json5==0.9.25
     # via jupyterlab-server
 jsonpointer==2.4
     # via jsonschema
-jsonschema[format-nongpl]==4.21.1
+jsonschema[format-nongpl]==4.22.0
     # via
     #   jupyter-events
     #   jupyterlab-server
@@ -203,7 +203,7 @@ mistune==3.0.2
     # via nbconvert
 nbclient==0.10.0
     # via nbconvert
-nbconvert==7.16.3
+nbconvert==7.16.4
     # via
     #   jupyter
     #   jupyter-server
@@ -277,7 +277,7 @@ pygments==2.17.2
     #   jupyter-console
     #   nbconvert
     #   qtconsole
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
@@ -294,7 +294,7 @@ pyyaml==6.0.1
     #   -c ./test.txt
     #   jupyter-events
     #   pre-commit
-pyzmq==26.0.2
+pyzmq==26.0.3
     # via
     #   ipykernel
     #   jupyter-client
@@ -305,7 +305,7 @@ qtconsole==5.5.1
     # via jupyter
 qtpy==2.4.1
     # via qtconsole
-referencing==0.35.0
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -359,7 +359,6 @@ tomli==2.0.1
     #   build
     #   jupyterlab
     #   pip-tools
-    #   pyproject-hooks
 tornado==6.4
     # via
     #   ipykernel
@@ -401,7 +400,7 @@ urllib3==1.26.18
     #   -c ./base.txt
     #   -c ./test.txt
     #   requests
-virtualenv==20.26.0
+virtualenv==20.26.1
     # via pre-commit
 wcwidth==0.2.13
     # via prompt-toolkit

--- a/requirements/extra-docx.txt
+++ b/requirements/extra-docx.txt
@@ -4,13 +4,14 @@
 #
 #    pip-compile ./extra-docx.in
 #
-lxml==4.9.4
+lxml==5.2.1
     # via
-    #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   python-docx
-python-docx==1.1.0
-    # via -r ./extra-docx.in
+python-docx==1.1.2
+    # via
+    #   -c ././deps/constraints.txt
+    #   -r ./extra-docx.in
 typing-extensions==4.11.0
     # via
     #   -c ./base.txt

--- a/requirements/extra-odt.txt
+++ b/requirements/extra-odt.txt
@@ -4,15 +4,16 @@
 #
 #    pip-compile ./extra-odt.in
 #
-lxml==4.9.4
+lxml==5.2.1
     # via
-    #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   python-docx
 pypandoc==1.13
     # via -r ./extra-odt.in
-python-docx==1.1.0
-    # via -r ./extra-odt.in
+python-docx==1.1.2
+    # via
+    #   -c ././deps/constraints.txt
+    #   -r ./extra-odt.in
 typing-extensions==4.11.0
     # via
     #   -c ./base.txt

--- a/requirements/extra-paddleocr.txt
+++ b/requirements/extra-paddleocr.txt
@@ -10,7 +10,7 @@ babel==2.14.0
     # via flask-babel
 bce-python-sdk==0.9.7
     # via visualdl
-blinker==1.8.0
+blinker==1.8.1
     # via flask
 cachetools==5.3.3
     # via premailer
@@ -77,9 +77,8 @@ lazy-loader==0.4
     # via scikit-image
 lmdb==1.4.1
     # via unstructured-paddleocr
-lxml==4.9.4
+lxml==5.2.1
     # via
-    #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   premailer
     #   unstructured-paddleocr

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -32,7 +32,7 @@ deprecated==1.2.14
     # via pikepdf
 effdet==0.4.1
     # via layoutparser
-filelock==3.13.4
+filelock==3.14.0
     # via
     #   huggingface-hub
     #   torch
@@ -45,8 +45,10 @@ fsspec==2024.3.1
     # via
     #   huggingface-hub
     #   torch
-google-api-core[grpc]==2.18.0
-    # via google-cloud-vision
+google-api-core[grpc]==2.19.0
+    # via
+    #   google-api-core
+    #   google-cloud-vision
 google-auth==2.29.0
     # via
     #   google-api-core
@@ -57,7 +59,7 @@ googleapis-common-protos==1.63.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.62.2
+grpcio==1.63.0
     # via
     #   google-api-core
     #   grpcio-status
@@ -85,9 +87,8 @@ kiwisolver==1.4.5
     # via matplotlib
 layoutparser[layoutmodels,tesseract]==0.3.4
     # via unstructured-inference
-lxml==4.9.4
+lxml==5.2.1
     # via
-    #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   pikepdf
 markupsafe==2.1.5
@@ -223,7 +224,7 @@ rapidfuzz==3.8.1
     # via
     #   -c ./base.txt
     #   unstructured-inference
-regex==2024.4.16
+regex==2024.4.28
     # via
     #   -c ./base.txt
     #   transformers

--- a/requirements/extra-pptx.txt
+++ b/requirements/extra-pptx.txt
@@ -4,10 +4,8 @@
 #
 #    pip-compile ./extra-pptx.in
 #
-lxml==4.9.4
-    # via
-    #   -c ././deps/constraints.txt
-    #   python-pptx
+lxml==5.2.1
+    # via python-pptx
 pillow==10.3.0
     # via python-pptx
 python-pptx==0.6.23

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -17,7 +17,7 @@ click==8.1.7
     # via
     #   -c ./base.txt
     #   sacremoses
-filelock==3.13.4
+filelock==3.14.0
     # via
     #   huggingface-hub
     #   torch
@@ -64,7 +64,7 @@ pyyaml==6.0.1
     # via
     #   huggingface-hub
     #   transformers
-regex==2024.4.16
+regex==2024.4.28
     # via
     #   -c ./base.txt
     #   sacremoses

--- a/requirements/ingest/astra.txt
+++ b/requirements/ingest/astra.txt
@@ -46,7 +46,9 @@ hpack==4.0.0
 httpcore==1.0.5
     # via httpx
 httpx[http2]==0.27.0
-    # via astrapy
+    # via
+    #   astrapy
+    #   httpx
 hyperframe==6.0.1
     # via h2
 idna==3.7

--- a/requirements/ingest/azure.txt
+++ b/requirements/ingest/azure.txt
@@ -80,7 +80,9 @@ portalocker==2.8.2
 pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.8.0
-    # via msal
+    # via
+    #   msal
+    #   pyjwt
 requests==2.31.0
     # via
     #   -c ./ingest/../base.txt

--- a/requirements/ingest/box.txt
+++ b/requirements/ingest/box.txt
@@ -9,7 +9,9 @@ attrs==23.2.0
 boxfs==0.3.0
     # via -r ./ingest/box.in
 boxsdk[jwt]==3.9.2
-    # via boxfs
+    # via
+    #   boxfs
+    #   boxsdk
 certifi==2024.2.2
     # via
     #   -c ./ingest/../base.txt

--- a/requirements/ingest/chroma.txt
+++ b/requirements/ingest/chroma.txt
@@ -46,9 +46,9 @@ deprecated==1.2.14
     # via opentelemetry-api
 exceptiongroup==1.2.1
     # via anyio
-fastapi==0.110.2
+fastapi==0.110.3
     # via chromadb
-filelock==3.13.4
+filelock==3.14.0
     # via huggingface-hub
 flatbuffers==24.3.25
     # via onnxruntime
@@ -58,7 +58,7 @@ google-auth==2.29.0
     # via kubernetes
 googleapis-common-protos==1.63.0
     # via opentelemetry-exporter-otlp-proto-grpc
-grpcio==1.62.2
+grpcio==1.63.0
     # via
     #   chromadb
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -214,7 +214,9 @@ urllib3==1.26.18
     #   kubernetes
     #   requests
 uvicorn[standard]==0.29.0
-    # via chromadb
+    # via
+    #   chromadb
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 watchfiles==0.21.0

--- a/requirements/ingest/clarifai.txt
+++ b/requirements/ingest/clarifai.txt
@@ -21,7 +21,7 @@ contextlib2==21.6.0
     # via schema
 googleapis-common-protos==1.63.0
     # via clarifai-grpc
-grpcio==1.62.2
+grpcio==1.63.0
     # via clarifai-grpc
 idna==3.7
     # via

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -30,7 +30,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-dataclasses-json==0.6.4
+dataclasses-json==0.6.5
     # via
     #   -c ./ingest/../base.txt
     #   langchain-community
@@ -51,11 +51,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==2.4
     # via jsonpatch
-langchain-community==0.0.34
+langchain-community==0.0.36
     # via -r ./ingest/embed-aws-bedrock.in
-langchain-core==0.1.46
+langchain-core==0.1.48
     # via langchain-community
-langsmith==0.1.51
+langsmith==0.1.52
     # via
     #   langchain-community
     #   langchain-core
@@ -75,7 +75,7 @@ numpy==1.26.4
     # via
     #   -c ./ingest/../base.txt
     #   langchain-community
-orjson==3.10.1
+orjson==3.10.2
     # via langsmith
 packaging==23.2
     # via

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -23,11 +23,11 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-dataclasses-json==0.6.4
+dataclasses-json==0.6.5
     # via
     #   -c ./ingest/../base.txt
     #   langchain-community
-filelock==3.13.4
+filelock==3.14.0
     # via
     #   huggingface-hub
     #   torch
@@ -62,11 +62,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==2.4
     # via jsonpatch
-langchain-community==0.0.34
+langchain-community==0.0.36
     # via -r ./ingest/embed-huggingface.in
-langchain-core==0.1.46
+langchain-core==0.1.48
     # via langchain-community
-langsmith==0.1.51
+langsmith==0.1.52
     # via
     #   langchain-community
     #   langchain-core
@@ -96,7 +96,7 @@ numpy==1.26.4
     #   scipy
     #   sentence-transformers
     #   transformers
-orjson==3.10.1
+orjson==3.10.2
     # via langsmith
 packaging==23.2
     # via
@@ -120,7 +120,7 @@ pyyaml==6.0.1
     #   langchain-community
     #   langchain-core
     #   transformers
-regex==2024.4.16
+regex==2024.4.28
     # via
     #   -c ./ingest/../base.txt
     #   transformers
@@ -150,7 +150,7 @@ tenacity==8.2.3
     # via
     #   langchain-community
     #   langchain-core
-threadpoolctl==3.4.0
+threadpoolctl==3.5.0
     # via scikit-learn
 tokenizers==0.19.1
     # via transformers

--- a/requirements/ingest/embed-octoai.txt
+++ b/requirements/ingest/embed-octoai.txt
@@ -38,13 +38,13 @@ idna==3.7
     #   anyio
     #   httpx
     #   requests
-openai==1.23.6
+openai==1.25.0
     # via -r ./ingest/embed-octoai.in
 pydantic==2.7.1
     # via openai
 pydantic-core==2.18.2
     # via pydantic
-regex==2024.4.16
+regex==2024.4.28
     # via
     #   -c ./ingest/../base.txt
     #   tiktoken

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -30,7 +30,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-dataclasses-json==0.6.4
+dataclasses-json==0.6.5
     # via
     #   -c ./ingest/../base.txt
     #   langchain-community
@@ -59,11 +59,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==2.4
     # via jsonpatch
-langchain-community==0.0.34
+langchain-community==0.0.36
     # via -r ./ingest/embed-openai.in
-langchain-core==0.1.46
+langchain-core==0.1.48
     # via langchain-community
-langsmith==0.1.51
+langsmith==0.1.52
     # via
     #   langchain-community
     #   langchain-core
@@ -83,9 +83,9 @@ numpy==1.26.4
     # via
     #   -c ./ingest/../base.txt
     #   langchain-community
-openai==1.23.6
+openai==1.25.0
     # via -r ./ingest/embed-openai.in
-orjson==3.10.1
+orjson==3.10.2
     # via langsmith
 packaging==23.2
     # via
@@ -104,7 +104,7 @@ pyyaml==6.0.1
     # via
     #   langchain-community
     #   langchain-core
-regex==2024.4.16
+regex==2024.4.28
     # via
     #   -c ./ingest/../base.txt
     #   tiktoken

--- a/requirements/ingest/embed-vertexai.txt
+++ b/requirements/ingest/embed-vertexai.txt
@@ -29,7 +29,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-dataclasses-json==0.6.4
+dataclasses-json==0.6.5
     # via
     #   -c ./ingest/../base.txt
     #   langchain
@@ -40,8 +40,9 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-google-api-core[grpc]==2.18.0
+google-api-core[grpc]==2.19.0
     # via
+    #   google-api-core
     #   google-cloud-aiplatform
     #   google-cloud-bigquery
     #   google-cloud-core
@@ -55,7 +56,7 @@ google-auth==2.29.0
     #   google-cloud-core
     #   google-cloud-resource-manager
     #   google-cloud-storage
-google-cloud-aiplatform==1.48.0
+google-cloud-aiplatform==1.49.0
     # via langchain-google-vertexai
 google-cloud-bigquery==3.21.0
     # via google-cloud-aiplatform
@@ -84,7 +85,7 @@ googleapis-common-protos[grpc]==1.63.0
     #   grpcio-status
 grpc-google-iam-v1==0.13.0
     # via google-cloud-resource-manager
-grpcio==1.62.2
+grpcio==1.63.0
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -103,23 +104,23 @@ jsonpatch==1.33
     #   langchain-core
 jsonpointer==2.4
     # via jsonpatch
-langchain==0.1.16
+langchain==0.1.17
     # via -r ./ingest/embed-vertexai.in
-langchain-community==0.0.34
+langchain-community==0.0.36
     # via
     #   -r ./ingest/embed-vertexai.in
     #   langchain
-langchain-core==0.1.46
+langchain-core==0.1.48
     # via
     #   langchain
     #   langchain-community
     #   langchain-google-vertexai
     #   langchain-text-splitters
-langchain-google-vertexai==1.0.2
+langchain-google-vertexai==1.0.3
     # via -r ./ingest/embed-vertexai.in
 langchain-text-splitters==0.0.1
     # via langchain
-langsmith==0.1.51
+langsmith==0.1.52
     # via
     #   langchain
     #   langchain-community
@@ -142,7 +143,7 @@ numpy==1.26.4
     #   langchain
     #   langchain-community
     #   shapely
-orjson==3.10.1
+orjson==3.10.2
     # via langsmith
 packaging==23.2
     # via

--- a/requirements/ingest/gcs.txt
+++ b/requirements/ingest/gcs.txt
@@ -41,7 +41,7 @@ fsspec==2024.3.1
     #   gcsfs
 gcsfs==2024.3.1
     # via -r ./ingest/gcs.in
-google-api-core==2.18.0
+google-api-core==2.19.0
     # via
     #   google-cloud-core
     #   google-cloud-storage

--- a/requirements/ingest/github.txt
+++ b/requirements/ingest/github.txt
@@ -30,7 +30,9 @@ pycparser==2.22
 pygithub==2.3.0
     # via -r ./ingest/github.in
 pyjwt[crypto]==2.8.0
-    # via pygithub
+    # via
+    #   pygithub
+    #   pyjwt
 pynacl==1.5.0
     # via pygithub
 requests==2.31.0

--- a/requirements/ingest/google-drive.txt
+++ b/requirements/ingest/google-drive.txt
@@ -15,7 +15,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-google-api-core==2.18.0
+google-api-core==2.19.0
     # via google-api-python-client
 google-api-python-client==2.127.0
     # via -r ./ingest/google-drive.in

--- a/requirements/ingest/mongodb.txt
+++ b/requirements/ingest/mongodb.txt
@@ -6,5 +6,5 @@
 #
 dnspython==2.6.1
     # via pymongo
-pymongo==4.7.0
+pymongo==4.7.1
     # via -r ./ingest/mongodb.in

--- a/requirements/ingest/onedrive.txt
+++ b/requirements/ingest/onedrive.txt
@@ -40,7 +40,9 @@ office365-rest-python-client==2.4.2
 pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.8.0
-    # via msal
+    # via
+    #   msal
+    #   pyjwt
 pytz==2024.1
     # via office365-rest-python-client
 requests==2.31.0

--- a/requirements/ingest/outlook.txt
+++ b/requirements/ingest/outlook.txt
@@ -34,7 +34,9 @@ office365-rest-python-client==2.4.2
 pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.8.0
-    # via msal
+    # via
+    #   msal
+    #   pyjwt
 pytz==2024.1
     # via office365-rest-python-client
 requests==2.31.0

--- a/requirements/ingest/qdrant.txt
+++ b/requirements/ingest/qdrant.txt
@@ -18,7 +18,7 @@ certifi==2024.2.2
     #   httpx
 exceptiongroup==1.2.1
     # via anyio
-grpcio==1.62.2
+grpcio==1.63.0
     # via
     #   grpcio-tools
     #   qdrant-client
@@ -33,7 +33,9 @@ hpack==4.0.0
 httpcore==1.0.5
     # via httpx
 httpx[http2]==0.27.0
-    # via qdrant-client
+    # via
+    #   httpx
+    #   qdrant-client
 hyperframe==6.0.1
     # via h2
 idna==3.7

--- a/requirements/ingest/salesforce.txt
+++ b/requirements/ingest/salesforce.txt
@@ -25,10 +25,9 @@ idna==3.7
     #   requests
 isodate==0.6.1
     # via zeep
-lxml==4.9.4
+lxml==5.2.1
     # via
     #   -c ./ingest/../base.txt
-    #   -c ./ingest/../deps/constraints.txt
     #   zeep
 more-itertools==10.2.0
     # via simple-salesforce

--- a/requirements/ingest/sharepoint.txt
+++ b/requirements/ingest/sharepoint.txt
@@ -34,7 +34,9 @@ office365-rest-python-client==2.4.2
 pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.8.0
-    # via msal
+    # via
+    #   msal
+    #   pyjwt
 pytz==2024.1
     # via office365-rest-python-client
 requests==2.31.0

--- a/requirements/ingest/weaviate.txt
+++ b/requirements/ingest/weaviate.txt
@@ -29,7 +29,7 @@ cryptography==42.0.5
     # via authlib
 exceptiongroup==1.2.1
     # via anyio
-grpcio==1.62.2
+grpcio==1.63.0
     # via
     #   grpcio-health-checking
     #   grpcio-tools
@@ -79,9 +79,9 @@ urllib3==1.26.18
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   requests
-validators==0.28.0
+validators==0.28.1
     # via weaviate-client
-weaviate-client==4.5.6
+weaviate-client==4.5.7
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/weaviate.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -39,7 +39,7 @@ flake8-print==5.0.0
     # via -r ./test.in
 freezegun==1.5.0
     # via -r ./test.in
-grpcio==1.62.2
+grpcio==1.63.0
     # via -r ./test.in
 idna==3.7
     # via
@@ -50,11 +50,10 @@ iniconfig==2.0.0
     # via pytest
 label-studio-sdk==0.0.32
     # via -r ./test.in
-label-studio-tools==0.0.3
+label-studio-tools==0.0.4
     # via label-studio-sdk
-lxml==4.9.4
+lxml==5.2.1
     # via
-    #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   label-studio-sdk
     #   label-studio-tools
@@ -97,7 +96,7 @@ pyflakes==3.2.0
     # via
     #   autoflake
     #   flake8
-pytest==8.1.2
+pytest==8.2.0
     # via
     #   pytest-cov
     #   pytest-mock

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.7-dev0"  # pragma: no cover
+__version__ = "0.13.7-dev1"  # pragma: no cover


### PR DESCRIPTION
**Summary**
`unstructured` will use table features added in the most recent version of `python-docx`.

Also update the `lxml` version constraint because `lxml>4.9.2` will not install on Apple Silicon (https://github.com/Unstructured-IO/unstructured/issues/1707).

`python-docx` requires `lxml` although other file formats require it as well.