### PR TITLE
rfctr(html): break coupling to DocumentLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.6-dev1
+## 0.14.6-dev2
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.6-dev1"  # pragma: no cover
+__version__ = "0.14.6-dev2"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -560,10 +560,12 @@ def assign_and_map_hash_ids(elements: list[Element]) -> list[Element]:
 def process_metadata() -> Callable[[Callable[_P, list[Element]]], Callable[_P, list[Element]]]:
     """Post-process element-metadata for this document.
 
-    This decorator adds a post-processing step to a document partitioner. It adds documentation for
-    `metadata_filename` and `include_metadata` parameters if not present. Also adds regex-metadata
-    when `regex_metadata` keyword-argument is provided and changes the element-id to a UUID when
-    `unique_element_ids` argument is provided and True.
+    This decorator adds a post-processing step to a document partitioner.
+
+    - Adds `metadata_filename` and `include_metadata` parameters to docstring if not present.
+    - Adds `.metadata.regex-metadata` when `regex_metadata` keyword-argument is provided.
+    - Updates element.id to a UUID when `unique_element_ids` argument is provided and True.
+
     """
 
     def decorator(func: Callable[_P, list[Element]]) -> Callable[_P, list[Element]]:

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -610,7 +610,15 @@ def add_metadata(func: Callable[_P, List[Element]]) -> Callable[_P, List[Element
 def add_filetype(
     filetype: FileType,
 ) -> Callable[[Callable[_P, List[Element]]], Callable[_P, List[Element]]]:
-    """..."""
+    """Post-process element-metadata for list[Element] from partitioning.
+
+    This decorator adds a post-processing step to a document partitioner.
+
+    - Adds `metadata_filename` and `include_metadata` parameters to docstring if not present.
+    - Adds `.metadata.regex-metadata` when `regex_metadata` keyword-argument is provided.
+    - Updates element.id to a UUID when `unique_element_ids` argument is provided and True.
+
+    """
 
     def decorator(func: Callable[_P, List[Element]]) -> Callable[_P, List[Element]]:
         @functools.wraps(func)

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -39,8 +39,6 @@ if TYPE_CHECKING:
     from unstructured_inference.inference.layout import DocumentLayout, PageLayout
     from unstructured_inference.inference.layoutelement import LayoutElement
 
-    from unstructured.documents.html import HTMLDocument
-
 HIERARCHY_RULE_SET = {
     "Title": [
         "Text",
@@ -542,8 +540,10 @@ def _get_page_image_metadata(page: PageLayout) -> dict[str, Any]:
 # FIXME: document here can be either DocumentLayout or HTMLDocument; HTMLDocument is defined in
 # unstructured.documents.html, which imports this module so we can't import the class for type
 # hints. Moreover, those two types of documents have different lists of attributes
+# UPDATE(scanny): HTMLDocument no longer uses this function, so it can be optimized for use by
+# DocumentLayout only.
 def document_to_element_list(
-    document: "DocumentLayout | HTMLDocument",
+    document: DocumentLayout,
     sortable: bool = False,
     include_page_breaks: bool = False,
     last_modification_date: Optional[str] = None,
@@ -555,7 +555,7 @@ def document_to_element_list(
     starting_page_number: int = 1,
     **kwargs: Any,
 ) -> list[Element]:
-    """Converts a DocumentLayout or HTMLDocument object to a list of unstructured elements."""
+    """Converts a DocumentLayout object to a list of unstructured elements."""
     elements: list[Element] = []
 
     num_pages = len(document.pages)


### PR DESCRIPTION
**Summary**
Remove use of `partition.common.document_to_element_list()` by `HTMLDocument`. The transitive coupling with layout-inference through this shared function have been the source of frustration and a drain on engineering time and there's no compelling reason for the two to share this code.

**Additional Context**
`partition_html()` uses `partition.common.document_to_element_list()` to get finalized elements from `HTMLDocument` (pages). This gives rise to a very nasty coupling between `DocumentLayout`, used by `unstructured_inference`, and `HTMLDocument`. `document_to_element_list()` has evolved to work for both callers, but they share very few common characteristics with each other.

This coupling is bad news for us and also, importantly, for the inference and page layout folks working on PDF and images.

Break that coupling so those inference-related functions can evolve whatever way they need to without being dragged down by legacy `HTMLDocument` connections.

The initial step is to extract a `document_to_element_list()` function of our own, getting rid of the coordinates and other
`DocumentLayout`-related bits we don't need. As you'll see in the next few PRs, all of this `document_to_element_list()` code will end up either going away or being relocated closer to where it's used in `HTMLDocument`.