### PR TITLE
chore: bump unstructured-inference 0.7.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 0.14.2-dev1
+## 0.14.2
 
 ### Enhancements
 
+* **Bump unstructured-inference==0.7.33**.
+
 ### Features
 
-  * Add attribution to the `pinecone` connector
+* **Add attribution to the `pinecone` connector**.
 
 ### Fixes
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -66,7 +66,7 @@ pygments==2.18.0
     #   sphinx-tabs
 pyyaml==6.0.1
     # via myst-parser
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./base.txt
     #   sphinx

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -71,7 +71,7 @@ rapidfuzz==3.9.1
     # via -r ./base.in
 regex==2024.5.15
     # via nltk
-requests==2.32.1
+requests==2.32.2
     # via
     #   -r ./base.in
     #   unstructured-client

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -66,7 +66,7 @@ pygments==2.18.0
     #   sphinx-tabs
 pyyaml==6.0.1
     # via myst-parser
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./base.txt
     #   sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -189,7 +189,7 @@ jupyterlab==4.2.0
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-server==2.27.1
+jupyterlab-server==2.27.2
     # via
     #   jupyterlab
     #   notebook
@@ -315,7 +315,7 @@ referencing==0.35.1
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./base.txt
     #   -c ./test.txt

--- a/requirements/extra-paddleocr.txt
+++ b/requirements/extra-paddleocr.txt
@@ -174,7 +174,7 @@ rapidfuzz==3.9.1
     #   unstructured-paddleocr
 rarfile==4.2
     # via visualdl
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./base.txt
     #   premailer

--- a/requirements/extra-pdf-image.in
+++ b/requirements/extra-pdf-image.in
@@ -7,6 +7,7 @@ pdfminer.six
 pikepdf
 pillow_heif
 pypdf
+pytesseract
 # Do not move to constraints.in, otherwise unstructured-inference will not be upgraded
 # when unstructured library is.
 unstructured-inference==0.7.33

--- a/requirements/extra-pdf-image.in
+++ b/requirements/extra-pdf-image.in
@@ -8,10 +8,11 @@ pikepdf
 pillow_heif
 pypdf
 pytesseract
+google-cloud-vision
+effdet
 # Do not move to constraints.in, otherwise unstructured-inference will not be upgraded
 # when unstructured library is.
 unstructured-inference==0.7.33
 # unstructured fork of pytesseract that provides an interface to allow for multiple output formats
 # from one tesseract call
 unstructured.pytesseract>=0.3.12
-google-cloud-vision

--- a/requirements/extra-pdf-image.in
+++ b/requirements/extra-pdf-image.in
@@ -9,7 +9,7 @@ pillow_heif
 pypdf
 # Do not move to constraints.in, otherwise unstructured-inference will not be upgraded
 # when unstructured library is.
-unstructured-inference==0.7.31
+unstructured-inference==0.7.33
 # unstructured fork of pytesseract that provides an interface to allow for multiple output formats
 # from one tesseract call
 unstructured.pytesseract>=0.3.12

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile ./extra-pdf-image.in
 #
-antlr4-python3-runtime==4.9.3
-    # via omegaconf
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -30,8 +28,6 @@ cycler==0.12.1
     # via matplotlib
 deprecated==1.2.14
     # via pikepdf
-effdet==0.4.1
-    # via layoutparser
 filelock==3.14.0
     # via
     #   huggingface-hub
@@ -84,7 +80,7 @@ jinja2==3.1.4
     # via torch
 kiwisolver==1.4.5
     # via matplotlib
-layoutparser[layoutmodels,tesseract]==0.3.4
+layoutparser==0.3.4
     # via unstructured-inference
 lxml==5.2.2
     # via
@@ -95,7 +91,7 @@ markupsafe==2.1.5
 matplotlib==3.7.2
     # via
     #   -c ././deps/constraints.txt
-    #   pycocotools
+    #   unstructured-inference
 mpmath==1.3.0
     # via sympy
 networkx==3.2.1
@@ -111,12 +107,9 @@ numpy==1.26.4
     #   onnxruntime
     #   opencv-python
     #   pandas
