### PR TITLE
Quickfix: re-apply skip accuracy calculation enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.8-dev1
+## 0.13.8-dev2
 
 ### Enhancements
 
@@ -10,6 +10,7 @@
 
 * **Add missing starting_page_num param to partition_image**
 * **Make the filename and file params for partition_image and partition_pdf match the other partitioners**
+* **Re-apply: skip accuracy calculation feature** Overwritten by mistake
 
 ## 0.13.7
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.8-dev1"  # pragma: no cover
+__version__ = "0.13.8-dev2"  # pragma: no cover

--- a/unstructured/metrics/evaluate.py
+++ b/unstructured/metrics/evaluate.py
@@ -343,7 +343,13 @@ class TextExtractionMetricsCalculator(BaseMetricsCalculator):
         connector = doc.parts[0] if len(doc.parts) > 1 else None
 
         output_cct, source_cct = self._get_ccts(doc)
-        accuracy = round(calculate_accuracy(output_cct, source_cct, self.weights), 3)
+        # NOTE(amadeusz): Levenshtein distance calculation takes too long
+        # skip it if file sizes differ wildly
+        if 0.5 < len(output_cct.encode()) / len(source_cct.encode()) < 2.0:
+            accuracy = round(calculate_accuracy(output_cct, source_cct, self.weights), 3)
+        else:
+            # 0.01 to distinguish it was set manually
+            accuracy = 0.01
         percent_missing = round(calculate_percent_missing_text(output_cct, source_cct), 3)
         return [filename, doctype, connector, accuracy, percent_missing]
 


### PR DESCRIPTION
Changes introduced [in this PR](https://github.com/Unstructured-IO/unstructured/pull/2977) have been overwritten by mistake after merging https://github.com/Unstructured-IO/unstructured/pull/2973 - git did not detect a conflict there due to redesign in evaluate.py

