### PR TITLE
remove unused links param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.13.8-dev2
+## 0.13.8-dev3
 
 ### Enhancements
 
@@ -11,6 +11,7 @@
 * **Add missing starting_page_num param to partition_image**
 * **Make the filename and file params for partition_image and partition_pdf match the other partitioners**
 * **Re-apply: skip accuracy calculation feature** Overwritten by mistake
+* **Remove links param from partition_pdf** `links` is extracted during partitioning and is not needed as a paramter in partition_pdf.
 
 ## 0.13.7
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.8-dev2"  # pragma: no cover
+__version__ = "0.13.8-dev3"  # pragma: no cover

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -6,7 +6,7 @@ import io
 import os
 import re
 import warnings
-from typing import IO, TYPE_CHECKING, Any, Iterator, Optional, Sequence, cast
+from typing import IO, TYPE_CHECKING, Any, Iterator, Optional, cast
 
 import numpy as np
 import pdf2image
@@ -128,7 +128,6 @@ def partition_pdf(
     metadata_filename: Optional[str] = None,  # used by decorator
     metadata_last_modified: Optional[str] = None,
     chunking_strategy: Optional[str] = None,  # used by decorator
-    links: Sequence[Link] = [],
     hi_res_model_name: Optional[str] = None,
     extract_images_in_pdf: bool = False,
     extract_image_block_types: Optional[list[str]] = None,


### PR DESCRIPTION
The `links` param in `partition_pdf` was never used by the partitioner, but added when that metadata element was created. This removes the unused parameter since `links` are extracted during partitioning.