### PR TITLE
docs: make 404 pages same as index

### DIFF
--- a/docs/source/404.rst
+++ b/docs/source/404.rst
@@ -1,0 +1,6 @@
+Unstructured Documentation
+==========================
+
+The Unstructured documentation page has moved! Check out our new and improved docs page at
+`https://docs.unstructured.io <https://docs.unstructured.io>`_ to learn more about our
+products and tools.


### PR DESCRIPTION
### Summary

Makes a custom 404 page that's the same as `index.html`, so any path shows the URL for the new docs.