### PR TITLE
fix param types for partition_image and _pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.13.8-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* **Make the filename and file params for partition_image and partition_pdf match the other partitioners**
+
 ## 0.13.7
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.7"  # pragma: no cover
+__version__ = "0.13.8-dev0"  # pragma: no cover

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
@@ -17,8 +17,8 @@ from unstructured.partition.utils.constants import PartitionStrategy
 @add_metadata
 @add_chunking_strategy
 def partition_image(
-    filename: str = "",
-    file: Optional[bytes] = None,
+    filename: Optional[str] = None,
+    file: Optional[IO[bytes]] = None,
     include_page_breaks: bool = False,
     infer_table_structure: bool = False,
     ocr_languages: Optional[str] = None,

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -117,7 +117,7 @@ def default_hi_res_model() -> str:
 @add_metadata_with_filetype(FileType.PDF)
 @add_chunking_strategy
 def partition_pdf(
-    filename: str = "",
+    filename: Optional[str] = None,
     file: Optional[IO[bytes]] = None,
     include_page_breaks: bool = False,
     strategy: str = PartitionStrategy.AUTO,


### PR DESCRIPTION
Make the `filename` and `file` params for `partition_image` and `partition_pdf` match the other partitioners