### PR TITLE
rfctr improve partitioner typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.7-dev4
+## 0.13.7-dev5
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.7-dev4"  # pragma: no cover
+__version__ = "0.13.7-dev5"  # pragma: no cover

--- a/unstructured/partition/api.py
+++ b/unstructured/partition/api.py
@@ -1,10 +1,8 @@
+from __future__ import annotations
+
 import contextlib
 import json
-from typing import (
-    IO,
-    List,
-    Optional,
-)
+from typing import IO, Optional
 
 import requests
 from unstructured_client import UnstructuredClient
@@ -25,7 +23,7 @@ def partition_via_api(
     api_key: str = "",
     metadata_filename: Optional[str] = None,
     **request_kwargs,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions a document using the Unstructured REST API. This is equivalent to
     running the document through partition.
 
@@ -84,10 +82,7 @@ def partition_via_api(
                 "If file is specified in partition_via_api, "
                 "metadata_filename must be specified as well.",
             )
-        files = shared.Files(
-            content=file,
-            file_name=metadata_filename,
-        )
+        files = shared.Files(content=file, file_name=metadata_filename)
 
     # NOTE(christine): Converts all list type parameters to JSON formatted strings
     # (e.g. ["image", "table"] -> '["image", "table"]')
@@ -96,10 +91,7 @@ def partition_via_api(
         if isinstance(v, list):
             request_kwargs[k] = json.dumps(v)
 
-    req = shared.PartitionParameters(
-        files=files,
-        **request_kwargs,
-    )
+    req = shared.PartitionParameters(files=files, **request_kwargs)
     response = sdk.general.partition(req)
 
     if response.status_code == 200:
@@ -111,15 +103,15 @@ def partition_via_api(
 
 
 def partition_multiple_via_api(
-    filenames: Optional[List[str]] = None,
-    content_types: Optional[List[str]] = None,
-    files: Optional[List[str]] = None,
-    file_filenames: Optional[List[str]] = None,
+    filenames: Optional[list[str]] = None,
+    content_types: Optional[list[str]] = None,
+    files: Optional[list[str]] = None,
+    file_filenames: Optional[list[str]] = None,
     api_url: str = "https://api.unstructured.io/general/v0/general",
     api_key: str = "",
-    metadata_filenames: Optional[List[str]] = None,
+    metadata_filenames: Optional[list[str]] = None,
     **request_kwargs,
-) -> List[List[Element]]:
+) -> list[list[Element]]:
     """Partitions multiple documents using the Unstructured REST API by batching
     the documents into a single HTTP request.
 

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -1,9 +1,13 @@
+"""Provides partitioning with automatic file-type detection."""
+
+from __future__ import annotations
+
 import io
-from typing import IO, Callable, Dict, List, Optional, Tuple
+from typing import IO, Any, Callable, Optional
 
 import requests
 
-from unstructured.documents.elements import DataSourceMetadata
+from unstructured.documents.elements import DataSourceMetadata, Element
 from unstructured.file_utils.filetype import (
     FILETYPE_TO_MIMETYPE,
     STR_TO_FILETYPE,
@@ -16,15 +20,13 @@ from unstructured.partition.common import exactly_one
 from unstructured.partition.email import partition_email
 from unstructured.partition.html import partition_html
 from unstructured.partition.json import partition_json
-from unstructured.partition.lang import (
-    check_language_args,
-)
+from unstructured.partition.lang import check_language_args
 from unstructured.partition.text import partition_text
 from unstructured.partition.utils.constants import PartitionStrategy
 from unstructured.partition.xml import partition_xml
 from unstructured.utils import dependency_exists
 
-PARTITION_WITH_EXTRAS_MAP: Dict[str, Callable] = {}
+PARTITION_WITH_EXTRAS_MAP: dict[str, Callable[..., list[Element]]] = {}
 
 if dependency_exists("pandas"):
     from unstructured.partition.csv import partition_csv
@@ -114,7 +116,7 @@ IMAGE_FILETYPES = [
 
 def _get_partition_with_extras(
     doc_type: str,
-    partition_with_extras_map: Optional[Dict[str, Callable]] = None,
+    partition_with_extras_map: Optional[dict[str, Callable[..., list[Element]]]] = None,
 ):
     if partition_with_extras_map is None:
         partition_with_extras_map = PARTITION_WITH_EXTRAS_MAP
@@ -138,15 +140,15 @@ def partition(
     strategy: str = PartitionStrategy.AUTO,
     encoding: Optional[str] = None,
     paragraph_grouper: Optional[Callable[[str], str]] = None,
-    headers: Dict[str, str] = {},
-    skip_infer_table_types: List[str] = [],
+    headers: dict[str, str] = {},
+    skip_infer_table_types: list[str] = [],
     ssl_verify: bool = True,
     ocr_languages: Optional[str] = None,  # changing to optional for deprecation
-    languages: Optional[List[str]] = None,
+    languages: Optional[list[str]] = None,
     detect_language_per_element: bool = False,
     pdf_infer_table_structure: bool = True,
     extract_images_in_pdf: bool = False,
-    extract_image_block_types: Optional[List[str]] = None,
+    extract_image_block_types: Optional[list[str]] = None,
     extract_image_block_output_dir: Optional[str] = None,
     extract_image_block_to_payload: bool = False,
     xml_keep_tags: bool = False,
@@ -157,7 +159,7 @@ def partition(
     model_name: Optional[str] = None,  # to be deprecated
     date_from_file_object: bool = False,
     starting_page_number: int = 1,
-    **kwargs,
+    **kwargs: Any,
 ):
     """Partitions a document into its constituent elements. Will use libmagic to determine
     the file's type and route it to the appropriate partitioning function. Applies the default
@@ -422,8 +424,8 @@ def partition(
     elif filetype == FileType.PDF:
         _partition_pdf = _get_partition_with_extras("pdf")
         elements = _partition_pdf(
-            filename=filename,  # type: ignore
-            file=file,  # type: ignore
+            filename=filename,
+            file=file,
             url=None,
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
@@ -438,9 +440,10 @@ def partition(
             **kwargs,
         )
     elif filetype in IMAGE_FILETYPES:
-        elements = partition_image(
-            filename=filename,  # type: ignore
-            file=file,  # type: ignore
+        _partition_image = _get_partition_with_extras("image")
+        elements = _partition_image(
+            filename=filename,
+            file=file,
             url=None,
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
@@ -557,10 +560,10 @@ def partition(
 def file_and_type_from_url(
     url: str,
     content_type: Optional[str] = None,
-    headers: Dict[str, str] = {},
+    headers: dict[str, str] = {},
     ssl_verify: bool = True,
     request_timeout: Optional[int] = None,
-) -> Tuple[io.BytesIO, Optional[FileType]]:
+) -> tuple[io.BytesIO, Optional[FileType]]:
     response = requests.get(url, headers=headers, verify=ssl_verify, timeout=request_timeout)
     file = io.BytesIO(response.content)
 
@@ -575,7 +578,7 @@ def file_and_type_from_url(
 
 def decide_table_extraction(
     filetype: Optional[FileType],
-    skip_infer_table_types: List[str],
+    skip_infer_table_types: list[str],
     pdf_infer_table_structure: bool,
 ) -> bool:
     doc_type = filetype.name.lower() if filetype else None

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -6,7 +6,7 @@ import subprocess
 from datetime import datetime
 from io import BufferedReader, BytesIO, TextIOWrapper
 from tempfile import SpooledTemporaryFile
-from typing import IO, TYPE_CHECKING, Any, BinaryIO, List, Optional
+from typing import IO, TYPE_CHECKING, Any, Optional, TypeVar, cast
 
 import emoji
 from tabulate import tabulate
@@ -191,14 +191,14 @@ def layout_list_to_list_items(
     coordinate_system: Optional[CoordinateSystem],
     metadata: Optional[ElementMetadata],
     detection_origin: Optional[str],
-) -> List[Element]:
+) -> list[Element]:
     """Converts a list LayoutElement to a list of ListItem elements."""
     split_items = ENUMERATED_BULLETS_RE.split(text) if text else []
     # NOTE(robinson) - this means there wasn't a match for the enumerated bullets
     if len(split_items) == 1:
         split_items = UNICODE_BULLETS_RE.split(text) if text else []
 
-    list_items: List[Element] = []
+    list_items: list[Element] = []
     for text_segment in split_items:
         if len(text_segment.strip()) > 0:
             # Both `coordinates` and `coordinate_system` must be present
@@ -216,13 +216,13 @@ def layout_list_to_list_items(
 
 
 def set_element_hierarchy(
-    elements: List[Element], ruleset: dict[str, list[str]] = HIERARCHY_RULE_SET
+    elements: list[Element], ruleset: dict[str, list[str]] = HIERARCHY_RULE_SET
 ) -> list[Element]:
     """Sets the parent_id for each element in the list of elements
     based on the element's category, depth and a ruleset
 
     """
-    stack: List[Element] = []
+    stack: list[Element] = []
     for element in elements:
         if element.metadata.parent_id is not None:
             continue
@@ -274,7 +274,7 @@ def add_element_metadata(
     coordinate_system: Optional[CoordinateSystem] = None,
     image_path: Optional[str] = None,
     detection_origin: Optional[str] = None,
-    languages: Optional[List[str]] = None,
+    languages: Optional[list[str]] = None,
     **kwargs: Any,
 ) -> Element:
     """Adds document metadata to the document element.
@@ -338,7 +338,7 @@ def remove_element_metadata(layout_elements) -> list[Element]:
 
     Document metadata includes information like the filename, source url, and page number.
     """
-    elements: List[Element] = []
+    elements: list[Element] = []
     metadata = ElementMetadata()
     for layout_element in layout_elements:
         element = normalize_layout_element(layout_element)
@@ -431,16 +431,25 @@ def exactly_one(**kwargs: Any) -> None:
         raise ValueError(message)
 
 
-def spooled_to_bytes_io_if_needed(
-    file_obj: bytes | BinaryIO | SpooledTemporaryFile[bytes] | None,
-) -> bytes | BinaryIO | None:
-    if isinstance(file_obj, SpooledTemporaryFile):
-        file_obj.seek(0)
-        contents = file_obj.read()
-        return BytesIO(contents)
-    else:
-        # Return the original file object if it's not a SpooledTemporaryFile
-        return file_obj
+_T = TypeVar("_T")
+
+
+def spooled_to_bytes_io_if_needed(file: _T | SpooledTemporaryFile[bytes]) -> _T | BytesIO:
+    """Convert `file` to `BytesIO` when it is a `SpooledTemporaryFile`.
+
+    Note that `file` does not need to be IO[bytes]. It can be `None` or `bytes` and this function
+    will not complain.
+
+    In Python <3.11, `SpooledTemporaryFile` does not implement `.readable()` or `.seekable()` which
+    triggers an exception when the file is loaded by certain packages. In particular, the stdlib
+    `zipfile.Zipfile` raises on opening a `SpooledTemporaryFile` as does `Pandas.read_csv()`.
+    """
+    if isinstance(file, SpooledTemporaryFile):
+        file.seek(0)
+        return BytesIO(cast(bytes, file.read()))
+
+    # -- return `file` unchanged otherwise --
+    return file
 
 
 def convert_to_bytes(file: bytes | IO[bytes]) -> bytes:
@@ -537,16 +546,16 @@ def document_to_element_list(
     source_format: Optional[str] = None,
     detection_origin: Optional[str] = None,
     sort_mode: str = SORT_MODE_XY_CUT,
-    languages: Optional[List[str]] = None,
+    languages: Optional[list[str]] = None,
     starting_page_number: int = 1,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Converts a DocumentLayout object to a list of unstructured elements."""
-    elements: List[Element] = []
+    elements: list[Element] = []
 
     num_pages = len(document.pages)
     for page_number, page in enumerate(document.pages, start=starting_page_number):
-        page_elements: List[Element] = []
+        page_elements: list[Element] = []
 
         page_image_metadata = _get_page_image_metadata(page)
         image_format = page_image_metadata.get("format")
@@ -566,7 +575,7 @@ def document_to_element_list(
                 infer_list_items=infer_list_items,
                 source_format=source_format if source_format else "html",
             )
-            if isinstance(element, List):
+            if isinstance(element, list):
                 for el in element:
                     if last_modification_date:
                         el.metadata.last_modified = last_modification_date
@@ -628,7 +637,7 @@ def document_to_element_list(
 
 
 def ocr_data_to_elements(
-    ocr_data: List["LayoutElement"],
+    ocr_data: list["LayoutElement"],
     image_size: tuple[int | float, int | float],
     common_metadata: Optional[ElementMetadata] = None,
     infer_list_items: bool = True,

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 import tempfile
-from typing import IO, Any, List, Optional
+from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
@@ -26,12 +28,12 @@ def partition_doc(
     metadata_last_modified: Optional[str] = None,
     libre_office_filter: Optional[str] = "MS Word 2007 XML",
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
     starting_page_number: int = 1,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions Microsoft Word Documents in .doc format into its document elements.
 
     Parameters

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import datetime
 import email
@@ -6,8 +8,8 @@ import re
 import sys
 from email.message import Message
 from functools import partial
-from tempfile import NamedTemporaryFile, SpooledTemporaryFile, TemporaryDirectory
-from typing import IO, Any, Callable, Dict, List, Optional, Tuple, Union
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import IO, Any, Callable, Optional
 
 from unstructured.file_utils.encoding import (
     COMMON_ENCODINGS,
@@ -59,17 +61,17 @@ from unstructured.nlp.patterns import EMAIL_DATETIMETZ_PATTERN_RE
 from unstructured.partition.html import partition_html
 from unstructured.partition.text import partition_text
 
-VALID_CONTENT_SOURCES: Final[List[str]] = ["text/html", "text/plain"]
+VALID_CONTENT_SOURCES: Final[list[str]] = ["text/html", "text/plain"]
 DETECTION_ORIGIN: str = "email"
 
 
-def _parse_received_data(data: str) -> List[Element]:
+def _parse_received_data(data: str) -> list[Element]:
     ip_address_names = extract_ip_address_name(data)
     ip_addresses = extract_ip_address(data)
     mapi_id = extract_mapi_id(data)
     datetimetz = extract_datetimetz(data)
 
-    elements: List[Element] = []
+    elements: list[Element] = []
     if ip_address_names and ip_addresses:
         for name, ip in zip(ip_address_names, ip_addresses):
             elements.append(ReceivedInfo(name=name, text=ip))
@@ -86,7 +88,7 @@ def _parse_received_data(data: str) -> List[Element]:
     return elements
 
 
-def _parse_email_address(data: str) -> Tuple[str, str]:
+def _parse_email_address(data: str) -> tuple[str, str]:
     email_address = extract_email_address(data)
 
     PATTERN = "<[a-z0-9\.\-+_]+@[a-z0-9\.\-+_]+\.[a-z]+>"  # noqa: W605 Note(harrell)
@@ -95,8 +97,8 @@ def _parse_email_address(data: str) -> Tuple[str, str]:
     return name, email_address[0]
 
 
-def partition_email_header(msg: Message) -> List[Element]:
-    elements: List[Element] = []
+def partition_email_header(msg: Message) -> list[Element]:
+    elements: list[Element] = []
     for item in msg.raw_items():
         if item[0] == "To":
             text = _parse_email_address(item[1])
@@ -180,7 +182,7 @@ def convert_to_iso_8601(time: str) -> Optional[str]:
 def extract_attachment_info(
     message: Message,
     output_dir: Optional[str] = None,
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     list_attachments = []
 
     for part in message.walk():
@@ -227,9 +229,8 @@ def has_embedded_image(element):
 
 
 def find_embedded_image(
-    element: Union[NarrativeText, Title],
-    indices: re.Match,
-) -> Tuple[Element, Element]:
+    element: NarrativeText | Title, indices: re.Match
+) -> tuple[Element, Element]:
     start, end = indices.start(), indices.end()
 
     image_raw_info = element.text[start:end]
@@ -239,9 +240,8 @@ def find_embedded_image(
 
 
 def parse_email(
-    filename: Optional[str] = None,
-    file: Optional[Union[IO[bytes], SpooledTemporaryFile]] = None,
-) -> Tuple[Optional[str], Message]:
+    filename: Optional[str] = None, file: Optional[IO[bytes]] = None
+) -> tuple[Optional[str], Message]:
     if filename is not None:
         with open(filename, "rb") as f:
             msg = email.message_from_binary_file(f)
@@ -268,7 +268,7 @@ def parse_email(
 @add_chunking_strategy
 def partition_email(
     filename: Optional[str] = None,
-    file: Optional[Union[IO[bytes], SpooledTemporaryFile[bytes]]] = None,
+    file: Optional[IO[bytes]] = None,
     text: Optional[str] = None,
     content_source: str = "text/html",
     encoding: Optional[str] = None,
@@ -278,14 +278,14 @@ def partition_email(
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     process_attachments: bool = False,
-    attachment_partitioner: Optional[Callable[..., List[Element]]] = None,
+    attachment_partitioner: Optional[Callable[..., list[Element]]] = None,
     min_partition: Optional[int] = 0,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions an .eml documents into its constituent elements.
     Parameters
     ----------
@@ -363,7 +363,7 @@ def partition_email(
         encoding = detected_encoding
 
     is_encrypted = False
-    content_map: Dict[str, str] = {}
+    content_map: dict[str, str] = {}
     for part in msg.walk():
         # NOTE(robinson) - content dispostiion is None for the content of the email itself.
         # Other dispositions include "attachment" for attachments
@@ -404,7 +404,7 @@ def partition_email(
                 )
                 break
 
-    elements: List[Element] = []
+    elements: list[Element] = []
 
     if is_encrypted:
         logger.warning(
@@ -476,7 +476,7 @@ def partition_email(
             elements[idx] = clean_element
             elements.insert(idx + 1, image_info)
 
-    header: List[Element] = []
+    header: list[Element] = []
     if include_headers:
         header = partition_email_header(msg)
     all_elements = header + elements

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -1,4 +1,6 @@
-from typing import IO, Any, List, Optional
+from __future__ import annotations
+
+from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
@@ -20,11 +22,11 @@ def partition_epub(
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions an EPUB document. The document is first converted to HTML and then
     partitioned using partition_html.
 

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -1,4 +1,6 @@
-from typing import IO, TYPE_CHECKING, Any, Dict, List, Optional
+from __future__ import annotations
+
+from typing import IO, TYPE_CHECKING, Any, Optional
 
 import requests
 
@@ -35,7 +37,7 @@ def partition_html(
     encoding: Optional[str] = None,
     include_page_breaks: bool = False,
     include_metadata: bool = True,
-    headers: Dict[str, str] = {},
+    headers: dict[str, str] = {},
     ssl_verify: bool = True,
     parser: VALID_PARSERS = None,
     source_format: Optional[str] = None,
@@ -44,12 +46,12 @@ def partition_html(
     metadata_last_modified: Optional[str] = None,
     skip_headers_and_footers: bool = False,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     detection_origin: Optional[str] = None,
     date_from_file_object: bool = False,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions an HTML document into its constituent elements.
 
     Parameters
@@ -173,11 +175,11 @@ def convert_and_partition_html(
     include_page_breaks: bool = False,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     detection_origin: Optional[str] = None,
     date_from_file_object: bool = False,
-) -> List[Element]:
+) -> list[Element]:
     """Converts a document to HTML and then partitions it using partition_html. Works with
     any file format support by pandoc.
 

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
@@ -20,18 +22,18 @@ def partition_image(
     include_page_breaks: bool = False,
     infer_table_structure: bool = False,
     ocr_languages: Optional[str] = None,
-    languages: Optional[List[str]] = None,
+    languages: Optional[list[str]] = None,
     strategy: str = PartitionStrategy.HI_RES,
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,
     hi_res_model_name: Optional[str] = None,
     extract_images_in_pdf: bool = False,
-    extract_image_block_types: Optional[List[str]] = None,
+    extract_image_block_types: Optional[list[str]] = None,
     extract_image_block_output_dir: Optional[str] = None,
     extract_image_block_to_payload: bool = False,
     date_from_file_object: bool = False,
-    **kwargs,
-) -> List[Element]:
+    **kwargs: Any,
+) -> list[Element]:
     """Parses an image into a list of interpreted elements.
 
     Parameters

--- a/unstructured/partition/lang.py
+++ b/unstructured/partition/lang.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import re
-from typing import Iterable, Iterator, List, Optional, Union
+from typing import Iterable, Iterator, Optional
 
 import iso639
 from langdetect import DetectorFactory, detect_langs, lang_detect_exception
@@ -143,7 +145,7 @@ PYTESSERACT_LANG_CODES = [
 ]
 
 
-def prepare_languages_for_tesseract(languages: Optional[List[str]] = ["eng"]) -> str:
+def prepare_languages_for_tesseract(languages: Optional[list[str]] = ["eng"]) -> str:
     """
     Entry point: convert languages (list of strings) into tesseract ocr langcode format (uses +)
     """
@@ -291,8 +293,8 @@ def _get_all_tesseract_langcodes_with_prefix(prefix: str) -> list[str]:
 
 def detect_languages(
     text: str,
-    languages: Optional[List[str]] = ["auto"],
-) -> Optional[List[str]]:
+    languages: Optional[list[str]] = ["auto"],
+) -> Optional[list[str]]:
     """
     Detects the list of languages present in the text (in the default "auto" mode),
     or formats and passes through the user inputted document languages if provided.
@@ -370,7 +372,7 @@ def detect_languages(
 
 def apply_lang_metadata(
     elements: Iterable[Element],
-    languages: Optional[List[str]],
+    languages: Optional[list[str]],
     detect_language_per_element: bool = False,
 ) -> Iterator[Element]:
     """Detect language and apply it to metadata.languages for each element in `elements`.
@@ -393,7 +395,7 @@ def apply_lang_metadata(
         return
 
     # Convert elements to a list to get the text, detect the language, and add it to the elements
-    if not isinstance(elements, List):
+    if not isinstance(elements, list):
         elements = list(elements)
 
     full_text = " ".join(e.text for e in elements if hasattr(e, "text"))
@@ -416,7 +418,7 @@ def apply_lang_metadata(
                 yield e
 
 
-def _clean_ocr_languages_arg(ocr_languages: Union[List[str], str]) -> str:
+def _clean_ocr_languages_arg(ocr_languages: list[str] | str) -> str:
     """Fix common incorrect definitions for ocr_languages:
     defining it as a list, adding extra quotation marks, adding brackets.
     Returns a single string of ocr_languages"""

--- a/unstructured/partition/md.py
+++ b/unstructured/partition/md.py
@@ -1,4 +1,6 @@
-from typing import IO, List, Optional, Union
+from __future__ import annotations
+
+from typing import IO, Any, Optional, Union
 
 import markdown
 import requests
@@ -38,11 +40,11 @@ def partition_md(
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
-    **kwargs,
-) -> List[Element]:
+    **kwargs: Any,
+) -> list[Element]:
     """Partitions a markdown file into its constituent elements
 
     Parameters

--- a/unstructured/partition/msg.py
+++ b/unstructured/partition/msg.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 import tempfile
-from typing import IO, Callable, Dict, List, Optional
+from typing import IO, Any, Callable, Optional
 
 import msg_parser
 
@@ -30,14 +32,14 @@ def partition_msg(
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     process_attachments: bool = False,
-    attachment_partitioner: Optional[Callable] = None,
+    attachment_partitioner: Optional[Callable[..., list[Element]]] = None,
     min_partition: Optional[int] = 0,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
-    **kwargs,
-) -> List[Element]:
+    **kwargs: Any,
+) -> list[Element]:
     """Partitions a MSFT Outlook .msg file
 
     Parameters
@@ -89,7 +91,7 @@ def partition_msg(
     content_type = msg_obj.header_dict.get("Content-Type", "")
     is_encrypted = "encrypted" in content_type
     text = msg_obj.body
-    elements: List[Element] = []
+    elements: list[Element] = []
     if is_encrypted:
         logger.warning(
             "Encrypted email detected. Partition function will return an empty list.",
@@ -166,7 +168,7 @@ def build_msg_metadata(
     filename: Optional[str],
     metadata_last_modified: Optional[str],
     last_modification_date: Optional[str],
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
 ) -> ElementMetadata:
     """Creates an ElementMetadata object from the header information in the email."""
     email_date = getattr(msg_obj, "sent_date", None)
@@ -198,7 +200,7 @@ def extract_msg_attachment_info(
     file: Optional[IO[bytes]] = None,
     output_dir: Optional[str] = None,
     msg_obj: Optional[msg_parser.MsOxMessage] = None,
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Extracts information from email message attachments and returns a list of dictionaries.
     If 'output_dir' is provided, attachments are also saved to that directory.
     """

--- a/unstructured/partition/odt.py
+++ b/unstructured/partition/odt.py
@@ -1,12 +1,11 @@
-from typing import Any, BinaryIO, List, Optional
+from __future__ import annotations
+
+from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.common import (
-    get_last_modified_date,
-    get_last_modified_date_from_file,
-)
+from unstructured.partition.common import get_last_modified_date, get_last_modified_date_from_file
 from unstructured.partition.docx import convert_and_partition_docx
 
 
@@ -15,18 +14,18 @@ from unstructured.partition.docx import convert_and_partition_docx
 @add_chunking_strategy
 def partition_odt(
     filename: Optional[str] = None,
-    file: Optional[BinaryIO] = None,
+    file: Optional[IO[bytes]] = None,
     include_metadata: bool = True,
     infer_table_structure: bool = True,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
     starting_page_number: int = 1,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions Open Office Documents in .odt format into its document elements.
 
     Parameters

--- a/unstructured/partition/org.py
+++ b/unstructured/partition/org.py
@@ -1,4 +1,6 @@
-from typing import IO, List, Optional
+from __future__ import annotations
+
+from typing import IO, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element
@@ -18,10 +20,10 @@ def partition_org(
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions an org document. The document is first converted to HTML and then
     partitioned using partition_html.
 

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -6,21 +6,7 @@ import io
 import os
 import re
 import warnings
-from tempfile import SpooledTemporaryFile
-from typing import (
-    IO,
-    TYPE_CHECKING,
-    Any,
-    BinaryIO,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import IO, TYPE_CHECKING, Any, Iterator, Optional, Sequence, cast
 
 import numpy as np
 import pdf2image
@@ -138,12 +124,12 @@ def default_hi_res_model() -> str:
 @add_chunking_strategy
 def partition_pdf(
     filename: str = "",
-    file: Optional[Union[BinaryIO, SpooledTemporaryFile[bytes]]] = None,
+    file: Optional[IO[bytes]] = None,
     include_page_breaks: bool = False,
     strategy: str = PartitionStrategy.AUTO,
     infer_table_structure: bool = False,
     ocr_languages: Optional[str] = None,  # changing to optional for deprecation
-    languages: Optional[List[str]] = None,
+    languages: Optional[list[str]] = None,
     include_metadata: bool = True,  # used by decorator
     metadata_filename: Optional[str] = None,  # used by decorator
     metadata_last_modified: Optional[str] = None,
@@ -151,13 +137,13 @@ def partition_pdf(
     links: Sequence[Link] = [],
     hi_res_model_name: Optional[str] = None,
     extract_images_in_pdf: bool = False,
-    extract_image_block_types: Optional[List[str]] = None,
+    extract_image_block_types: Optional[list[str]] = None,
     extract_image_block_output_dir: Optional[str] = None,
     extract_image_block_to_payload: bool = False,
     date_from_file_object: bool = False,
     starting_page_number: int = 1,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Parses a pdf document into a list of interpreted elements.
     Parameters
     ----------
@@ -239,23 +225,23 @@ def partition_pdf(
 
 def partition_pdf_or_image(
     filename: str = "",
-    file: Optional[Union[bytes, BinaryIO, SpooledTemporaryFile]] = None,
+    file: Optional[bytes | IO[bytes]] = None,
     is_image: bool = False,
     include_page_breaks: bool = False,
     strategy: str = PartitionStrategy.AUTO,
     infer_table_structure: bool = False,
     ocr_languages: Optional[str] = None,
-    languages: Optional[List[str]] = None,
+    languages: Optional[list[str]] = None,
     metadata_last_modified: Optional[str] = None,
     hi_res_model_name: Optional[str] = None,
     extract_images_in_pdf: bool = False,
-    extract_image_block_types: Optional[List[str]] = None,
+    extract_image_block_types: Optional[list[str]] = None,
     extract_image_block_output_dir: Optional[str] = None,
     extract_image_block_to_payload: bool = False,
     date_from_file_object: bool = False,
     starting_page_number: int = 1,
-    **kwargs,
-) -> List[Element]:
+    **kwargs: Any,
+) -> list[Element]:
     """Parses a pdf or image document into a list of interpreted elements."""
     # TODO(alan): Extract information about the filetype to be processed from the template
     # route. Decoding the routing should probably be handled by a single function designed for
@@ -351,9 +337,9 @@ def partition_pdf_or_image(
 
 def extractable_elements(
     filename: str = "",
-    file: Optional[Union[bytes, IO[bytes]]] = None,
+    file: Optional[bytes | IO[bytes]] = None,
     include_page_breaks: bool = False,
-    languages: Optional[List[str]] = None,
+    languages: Optional[list[str]] = None,
     metadata_last_modified: Optional[str] = None,
     starting_page_number: int = 1,
     **kwargs: Any,
@@ -372,10 +358,10 @@ def extractable_elements(
 
 
 def get_the_last_modification_date_pdf_or_img(
-    file: Optional[Union[bytes, BinaryIO, SpooledTemporaryFile]] = None,
+    file: Optional[bytes | IO[bytes]] = None,
     filename: Optional[str] = "",
     date_from_file_object: bool = False,
-) -> Union[str, None]:
+) -> str | None:
     last_modification_date = None
     if not file and filename:
         last_modification_date = get_last_modified_date(filename=filename)
@@ -389,11 +375,11 @@ def get_the_last_modification_date_pdf_or_img(
 @requires_dependencies("unstructured_inference")
 def _partition_pdf_or_image_local(
     filename: str = "",
-    file: Optional[Union[bytes, BinaryIO]] = None,
+    file: Optional[bytes | IO[bytes]] = None,
     is_image: bool = False,
     infer_table_structure: bool = False,
     include_page_breaks: bool = False,
-    languages: Optional[List[str]] = None,
+    languages: Optional[list[str]] = None,
     ocr_mode: str = OCRMode.FULL_PAGE.value,
     model_name: Optional[str] = None,  # to be deprecated in favor of `hi_res_model_name`
     hi_res_model_name: Optional[str] = None,
@@ -401,14 +387,14 @@ def _partition_pdf_or_image_local(
     metadata_last_modified: Optional[str] = None,
     pdf_text_extractable: bool = False,
     extract_images_in_pdf: bool = False,
-    extract_image_block_types: Optional[List[str]] = None,
+    extract_image_block_types: Optional[list[str]] = None,
     extract_image_block_output_dir: Optional[str] = None,
     extract_image_block_to_payload: bool = False,
     analysis: bool = False,
     analyzed_image_output_dir_path: Optional[str] = None,
     starting_page_number: int = 1,
-    **kwargs,
-) -> List[Element]:
+    **kwargs: Any,
+) -> list[Element]:
     """Partition using package installed locally"""
     from unstructured_inference.inference.layout import (
         process_data_with_model,
@@ -540,7 +526,7 @@ def _partition_pdf_or_image_local(
         sortable=True,
         include_page_breaks=include_page_breaks,
         last_modification_date=metadata_last_modified,
-        # NOTE(crag): do not attempt to derive ListItem's from a layout-recognized "List"
+        # NOTE(crag): do not attempt to derive ListItem's from a layout-recognized "list"
         # block with NLP rules. Otherwise, the assumptions in
         # unstructured.partition.common::layout_list_to_list_items often result in weird chunking.
         infer_list_items=False,
@@ -601,7 +587,7 @@ def _partition_pdf_or_image_local(
     return out_elements
 
 
-def _process_uncategorized_text_elements(elements: List[Element]):
+def _process_uncategorized_text_elements(elements: list[Element]):
     """Processes a list of elements, creating a new list where elements with the
     category `UncategorizedText` are replaced with corresponding
     elements created from their text content."""
@@ -622,11 +608,11 @@ def _partition_pdf_with_pdfminer(
     filename: str,
     file: Optional[IO[bytes]],
     include_page_breaks: bool,
-    languages: List[str],
+    languages: list[str],
     metadata_last_modified: Optional[str],
     starting_page_number: int = 1,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions a PDF using PDFMiner instead of using a layoutmodel. Used for faster
     processing or detectron2 is not available.
 
@@ -641,7 +627,7 @@ def _partition_pdf_with_pdfminer(
     exactly_one(filename=filename, file=file)
     if filename:
         with open_filename(filename, "rb") as fp:
-            fp = cast(BinaryIO, fp)
+            fp = cast(IO[bytes], fp)
             elements = _process_pdfminer_pages(
                 fp=fp,
                 filename=filename,
@@ -653,9 +639,8 @@ def _partition_pdf_with_pdfminer(
             )
 
     elif file:
-        fp = cast(BinaryIO, file)
         elements = _process_pdfminer_pages(
-            fp=fp,
+            fp=file,
             filename=filename,
             include_page_breaks=include_page_breaks,
             languages=languages,
@@ -701,10 +686,10 @@ def pdfminer_interpreter_init_resources(wrapped, instance, args, kwargs):
 
 @requires_dependencies("pdfminer")
 def _process_pdfminer_pages(
-    fp: BinaryIO,
+    fp: IO[bytes],
     filename: str,
     include_page_breaks: bool,
-    languages: List[str],
+    languages: list[str],
     metadata_last_modified: Optional[str],
     sort_mode: str = SORT_MODE_XY_CUT,
     annotation_threshold: Optional[float] = env_config.PDF_ANNOTATION_THRESHOLD,
@@ -713,14 +698,14 @@ def _process_pdfminer_pages(
 ):
     """Uses PDFMiner to split a document into pages and process them."""
 
-    elements: List[Element] = []
+    elements: list[Element] = []
 
     for page_number, (page, page_layout) in enumerate(
         open_pdfminer_pages_generator(fp), start=starting_page_number
     ):
         width, height = page_layout.width, page_layout.height
 
-        page_elements: List[Element] = []
+        page_elements: list[Element] = []
         annotation_list = []
 
         coordinate_system = PixelSpace(
@@ -734,7 +719,7 @@ def _process_pdfminer_pages(
             x1, y1, x2, y2 = rect_to_bbox(obj.bbox, height)
             bbox = (x1, y1, x2, y2)
 
-            urls_metadata: List[Dict[str, Any]] = []
+            urls_metadata: list[dict[str, Any]] = []
 
             if len(annotation_list) > 0 and isinstance(obj, LTTextBox):
                 annotations_within_element = check_annotations_within_element(
@@ -748,7 +733,7 @@ def _process_pdfminer_pages(
                     urls_metadata.append(map_bbox_and_index(words, annot))
 
             if hasattr(obj, "get_text"):
-                _text_snippets: List = [obj.get_text()]
+                _text_snippets: list[str] = [obj.get_text()]
             else:
                 _text = _extract_text(obj)
                 _text_snippets = re.split(PARAGRAPH_PATTERN, _text)
@@ -796,11 +781,11 @@ def _process_pdfminer_pages(
 
 
 def _combine_list_elements(
-    elements: List[Element], coordinate_system: Union[PixelSpace, PointSpace]
-) -> List[Element]:
+    elements: list[Element], coordinate_system: PixelSpace | PointSpace
+) -> list[Element]:
     """Combine elements that should be considered a single ListItem element."""
     tmp_element = None
-    updated_elements: List[Element] = []
+    updated_elements: list[Element] = []
     for element in elements:
         if isinstance(element, ListItem):
             tmp_element = element
@@ -824,10 +809,10 @@ def _combine_list_elements(
 
 
 def _get_links_from_urls_metadata(
-    urls_metadata: List[Dict[str, Any]], moved_indices: np.ndarray
-) -> List[Link]:
+    urls_metadata: list[dict[str, Any]], moved_indices: np.ndarray
+) -> list[Link]:
     """Extracts links from a list of URL metadata."""
-    links: List[Link] = []
+    links: list[Link] = []
     for url in urls_metadata:
         with contextlib.suppress(IndexError):
             links.append(
@@ -844,7 +829,7 @@ def _get_links_from_urls_metadata(
 
 
 def _combine_coordinates_into_element1(
-    element1: Element, element2: Element, coordinate_system: Union[PixelSpace, PointSpace]
+    element1: Element, element2: Element, coordinate_system: PixelSpace | PointSpace
 ) -> Element:
     """Combine the coordiantes of two elements and apply the updated coordiantes to `elements1`"""
     x1 = min(
@@ -873,7 +858,7 @@ def _combine_coordinates_into_element1(
 
 def convert_pdf_to_images(
     filename: str = "",
-    file: Optional[Union[bytes, IO[bytes]]] = None,
+    file: Optional[bytes | IO[bytes]] = None,
     chunk_size: int = 10,
 ) -> Iterator[PILImage.Image]:
     # Convert a PDF in small chunks of pages at a time (e.g. 1-10, 11-20... and so on)
@@ -907,13 +892,13 @@ def convert_pdf_to_images(
 
 def _partition_pdf_or_image_with_ocr(
     filename: str = "",
-    file: Optional[Union[bytes, IO[bytes]]] = None,
+    file: Optional[bytes | IO[bytes]] = None,
     include_page_breaks: bool = False,
-    languages: Optional[List[str]] = ["eng"],
+    languages: Optional[list[str]] = ["eng"],
     is_image: bool = False,
     metadata_last_modified: Optional[str] = None,
     starting_page_number: int = 1,
-    **kwargs,
+    **kwargs: Any,
 ):
     """Partitions an image or PDF using OCR. For PDFs, each page is converted
     to an image prior to processing."""
@@ -953,13 +938,13 @@ def _partition_pdf_or_image_with_ocr(
 
 def _partition_pdf_or_image_with_ocr_from_image(
     image: PILImage,
-    languages: Optional[List[str]] = None,
+    languages: Optional[list[str]] = None,
     page_number: int = 1,
     include_page_breaks: bool = False,
     metadata_last_modified: Optional[str] = None,
     sort_mode: str = SORT_MODE_XY_CUT,
     **kwargs,
-) -> List[Element]:
+) -> list[Element]:
     """Extract `unstructured` elements from an image using OCR and perform partitioning."""
 
     from unstructured.partition.pdf_image.ocr import (
@@ -1046,29 +1031,29 @@ def check_coords_within_boundary(
 
 
 def get_uris(
-    annots: Union[PDFObjRef, List[PDFObjRef]],
+    annots: PDFObjRef | list[PDFObjRef],
     height: float,
-    coordinate_system: Union[PixelSpace, PointSpace],
+    coordinate_system: PixelSpace | PointSpace,
     page_number: int,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Extracts URI annotations from a single or a list of PDF object references on a specific page.
     The type of annots (list or not) depends on the pdf formatting. The function detectes the type
-    of annots and then pass on to get_uris_from_annots function as a List.
+    of annots and then pass on to get_uris_from_annots function as a list.
 
     Args:
-        annots (Union[PDFObjRef, List[PDFObjRef]]): A single or a list of PDF object references
+        annots (PDFObjRef | list[PDFObjRef]): A single or a list of PDF object references
             representing annotations on the page.
         height (float): The height of the page in the specified coordinate system.
-        coordinate_system (Union[PixelSpace, PointSpace]): The coordinate system used to represent
+        coordinate_system (PixelSpace | PointSpace): The coordinate system used to represent
             the annotations' coordinates.
         page_number (int): The page number from which to extract annotations.
 
     Returns:
-        List[dict]: A list of dictionaries, each containing information about a URI annotation,
+        list[dict]: A list of dictionaries, each containing information about a URI annotation,
         including its coordinates, bounding box, type, URI link, and page number.
     """
-    if isinstance(annots, List):
+    if isinstance(annots, list):
         return get_uris_from_annots(annots, height, coordinate_system, page_number)
     resolved_annots = annots.resolve()
     if resolved_annots is None:
@@ -1077,24 +1062,24 @@ def get_uris(
 
 
 def get_uris_from_annots(
-    annots: List[PDFObjRef],
-    height: Union[int, float],
-    coordinate_system: Union[PixelSpace, PointSpace],
+    annots: list[PDFObjRef],
+    height: int | float,
+    coordinate_system: PixelSpace | PointSpace,
     page_number: int,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Extracts URI annotations from a list of PDF object references.
 
     Args:
-        annots (List[PDFObjRef]): A list of PDF object references representing annotations on
+        annots (list[PDFObjRef]): A list of PDF object references representing annotations on
             a page.
-        height (Union[int, float]): The height of the page in the specified coordinate system.
-        coordinate_system (Union[PixelSpace, PointSpace]): The coordinate system used to represent
+        height (int | float): The height of the page in the specified coordinate system.
+        coordinate_system (PixelSpace | PointSpace): The coordinate system used to represent
             the annotations' coordinates.
         page_number (int): The page number from which to extract annotations.
 
     Returns:
-        List[dict]: A list of dictionaries, each containing information about a URI annotation,
+        list[dict]: A list of dictionaries, each containing information about a URI annotation,
         including its coordinates, bounding box, type, URI link, and page number.
     """
     annotation_list = []
@@ -1159,16 +1144,16 @@ def try_resolve(annot: PDFObjRef):
 
 
 def calculate_intersection_area(
-    bbox1: Tuple[float, float, float, float],
-    bbox2: Tuple[float, float, float, float],
+    bbox1: tuple[float, float, float, float],
+    bbox2: tuple[float, float, float, float],
 ) -> float:
     """
     Calculate the area of intersection between two bounding boxes.
 
     Args:
-        bbox1 (Tuple[float, float, float, float]): The coordinates of the first bounding box
+        bbox1 (tuple[float, float, float, float]): The coordinates of the first bounding box
             in the format (x1, y1, x2, y2).
-        bbox2 (Tuple[float, float, float, float]): The coordinates of the second bounding box
+        bbox2 (tuple[float, float, float, float]): The coordinates of the second bounding box
             in the format (x1, y1, x2, y2).
 
     Returns:
@@ -1192,12 +1177,12 @@ def calculate_intersection_area(
         return 0.0
 
 
-def calculate_bbox_area(bbox: Tuple[float, float, float, float]) -> float:
+def calculate_bbox_area(bbox: tuple[float, float, float, float]) -> float:
     """
     Calculate the area of a bounding box.
 
     Args:
-        bbox (Tuple[float, float, float, float]): The coordinates of the bounding box
+        bbox (tuple[float, float, float, float]): The coordinates of the bounding box
             in the format (x1, y1, x2, y2).
 
     Returns:
@@ -1209,18 +1194,18 @@ def calculate_bbox_area(bbox: Tuple[float, float, float, float]) -> float:
 
 
 def check_annotations_within_element(
-    annotation_list: List[Dict[str, Any]],
-    element_bbox: Tuple[float, float, float, float],
+    annotation_list: list[dict[str, Any]],
+    element_bbox: tuple[float, float, float, float],
     page_number: int,
     annotation_threshold: float,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Filter annotations that are within or highly overlap with a specified element on a page.
 
     Args:
-        annotation_list (List[Dict[str,Any]]): A list of dictionaries, each containing information
+        annotation_list (list[dict[str,Any]]): A list of dictionaries, each containing information
             about an annotation.
-        element_bbox (Tuple[float, float, float, float]): The bounding box coordinates of the
+        element_bbox (tuple[float, float, float, float]): The bounding box coordinates of the
             specified element in the bbox format (x1, y1, x2, y2).
         page_number (int): The page number to which the annotations and element belong.
         annotation_threshold (float, optional): The threshold value (between 0.0 and 1.0)
@@ -1228,7 +1213,7 @@ def check_annotations_within_element(
             within the element. Default is 0.9.
 
     Returns:
-        List[Dict[str,Any]]: A list of dictionaries containing information about annotations
+        list[dict[str,Any]]: A list of dictionaries containing information about annotations
         that are within or highly overlap with the specified element on the given page, based on
         the specified threshold.
     """
@@ -1247,7 +1232,7 @@ def check_annotations_within_element(
 def get_word_bounding_box_from_element(
     obj: LTTextBox,
     height: float,
-) -> Tuple[List[LTChar], List[Dict[str, Any]]]:
+) -> tuple[list[LTChar], list[dict[str, Any]]]:
     """
     Extracts characters and word bounding boxes from a PDF text element.
 
@@ -1256,9 +1241,9 @@ def get_word_bounding_box_from_element(
         height (float): The height of the page in the specified coordinate system.
 
     Returns:
-        Tuple[List[LTChar], List[Dict[str,Any]]]: A tuple containing two lists:
-            - List[LTChar]: A list of LTChar objects representing individual characters.
-            - List[Dict[str,Any]]]: A list of dictionaries, each containing information about
+        tuple[list[LTChar], list[dict[str,Any]]]: A tuple containing two lists:
+            - list[LTChar]: A list of LTChar objects representing individual characters.
+            - list[dict[str,Any]]]: A list of dictionaries, each containing information about
                 a word, including its text, bounding box, and start index in the element's text.
     """
     characters = []
@@ -1307,14 +1292,14 @@ def get_word_bounding_box_from_element(
     return characters, words
 
 
-def map_bbox_and_index(words: List[Dict[str, Any]], annot: Dict[str, Any]):
+def map_bbox_and_index(words: list[dict[str, Any]], annot: dict[str, Any]):
     """
     Maps a bounding box annotation to the corresponding text and start index within a list of words.
 
     Args:
-        words (List[Dict[str,Any]]): A list of dictionaries, each containing information about
+        words (list[dict[str,Any]]): A list of dictionaries, each containing information about
             a word, including its text, bounding box, and start index.
-        annot (Dict[str,Any]): The annotation dictionary to be mapped, which will be updated with
+        annot (dict[str,Any]): The annotation dictionary to be mapped, which will be updated with
         "text" and "start_index" fields.
 
     Returns:

--- a/unstructured/partition/pdf_image/inference_utils.py
+++ b/unstructured/partition/pdf_image/inference_utils.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, List, Optional, Union, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
 
 from unstructured_inference.constants import Source
 from unstructured_inference.inference.elements import TextRegion
@@ -14,23 +16,15 @@ if TYPE_CHECKING:
 
 
 def build_text_region_from_coords(
-    x1: Union[int, float],
-    y1: Union[int, float],
-    x2: Union[int, float],
-    y2: Union[int, float],
+    x1: int | float,
+    y1: int | float,
+    x2: int | float,
+    y2: int | float,
     text: Optional[str] = None,
     source: Optional[Source] = None,
 ) -> TextRegion:
     """"""
-
-    return TextRegion.from_coords(
-        x1,
-        y1,
-        x2,
-        y2,
-        text=text,
-        source=source,
-    )
+    return TextRegion.from_coords(x1, y1, x2, y2, text=text, source=source)
 
 
 def build_layout_element(
@@ -45,10 +39,10 @@ def build_layout_element(
 
 
 def build_layout_elements_from_ocr_regions(
-    ocr_regions: List[TextRegion],
+    ocr_regions: list[TextRegion],
     ocr_text: Optional[str] = None,
     group_by_ocr_text: bool = False,
-) -> List[LayoutElement]:
+) -> list[LayoutElement]:
     """
     Get layout elements from OCR regions
     """
@@ -74,10 +68,7 @@ def build_layout_elements_from_ocr_regions(
 
             grouped_regions.append(regions)
     else:
-        grouped_regions = cast(
-            List[List[TextRegion]],
-            partition_groups_from_regions(ocr_regions),
-        )
+        grouped_regions = partition_groups_from_regions(ocr_regions)
 
     merged_regions = [merge_text_regions(group) for group in grouped_regions]
     return [
@@ -88,12 +79,12 @@ def build_layout_elements_from_ocr_regions(
     ]
 
 
-def merge_text_regions(regions: List[TextRegion]) -> TextRegion:
+def merge_text_regions(regions: list[TextRegion]) -> TextRegion:
     """
     Merge a list of TextRegion objects into a single TextRegion.
 
     Parameters:
-    - group (List[TextRegion]): A list of TextRegion objects to be merged.
+    - group (list[TextRegion]): A list of TextRegion objects to be merged.
 
     Returns:
     - TextRegion: A single merged TextRegion object.

--- a/unstructured/partition/rst.py
+++ b/unstructured/partition/rst.py
@@ -1,4 +1,6 @@
-from typing import IO, List, Optional
+from __future__ import annotations
+
+from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
@@ -19,11 +21,11 @@ def partition_rst(
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
-    **kwargs,
-) -> List[Element]:
+    **kwargs: Any,
+) -> list[Element]:
     """Partitions an RST document. The document is first converted to HTML and then
     partitioned using partition_html.
 

--- a/unstructured/partition/rtf.py
+++ b/unstructured/partition/rtf.py
@@ -1,4 +1,6 @@
-from typing import IO, List, Optional
+from __future__ import annotations
+
+from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
@@ -19,11 +21,11 @@ def partition_rtf(
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
-    **kwargs,
-) -> List[Element]:
+    **kwargs: Any,
+) -> list[Element]:
     """Partitions an RTF document. The document is first converted to HTML and then
     partitioned using partition_html.
 

--- a/unstructured/partition/text.py
+++ b/unstructured/partition/text.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import copy
 import re
 import textwrap
-from typing import IO, Any, Callable, List, Optional, Tuple
+from typing import IO, Any, Callable, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.cleaners.core import (
@@ -50,7 +52,7 @@ def partition_text(
     paragraph_grouper: Optional[Callable[[str], str]] = None,
     metadata_filename: Optional[str] = None,
     include_metadata: bool = True,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     max_partition: Optional[int] = 1500,
     min_partition: Optional[int] = 0,
     metadata_last_modified: Optional[str] = None,
@@ -59,7 +61,7 @@ def partition_text(
     detection_origin: Optional[str] = "text",
     date_from_file_object: bool = False,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions an .txt documents into its constituent paragraph elements.
     If paragraphs are below "min_partition" or above "max_partition" boundaries,
     they are combined or split.
@@ -127,7 +129,7 @@ def _partition_text(
     paragraph_grouper: Optional[Callable[[str], str]] = None,
     metadata_filename: Optional[str] = None,
     include_metadata: bool = True,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     max_partition: Optional[int] = 1500,
     min_partition: Optional[int] = 0,
     metadata_last_modified: Optional[str] = None,
@@ -136,7 +138,7 @@ def _partition_text(
     detection_origin: Optional[str] = "text",
     date_from_file_object: bool = False,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """internal API for `partition_text`"""
     if text is not None and text.strip() == "" and not file and not filename:
         return []
@@ -181,7 +183,7 @@ def _partition_text(
         max_partition=max_partition,
     )
 
-    elements: List[Element] = []
+    elements: list[Element] = []
     if include_metadata:
         metadata = ElementMetadata(
             filename=metadata_filename or filename,
@@ -216,7 +218,7 @@ def is_empty_bullet(text: str) -> bool:
 
 
 def _get_height_percentage(
-    coordinates: Optional[Tuple[Tuple[float, float], ...]] = None,
+    coordinates: Optional[tuple[tuple[float, float], ...]] = None,
     coordinate_system: Optional[CoordinateSystem] = None,
 ) -> float:
     avg_y = sum([coordinate[1] for coordinate in coordinates]) / len(coordinates)
@@ -224,7 +226,7 @@ def _get_height_percentage(
 
 
 def is_in_header_position(
-    coordinates: Optional[Tuple[Tuple[float, float], ...]] = None,
+    coordinates: Optional[tuple[tuple[float, float], ...]] = None,
     coordinate_system: Optional[CoordinateSystem] = None,
     threshold: float = 0.07,
 ) -> bool:
@@ -238,7 +240,7 @@ def is_in_header_position(
 
 
 def is_in_footer_position(
-    coordinates: Optional[Tuple[Tuple[float, float], ...]] = None,
+    coordinates: Optional[tuple[tuple[float, float], ...]] = None,
     coordinate_system: Optional[CoordinateSystem] = None,
     threshold: float = 0.93,
 ) -> bool:
@@ -253,7 +255,7 @@ def is_in_footer_position(
 
 def element_from_text(
     text: str,
-    coordinates: Optional[Tuple[Tuple[float, float], ...]] = None,
+    coordinates: Optional[tuple[tuple[float, float], ...]] = None,
     coordinate_system: Optional[CoordinateSystem] = None,
 ) -> Element:
     if is_in_header_position(coordinates, coordinate_system):
@@ -310,17 +312,17 @@ def element_from_text(
 
 
 def _combine_paragraphs_less_than_min(
-    split_paragraphs: List[str],
+    split_paragraphs: list[str],
     max_partition: Optional[int] = 1500,
     min_partition: Optional[int] = 0,
-) -> List[str]:
+) -> list[str]:
     """Combine paragraphs less than `min_partition` while not exceeding `max_partition`."""
     min_partition = min_partition or 0
     max_possible_partition = len(" ".join(split_paragraphs))
     max_partition = max_partition or max_possible_partition
 
-    combined_paras: List[str] = []
-    combined_idxs: List[int] = []
+    combined_paras: list[str] = []
+    combined_idxs: list[int] = []
     for i, para in enumerate(split_paragraphs):
         if i in combined_idxs:
             continue
@@ -348,11 +350,11 @@ def _split_by_paragraph(
     file_text: str,
     min_partition: Optional[int] = 0,
     max_partition: Optional[int] = 1500,
-) -> List[str]:
+) -> list[str]:
     """Split text into paragraphs that fit within the `min_` and `max_partition` window."""
     paragraphs = re.split(PARAGRAPH_PATTERN, file_text.strip())
 
-    split_paragraphs: List[str] = []
+    split_paragraphs: list[str] = []
     for paragraph in paragraphs:
         split_paragraphs.extend(
             _split_content_to_fit_max(
@@ -370,7 +372,7 @@ def _split_by_paragraph(
     return combined_paragraphs
 
 
-def _split_content_size_n(content: str, n: int) -> List[str]:
+def _split_content_size_n(content: str, n: int) -> list[str]:
     """Splits a section of content into chunks that are at most
     size n without breaking apart words."""
     segments = []
@@ -384,11 +386,11 @@ def _split_content_size_n(content: str, n: int) -> List[str]:
 def _split_content_to_fit_max(
     content: str,
     max_partition: Optional[int] = 1500,
-) -> List[str]:
+) -> list[str]:
     """Splits a paragraph or section of content so that all of the elements fit into the
     max partition window."""
     sentences = sent_tokenize(content)
-    chunks: List[str] = []
+    chunks: list[str] = []
     tmp_chunk = ""
     # Initialize an empty string to collect sentence segments (`tmp_chunk`).
     for sentence in sentences:
@@ -425,7 +427,7 @@ def _split_content_to_fit_max(
 def _split_in_half_at_breakpoint(
     content: str,
     breakpoint: str = " ",
-) -> List[str]:
+) -> list[str]:
     """Splits a segment of content at the breakpoint closest to the middle"""
     mid = len(content) // 2
     for i in range(len(content) // 2):

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -1,4 +1,6 @@
-"""partition.py implements logic for partitioning plain text documents into sections."""
+"""Provides functions for classifying text for Element selection during partitioning."""
+
+from __future__ import annotations
 
 import os
 import re

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -1,5 +1,6 @@
-from tempfile import SpooledTemporaryFile
-from typing import IO, BinaryIO, List, Optional, Union, cast
+from __future__ import annotations
+
+from typing import IO, Any, Optional
 
 import pandas as pd
 from lxml.html.soupparser import fromstring as soupparser_fromstring
@@ -26,17 +27,17 @@ DETECTION_ORIGIN: str = "tsv"
 @add_metadata_with_filetype(FileType.TSV)
 def partition_tsv(
     filename: Optional[str] = None,
-    file: Optional[Union[IO[bytes], SpooledTemporaryFile]] = None,
+    file: Optional[IO[bytes]] = None,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     include_header: bool = False,
     include_metadata: bool = True,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     # NOTE (jennings) partition_tsv generates a single TableElement
     # so detect_language_per_element is not included as a param
     date_from_file_object: bool = False,
-    **kwargs,
-) -> List[Element]:
+    **kwargs: Any,
+) -> list[Element]:
     """Partitions TSV files into document elements.
 
     Parameters
@@ -68,9 +69,9 @@ def partition_tsv(
         table = pd.read_csv(filename, sep="\t", header=header)
         last_modification_date = get_last_modified_date(filename)
     elif file:
-        f = spooled_to_bytes_io_if_needed(
-            cast(Union[BinaryIO, SpooledTemporaryFile], file),
-        )
+        # -- Note(scanny): `SpooledTemporaryFile` on Python<3.11 does not implement `.readable()`
+        # -- which triggers an exception on `pd.DataFrame.read_csv()` call.
+        f = spooled_to_bytes_io_if_needed(file)
         table = pd.read_csv(f, sep="\t", header=header)
         last_modification_date = (
             get_last_modified_date_from_file(file) if date_from_file_object else None

--- a/unstructured/partition/utils/sorting.py
+++ b/unstructured/partition/utils/sorting.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import os
-from typing import TYPE_CHECKING, Any, List, Tuple
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -12,7 +14,7 @@ if TYPE_CHECKING:
     from unstructured_inference.inference.elements import TextRegion
 
 
-def coordinates_to_bbox(coordinates: CoordinatesMetadata) -> Tuple[int, int, int, int]:
+def coordinates_to_bbox(coordinates: CoordinatesMetadata) -> tuple[int, int, int, int]:
     """
     Convert coordinates to a bounding box representation.
 
@@ -20,7 +22,7 @@ def coordinates_to_bbox(coordinates: CoordinatesMetadata) -> Tuple[int, int, int
         coordinates (CoordinatesMetadata): Metadata containing points to represent the bounding box.
 
     Returns:
-        Tuple[int, int, int, int]: A tuple representing the bounding box in the format
+        tuple[int, int, int, int]: A tuple representing the bounding box in the format
         (left, top, right, bottom).
     """
 
@@ -30,17 +32,17 @@ def coordinates_to_bbox(coordinates: CoordinatesMetadata) -> Tuple[int, int, int
     return int(left), int(top), int(right), int(bottom)
 
 
-def shrink_bbox(bbox: Tuple[int, int, int, int], shrink_factor) -> Tuple[int, int, int, int]:
+def shrink_bbox(bbox: tuple[int, int, int, int], shrink_factor) -> tuple[int, int, int, int]:
     """
     Shrink a bounding box by a given shrink factor while maintaining its top and left.
 
     Parameters:
-        bbox (Tuple[int, int, int, int]): The original bounding box represented by
+        bbox (tuple[int, int, int, int]): The original bounding box represented by
         (left, top, right, bottom).
         shrink_factor (float): The factor by which to shrink the bounding box (0.0 to 1.0).
 
     Returns:
-        Tuple[int, int, int, int]: The shrunken bounding box represented by
+        tuple[int, int, int, int]: The shrunken bounding box represented by
         (left, top, right, bottom).
     """
 
@@ -95,16 +97,16 @@ def bbox_is_valid(bbox: Any) -> bool:
 
 
 def sort_page_elements(
-    page_elements: List[Element],
+    page_elements: list[Element],
     sort_mode: str = SORT_MODE_XY_CUT,
     shrink_factor: float = 0.9,
     xy_cut_primary_direction: str = "x",
-) -> List[Element]:
+) -> list[Element]:
     """
     Sorts a list of page elements based on the specified sorting mode.
 
     Parameters:
-    - page_elements (List[Element]): A list of elements representing parts of a page. Each element
+    - page_elements (list[Element]): A list of elements representing parts of a page. Each element
      should have metadata containing coordinates.
     - sort_mode (str, optional): The mode by which the elements will be sorted. Default is
      SORT_MODE_XY_CUT.
@@ -116,7 +118,7 @@ def sort_page_elements(
         - If an unrecognized sort_mode is provided, the function returns the elements as-is.
 
     Returns:
-    - List[Element]: A list of sorted page elements.
+    - list[Element]: A list of sorted page elements.
     """
 
     shrink_factor = float(
@@ -159,7 +161,7 @@ def sort_page_elements(
             shrunken_bbox = shrink_bbox(bbox, shrink_factor)
             shrunken_bboxes.append(shrunken_bbox)
 
-        res: List[int] = []
+        res: list[int] = []
         xy_cut_sorting_func = (
             recursive_xy_cut_swapped if xy_cut_primary_direction == "x" else recursive_xy_cut
         )
@@ -198,7 +200,7 @@ def sort_bboxes_by_xy_cut(
         shrunken_bbox = shrink_bbox(bbox, shrink_factor)
         shrunken_bboxes.append(shrunken_bbox)
 
-    res: List[int] = []
+    res: list[int] = []
     xy_cut_sorting_func = (
         recursive_xy_cut_swapped if xy_cut_primary_direction == "x" else recursive_xy_cut
     )
@@ -211,11 +213,11 @@ def sort_bboxes_by_xy_cut(
 
 
 def sort_text_regions(
-    elements: List["TextRegion"],
+    elements: list["TextRegion"],
     sort_mode: str = SORT_MODE_XY_CUT,
     shrink_factor: float = 0.9,
     xy_cut_primary_direction: str = "x",
-) -> List["TextRegion"]:
+) -> list["TextRegion"]:
     """Sort a list of TextRegion elements based on the specified sorting mode."""
 
     if not elements:

--- a/unstructured/partition/xml.py
+++ b/unstructured/partition/xml.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import copy
 from io import BytesIO
-from tempfile import SpooledTemporaryFile
-from typing import IO, Any, BinaryIO, Iterator, List, Optional, Union, cast
+from typing import IO, Any, Iterator, Optional, cast
 
 from lxml import etree
 
@@ -28,7 +29,7 @@ DETECTION_ORIGIN: str = "xml"
 
 def get_leaf_elements(
     filename: Optional[str] = None,
-    file: Optional[Union[IO[bytes], SpooledTemporaryFile]] = None,
+    file: Optional[IO[bytes]] = None,
     text: Optional[str] = None,
     xml_path: Optional[str] = None,
 ) -> Iterator[Optional[str]]:
@@ -37,20 +38,14 @@ def get_leaf_elements(
     if filename:
         return _get_leaf_elements(filename, xml_path=xml_path)
     elif file:
-        f = cast(
-            IO[bytes],
-            spooled_to_bytes_io_if_needed(
-                cast(Union[BinaryIO, SpooledTemporaryFile], file),
-            ),
-        )
-        return _get_leaf_elements(f, xml_path=xml_path)
+        return _get_leaf_elements(file=spooled_to_bytes_io_if_needed(file), xml_path=xml_path)
     else:
         b = BytesIO(bytes(cast(str, text), encoding="utf-8"))
         return _get_leaf_elements(b, xml_path=xml_path)
 
 
 def _get_leaf_elements(
-    file: Union[str, IO[bytes]],
+    file: str | IO[bytes],
     xml_path: Optional[str] = None,
 ) -> Iterator[Optional[str]]:
     """Parse the XML tree in a memory efficient manner if possible."""
@@ -84,7 +79,7 @@ def _get_leaf_elements(
 @add_chunking_strategy
 def partition_xml(
     filename: Optional[str] = None,
-    file: Optional[Union[IO[bytes], SpooledTemporaryFile[bytes]]] = None,
+    file: Optional[IO[bytes]] = None,
     text: Optional[str] = None,
     xml_keep_tags: bool = False,
     xml_path: Optional[str] = None,
@@ -93,11 +88,11 @@ def partition_xml(
     encoding: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,
-    languages: Optional[List[str]] = ["auto"],
+    languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
     **kwargs: Any,
-) -> List[Element]:
+) -> list[Element]:
     """Partitions an XML document into its document elements.
 
     Parameters
@@ -133,7 +128,7 @@ def partition_xml(
     """
     exactly_one(filename=filename, file=file, text=text)
 
-    elements: List[Element] = []
+    elements: list[Element] = []
 
     last_modification_date = None
     if filename:
@@ -154,18 +149,14 @@ def partition_xml(
 
     if xml_keep_tags:
         if filename:
-            _, raw_text = read_txt_file(filename=filename, encoding=encoding)
+            raw_text = read_txt_file(filename=filename, encoding=encoding)[1]
         elif file:
-            f = spooled_to_bytes_io_if_needed(
-                cast(Union[BinaryIO, SpooledTemporaryFile], file),
-            )
-            _, raw_text = read_txt_file(file=f, encoding=encoding)
-        elif text:
+            raw_text = read_txt_file(file=spooled_to_bytes_io_if_needed(file), encoding=encoding)[1]
+        else:
+            assert text is not None
             raw_text = text
 
-        elements = [
-            Text(text=raw_text, metadata=metadata),
-        ]
+        elements = [Text(text=raw_text, metadata=metadata)]
 
     else:
         leaf_elements = get_leaf_elements(


### PR DESCRIPTION
**Summary**
Remedy the persistent type errors when importing `unstructured`. Give the partitioner type annotations a general scrubbing while we're at it.