-    #   pycocotools
     #   scipy
     #   torchvision
     #   transformers
-omegaconf==2.3.0
-    # via effdet
 onnx==1.16.0
     # via
     #   -r ./extra-pdf-image.in
@@ -136,7 +129,6 @@ packaging==23.2
     #   matplotlib
     #   onnxruntime
     #   pikepdf
-    #   pytesseract
     #   transformers
     #   unstructured-pytesseract
 pandas==2.2.2
@@ -161,7 +153,6 @@ pillow==10.3.0
     #   pdfplumber
     #   pikepdf
     #   pillow-heif
-    #   pytesseract
     #   torchvision
     #   unstructured-pytesseract
 pillow-heif==0.16.0
@@ -188,10 +179,6 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pycocotools==2.0.7
-    # via
-    #   -c ././deps/constraints.txt
-    #   effdet
 pycparser==2.22
     # via cffi
 pyparsing==3.0.9
@@ -202,8 +189,6 @@ pypdf==4.2.0
     # via -r ./extra-pdf-image.in
 pypdfium2==4.30.0
     # via pdfplumber
-pytesseract==0.3.10
-    # via layoutparser
 python-dateutil==2.9.0.post0
     # via
     #   -c ./base.txt
@@ -217,7 +202,6 @@ pyyaml==6.0.1
     # via
     #   huggingface-hub
     #   layoutparser
-    #   omegaconf
     #   timm
     #   transformers
 rapidfuzz==3.9.1
@@ -228,7 +212,7 @@ regex==2024.5.15
     # via
     #   -c ./base.txt
     #   transformers
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./base.txt
     #   google-api-core
@@ -253,21 +237,17 @@ sympy==1.12
     #   onnxruntime
     #   torch
 timm==1.0.3
-    # via effdet
+    # via unstructured-inference
 tokenizers==0.19.1
     # via transformers
 torch==2.3.0
     # via
     #   -c ././deps/constraints.txt
-    #   effdet
-    #   layoutparser
     #   timm
     #   torchvision
+    #   unstructured-inference
 torchvision==0.18.0
-    # via
-    #   effdet
-    #   layoutparser
-    #   timm
+    # via timm
 tqdm==4.66.4
     # via
     #   -c ./base.txt
@@ -285,7 +265,7 @@ typing-extensions==4.11.0
     #   torch
 tzdata==2024.1
     # via pandas
-unstructured-inference==0.7.31
+unstructured-inference==0.7.33
     # via -r ./extra-pdf-image.in
 unstructured-pytesseract==0.3.12
     # via

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -129,6 +129,7 @@ packaging==23.2
     #   matplotlib
     #   onnxruntime
     #   pikepdf
+    #   pytesseract
     #   transformers
     #   unstructured-pytesseract
 pandas==2.2.2
@@ -153,6 +154,7 @@ pillow==10.3.0
     #   pdfplumber
     #   pikepdf
     #   pillow-heif
+    #   pytesseract
     #   torchvision
     #   unstructured-pytesseract
 pillow-heif==0.16.0
@@ -189,6 +191,8 @@ pypdf==4.2.0
     # via -r ./extra-pdf-image.in
 pypdfium2==4.30.0
     # via pdfplumber
+pytesseract==0.3.10
+    # via -r ./extra-pdf-image.in
 python-dateutil==2.9.0.post0
     # via
     #   -c ./base.txt
@@ -254,7 +258,7 @@ tqdm==4.66.4
     #   huggingface-hub
     #   iopath
     #   transformers
-transformers==4.41.0
+transformers==4.41.1
     # via unstructured-inference
 typing-extensions==4.11.0
     # via

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile ./extra-pdf-image.in
 #
+antlr4-python3-runtime==4.9.3
+    # via omegaconf
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -28,6 +30,8 @@ cycler==0.12.1
     # via matplotlib
 deprecated==1.2.14
     # via pikepdf
+effdet==0.4.1
+    # via -r ./extra-pdf-image.in
 filelock==3.14.0
     # via
     #   huggingface-hub
@@ -91,6 +95,7 @@ markupsafe==2.1.5
 matplotlib==3.7.2
     # via
     #   -c ././deps/constraints.txt
