### PR TITLE
feat(docx): add strategy parameter to partition_docx()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.13.8-dev10
+## 0.13.8-dev11
 
 ### Enhancements
 
 * **Faster evaluation** Support for concurrent processing of documents during evaluation
+* **Add strategy parameter to `partition_docx()`.** Behavior of future enhancements may be sensitive the partitioning strategy. Add this parameter so `partition_docx()` is aware of the requested strategy.
 
 ### Features
 

--- a/test_unstructured/partition/docx/test_docx.py
+++ b/test_unstructured/partition/docx/test_docx.py
@@ -40,7 +40,10 @@ from unstructured.documents.elements import (
     Title,
 )
 from unstructured.partition.docx import DocxPartitionerOptions, _DocxPartitioner, partition_docx
-from unstructured.partition.utils.constants import UNSTRUCTURED_INCLUDE_DEBUG_METADATA
+from unstructured.partition.utils.constants import (
+    UNSTRUCTURED_INCLUDE_DEBUG_METADATA,
+    PartitionStrategy,
+)
 
 # -- docx-file loading behaviors -----------------------------------------------------------------
 
@@ -701,6 +704,7 @@ def opts_args() -> dict[str, Any]:
         "infer_table_structure": True,
         "metadata_file_path": None,
         "metadata_last_modified": None,
+        "strategy": None,
     }
 
 
@@ -904,6 +908,20 @@ class DescribeDocxPartitionerOptions:
         assert opts.page_number == 3
         list(opts.increment_page_number())
         assert opts.page_number == 4
+
+    # -- .strategy -------------------------------
+
+    @pytest.mark.parametrize(
+        ("arg_value", "expected_value"),
+        [(None, "hi_res"), (PartitionStrategy.FAST, "fast"), (PartitionStrategy.HI_RES, "hi_res")],
+    )
+    def it_knows_which_partitioning_strategy_to_use(
+        self, opts_args: dict[str, Any], arg_value: str, expected_value: str
+    ):
+        opts_args["strategy"] = arg_value
+        opts = DocxPartitionerOptions(**opts_args)
+
+        assert opts.strategy == expected_value
 
     # -- ._document_contains_pagebreaks ----------
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.13.8-dev10"  # pragma: no cover
+__version__ = "0.13.8-dev11"  # pragma: no cover


### PR DESCRIPTION
**Summary**
The behavior of an image sub-partitioner can be partially determined by the partitioning strategy, for example whether it is "hi_res" or "fast". Add this parameter to `partition_docx()` so it can pass it along to `DocxPartitionerOptions` which will make it available to any image sub-partitioners.