### PR TITLE
feat: `parition_pdf()` add ability to get `cid` ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.7-dev6
+## 0.13.7-dev7
 
 ### Enhancements
 
@@ -6,6 +6,8 @@
 * **Extract OCRAgent.get_agent().** Generalize access to the configured OCRAgent instance beyond its use for PDFs.
 
 ### Features
+
+* **add ability to get ratio of `cid` characters in embedded text extracted by `pdfminer`**.
 
 ### Fixes
 

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -179,6 +179,33 @@ def test_valid_text(text, outcome):
     assert pdf_image_utils.valid_text(text) == outcome
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("base", 0.0),
+        ("", 0.0),
+        ("(cid:2)", 1.0),
+        ("(cid:1)a", 0.5),
+        ("c(cid:1)ab", 0.25),
+    ],
+)
+def test_cid_ratio(text, expected):
+    assert pdf_image_utils.cid_ratio(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("base", False),
+        ("(cid:2)", True),
+        ("(cid:1234567890)", True),
+        ("jkl;(cid:12)asdf", True),
+    ],
+)
+def test_is_cid_present(text, expected):
+    assert pdf_image_utils.is_cid_present(text) == expected
+
+
 def test_pad_bbox():
     bbox = (100, 100, 200, 200)
     padding = (10, 20)  # Horizontal padding 10, Vertical padding 20

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.7-dev6"  # pragma: no cover
+__version__ = "0.13.7-dev7"  # pragma: no cover

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import re
 import tempfile
 from copy import deepcopy
 from io import BytesIO
@@ -228,6 +229,23 @@ def valid_text(text: str) -> bool:
     if not text:
         return False
     return "(cid:" not in text
+
+
+def cid_ratio(text: str) -> float:
+    """Gets ratio of unknown 'cid' characters extracted from text to all characters."""
+    if not is_cid_present(text):
+        return 0.0
+    cid_pattern = r"\(cid\:(\d+)\)"
+    unmatched, n_cid = re.subn(cid_pattern, "", text)
+    total = n_cid + len(unmatched)
+    return n_cid / total
+
+
+def is_cid_present(text: str) -> bool:
+    """Checks if a cid code is present in a text selection."""
+    if len(text) < len("(cid:x)"):
+        return False
+    return text.find("(cid:") != -1
 
 
 def annotate_layout_elements_with_image(


### PR DESCRIPTION
This PR adds the ability to get the ratio of `cid` characters in embedded text extracted by `pdfminer`. This PR is the second part of moving `cid` related code from `unstructured-inference` to `unstructured` and works together with https://github.com/Unstructured-IO/unstructured-inference/pull/342.