+    #   pycocotools
     #   unstructured-inference
 mpmath==1.3.0
     # via sympy
@@ -107,9 +112,12 @@ numpy==1.26.4
     #   onnxruntime
     #   opencv-python
     #   pandas
+    #   pycocotools
     #   scipy
     #   torchvision
     #   transformers
+omegaconf==2.3.0
+    # via effdet
 onnx==1.16.0
     # via
     #   -r ./extra-pdf-image.in
@@ -181,6 +189,10 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
+pycocotools==2.0.7
+    # via
+    #   -c ././deps/constraints.txt
+    #   effdet
 pycparser==2.22
     # via cffi
 pyparsing==3.0.9
@@ -206,6 +218,7 @@ pyyaml==6.0.1
     # via
     #   huggingface-hub
     #   layoutparser
+    #   omegaconf
     #   timm
     #   transformers
 rapidfuzz==3.9.1
@@ -241,17 +254,22 @@ sympy==1.12
     #   onnxruntime
     #   torch
 timm==1.0.3
-    # via unstructured-inference
+    # via
+    #   effdet
+    #   unstructured-inference
 tokenizers==0.19.1
     # via transformers
 torch==2.3.0
     # via
     #   -c ././deps/constraints.txt
+    #   effdet
     #   timm
     #   torchvision
     #   unstructured-inference
 torchvision==0.18.0
-    # via timm
+    # via
+    #   effdet
+    #   timm
 tqdm==4.66.4
     # via
     #   -c ./base.txt

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -100,7 +100,7 @@ tqdm==4.66.4
     #   huggingface-hub
     #   sacremoses
     #   transformers
-transformers==4.41.0
+transformers==4.41.1
     # via -r ./huggingface.in
 typing-extensions==4.11.0
     # via

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -71,7 +71,7 @@ regex==2024.5.15
     #   -c ./base.txt
     #   sacremoses
     #   transformers
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./base.txt
     #   huggingface-hub

--- a/requirements/ingest/airtable.txt
+++ b/requirements/ingest/airtable.txt
@@ -27,7 +27,7 @@ pydantic==2.7.1
     # via pyairtable
 pydantic-core==2.18.2
     # via pydantic
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   pyairtable

--- a/requirements/ingest/astra.txt
+++ b/requirements/ingest/astra.txt
@@ -8,7 +8,7 @@ anyio==3.7.1
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   httpx
-astrapy==1.1.0
+astrapy==1.2.0
     # via -r ./ingest/astra.in
 bson==0.5.10
     # via astrapy
@@ -69,7 +69,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ./ingest/../base.txt
     #   bson
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   cassio

--- a/requirements/ingest/azure-cognitive-search.txt
+++ b/requirements/ingest/azure-cognitive-search.txt
@@ -25,7 +25,7 @@ idna==3.7
     #   requests
 isodate==0.6.1
     # via azure-search-documents
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   azure-core

--- a/requirements/ingest/azure.txt
+++ b/requirements/ingest/azure.txt
@@ -82,7 +82,7 @@ pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.8.0
     # via msal
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   azure-core

--- a/requirements/ingest/box.txt
+++ b/requirements/ingest/box.txt
@@ -8,7 +8,7 @@ attrs==23.2.0
     # via boxsdk
 boxfs==0.3.0
     # via -r ./ingest/box.in
-boxsdk[jwt]==3.9.2
+boxsdk[jwt]==3.10.0
     # via boxfs
 certifi==2024.2.2
     # via
@@ -40,7 +40,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ./ingest/../base.txt
     #   boxsdk
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   boxsdk

--- a/requirements/ingest/chroma.txt
+++ b/requirements/ingest/chroma.txt
@@ -161,7 +161,7 @@ pyyaml==6.0.1
     #   huggingface-hub
     #   kubernetes
     #   uvicorn
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   chromadb

--- a/requirements/ingest/clarifai.txt
+++ b/requirements/ingest/clarifai.txt
@@ -56,7 +56,7 @@ python-rapidjson==1.17
     # via tritonclient
 pyyaml==6.0.1
     # via clarifai
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   clarifai-grpc

