### PR TITLE
chore: use python3 consistently in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ install-huggingface:
 
 .PHONY: install-nltk-models
 install-nltk-models:
-	python -c "import nltk; nltk.download('punkt')"
-	python -c "import nltk; nltk.download('averaged_perceptron_tagger')"
+	python3 -c "import nltk; nltk.download('punkt')"
+	python3 -c "import nltk; nltk.download('averaged_perceptron_tagger')"
 
 .PHONY: install-test
 install-test:


### PR DESCRIPTION
This PR changes two `python` commands in `Makefile` to use `python3` to be consistent with other make commands. This makes it more explicit on which python to use when the makefile is used outside of a controlled virtualenv where only one python exists.