### PR TITLE
fix: set `skip_infer_tables` explicitly in `test_partition_via_api_with_no_strategy`

### DIFF
--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -167,8 +167,7 @@ def test_partition_via_api_raises_with_bad_response(monkeypatch):
 
 
 @pytest.mark.skipif(skip_outside_ci, reason="Skipping test run outside of CI")
-# @pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
-# @pytest.mark.skip()
+@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_with_no_strategy():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.pdf")
 

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -166,8 +166,11 @@ def test_partition_via_api_raises_with_bad_response(monkeypatch):
         partition_via_api(filename=filename)
 
 
-@pytest.mark.skipif(skip_outside_ci, reason="Skipping test run outside of CI")
-@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
+# NOTE(robinson) - temporarily disabling because in tests on main this test is failing
+# even thogu hte element text on the expected and actual output match
+# @pytest.mark.skipif(skip_outside_ci, reason="Skipping test run outside of CI")
+# @pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
+@pytest.mark.skip
 def test_partition_via_api_with_no_strategy():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.pdf")
 

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -166,11 +166,9 @@ def test_partition_via_api_raises_with_bad_response(monkeypatch):
         partition_via_api(filename=filename)
 
 
-# NOTE(robinson) - temporarily disabling because in tests on main this test is failing
-# even thogu hte element text on the expected and actual output match
-# @pytest.mark.skipif(skip_outside_ci, reason="Skipping test run outside of CI")
+@pytest.mark.skipif(skip_outside_ci, reason="Skipping test run outside of CI")
 # @pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
-@pytest.mark.skip()
+# @pytest.mark.skip()
 def test_partition_via_api_with_no_strategy():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.pdf")
 
@@ -178,8 +176,11 @@ def test_partition_via_api_with_no_strategy():
         filename=filename,
         strategy="auto",
         api_key=get_api_key(),
+        skip_infer_table_types=["pdf"],
     )
-    elements_hi_res = partition_via_api(filename=filename, strategy="hi_res", api_key=get_api_key())
+    elements_hi_res = partition_via_api(
+        filename=filename, strategy="hi_res", api_key=get_api_key(), skip_infer_table_types=["pdf"]
+    )
 
     # confirm that hi_res strategy was not passed as default to partition by comparing outputs
     # elements_hi_res[3].text =

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -170,7 +170,7 @@ def test_partition_via_api_raises_with_bad_response(monkeypatch):
 # even thogu hte element text on the expected and actual output match
 # @pytest.mark.skipif(skip_outside_ci, reason="Skipping test run outside of CI")
 # @pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
-@pytest.mark.skip
+@pytest.mark.skip()
 def test_partition_via_api_with_no_strategy():
     filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "layout-parser-paper-fast.pdf")
 


### PR DESCRIPTION
### Summary

A `partition_via_api` test that only runs on `main` was [failing](https://github.com/Unstructured-IO/unstructured/actions/runs/9159429513/job/25181600959) with the following output, likely due to the change in the default behavior for `skip_infer_table_types`. This PR explicitly sets the `skip_infer_table_types` param to avoid the failure..

```python
=========================== short test summary info ============================
FAILED test_unstructured/partition/test_api.py::test_partition_via_api_with_no_strategy - AssertionError: assert 'Zejiang Shen® (<), Ruochen Zhang?, Melissa Dell®, Benjamin Charles Germain Lee?, Jacob Carlson®, and Weining Li®' != 'Zejiang Shen® (<), Ruochen Zhang?, Melissa Dell®, Benjamin Charles Germain Lee?, Jacob Carlson®, and Weining Li®'
 +  where 'Zejiang Shen® (<), Ruochen Zhang?, Melissa Dell®, Benjamin Charles Germain Lee?, Jacob Carlson®, and Weining Li®' = <unstructured.documents.elements.Text object at 0x7fb9069fc610>.text
 +  and   'Zejiang Shen® (<), Ruochen Zhang?, Melissa Dell®, Benjamin Charles Germain Lee?, Jacob Carlson®, and Weining Li®' = <unstructured.documents.elements.Text object at 0x7fb90648ad90>.text
= 1 failed, 2299 passed, 9 skipped, 2 deselected, 2 xfailed, 9 xpassed, 14 warnings in 1241.64s (0:20:41) =
make: *** [Makefile:302: test] Error 1
```

### Testing

After temporarily removing the "skip if not on `main`" `pytest` mark, the [unit tests pass](https://github.com/Unstructured-IO/unstructured/actions/runs/9163268381/job/25192040902?pr=3057O) on the feature branch.