### PR TITLE
rfctr(docx): organize docx tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.2-dev0
+## 0.14.2-dev1
 
 ### Enhancements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.pyright]
 pythonPlatform = "Linux"
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 reportUnnecessaryCast = true
 reportUnnecessaryTypeIgnoreComment = true
 stubPath = "./typings"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.2-dev0"  # pragma: no cover
+__version__ = "0.14.2-dev1"  # pragma: no cover


### PR DESCRIPTION
**Summary**
I preparation for adding DOCX pluggable image extraction, organize a few of the DOCX tests to be parallel to very similar tests for the DOC and ODT partitioners.