### PR TITLE
rfctr(html): organize and improve HTMLDocument tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.5-dev4
+## 0.14.5-dev5
 
 ### Enhancements
 

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import os
 import pathlib
 from typing import cast
 
@@ -12,7 +11,13 @@ import pytest
 from lxml import etree
 from lxml import html as lxml_html
 
-from test_unstructured.unit_utils import FixtureRequest, Mock, function_mock, property_mock
+from test_unstructured.unit_utils import (
+    FixtureRequest,
+    Mock,
+    example_doc_path,
+    function_mock,
+    property_mock,
+)
 from unstructured.documents import html
 from unstructured.documents.base import Page
 from unstructured.documents.elements import (
@@ -23,11 +28,6 @@ from unstructured.documents.elements import (
     Title,
 )
 from unstructured.documents.html import (
-    HEADING_TAGS,
-    LIST_ITEM_TAGS,
-    SECTION_TAGS,
-    TABLE_TAGS,
-    TEXT_TAGS,
     HTMLAddress,
     HTMLDocument,
     HTMLNarrativeText,
@@ -37,8 +37,6 @@ from unstructured.documents.html import (
     TagsMixin,
     _parse_HTMLTable_from_table_elem,
 )
-
-DIRECTORY = pathlib.Path(__file__).parent.resolve()
 
 TAGS = (
     (
@@ -62,11 +60,11 @@ VOID_TAGS = (
     .split("<")[1:]
 )
 
-INCLUDED_TAGS = TEXT_TAGS + HEADING_TAGS + LIST_ITEM_TAGS + SECTION_TAGS
+INCLUDED_TAGS = html.TEXT_TAGS + html.HEADING_TAGS + html.LIST_ITEM_TAGS + html.SECTION_TAGS
 EXCLUDED_TAGS = [
     tag
     for tag in TAGS
-    if tag not in (INCLUDED_TAGS + TABLE_TAGS + VOID_TAGS + ["html", "head", "body"])
+    if tag not in (INCLUDED_TAGS + html.TABLE_TAGS + VOID_TAGS + ["html", "head", "body"])
 ]
 
 
@@ -159,6 +157,32 @@ def test_it_does_not_emit_an_HTMLTable_element_for_a_table_with_no_text():
     assert html_document.elements == []
 
 
+def test_it_grabs_bulleted_text_in_tables_as_ListItem_elements():
+    html_document = HTMLDocument.from_string(
+        "<html>\n"
+        "  <body>\n"
+        "    <table>\n"
+        "      <tbody>\n"
+        "        <tr>\n"
+        "          <td>&#8226;</td>\n"
+        "          <td><p>Happy Groundhog's day!</p></td>\n"
+        "        </tr>\n"
+        "        <tr>\n"
+        "          <td>&#8226;</td>\n"
+        "          <td><p>Looks like six more weeks of winter ...</p></td>\n"
+        "        </tr>\n"
+        "      </tbody>\n"
+        "    </table>\n"
+        "  </body>\n"
+        "</html>\n"
+    )
+
+    assert html_document.elements == [
+        ListItem(text="Happy Groundhog's day!"),
+        ListItem(text="Looks like six more weeks of winter ..."),
+    ]
+
+
 def test_it_does_not_consider_an_empty_table_a_bulleted_text_table():
     html_str = (
         "<html>\n"
@@ -224,8 +248,7 @@ def test_it_provides_parseable_HTML_in_text_as_html():
 
 
 def test_it_does_not_extract_text_in_script_tags():
-    filename = os.path.join(DIRECTORY, "..", "..", "example-docs", "example-with-scripts.html")
-    doc = HTMLDocument.from_file(filename=filename)
+    doc = HTMLDocument.from_file(example_doc_path("example-with-scripts.html"))
     assert all("function (" not in element.text for element in doc.elements)
 
 
@@ -248,7 +271,7 @@ def test_it_does_not_extract_text_in_style_tags():
 # -- TagsMixin -----------------------------------------------------------------------------------
 
 
-def test_raises_error_no_tag():
+def test_TagsMixin_element_raises_on_construction_with_no_or_None_tag():
     with pytest.raises(TypeError):
         TagsMixin(tag=None)
     with pytest.raises(TypeError):
@@ -259,111 +282,70 @@ def test_raises_error_no_tag():
 
 
 def test_read_html_doc(tmp_path: pathlib.Path):
-    TITLE1 = "A Great and Glorious Section"
-    SECTION1 = "Dear Leader is the best. He is such a wonderful engineer!"
-    TITLE2 = "Another Magnificent Title"
-    SECTION2 = "The last section is a title because of its capitalization patterns!"
-    TABLE_SECTION = "Skip me because I'm in a table"
-    TITLE3 = "A New Beginning"
-    SECTION3 = "Here is the start of a new page."
-
-    doc = f"""<html>
-    <body>
-        <header>
-            <p>Here is a header. We want to ignore anything that is in this section.</p>
-        </header>
-        <h1>{TITLE1}</h1>
-        <p>{SECTION1}</p>
-        <p></p>
-        <p>{TITLE2}</p>
-        <p><b>{SECTION2}</b></p>
-        <table>
-            <tbody>
-                <tr>
-                    <td><p>{TABLE_SECTION}</p></td>
-                </tr>
-            </tbody>
-        </table>
-        <hr>
-        <h2>{TITLE3}</h2>
-        <div>{SECTION3}</div>
-        <footer>
-            <p>Here is a footer. We want to ignore anything that is in this section</p>
-        </footer>
-        <div>
-            <p>Let's ignore anything after the footer too since it's probably garbage.</p>
-        </div>
-    </body>
-</html>"""
     filename = str(tmp_path / "sample-doc.html")
     with open(filename, "w") as f:
-        f.write(doc)
+        f.write(
+            "<html>\n"
+            "  <body>\n"
+            "    <header>\n"
+            "      <p>Here is a header. We want to ignore anything that is in this section.</p>\n"
+            "    </header>\n"
+            "    <h1>A Great and Glorious Section</h1>\n"
+            "    <p>Dear Leader is the best. He is such a wonderful engineer!</p>\n"
+            "    <p></p>\n"
+            "    <p>Another Magnificent Title</p>\n"
+            "    <p><b>The prior element is a title based on its capitalization patterns!</b></p>\n"
+            "    <table>\n"
+            "      <tbody>\n"
+            "        <tr>\n"
+            "          <td><p>Skip me because I'm in a table</p></td>\n"
+            "        </tr>\n"
+            "      </tbody>\n"
+            "    </table>\n"
+            "    <hr>\n"
+            "    <h2>A New Beginning</h2>\n"
+            "    <div>Here is the start of a new page.</div>\n"
+            "    <footer>\n"
+            "      <p>Here is a footer. We want to ignore anything that is in this section</p>\n"
+            "    </footer>\n"
+            "    <div>\n"
+            "      <p>Let's ignore anything after the footer too since it's probably garbage.</p>\n"
+            "    </div>\n"
+            "  </body>\n"
+            "</html>\n"
+        )
 
     html_document = HTMLDocument.from_file(filename=filename).doc_after_cleaners(
-        skip_headers_and_footers=True,
-        skip_table=True,
+        skip_headers_and_footers=True, skip_table=True
     )
-    print("original pages: ", HTMLDocument.from_file(filename=filename).pages)
-    print("filtered pages: ", html_document.pages)
-    print([el.text for el in html_document.pages[0].elements])
 
     assert len(html_document.pages) == 2
-
+    assert all(isinstance(p, Page) for p in html_document.pages)
+    # --
     page_one = html_document.pages[0]
     assert len(page_one.elements) == 4
     assert page_one.elements == [
-        Title(text=TITLE1),
-        NarrativeText(text=SECTION1),
-        Title(text=TITLE2),
-        NarrativeText(text=SECTION2),
+        Title("A Great and Glorious Section"),
+        NarrativeText("Dear Leader is the best. He is such a wonderful engineer!"),
+        Title("Another Magnificent Title"),
+        NarrativeText("The prior element is a title based on its capitalization patterns!"),
     ]
-
+    # --
     page_two = html_document.pages[1]
     assert len(page_two.elements) == 2
     assert page_two.elements == [
-        Title(text=TITLE3),
-        NarrativeText(text=SECTION3),
+        Title("A New Beginning"),
+        NarrativeText("Here is the start of a new page."),
     ]
-
-    pages = html_document.pages
-    assert all(isinstance(page, Page) for page in pages)
 
 
 # -- HTMLDocument.from_pages() -------------------------------------------------------------------
 
 
-def test_read_with_existing_pages():
+def test_HTMLDocument_can_construct_from_existing_pages():
     page = Page(number=0)
     html_document = HTMLDocument.from_pages([page])
     assert html_document.pages == [page]
-
-
-# -- HTMLDocument.from_string() ------------------------------------------------------------------
-
-
-def test_html_grabs_bulleted_text_in_tables():
-    html_str = """<html>
-    <body>
-        <table>
-            <tbody>
-                <tr>
-                    <td>&#8226;</td>
-                    <td><p>Happy Groundhog's day!</p></td>
-                </tr>
-                <tr>
-                    <td>&#8226;</td>
-                    <td><p>Looks like six more weeks of winter ...</p></td>
-                </tr>
-            </tbody>
-        </table>
-    </body>
-</html>"""
-    html_document = HTMLDocument.from_string(html_str)
-
-    assert html_document.elements == [
-        ListItem(text="Happy Groundhog's day!"),
-        ListItem(text="Looks like six more weeks of winter ..."),
-    ]
 
 
 # -- HTMLDocument.doc_after_cleaners() -----------------------------------------------------------
@@ -376,18 +358,19 @@ def test_include_headers_and_footers(sample_doc: HTMLDocument):
 
 def test_read_without_skipping_table(is_possible_narrative_text_: Mock):
     is_possible_narrative_text_.return_value = True
-    doc = """<html>
-    <body>
-        <table>
-            <tbody>
-                <tr>
-                    <td><p>Hi there! I am Matt!</p></td>
-                </tr>
-            </tbody>
-        </table>
-    </body>
-</html>"""
-    document = HTMLDocument.from_string(doc).doc_after_cleaners(skip_table=False)
+    document = HTMLDocument.from_string(
+        "<html>\n"
+        "  <body>\n"
+        "    <table>\n"
+        "      <tbody>\n"
+        "        <tr>\n"
+        "          <td><p>Hi there! I am Matt!</p></td>\n"
+        "        </tr>\n"
+        "      </tbody>\n"
+        "    </table>\n"
+        "  </body>\n"
+        "</html>\n"
+    ).doc_after_cleaners(skip_table=False)
     assert document.pages[0].elements[0] == Table(text="Hi there! I am Matt!")
 
 
@@ -401,7 +384,7 @@ def test_tag_types_table(sample_doc: HTMLDocument):
     assert len(html_document.pages[0].elements) == 2
 
 
-def test_raises_error_wrong_elements(sample_doc: HTMLDocument, pages_prop_: Mock):
+def test_cleaner_raises_on_non_element_elements(sample_doc: HTMLDocument, pages_prop_: Mock):
     page = Page(0)
     page.elements = [
         "this should def not be a string"  # pyright: ignore[reportAttributeAccessIssue]
@@ -411,14 +394,15 @@ def test_raises_error_wrong_elements(sample_doc: HTMLDocument, pages_prop_: Mock
         sample_doc.doc_after_cleaners()
 
 
-def test_filter_in_place():
-    html_doc = """
-    <table><tbody><tr><td>A table thing.</td></tr></tbody></table>
-    <p>A non-table thing</p>
-    """
-    doc = HTMLDocument.from_string(html_doc)
+def test_cleaner_can_filter_out_tables_in_place():
+    doc = HTMLDocument.from_string(
+        "<table><tbody><tr><td>A table thing.</td></tr></tbody></table>\n"
+        "<p>A non-table thing</p>\n"
+    )
     assert len(doc.elements) == 2
+
     doc.doc_after_cleaners(skip_table=True, inplace=True)
+
     assert len(doc.elements) == 1
 
 
@@ -426,147 +410,138 @@ def test_filter_in_place():
 
 
 def test_parses_tags_correctly():
-    raw_html = """<html>
-    <body>
-        <table>
-            <tbody>
-                <tr>
-                    <td><p>Hi there!</p></td>
-                </tr>
-            </tbody>
-        </table>
-    </body>
-</html>"""
-    doc = HTMLDocument.from_string(raw_html)
+    doc = HTMLDocument.from_string(
+        "<html>\n"
+        "  <body>\n"
+        "    <table>\n"
+        "      <tbody>\n"
+        "        <tr>\n"
+        "          <td><p>Hi there!</p></td>\n"
+        "        </tr>\n"
+        "      </tbody>\n"
+        "    </table>\n"
+        "  </body>\n"
+        "</html>\n"
+    )
     element = cast(TagsMixin, doc.elements[0])
     assert element.ancestortags == ("html", "body")
     assert element.tag == "table"
 
 
 def test_nested_text_tags():
-    tag1, tag2 = [tag for tag in TEXT_TAGS if tag not in TABLE_TAGS][:2]
-    html_str = f"""
-    <body>
-        <{tag1}>
-            <{tag2}>
-                There is some text here.
-            </{tag2}>
-        </{tag1}>
-    </body>
-    """
+    tag1, tag2 = [tag for tag in html.TEXT_TAGS if tag not in html.TABLE_TAGS][:2]
+    html_str = (
+        f"<body>\n"
+        f"    <{tag1}>\n"
+        f"        <{tag2}>\n"
+        f"            There is some text here.\n"
+        f"        </{tag2}>\n"
+        f"    </{tag1}>\n"
+        f"</body>\n"
+    )
+
     html_document = HTMLDocument.from_string(html_str).doc_after_cleaners(skip_table=False)
+
     assert len(html_document.pages[0].elements) == 1
 
 
 def test_containers_with_text_are_processed():
-    html_str = """<div dir=3D"ltr">Hi All,<div><br></div>
-   <div>Get excited for our first annual family day!</div>
-   <div>Best.<br clear=3D"all">
-      <div><br></div>
-      -- <br>
-      <div dir=3D"ltr">
-         <div dir=3D"ltr">Dino the Datasaur<div>Unstructured Technologies<br><div>Data Scientist
-                </div>
-                <div>Doylestown, PA 18901</div>
-               <div><br></div>
-            </div>
-         </div>
-      </div>
-   </div>
-</div>"""
-    html_document = HTMLDocument.from_string(html_str)
+    html_document = HTMLDocument.from_string(
+        '<div dir=3D"ltr">Hi All,<div><br></div>\n'
+        "  <div>Get excited for our first annual family day!</div>\n"
+        '  <div>Best.<br clear=3D"all">\n'
+        "    <div><br></div>\n"
+        "    -- <br>\n"
+        '    <div dir=3D"ltr">\n'
+        '      <div dir=3D"ltr">Dino the Datasaur<div>\n'
+        "      Unstructured Technologies<br>\n"
+        "      <div>Data Scientist</div>\n"
+        "        <div>Doylestown, PA 18901</div>\n"
+        "        <div><br></div>\n"
+        "      </div>\n"
+        "      </div>\n"
+        "    </div>\n"
+        "  </div>\n"
+        "</div>\n"
+    )
 
     assert html_document.elements == [
         HTMLText(text="Hi All,", tag="div"),
         HTMLNarrativeText(text="Get excited for our first annual family day!", tag="div"),
         HTMLTitle(text="Best.", tag="div"),
-        HTMLText(text="\n      -- ", tag="div"),
+        HTMLText(text="\n    -- ", tag="div"),
         HTMLTitle(text="Dino the Datasaur", tag="div"),
-        HTMLTitle(text="Unstructured Technologies", tag="div"),
+        HTMLTitle(text="\n      Unstructured Technologies", tag="div"),
         HTMLTitle(text="Data Scientist", tag="div"),
         HTMLAddress(text="Doylestown, PA 18901", tag="div"),
     ]
 
 
 def test_html_grabs_bulleted_text_in_tags():
-    html_str = """<html>
-    <body>
-        <ol>
-            <li>Happy Groundhog's day!</li>
-            <li>Looks like six more weeks of winter ...</li>
-        </ol>
-    </body>
-</html>"""
-    html_document = HTMLDocument.from_string(html_str)
-
-    assert html_document.elements == [
+    assert HTMLDocument.from_string(
+        "<html>\n"
+        "  <body>\n"
+        "    <ol>\n"
+        "      <li>Happy Groundhog's day!</li>\n"
+        "      <li>Looks like six more weeks of winter ...</li>\n"
+        "    </ol>\n"
+        "  </body>\n"
+        "</html>\n"
+    ).elements == [
         ListItem(text="Happy Groundhog's day!"),
         ListItem(text="Looks like six more weeks of winter ..."),
     ]
 
 
 def test_html_grabs_bulleted_text_in_paras():
-    html_str = """<html>
-    <body>
-        <p>
-            <span>&#8226; Happy Groundhog's day!</span>
-        </p>
-        <p>
-            <span>&#8226; Looks like six more weeks of winter ...</span>
-        </p>
-    </body>
-</html>"""
-    html_document = HTMLDocument.from_string(html_str)
-
-    assert html_document.elements == [
+    assert HTMLDocument.from_string(
+        "<html>\n"
+        "  <body>\n"
+        "    <p>\n"
+        "      <span>&#8226; Happy Groundhog's day!</span>\n"
+        "    </p>\n"
+        "    <p>\n"
+        "      <span>&#8226; Looks like six more weeks of winter ...</span>\n"
+        "    </p>\n"
+        "  </body>\n"
+        "</html>\n"
+    ).elements == [
         ListItem(text="Happy Groundhog's day!"),
         ListItem(text="Looks like six more weeks of winter ..."),
     ]
 
 
 def test_joins_tag_text_correctly():
-    raw_html = "<p>Hello again peet mag<i>ic</i>al</p>"
-    doc = HTMLDocument.from_string(raw_html)
-    el = doc.elements[0]
-    assert el.text == "Hello again peet magical"
+    doc = HTMLDocument.from_string("<p>Hello again peet mag<i>ic</i>al</p>")
+    assert doc.elements[0].text == "Hello again peet magical"
 
 
 def test_sample_doc_with_emoji():
-    raw_html = """
-    <html charset="unicode">
-        <p>Hello again 😀</p>
-    </html>
-    """
-    doc = HTMLDocument.from_string(raw_html)
+    doc = HTMLDocument.from_string('<html charset="unicode">\n<p>Hello again 😀</p>\n</html>')
     # NOTE(robinson) - unclear why right now, but the output is the emoji on the test runners
     # and the byte string representation when running locally on mac
     assert doc.elements[0].text in ["Hello again ð\x9f\x98\x80", "Hello again 😀"]
 
 
 def test_only_plain_text_in_body():
-    raw_html = "<body>Hello</body>"
-    doc = HTMLDocument.from_string(raw_html)
-    assert doc.elements[0].text == "Hello"
+    assert HTMLDocument.from_string("<body>Hello</body>").elements[0].text == "Hello"
 
 
 def test_plain_text_before_anything_in_body():
-    raw_html = "<body>Hello<p>World</p></body>"
-    doc = HTMLDocument.from_string(raw_html)
+    doc = HTMLDocument.from_string("<body>Hello<p>World</p></body>")
     assert doc.elements[0].text == "Hello"
     assert doc.elements[1].text == "World"
 
 
 def test_line_break_in_container():
-    raw_html = "<div>Hello<br/>World</div>"
-    doc = HTMLDocument.from_string(raw_html)
+    doc = HTMLDocument.from_string("<div>Hello<br/>World</div>")
     assert doc.elements[0].text == "Hello"
     assert doc.elements[1].text == "World"
 
 
-@pytest.mark.parametrize("tag", TEXT_TAGS)
+@pytest.mark.parametrize("tag", html.TEXT_TAGS)
 def test_line_break_in_text_tag(tag: str):
-    raw_html = f"<{tag}>Hello<br/>World</{tag}>"
-    doc = HTMLDocument.from_string(raw_html)
+    doc = HTMLDocument.from_string(f"<{tag}>Hello<br/>World</{tag}>")
     assert doc.elements[0].text == "Hello"
     assert doc.elements[1].text == "World"
 
@@ -574,7 +549,7 @@ def test_line_break_in_text_tag(tag: str):
 # -- HTMLDocument.pages --------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("tag", [tag for tag in TEXT_TAGS if tag not in TABLE_TAGS])
+@pytest.mark.parametrize("tag", [tag for tag in html.TEXT_TAGS if tag not in html.TABLE_TAGS])
 def test_tag_types(tag: str):
     html_str = f"""
     <body>
@@ -604,20 +579,12 @@ def test_exclude_tag_types(tag: str):
 
 
 def test_has_table_ancestor():
-    title = HTMLTitle(
-        "I am a Title",
-        tag="td",
-        ancestortags=["html", "body", "table", "tr"],
-    )
+    title = HTMLTitle("I am a Title", tag="td", ancestortags=["html", "body", "table", "tr"])
     assert html.has_table_ancestor(title)
 
 
 def test_has_no_table_ancestor():
-    title = HTMLTitle(
-        "I am a Title",
-        tag="p",
-        ancestortags=["html", "body"],
-    )
+    title = HTMLTitle("I am a Title", tag="p", ancestortags=["html", "body"])
     assert not html.has_table_ancestor(title)
 
 
@@ -1062,7 +1029,6 @@ class Describe_parse_HTMLTable_from_table_elem:
         assert html_table.text == (
             "☒ ANNUAL REPORT PURSUANT TO SECTION 13 OR 15(d) OF THE SECURITIES EXCHANGE ACT OF 1934"
         )
-        print(f"{html_table.text_as_html=}")
         assert html_table.text_as_html == (
             "<table>"
             "<tr><td></td><td></td></tr>"

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -245,6 +245,183 @@ def test_it_does_not_extract_text_in_style_tags():
     assert element.text == "Lorem ipsum dolor"
 
 
+# -- TagsMixin -----------------------------------------------------------------------------------
+
+
+def test_raises_error_no_tag():
+    with pytest.raises(TypeError):
+        TagsMixin(tag=None)
+    with pytest.raises(TypeError):
+        TagsMixin()
+
+
+# -- HTMLDocument.from_file() --------------------------------------------------------------------
+
+
+def test_read_html_doc(tmp_path: pathlib.Path):
+    TITLE1 = "A Great and Glorious Section"
+    SECTION1 = "Dear Leader is the best. He is such a wonderful engineer!"
+    TITLE2 = "Another Magnificent Title"
+    SECTION2 = "The last section is a title because of its capitalization patterns!"
+    TABLE_SECTION = "Skip me because I'm in a table"
+    TITLE3 = "A New Beginning"
+    SECTION3 = "Here is the start of a new page."
+
+    doc = f"""<html>
+    <body>
+        <header>
+            <p>Here is a header. We want to ignore anything that is in this section.</p>
+        </header>
+        <h1>{TITLE1}</h1>
+        <p>{SECTION1}</p>
+        <p></p>
+        <p>{TITLE2}</p>
+        <p><b>{SECTION2}</b></p>
+        <table>
+            <tbody>
+                <tr>
+                    <td><p>{TABLE_SECTION}</p></td>
+                </tr>
+            </tbody>
+        </table>
+        <hr>
+        <h2>{TITLE3}</h2>
+        <div>{SECTION3}</div>
+        <footer>
+            <p>Here is a footer. We want to ignore anything that is in this section</p>
+        </footer>
+        <div>
+            <p>Let's ignore anything after the footer too since it's probably garbage.</p>
+        </div>
+    </body>
+</html>"""
+    filename = str(tmp_path / "sample-doc.html")
+    with open(filename, "w") as f:
+        f.write(doc)
+
+    html_document = HTMLDocument.from_file(filename=filename).doc_after_cleaners(
+        skip_headers_and_footers=True,
+        skip_table=True,
+    )
+    print("original pages: ", HTMLDocument.from_file(filename=filename).pages)
+    print("filtered pages: ", html_document.pages)
+    print([el.text for el in html_document.pages[0].elements])
+
+    assert len(html_document.pages) == 2
+
+    page_one = html_document.pages[0]
+    assert len(page_one.elements) == 4
+    assert page_one.elements == [
+        Title(text=TITLE1),
+        NarrativeText(text=SECTION1),
+        Title(text=TITLE2),
+        NarrativeText(text=SECTION2),
+    ]
+
+    page_two = html_document.pages[1]
+    assert len(page_two.elements) == 2
+    assert page_two.elements == [
+        Title(text=TITLE3),
+        NarrativeText(text=SECTION3),
+    ]
+
+    pages = html_document.pages
+    assert all(isinstance(page, Page) for page in pages)
+
+
+# -- HTMLDocument.from_pages() -------------------------------------------------------------------
+
+
+def test_read_with_existing_pages():
+    page = Page(number=0)
+    html_document = HTMLDocument.from_pages([page])
+    assert html_document.pages == [page]
+
+
+# -- HTMLDocument.from_string() ------------------------------------------------------------------
+
+
+def test_html_grabs_bulleted_text_in_tables():
+    html_str = """<html>
+    <body>
+        <table>
+            <tbody>
+                <tr>
+                    <td>&#8226;</td>
+                    <td><p>Happy Groundhog's day!</p></td>
+                </tr>
+                <tr>
+                    <td>&#8226;</td>
+                    <td><p>Looks like six more weeks of winter ...</p></td>
+                </tr>
+            </tbody>
+        </table>
+    </body>
+</html>"""
+    html_document = HTMLDocument.from_string(html_str)
+
+    assert html_document.elements == [
+        ListItem(text="Happy Groundhog's day!"),
+        ListItem(text="Looks like six more weeks of winter ..."),
+    ]
+
+
+# -- HTMLDocument.doc_after_cleaners() -----------------------------------------------------------
+
+
+def test_include_headers_and_footers(sample_doc: HTMLDocument):
+    html_document = sample_doc.doc_after_cleaners(skip_headers_and_footers=False)
+    assert len(html_document.pages[1].elements) == 3
+
+
+def test_read_without_skipping_table(is_possible_narrative_text_: Mock):
+    is_possible_narrative_text_.return_value = True
+    doc = """<html>
+    <body>
+        <table>
+            <tbody>
+                <tr>
+                    <td><p>Hi there! I am Matt!</p></td>
+                </tr>
+            </tbody>
+        </table>
+    </body>
+</html>"""
+    document = HTMLDocument.from_string(doc).doc_after_cleaners(skip_table=False)
+    assert document.pages[0].elements[0] == Table(text="Hi there! I am Matt!")
+
+
+def test_include_table_text(sample_doc: HTMLDocument):
+    html_document = sample_doc.doc_after_cleaners(skip_table=False)
+    assert len(html_document.pages[0].elements) == 2
+
+
+def test_tag_types_table(sample_doc: HTMLDocument):
+    html_document = sample_doc.doc_after_cleaners(skip_table=True)
+    assert len(html_document.pages[0].elements) == 2
+
+
+def test_raises_error_wrong_elements(sample_doc: HTMLDocument, pages_prop_: Mock):
+    page = Page(0)
+    page.elements = [
+        "this should def not be a string"  # pyright: ignore[reportAttributeAccessIssue]
+    ]
+    pages_prop_.return_value = [page]
+    with pytest.raises(ValueError):
+        sample_doc.doc_after_cleaners()
+
+
+def test_filter_in_place():
+    html_doc = """
+    <table><tbody><tr><td>A table thing.</td></tr></tbody></table>
+    <p>A non-table thing</p>
+    """
+    doc = HTMLDocument.from_string(html_doc)
+    assert len(doc.elements) == 2
+    doc.doc_after_cleaners(skip_table=True, inplace=True)
+    assert len(doc.elements) == 1
+
+
 # -- HTMLDocument.elements -----------------------------------------------------------------------
 
 
@@ -264,6 +441,163 @@ def test_parses_tags_correctly():
     element = cast(TagsMixin, doc.elements[0])
     assert element.ancestortags == ("html", "body")
     assert element.tag == "table"
+
+
+def test_nested_text_tags():
+    tag1, tag2 = [tag for tag in TEXT_TAGS if tag not in TABLE_TAGS][:2]
+    html_str = f"""
+    <body>
+        <{tag1}>
+            <{tag2}>
+                There is some text here.
+            </{tag2}>
+        </{tag1}>
+    </body>
+    """
+    html_document = HTMLDocument.from_string(html_str).doc_after_cleaners(skip_table=False)
+    assert len(html_document.pages[0].elements) == 1
+
+
+def test_containers_with_text_are_processed():
+    html_str = """<div dir=3D"ltr">Hi All,<div><br></div>
+   <div>Get excited for our first annual family day!</div>
+   <div>Best.<br clear=3D"all">
+      <div><br></div>
+      -- <br>
+      <div dir=3D"ltr">
+         <div dir=3D"ltr">Dino the Datasaur<div>Unstructured Technologies<br><div>Data Scientist
+                </div>
+                <div>Doylestown, PA 18901</div>
+               <div><br></div>
+            </div>
+         </div>
+      </div>
+   </div>
+</div>"""
+    html_document = HTMLDocument.from_string(html_str)
+
+    assert html_document.elements == [
+        HTMLText(text="Hi All,", tag="div"),
+        HTMLNarrativeText(text="Get excited for our first annual family day!", tag="div"),
+        HTMLTitle(text="Best.", tag="div"),
+        HTMLText(text="\n      -- ", tag="div"),
+        HTMLTitle(text="Dino the Datasaur", tag="div"),
+        HTMLTitle(text="Unstructured Technologies", tag="div"),
+        HTMLTitle(text="Data Scientist", tag="div"),
+        HTMLAddress(text="Doylestown, PA 18901", tag="div"),
+    ]
+
+
+def test_html_grabs_bulleted_text_in_tags():
+    html_str = """<html>
+    <body>
+        <ol>
+            <li>Happy Groundhog's day!</li>
+            <li>Looks like six more weeks of winter ...</li>
+        </ol>
+    </body>
+</html>"""
+    html_document = HTMLDocument.from_string(html_str)
+
+    assert html_document.elements == [
+        ListItem(text="Happy Groundhog's day!"),
+        ListItem(text="Looks like six more weeks of winter ..."),
+    ]
+
+
+def test_html_grabs_bulleted_text_in_paras():
+    html_str = """<html>
+    <body>
+        <p>
+            <span>&#8226; Happy Groundhog's day!</span>
+        </p>
+        <p>
+            <span>&#8226; Looks like six more weeks of winter ...</span>
+        </p>
+    </body>
+</html>"""
+    html_document = HTMLDocument.from_string(html_str)
+
+    assert html_document.elements == [
+        ListItem(text="Happy Groundhog's day!"),
+        ListItem(text="Looks like six more weeks of winter ..."),
+    ]
+
+
+def test_joins_tag_text_correctly():
+    raw_html = "<p>Hello again peet mag<i>ic</i>al</p>"
+    doc = HTMLDocument.from_string(raw_html)
+    el = doc.elements[0]
+    assert el.text == "Hello again peet magical"
+
+
+def test_sample_doc_with_emoji():
+    raw_html = """
+    <html charset="unicode">
+        <p>Hello again 😀</p>
+    </html>
+    """
+    doc = HTMLDocument.from_string(raw_html)
+    # NOTE(robinson) - unclear why right now, but the output is the emoji on the test runners
+    # and the byte string representation when running locally on mac
+    assert doc.elements[0].text in ["Hello again ð\x9f\x98\x80", "Hello again 😀"]
+
+
+def test_only_plain_text_in_body():
+    raw_html = "<body>Hello</body>"
+    doc = HTMLDocument.from_string(raw_html)
+    assert doc.elements[0].text == "Hello"
+
+
+def test_plain_text_before_anything_in_body():
+    raw_html = "<body>Hello<p>World</p></body>"
+    doc = HTMLDocument.from_string(raw_html)
+    assert doc.elements[0].text == "Hello"
+    assert doc.elements[1].text == "World"
+
+
+def test_line_break_in_container():
+    raw_html = "<div>Hello<br/>World</div>"
+    doc = HTMLDocument.from_string(raw_html)
+    assert doc.elements[0].text == "Hello"
+    assert doc.elements[1].text == "World"
+
+
+@pytest.mark.parametrize("tag", TEXT_TAGS)
+def test_line_break_in_text_tag(tag: str):
+    raw_html = f"<{tag}>Hello<br/>World</{tag}>"
+    doc = HTMLDocument.from_string(raw_html)
+    assert doc.elements[0].text == "Hello"
+    assert doc.elements[1].text == "World"
+
+
+# -- HTMLDocument.pages --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tag", [tag for tag in TEXT_TAGS if tag not in TABLE_TAGS])
+def test_tag_types(tag: str):
+    html_str = f"""
+    <body>
+        <{tag}>
+            There is some text here.
+        </{tag}>
+    </body>
+    """
+    html_document = HTMLDocument.from_string(html_str)
+    assert len(html_document.pages[0].elements) == 1
+
+
+@pytest.mark.parametrize("tag", EXCLUDED_TAGS)
+def test_exclude_tag_types(tag: str):
+    html_str = f"""
+    <body>
+        <{tag}>
+            There is some text here.
+        </{tag}>
+    </body>
+    """
+    html_document = HTMLDocument.from_string(html_str)
+    assert len(html_document.pages) == 0
 
 
 # -- has_table_ancestor() ------------------------------------------------------------------------
@@ -287,24 +621,34 @@ def test_has_no_table_ancestor():
     assert not html.has_table_ancestor(title)
 
 
-# -- HTMLDocument.doc_after_cleaners() -----------------------------------------------------------
+# -- _bulleted_text_from_table() -----------------------------------------------------------------
 
 
-def test_read_without_skipping_table(is_possible_narrative_text_: Mock):
-    is_possible_narrative_text_.return_value = True
+def test_bulletized_bulleted_text_from_table():
     doc = """<html>
     <body>
         <table>
             <tbody>
                 <tr>
-                    <td><p>Hi there! I am Matt!</p></td>
+                    <td>•</td>
+                    <td><p>Happy Groundhog's day!</p></td>
+                </tr>
+                <tr>
+                    <td>•</td>
+                    <td><p>Looks like six more weeks of winter ...</p></td>
                 </tr>
             </tbody>
         </table>
     </body>
 </html>"""
-    document = HTMLDocument.from_string(doc).doc_after_cleaners(skip_table=False)
-    assert document.pages[0].elements[0] == Table(text="Hi there! I am Matt!")
+    document_tree = etree.fromstring(doc, etree.HTMLParser())
+    table = document_tree.find(".//table")
+    assert table is not None
+    bulleted_text = html._bulleted_text_from_table(table)
+    assert bulleted_text == [
+        ListItem(text="Happy Groundhog's day!"),
+        ListItem(text="Looks like six more weeks of winter ..."),
+    ]
 
 
 # -- _construct_text() ---------------------------------------------------------------------------
@@ -326,6 +670,110 @@ def test_construct_text(doc: str, expected: str):
     assert para is not None
     text = html._construct_text(para)
     assert text == expected
+
+
+# -- _find_articles() ----------------------------------------------------------------------------
+
+
+def test_find_articles():
+    html_str = """<header></header>
+    <body>
+    <p>Lots preamble stuff yada yada yada</p>
+        <article>
+            <h2>A Wonderful Section!</h2>
+            <p>Look at this amazing section!</p>
+        </article>
+        <article>
+            <h2>Another Wonderful Section!</h2>
+            <p>Look at this other amazing section!</p>
+        </article>
+    </body>"""
+    html_document = HTMLDocument.from_string(html_str)
+    document_tree = html_document.document_tree
+    articles = html._find_articles(document_tree)
+    assert len(articles) == 2
+
+
+def test_find_articles_returns_doc_when_none_present():
+    html_str = """<header></header>
+    <body>
+    <p>Lots preamble stuff yada yada yada</p>
+        <section>
+            <h2>A Wonderful Section!</h2>
+            <p>Look at this amazing section!</p>
+        </section>
+        <section>
+            <h2>Another Wonderful Section!</h2>
+            <p>Look at this other amazing section!</p>
+        </section>
+    </body>"""
+    html_document = HTMLDocument.from_string(html_str)
+    document_tree = html_document.document_tree
+    articles = html._find_articles(document_tree)
+    assert len(articles) == 1
+
+
+# -- _find_main() --------------------------------------------------------------------------------
+
+
+def test_find_main():
+    html_str = """<header></header>
+    <body>
+        <p>Lots preamble stuff yada yada yada</p>
+        <main>
+            <article>
+                <section>
+                    <h2>A Wonderful Section!</h2>
+                    <p>Look at this amazing section!</p>
+                </section>
+                <section>
+                    <h2>Another Wonderful Section!</h2>
+                    <p>Look at this other amazing section!</p>
+                </section>
+            </article>
+        </main>
+    </body>"""
+    html_document = HTMLDocument.from_string(html_str)
+    document_tree = html_document.document_tree
+    main_tag = html._find_main(document_tree)
+    assert main_tag.tag == "main"
+
+
+def test_find_main_returns_doc_when_main_not_present():
+    html_str = """<header></header>
+    <body>
+    <p>Lots preamble stuff yada yada yada</p>
+        <article>
+            <section>
+                <h2>A Wonderful Section!</h2>
+                <p>Look at this amazing section!</p>
+            </section>
+            <section>
+                <h2>Another Wonderful Section!</h2>
+                <p>Look at this other amazing section!</p>
+            </section>
+        </article>
+    </body>"""
+    html_document = HTMLDocument.from_string(html_str)
+    document_tree = html_document.document_tree
+    root = html._find_main(document_tree)
+    assert root.tag == "html"
+
+
+# -- _get_bullet_descendants() -------------------------------------------------------------------
+
+
+def test_get_bullet_descendants():
+    div_1 = "<div><p>●</p><p>●</p></div>"
+    document_tree_1 = etree.fromstring(div_1, etree.HTMLParser())
+    element = document_tree_1.find(".//div")
+
+    div_2 = "<div><p>An excellent point!</p></div>"
+    document_tree_2 = etree.fromstring(div_2, etree.HTMLParser())
+    next_element = document_tree_2.find(".//div")
+
+    descendants = html._get_bullet_descendants(element, next_element)
+    assert len(descendants) == 1
 
 
 # -- _get_emphasized_texts_from_tag() ------------------------------------------------------------
@@ -418,6 +866,17 @@ def test_get_links_from_tag(doc: str, root: str, expected: list[dict[str, str]])
     assert links == expected
 
 
+# -- _is_text_tag() ------------------------------------------------------------------------------
+
+
+def test_adjacent_spans_are_text_tags():
+    doc = """<div><span>&#8226;</span><span>A bullet!</span></div>"""
+    document_tree = etree.fromstring(doc, etree.HTMLParser())
+    el = document_tree.find(".//div")
+    assert el is not None
+    assert html._is_text_tag(el) is True
+
+
 # -- _parse_tag() --------------------------------------------------------------------------------
 
 
@@ -428,18 +887,6 @@ def test_parse_nothing():
     assert el is not None
     parsed_el = html._parse_tag(el)
     assert parsed_el is None
-
-
-# -- HTMLDocument.from_pages() -------------------------------------------------------------------
-
-
-def test_read_with_existing_pages():
-    page = Page(number=0)
-    html_document = HTMLDocument.from_pages([page])
-    assert html_document.pages == [page]
-
-
-# -- _parse_tag() --------------------------------------------------------------------------------
 
 
 def test_parse_not_anything(is_narrative_tag_: Mock, is_possible_title_: Mock):
@@ -480,17 +927,6 @@ def test_parse_tag_ignores_stubs():
     assert parsed_el is None
 
 
-# -- _is_text_tag() ------------------------------------------------------------------------------
-
-
-def test_adjacent_spans_are_text_tags():
-    doc = """<div><span>&#8226;</span><span>A bullet!</span></div>"""
-    document_tree = etree.fromstring(doc, etree.HTMLParser())
-    el = document_tree.find(".//div")
-    assert el is not None
-    assert html._is_text_tag(el) is True
-
-
 # -- _process_list_item() ------------------------------------------------------------------------
 
 
@@ -510,25 +946,6 @@ def test_process_list_item_gets_next_section():
     assert el is not None
     parsed_el, _ = html._process_list_item(el, max_predecessor_len=10)
     assert parsed_el == ListItem(text="An excellent point!")
-
-
-# -- _get_bullet_descendants() -------------------------------------------------------------------
-
-
-def test_get_bullet_descendants():
-    div_1 = "<div><p>●</p><p>●</p></div>"
-    document_tree_1 = etree.fromstring(div_1, etree.HTMLParser())
-    element = document_tree_1.find(".//div")
-
-    div_2 = "<div><p>An excellent point!</p></div>"
-    document_tree_2 = etree.fromstring(div_2, etree.HTMLParser())
-    next_element = document_tree_2.find(".//div")
-
-    descendants = html._get_bullet_descendants(element, next_element)
-    assert len(descendants) == 1
-
-
-# -- _process_list_item() ------------------------------------------------------------------------
 
 
 def test_process_list_item_returns_none_if_next_blank():
@@ -582,447 +999,6 @@ def test_process_list_item_ignores_deep_divs():
     assert el is not None
     parsed_el, _ = html._process_list_item(el, max_predecessor_len=2)
     assert parsed_el is None
-
-
-# -- HTMLDocument.from_file() --------------------------------------------------------------------
-
-
-def test_read_html_doc(tmp_path: pathlib.Path):
-    TITLE1 = "A Great and Glorious Section"
-    SECTION1 = "Dear Leader is the best. He is such a wonderful engineer!"
-    TITLE2 = "Another Magnificent Title"
-    SECTION2 = "The last section is a title because of its capitalization patterns!"
-    TABLE_SECTION = "Skip me because I'm in a table"
-    TITLE3 = "A New Beginning"
-    SECTION3 = "Here is the start of a new page."
-
-    doc = f"""<html>
-    <body>
-        <header>
-            <p>Here is a header. We want to ignore anything that is in this section.</p>
-        </header>
-        <h1>{TITLE1}</h1>
-        <p>{SECTION1}</p>
-        <p></p>
-        <p>{TITLE2}</p>
-        <p><b>{SECTION2}</b></p>
-        <table>
-            <tbody>
-                <tr>
-                    <td><p>{TABLE_SECTION}</p></td>
-                </tr>
-            </tbody>
-        </table>
-        <hr>
-        <h2>{TITLE3}</h2>
-        <div>{SECTION3}</div>
-        <footer>
-            <p>Here is a footer. We want to ignore anything that is in this section</p>
-        </footer>
-        <div>
-            <p>Let's ignore anything after the footer too since it's probably garbage.</p>
-        </div>
-    </body>
-</html>"""
-    filename = str(tmp_path / "sample-doc.html")
-    with open(filename, "w") as f:
-        f.write(doc)
-
-    html_document = HTMLDocument.from_file(filename=filename).doc_after_cleaners(
-        skip_headers_and_footers=True,
-        skip_table=True,
-    )
-    print("original pages: ", HTMLDocument.from_file(filename=filename).pages)
-    print("filtered pages: ", html_document.pages)
-    print([el.text for el in html_document.pages[0].elements])
-
-    assert len(html_document.pages) == 2
-
-    page_one = html_document.pages[0]
-    assert len(page_one.elements) == 4
-    assert page_one.elements == [
-        Title(text=TITLE1),
-        NarrativeText(text=SECTION1),
-        Title(text=TITLE2),
-        NarrativeText(text=SECTION2),
-    ]
-
-    page_two = html_document.pages[1]
-    assert len(page_two.elements) == 2
-    assert page_two.elements == [
-        Title(text=TITLE3),
-        NarrativeText(text=SECTION3),
-    ]
-
-    pages = html_document.pages
-    assert all(isinstance(page, Page) for page in pages)
-
-
-# -- _find_main() --------------------------------------------------------------------------------
-
-
-def test_find_main():
-    html_str = """<header></header>
-    <body>
-        <p>Lots preamble stuff yada yada yada</p>
-        <main>
-            <article>
-                <section>
-                    <h2>A Wonderful Section!</h2>
-                    <p>Look at this amazing section!</p>
-                </section>
-                <section>
-                    <h2>Another Wonderful Section!</h2>
-                    <p>Look at this other amazing section!</p>
-                </section>
-            </article>
-        </main>
-    </body>"""
-    html_document = HTMLDocument.from_string(html_str)
-    document_tree = html_document.document_tree
-    main_tag = html._find_main(document_tree)
-    assert main_tag.tag == "main"
-
-
-def test_find_main_returns_doc_when_main_not_present():
-    html_str = """<header></header>
-    <body>
-    <p>Lots preamble stuff yada yada yada</p>
-        <article>
-            <section>
-                <h2>A Wonderful Section!</h2>
-                <p>Look at this amazing section!</p>
-            </section>
-            <section>
-                <h2>Another Wonderful Section!</h2>
-                <p>Look at this other amazing section!</p>
-            </section>
-        </article>
-    </body>"""
-    html_document = HTMLDocument.from_string(html_str)
-    document_tree = html_document.document_tree
-    root = html._find_main(document_tree)
-    assert root.tag == "html"
-
-
-# -- _find_articles() ----------------------------------------------------------------------------
-
-
-def test_find_articles():
-    html_str = """<header></header>
-    <body>
-    <p>Lots preamble stuff yada yada yada</p>
-        <article>
-            <h2>A Wonderful Section!</h2>
-            <p>Look at this amazing section!</p>
-        </article>
-        <article>
-            <h2>Another Wonderful Section!</h2>
-            <p>Look at this other amazing section!</p>
-        </article>
-    </body>"""
-    html_document = HTMLDocument.from_string(html_str)
-    document_tree = html_document.document_tree
-    articles = html._find_articles(document_tree)
-    assert len(articles) == 2
-
-
-def test_find_articles_returns_doc_when_none_present():
-    html_str = """<header></header>
-    <body>
-    <p>Lots preamble stuff yada yada yada</p>
-        <section>
-            <h2>A Wonderful Section!</h2>
-            <p>Look at this amazing section!</p>
-        </section>
-        <section>
-            <h2>Another Wonderful Section!</h2>
-            <p>Look at this other amazing section!</p>
-        </section>
-    </body>"""
-    html_document = HTMLDocument.from_string(html_str)
-    document_tree = html_document.document_tree
-    articles = html._find_articles(document_tree)
-    assert len(articles) == 1
-
-
-# -- `skip_headers_and_footers` arg --------------------------------------------------------------
-
-
-def test_include_headers_and_footers(sample_doc: HTMLDocument):
-    html_document = sample_doc.doc_after_cleaners(skip_headers_and_footers=False)
-    assert len(html_document.pages[1].elements) == 3
-
-
-# -- `skip_table` arg ----------------------------------------------------------------------------
-
-
-def test_include_table_text(sample_doc: HTMLDocument):
-    html_document = sample_doc.doc_after_cleaners(skip_table=False)
-    assert len(html_document.pages[0].elements) == 2
-
-
-# -- HTMLDocument.pages --------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("tag", [tag for tag in TEXT_TAGS if tag not in TABLE_TAGS])
-def test_tag_types(tag: str):
-    html_str = f"""
-    <body>
-        <{tag}>
-            There is some text here.
-        </{tag}>
-    </body>
-    """
-    html_document = HTMLDocument.from_string(html_str)
-    assert len(html_document.pages[0].elements) == 1
-
-
-@pytest.mark.parametrize("tag", EXCLUDED_TAGS)
-def test_exclude_tag_types(tag: str):
-    html_str = f"""
-    <body>
-        <{tag}>
-            There is some text here.
-        </{tag}>
-    </body>
-    """
-    html_document = HTMLDocument.from_string(html_str)
-    assert len(html_document.pages) == 0
-
-
-# -- HTMLDocument.doc_after_cleaners -------------------------------------------------------------
-
-
-def test_tag_types_table(sample_doc: HTMLDocument):
-    html_document = sample_doc.doc_after_cleaners(skip_table=True)
-    assert len(html_document.pages[0].elements) == 2
-
-
-# -- HTMLDocument.elements -----------------------------------------------------------------------
-
-
-def test_nested_text_tags():
-    tag1, tag2 = [tag for tag in TEXT_TAGS if tag not in TABLE_TAGS][:2]
-    html_str = f"""
-    <body>
-        <{tag1}>
-            <{tag2}>
-                There is some text here.
-            </{tag2}>
-        </{tag1}>
-    </body>
-    """
-    html_document = HTMLDocument.from_string(html_str).doc_after_cleaners(skip_table=False)
-    assert len(html_document.pages[0].elements) == 1
-
-
-def test_containers_with_text_are_processed():
-    html_str = """<div dir=3D"ltr">Hi All,<div><br></div>
-   <div>Get excited for our first annual family day!</div>
-   <div>Best.<br clear=3D"all">
-      <div><br></div>
-      -- <br>
-      <div dir=3D"ltr">
-         <div dir=3D"ltr">Dino the Datasaur<div>Unstructured Technologies<br><div>Data Scientist
-                </div>
-                <div>Doylestown, PA 18901</div>
-               <div><br></div>
-            </div>
-         </div>
-      </div>
-   </div>
-</div>"""
-    html_document = HTMLDocument.from_string(html_str)
-
-    assert html_document.elements == [
-        HTMLText(text="Hi All,", tag="div"),
-        HTMLNarrativeText(text="Get excited for our first annual family day!", tag="div"),
-        HTMLTitle(text="Best.", tag="div"),
-        HTMLText(text="\n      -- ", tag="div"),
-        HTMLTitle(text="Dino the Datasaur", tag="div"),
-        HTMLTitle(text="Unstructured Technologies", tag="div"),
-        HTMLTitle(text="Data Scientist", tag="div"),
-        HTMLAddress(text="Doylestown, PA 18901", tag="div"),
-    ]
-
-
-def test_html_grabs_bulleted_text_in_tags():
-    html_str = """<html>
-    <body>
-        <ol>
-            <li>Happy Groundhog's day!</li>
-            <li>Looks like six more weeks of winter ...</li>
-        </ol>
-    </body>
-</html>"""
-    html_document = HTMLDocument.from_string(html_str)
-
-    assert html_document.elements == [
-        ListItem(text="Happy Groundhog's day!"),
-        ListItem(text="Looks like six more weeks of winter ..."),
-    ]
-
-
-def test_html_grabs_bulleted_text_in_paras():
-    html_str = """<html>
-    <body>
-        <p>
-            <span>&#8226; Happy Groundhog's day!</span>
-        </p>
-        <p>
-            <span>&#8226; Looks like six more weeks of winter ...</span>
-        </p>
-    </body>
-</html>"""
-    html_document = HTMLDocument.from_string(html_str)
-
-    assert html_document.elements == [
-        ListItem(text="Happy Groundhog's day!"),
-        ListItem(text="Looks like six more weeks of winter ..."),
-    ]
-
-
-# -- _bulleted_text_from_table() -----------------------------------------------------------------
-
-
-def test_bulletized_bulleted_text_from_table():
-    doc = """<html>
-    <body>
-        <table>
-            <tbody>
-                <tr>
-                    <td>•</td>
-                    <td><p>Happy Groundhog's day!</p></td>
-                </tr>
-                <tr>
-                    <td>•</td>
-                    <td><p>Looks like six more weeks of winter ...</p></td>
-                </tr>
-            </tbody>
-        </table>
-    </body>
-</html>"""
-    document_tree = etree.fromstring(doc, etree.HTMLParser())
-    table = document_tree.find(".//table")
-    assert table is not None
-    bulleted_text = html._bulleted_text_from_table(table)
-    assert bulleted_text == [
-        ListItem(text="Happy Groundhog's day!"),
-        ListItem(text="Looks like six more weeks of winter ..."),
-    ]
-
-
-# -- HTMLDocument.from_string() ------------------------------------------------------------------
-
-
-def test_html_grabs_bulleted_text_in_tables():
-    html_str = """<html>
-    <body>
-        <table>
-            <tbody>
-                <tr>
-                    <td>&#8226;</td>
-                    <td><p>Happy Groundhog's day!</p></td>
-                </tr>
-                <tr>
-                    <td>&#8226;</td>
-                    <td><p>Looks like six more weeks of winter ...</p></td>
-                </tr>
-            </tbody>
-        </table>
-    </body>
-</html>"""
-    html_document = HTMLDocument.from_string(html_str)
-
-    assert html_document.elements == [
-        ListItem(text="Happy Groundhog's day!"),
-        ListItem(text="Looks like six more weeks of winter ..."),
-    ]
-
-
-# -- TagsMixin -----------------------------------------------------------------------------------
-
-
-def test_raises_error_no_tag():
-    with pytest.raises(TypeError):
-        TagsMixin(tag=None)
-    with pytest.raises(TypeError):
-        TagsMixin()
-
-
-# -- HTMLDocument.doc_after_cleaners() -----------------------------------------------------------
-
-
-def test_raises_error_wrong_elements(sample_doc: HTMLDocument, pages_prop_: Mock):
-    page = Page(0)
-    page.elements = [
-        "this should def not be a string"  # pyright: ignore[reportAttributeAccessIssue]
-    ]
-    pages_prop_.return_value = [page]
-    with pytest.raises(ValueError):
-        sample_doc.doc_after_cleaners()
-
-
-def test_filter_in_place():
-    html_doc = """
-    <table><tbody><tr><td>A table thing.</td></tr></tbody></table>
-    <p>A non-table thing</p>
-    """
-    doc = HTMLDocument.from_string(html_doc)
-    assert len(doc.elements) == 2
-    doc.doc_after_cleaners(skip_table=True, inplace=True)
-    assert len(doc.elements) == 1
-
-
-# -- HTMLDocument.elements -----------------------------------------------------------------------
-
-
-def test_joins_tag_text_correctly():
-    raw_html = "<p>Hello again peet mag<i>ic</i>al</p>"
-    doc = HTMLDocument.from_string(raw_html)
-    el = doc.elements[0]
-    assert el.text == "Hello again peet magical"
-
-
-def test_sample_doc_with_emoji():
-    raw_html = """
-    <html charset="unicode">
-        <p>Hello again 😀</p>
-    </html>
-    """
-    doc = HTMLDocument.from_string(raw_html)
-    # NOTE(robinson) - unclear why right now, but the output is the emoji on the test runners
-    # and the byte string representation when running locally on mac
-    assert doc.elements[0].text in ["Hello again ð\x9f\x98\x80", "Hello again 😀"]
-
-
-def test_only_plain_text_in_body():
-    raw_html = "<body>Hello</body>"
-    doc = HTMLDocument.from_string(raw_html)
-    assert doc.elements[0].text == "Hello"
-
-
-def test_plain_text_before_anything_in_body():
-    raw_html = "<body>Hello<p>World</p></body>"
-    doc = HTMLDocument.from_string(raw_html)
-    assert doc.elements[0].text == "Hello"
-    assert doc.elements[1].text == "World"
-
-
-def test_line_break_in_container():
-    raw_html = "<div>Hello<br/>World</div>"
-    doc = HTMLDocument.from_string(raw_html)
-    assert doc.elements[0].text == "Hello"
-    assert doc.elements[1].text == "World"
-
-
-@pytest.mark.parametrize("tag", TEXT_TAGS)
-def test_line_break_in_text_tag(tag: str):
-    raw_html = f"<{tag}>Hello<br/>World</{tag}>"
-    doc = HTMLDocument.from_string(raw_html)
-    assert doc.elements[0].text == "Hello"
-    assert doc.elements[1].text == "World"
 
 
 # -- unit-level tests ----------------------------------------------------------------------------

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.5-dev4"  # pragma: no cover
+__version__ = "0.14.5-dev5"  # pragma: no cover

--- a/unstructured/documents/xml.py
+++ b/unstructured/documents/xml.py
@@ -41,7 +41,7 @@ class XMLDocument(Document):
 
         self.stylesheet = stylesheet
         self.parser = parser
-        self.document_tree = None
+        self.document_tree: etree._Element = None
         super().__init__()
 
     def _parse_pages_from_element_tree(self) -> List[Page]:

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
     from unstructured_inference.inference.layout import DocumentLayout, PageLayout
     from unstructured_inference.inference.layoutelement import LayoutElement
 
+    from unstructured.documents.html import HTMLDocument
+
 HIERARCHY_RULE_SET = {
     "Title": [
         "Text",
@@ -541,7 +543,7 @@ def _get_page_image_metadata(page: PageLayout) -> dict[str, Any]:
 # unstructured.documents.html, which imports this module so we can't import the class for type
 # hints. Moreover, those two types of documents have different lists of attributes
 def document_to_element_list(
-    document: "DocumentLayout",
+    document: "DocumentLayout | HTMLDocument",
     sortable: bool = False,
     include_page_breaks: bool = False,
     last_modification_date: Optional[str] = None,


### PR DESCRIPTION
**Summary**
In preparation for further work on HTMLDocument, organize the organic growth in `documents/tests_html.py` and improving typing and expression.

**Reviewers:** Commits are groomed and review is probably eased by going commit-by-commit