### PR TITLE
fix(test): Remedy macOS-only test failure not triggered by CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.7-dev3
+## 0.13.7-dev4
 
 ### Enhancements
 
@@ -9,6 +9,7 @@
 ### Fixes
 
 * **`partition_docx()` handles short table rows.** The DOCX format allows a table row to start late and/or end early, meaning cells at the beginning or end of a row can be omitted. While there are legitimate uses for this capability, using it in practice is relatively rare. However, it can happen unintentionally when adjusting cell borders with the mouse. Accommodate this case and generate accurate `.text` and `.metadata.text_as_html` for these tables.
+* **Remedy macOS test failure not triggered by CI.** Generalize temp-file detection beyond hard-coded Linux-specific prefix.
 
 ## 0.13.6
 

--- a/test_unstructured/partition/docx/test_doc.py
+++ b/test_unstructured/partition/docx/test_doc.py
@@ -251,6 +251,21 @@ def test_partition_doc_suppresses_modified_date_from_file_by_default(mocker: Moc
     assert elements[0].metadata.last_modified is None
 
 
+def test_partition_doc_pulls_modified_date_from_file_when_date_from_file_object_arg_is_True(
+    mocker: MockFixture,
+):
+    modified_date_on_file = "2024-05-01T09:24:28"
+    mocker.patch(
+        "unstructured.partition.doc.get_last_modified_date_from_file",
+        return_value=modified_date_on_file,
+    )
+
+    with open(example_doc_path("fake.doc"), "rb") as f:
+        elements = partition_doc(file=f, date_from_file_object=True)
+
+    assert elements[0].metadata.last_modified == modified_date_on_file
+
+
 def test_partition_doc_from_file_explicit_get_metadata_date(
     mocker,
     filename="example-docs/fake.doc",

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.7-dev3"  # pragma: no cover
+__version__ = "0.13.7-dev4"  # pragma: no cover

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -69,7 +69,12 @@ from unstructured.partition.text_type import (
     is_possible_title,
     is_us_city_state_zip,
 )
-from unstructured.utils import dependency_exists, lazyproperty, requires_dependencies
+from unstructured.utils import (
+    dependency_exists,
+    is_temp_file_path,
+    lazyproperty,
+    requires_dependencies,
+)
 
 if dependency_exists("pypandoc"):
     import pypandoc
@@ -772,7 +777,7 @@ class _DocxPartitioner:
 
         # -- if the file is on the filesystem, get its date from there --
         if file_path is not None:
-            return None if file_path.startswith("/tmp") else get_last_modified_date(file_path)
+            return None if is_temp_file_path(file_path) else get_last_modified_date(file_path)
 
         # -- otherwise, as long as user explicitly requested it, try getting it from the file-like
         # -- object (unlikely since BytesIO and its brethren have no such metadata).

--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -47,7 +47,7 @@ from unstructured.partition.text_type import (
     is_possible_title,
 )
 from unstructured.partition.utils.constants import PartitionStrategy
-from unstructured.utils import lazyproperty
+from unstructured.utils import is_temp_file_path, lazyproperty
 
 DETECTION_ORIGIN = "pptx"
 
@@ -442,7 +442,7 @@ class PptxPartitionerOptions:
         if self._file_path:
             return (
                 None
-                if self._file_path.startswith("/tmp")
+                if is_temp_file_path(self._file_path)
                 else get_last_modified_date(self._file_path)
             )
 

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import subprocess
+import tempfile
 import threading
 from datetime import datetime
 from functools import wraps
@@ -73,6 +74,15 @@ def htmlify_matrix_of_cell_texts(matrix: Sequence[Sequence[str]]) -> str:
             yield f"<td>{s.strip()}</td>"
 
     return f"<table>{''.join(iter_trs(matrix))}</table>" if matrix else ""
+
+
+def is_temp_file_path(file_path: str) -> bool:
+    """True when file_path is in the Python-defined tempdir.
+
+    The Python-defined temp directory is platform dependent (macOS != Linux != Windows)
+    and can also be determined by an environment variable (TMPDIR, TEMP, or TMP).
+    """
+    return file_path.startswith(tempfile.gettempdir())
 
 
 class lazyproperty(Generic[_T]):


### PR DESCRIPTION
**Summary**
A crude and OS-specific mechanism was used to detect when a path represented a temp-file. Change that to be robust across operating systems and localized configurations. The specific problem was for DOC files but this PR fixes it for PPT too which was prone to the same problem.