### PR TITLE
Astra DB: explicit projection when reading from Astra DB

### DIFF
--- a/test_unstructured_ingest/python/test-ingest-astra-output.py
+++ b/test_unstructured_ingest/python/test-ingest-astra-output.py
@@ -49,12 +49,16 @@ def check(ctx):
 
     # Grab an embedding from the collection and search against itself
     # Should get the same document back as the most similar
-    find_one = astra_db_collection.find_one()
+    find_one = astra_db_collection.find_one(projection={"*": 1})
     random_vector = find_one["data"]["document"]["$vector"]
     random_text = find_one["data"]["document"]["content"]
 
     # Perform a similarity search
-    find_result = astra_db_collection.vector_find(random_vector, limit=1)
+    find_result = astra_db_collection.vector_find(
+        random_vector,
+        limit=1,
+        fields=["*"],
+    )
 
     # Check that we retrieved the coded cleats copy data
     assert find_result[0]["content"] == random_text


### PR DESCRIPTION
In view of upcoming changes in the Astra DB Data API, this PR explicitly sets a projection every time a `find` command (or equivalent) is executed, in order to ensure all necessary fields of the document are returned by the API.

This occurs in the two method calls `find_one` and `vector_find` in the test `test-ingest-astra-output.py`.

With this change, future versions of the Data API, which may implement an exclude-vector-by-default policy, will not cause any disruption in these tests.