--- a/requirements/ingest/confluence.txt
+++ b/requirements/ingest/confluence.txt
@@ -31,7 +31,7 @@ oauthlib==3.2.2
     # via
     #   atlassian-python-api
     #   requests-oauthlib
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   atlassian-python-api

--- a/requirements/ingest/databricks-volumes.txt
+++ b/requirements/ingest/databricks-volumes.txt
@@ -29,7 +29,7 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   databricks-sdk

--- a/requirements/ingest/dropbox.txt
+++ b/requirements/ingest/dropbox.txt
@@ -28,7 +28,7 @@ idna==3.7
     #   requests
 ply==3.11
     # via stone
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   dropbox

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -60,7 +60,7 @@ langchain==0.2.0
     # via langchain-community
 langchain-community==0.2.0
     # via -r ./ingest/embed-aws-bedrock.in
-langchain-core==0.2.0
+langchain-core==0.2.1
     # via
     #   langchain
     #   langchain-community
@@ -114,7 +114,7 @@ pyyaml==6.0.1
     #   langchain
     #   langchain-community
     #   langchain-core
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   langchain

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -67,7 +67,7 @@ langchain-core==0.2.1
     #   langchain-text-splitters
 langchain-text-splitters==0.2.0
     # via langchain
-langsmith==0.1.60
+langsmith==0.1.61
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -72,7 +72,7 @@ langchain==0.2.0
     # via langchain-community
 langchain-community==0.2.0
     # via -r ./ingest/embed-huggingface.in
-langchain-core==0.2.0
+langchain-core==0.2.1
     # via
     #   langchain
     #   langchain-community
@@ -142,7 +142,7 @@ regex==2024.5.15
     # via
     #   -c ./ingest/../base.txt
     #   transformers
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   huggingface-hub

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -79,7 +79,7 @@ langchain-core==0.2.1
     #   langchain-text-splitters
 langchain-text-splitters==0.2.0
     # via langchain
-langsmith==0.1.60
+langsmith==0.1.61
     # via
     #   langchain
     #   langchain-community
@@ -186,7 +186,7 @@ tqdm==4.66.4
     #   huggingface-hub
     #   sentence-transformers
     #   transformers
-transformers==4.41.0
+transformers==4.41.1
     # via sentence-transformers
 typing-extensions==4.11.0
     # via

--- a/requirements/ingest/embed-octoai.txt
+++ b/requirements/ingest/embed-octoai.txt
@@ -48,7 +48,7 @@ regex==2024.5.15
     # via
     #   -c ./ingest/../base.txt
     #   tiktoken
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   tiktoken

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -75,7 +75,7 @@ langchain-core==0.2.1
     #   langchain-text-splitters
 langchain-text-splitters==0.2.0
     # via langchain
-langsmith==0.1.60
+langsmith==0.1.61
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -68,7 +68,7 @@ langchain==0.2.0
     # via langchain-community
 langchain-community==0.2.0
     # via -r ./ingest/embed-openai.in
-langchain-core==0.2.0
+langchain-core==0.2.1
     # via
     #   langchain
     #   langchain-community
@@ -125,7 +125,7 @@ regex==2024.5.15
     # via
     #   -c ./ingest/../base.txt
     #   tiktoken
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   langchain

--- a/requirements/ingest/embed-vertexai.txt
+++ b/requirements/ingest/embed-vertexai.txt
@@ -117,7 +117,7 @@ langchain-google-vertexai==1.0.4
     # via -r ./ingest/embed-vertexai.in
 langchain-text-splitters==0.2.0
     # via langchain
-langsmith==0.1.60
+langsmith==0.1.61
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-vertexai.txt
+++ b/requirements/ingest/embed-vertexai.txt
@@ -55,9 +55,9 @@ google-auth==2.29.0
     #   google-cloud-core
     #   google-cloud-resource-manager
     #   google-cloud-storage
-google-cloud-aiplatform==1.51.0
+google-cloud-aiplatform==1.52.0
     # via langchain-google-vertexai
-google-cloud-bigquery==3.23.0
+google-cloud-bigquery==3.23.1
     # via google-cloud-aiplatform
 google-cloud-core==2.4.1
     # via
