### PR TITLE
remove unnecessary warning log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.7-dev7
+## 0.13.7-dev8
 
 ### Enhancements
 
@@ -13,6 +13,7 @@
 
 * **`partition_docx()` handles short table rows.** The DOCX format allows a table row to start late and/or end early, meaning cells at the beginning or end of a row can be omitted. While there are legitimate uses for this capability, using it in practice is relatively rare. However, it can happen unintentionally when adjusting cell borders with the mouse. Accommodate this case and generate accurate `.text` and `.metadata.text_as_html` for these tables.
 * **Remedy macOS test failure not triggered by CI.** Generalize temp-file detection beyond hard-coded Linux-specific prefix.
+* **Remove unnecessary warning log for using default layout model.**
 
 ## 0.13.6
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.7-dev7"  # pragma: no cover
+__version__ = "0.13.7-dev8"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -108,12 +108,6 @@ def default_hi_res_model() -> str:
     # the default hi res model name is done on importing of this submodule; this allows (if user
     # prefers) for setting env after importing the sub module and changing the default model name
 
-    # if tabler structure is needed we defaul to use yolox for better table detection
-    logger.warning(
-        "This function will be deprecated in a future release and `unstructured` will simply "
-        "use the DEFAULT_MODEL from `unstructured_inference.model.base` to set default model "
-        "name"
-    )
     from unstructured_inference.models.base import DEFAULT_MODEL
 
     return os.environ.get("UNSTRUCTURED_HI_RES_MODEL_NAME", DEFAULT_MODEL)


### PR DESCRIPTION
The warning log about default model not set is no longer needed. This PR removes this log to reduce confusion.