@@ -107,7 +107,7 @@ langchain==0.2.0
     #   langchain-community
 langchain-community==0.2.0
     # via -r ./ingest/embed-vertexai.in
-langchain-core==0.2.0
+langchain-core==0.2.1
     # via
     #   langchain
     #   langchain-community
@@ -189,7 +189,7 @@ pyyaml==6.0.1
     #   langchain
     #   langchain-community
     #   langchain-core
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   google-api-core

--- a/requirements/ingest/gcs.txt
+++ b/requirements/ingest/gcs.txt
@@ -92,7 +92,7 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   gcsfs

--- a/requirements/ingest/github.txt
+++ b/requirements/ingest/github.txt
@@ -33,7 +33,7 @@ pyjwt[crypto]==2.8.0
     # via pygithub
 pynacl==1.5.0
     # via pygithub
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   pygithub

--- a/requirements/ingest/gitlab.txt
+++ b/requirements/ingest/gitlab.txt
@@ -19,7 +19,7 @@ idna==3.7
     #   requests
 python-gitlab==4.5.0
     # via -r ./ingest/gitlab.in
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   python-gitlab

--- a/requirements/ingest/google-drive.txt
+++ b/requirements/ingest/google-drive.txt
@@ -54,7 +54,7 @@ pyparsing==3.0.9
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   httplib2
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   google-api-core

--- a/requirements/ingest/jira.txt
+++ b/requirements/ingest/jira.txt
@@ -31,7 +31,7 @@ oauthlib==3.2.2
     # via
     #   atlassian-python-api
     #   requests-oauthlib
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   atlassian-python-api

--- a/requirements/ingest/onedrive.txt
+++ b/requirements/ingest/onedrive.txt
@@ -43,7 +43,7 @@ pyjwt[crypto]==2.8.0
     # via msal
 pytz==2024.1
     # via office365-rest-python-client
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   msal

--- a/requirements/ingest/opensearch.txt
+++ b/requirements/ingest/opensearch.txt
@@ -24,7 +24,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ./ingest/../base.txt
     #   opensearch-py
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   opensearch-py

--- a/requirements/ingest/outlook.txt
+++ b/requirements/ingest/outlook.txt
@@ -37,7 +37,7 @@ pyjwt[crypto]==2.8.0
     # via msal
 pytz==2024.1
     # via office365-rest-python-client
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   msal

--- a/requirements/ingest/reddit.txt
+++ b/requirements/ingest/reddit.txt
@@ -21,7 +21,7 @@ praw==7.7.1
     # via -r ./ingest/reddit.in
 prawcore==2.4.0
     # via praw
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   prawcore

--- a/requirements/ingest/salesforce.txt
+++ b/requirements/ingest/salesforce.txt
@@ -41,7 +41,7 @@ pyjwt[crypto]==2.8.0
     # via simple-salesforce
 pytz==2024.1
     # via zeep
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   requests-file

--- a/requirements/ingest/sharepoint.txt
+++ b/requirements/ingest/sharepoint.txt
@@ -37,7 +37,7 @@ pyjwt[crypto]==2.8.0
     # via msal
 pytz==2024.1
     # via office365-rest-python-client
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   msal

--- a/requirements/ingest/weaviate.txt
+++ b/requirements/ingest/weaviate.txt
@@ -61,7 +61,7 @@ pydantic==2.7.1
     # via weaviate-client
 pydantic-core==2.18.2
     # via pydantic
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   weaviate-client

--- a/requirements/ingest/wikipedia.txt
+++ b/requirements/ingest/wikipedia.txt
@@ -21,7 +21,7 @@ idna==3.7
     # via
     #   -c ./ingest/../base.txt
     #   requests
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./ingest/../base.txt
     #   wikipedia

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -122,7 +122,7 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.1
+requests==2.32.2
     # via
     #   -c ./base.txt
     #   label-studio-sdk

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.2-dev1"  # pragma: no cover
+__version__ = "0.14.2"  # pragma: no cover


### PR DESCRIPTION
Summary:
- bump unstructured-inference to `0.7.33`
- cut a release for `0.14.2`
- add some dependencies that previously came through from the layoutparser extras