### PR TITLE
rfctr(html): drop page concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.6-dev4
+## 0.14.6-dev5
 
 ### Enhancements
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 license_files = LICENSE.md
 
 [flake8]
-ignore = E203,W503
+ignore = E203,E704,W503
 max-line-length = 100
 exclude =
     .venv

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import pathlib
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from lxml import etree
@@ -356,7 +356,7 @@ def test_parses_tags_correctly(opts_args: dict[str, Any]):
     opts = HtmlPartitionerOptions(**opts_args)
     doc = HTMLDocument.load(opts)
 
-    element = cast(TagsMixin, doc.elements[0])
+    element = doc._html_elements[0]
     assert element.tag == "table"
 
 

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -298,7 +298,6 @@ def test_read_html_doc(tmp_path: pathlib.Path):
             "        </tr>\n"
             "      </tbody>\n"
             "    </table>\n"
-            "    <hr>\n"
             "    <h2>A New Beginning</h2>\n"
             "    <div>Here is the start of a new page.</div>\n"
             "  </body>\n"
@@ -307,22 +306,16 @@ def test_read_html_doc(tmp_path: pathlib.Path):
 
     html_document = HTMLDocument.from_file(filename)
 
-    assert len(html_document.pages) == 2
+    assert len(html_document.pages) == 1
     assert all(isinstance(p, Page) for p in html_document.pages)
-    # --
     p = html_document.pages[0]
-    assert len(p.elements) == 5
+    assert len(p.elements) == 7
     assert p.elements == [
         Title("A Great and Glorious Section"),
         NarrativeText("Dear Leader is the best. He is such a wonderful engineer!"),
         Title("Another Magnificent Title"),
         NarrativeText("The prior element is a title based on its capitalization patterns!"),
         Table("I'm in a table"),
-    ]
-    # --
-    p = html_document.pages[1]
-    assert len(p.elements) == 2
-    assert p.elements == [
         Title("A New Beginning"),
         NarrativeText("Here is the start of a new page."),
     ]

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -30,7 +30,6 @@ from unstructured.documents.elements import (
 from unstructured.documents.html import (
     HTMLDocument,
     HtmlPartitionerOptions,
-    Page,
     _parse_HTMLTable_from_table_elem,
 )
 from unstructured.documents.html_elements import (
@@ -319,13 +318,10 @@ def test_read_html_doc(tmp_path: pathlib.Path, opts_args: dict[str, Any]):
     opts_args["file_path"] = file_path
     opts = HtmlPartitionerOptions(**opts_args)
 
-    html_document = HTMLDocument.load(opts)
+    elements = HTMLDocument.load(opts).elements
 
-    assert len(html_document.pages) == 1
-    assert all(isinstance(p, Page) for p in html_document.pages)
-    p = html_document.pages[0]
-    assert len(p.elements) == 7
-    assert p.elements == [
+    assert len(elements) == 7
+    assert elements == [
         Title("A Great and Glorious Section"),
         NarrativeText("Dear Leader is the best. He is such a wonderful engineer!"),
         Title("Another Magnificent Title"),
@@ -371,9 +367,9 @@ def test_nested_text_tags(opts_args: dict[str, Any]):
         "</body>\n"
     )
     opts = HtmlPartitionerOptions(**opts_args)
-    html_document = HTMLDocument.load(opts)
+    elements = HTMLDocument.load(opts).elements
 
-    assert len(html_document.pages[0].elements) == 1
+    assert len(elements) == 1
 
 
 def test_containers_with_text_are_processed(opts_args: dict[str, Any]):
@@ -495,23 +491,24 @@ def test_line_break_in_text_tag(tag: str, opts_args: dict[str, Any]):
     assert doc.elements[1].text == "World"
 
 
-# -- HTMLDocument.pages --------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize("tag", [tag for tag in html.TEXT_TAGS if tag not in html.TABLE_TAGS])
 def test_tag_types(tag: str, opts_args: dict[str, Any]):
     opts_args["text"] = f"<body>\n  <{tag}>\n    There is some text here.\n  </{tag}>\n</body>\n"
     opts = HtmlPartitionerOptions(**opts_args)
-    html_document = HTMLDocument.load(opts)
-    assert len(html_document.pages[0].elements) == 1
+
+    elements = HTMLDocument.load(opts).elements
+
+    assert len(elements) == 1
 
 
 @pytest.mark.parametrize("tag", EXCLUDED_TAGS)
 def test_exclude_tag_types(tag: str, opts_args: dict[str, Any]):
     opts_args["text"] = f"<body>\n  <{tag}>\n    There is some text here.\n  </{tag}>\n</body>\n"
     opts = HtmlPartitionerOptions(**opts_args)
-    html_document = HTMLDocument.load(opts)
-    assert len(html_document.pages) == 0
+
+    elements = HTMLDocument.load(opts).elements
+
+    assert len(elements) == 0
 
 
 # -- _bulleted_text_from_table() -----------------------------------------------------------------

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -785,44 +785,6 @@ def test_process_list_item_ignores_deep_divs():
 class DescribeHTMLDocument:
     """Unit-test suite for `unstructured.documents.html.HTMLDocument`."""
 
-    # -- ._articles ------------------------------
-
-    def it_can_find_the_article_elements_in_the_element_tree(self):
-        html_document = HTMLDocument.from_string(
-            "<header></header>\n"
-            "<body>\n"
-            "  <p>Lots preamble stuff yada yada yada</p>\n"
-            "  <article>\n"
-            "    <h2>A Wonderful Section!</h2>\n"
-            "    <p>Look at this amazing section!</p>\n"
-            "  </article>\n"
-            "  <article>\n"
-            "    <h2>Another Wonderful Section!</h2>\n"
-            "    <p>Look at this other amazing section!</p>\n"
-            "  </article>\n"
-            "</body>\n"
-        )
-        assert len(html_document._articles) == 2
-        assert all(a.tag == "article" for a in html_document._articles)
-
-    def but_it_returns_the_root_element_when_no_articles_are_present(self):
-        html_document = HTMLDocument.from_string(
-            "<header></header>\n"
-            "<body>\n"
-            "  <p>Lots preamble stuff yada yada yada</p>\n"
-            "  <section>\n"
-            "    <h2>A Wonderful Section!</h2>\n"
-            "    <p>Look at this amazing section!</p>\n"
-            "  </section>\n"
-            "  <section>\n"
-            "    <h2>Another Wonderful Section!</h2>\n"
-            "    <p>Look at this other amazing section!</p>\n"
-            "  </section>\n"
-            "</body>\n"
-        )
-        assert len(html_document._articles) == 1
-        assert html_document._articles[0].tag == "html"
-
     # -- ._main ----------------------------------
 
     def it_can_find_the_main_element_in_the_document(self):

--- a/test_unstructured/documents/test_html.py
+++ b/test_unstructured/documents/test_html.py
@@ -357,7 +357,6 @@ def test_parses_tags_correctly(opts_args: dict[str, Any]):
     doc = HTMLDocument.load(opts)
 
     element = cast(TagsMixin, doc.elements[0])
-    assert element.ancestortags == ("html", "body")
     assert element.tag == "table"
 
 

--- a/test_unstructured/partition/test_html.py
+++ b/test_unstructured/partition/test_html.py
@@ -316,39 +316,6 @@ def test_partition_html_from_filename_can_suppress_metadata():
     assert all(e.metadata.to_dict() == {} for e in elements)
 
 
-# -- `include_page_breaks` arg -------------------------------------------------------------------
-
-
-def test_partition_html_generates_no_page_breaks_by_default():
-    elements = partition_html(example_doc_path("example-10k-1p.html"))
-    assert all(e.category != "PageBreak" for e in elements)
-
-
-def test_partition_html_generates_page_breaks_when_so_instructed():
-    elements = partition_html(example_doc_path("example-10k-1p.html"), include_page_breaks=True)
-
-    assert any(e.category == "PageBreak" for e in elements)
-    assert all(e.metadata.filename == "example-10k-1p.html" for e in elements)
-
-
-def test_partition_html_can_turn_off_assemble_articles():
-    html_text = (
-        "<html>\n"
-        "   <article>\n"
-        "       <h1>Some important stuff is going on!</h1>\n"
-        "       <p>Here is a description of that stuff</p>\n"
-        "   </article>\n"
-        "   <article>\n"
-        "       <h1>Some other important stuff is going on!</h1>\n"
-        "       <p>Here is a description of that stuff</p>\n"
-        "   </article>\n"
-        "   <h4>This is outside of the article.</h4>\n"
-        "</html>\n"
-    )
-    elements = partition_html(text=html_text, html_assemble_articles=False)
-    assert elements[-1] == Title("This is outside of the article.")
-
-
 # -- `skip_headers_and_footers` arg --------------------------------------------------------------
 
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.6-dev4"  # pragma: no cover
+__version__ = "0.14.6-dev5"  # pragma: no cover

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -67,10 +67,6 @@ class HTMLDocument:
         return cast(list[Element], self._html_elements)
 
     @lazyproperty
-    def pages(self) -> list[Page]:
-        return self._parse_pages_from_element_tree()
-
-    @lazyproperty
     def _document_tree(self) -> etree._Element:
         """The root HTML element."""
         content = self._html_text
@@ -110,6 +106,7 @@ class HTMLDocument:
 
         Elements are sequenced in document order.
         """
+        pages = self._parse_pages_from_element_tree()
 
         def document_to_element_list() -> Iterator[HtmlElement]:
             """Converts an HTMLDocument object to a list of unstructured elements."""
@@ -124,7 +121,7 @@ class HTMLDocument:
                     )
                     yield element
 
-            for page in self.pages:
+            for page in pages:
                 yield from iter_page_elements(page)
 
         return list(document_to_element_list())

--- a/unstructured/documents/html.py
+++ b/unstructured/documents/html.py
@@ -36,8 +36,7 @@ LIST_TAGS: Final[list[str]] = ["ul", "ol", "dl"]
 HEADING_TAGS: Final[list[str]] = ["h1", "h2", "h3", "h4", "h5", "h6"]
 TABLE_TAGS: Final[list[str]] = ["table", "tbody", "td", "tr"]
 TEXTBREAK_TAGS: Final[list[str]] = ["br"]
-PAGEBREAK_TAGS: Final[list[str]] = ["hr"]
-EMPTY_TAGS: Final[list[str]] = PAGEBREAK_TAGS + TEXTBREAK_TAGS
+EMPTY_TAGS: Final[list[str]] = ["br", "hr"]
 HEADER_OR_FOOTER_TAGS: Final[list[str]] = ["header", "footer"]
 SECTION_TAGS: Final[list[str]] = ["div", "pre"]
 
@@ -183,9 +182,6 @@ class HTMLDocument:
                 if element or tag_elem.tag == "table":
                     descendanttag_elems = tuple(tag_elem.iterdescendants())
 
-            elif tag_elem.tag in PAGEBREAK_TAGS:
-                yield PageBreak("")
-
     def _parse_pages_from_element_tree(self) -> list[Page]:
         """Parse HTML elements into pages.
 
@@ -205,17 +201,7 @@ class HTMLDocument:
         page = Page(number=page_number)
 
         for article in self._articles:
-            for element in self._parse_article_to_elements(article):
-                # -- `<hr/>` element produces a `PageBreak` element, but is not added to elements --
-                if element == PageBreak(""):
-                    # -- ignore leading page-break and second and later consecutive page-breaks --
-                    if not page.elements:
-                        continue
-                    pages.append(page)
-                    page_number += 1
-                    page = Page(number=page_number)
-                else:
-                    page.elements.append(element)
+            page.elements = list(self._parse_article_to_elements(article))
 
             # -- create new page for each article, but not when article was empty --
             if len(page.elements) > 0:

--- a/unstructured/documents/html_elements.py
+++ b/unstructured/documents/html_elements.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Protocol, Sequence
 
 from unstructured.documents.elements import (
     Address,
+    ElementMetadata,
     EmailAddress,
     Link,
     ListItem,
@@ -14,6 +15,23 @@ from unstructured.documents.elements import (
     Text,
     Title,
 )
+
+
+class HtmlElement(Protocol):
+    """Interface provided by HTML-specific elements like HTMLNarrativeText."""
+
+    emphasized_texts: Sequence[Dict[str, str]]
+    links: Sequence[Link]
+    metadata: ElementMetadata
+    tag: str
+    text_as_html: str | None
+
+    def __init__(
+        self,
+        text: str,
+        tag: str,
+        metadata: ElementMetadata | None = None,
+    ): ...
 
 
 class TagsMixin:

--- a/unstructured/documents/html_elements.py
+++ b/unstructured/documents/html_elements.py
@@ -23,7 +23,6 @@ class TagsMixin:
         self,
         *args: Any,
         tag: Optional[str] = None,
-        ancestortags: Sequence[str] = (),
         links: Sequence[Link] = [],
         emphasized_texts: Sequence[Dict[str, str]] = [],
         text_as_html: Optional[str] = None,
@@ -33,7 +32,6 @@ class TagsMixin:
             raise TypeError("tag argument must be passed and not None")
         else:
             self.tag = tag
-        self.ancestortags = ancestortags
         self.links = links
         self.emphasized_texts = emphasized_texts
         self.text_as_html = text_as_html

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import IO, Any, Optional, cast
+from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
@@ -9,7 +9,6 @@ from unstructured.documents.html import (
     HtmlPartitionerOptions,
     document_to_element_list,
 )
-from unstructured.documents.html_elements import TagsMixin
 from unstructured.file_utils.file_conversion import convert_file_to_html_text
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.common import get_last_modified_date, get_last_modified_date_from_file
@@ -102,9 +101,6 @@ def partition_html(
 
     document = HTMLDocument.load(opts)
 
-    if skip_headers_and_footers:
-        document = _filter_footer_and_header(document)
-
     elements = list(
         apply_lang_metadata(
             document_to_element_list(document, last_modified=opts.last_modified, **kwargs),
@@ -187,14 +183,3 @@ def convert_and_partition_html(
         detect_language_per_element=detect_language_per_element,
         detection_origin=detection_origin,
     )
-
-
-def _filter_footer_and_header(document: HTMLDocument) -> HTMLDocument:
-    for page in document.pages:
-        page.elements = [
-            e
-            for e in page.elements
-            if "header" not in cast(TagsMixin, e).ancestortags
-            and "footer" not in cast(TagsMixin, e).ancestortags
-        ]
-    return document

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -33,7 +33,6 @@ def partition_html(
     ssl_verify: bool = True,
     date_from_file_object: bool = False,
     detect_language_per_element: bool = False,
-    html_assemble_articles: bool = False,
     languages: Optional[list[str]] = ["auto"],
     metadata_last_modified: Optional[str] = None,
     skip_headers_and_footers: bool = False,
@@ -101,17 +100,15 @@ def partition_html(
         return None
 
     if filename is not None:
-        document = HTMLDocument.from_file(
-            filename, encoding=encoding, assemble_articles=html_assemble_articles
-        )
+        document = HTMLDocument.from_file(filename, encoding=encoding)
 
     elif file is not None:
         _, file_text = read_txt_file(file=file, encoding=encoding)
-        document = HTMLDocument.from_string(file_text, assemble_articles=html_assemble_articles)
+        document = HTMLDocument.from_string(file_text)
 
     elif text is not None:
         _text: str = str(text)
-        document = HTMLDocument.from_string(_text, assemble_articles=html_assemble_articles)
+        document = HTMLDocument.from_string(_text)
 
     else:
         assert url is not None

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -4,11 +4,7 @@ from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
-from unstructured.documents.html import (
-    HTMLDocument,
-    HtmlPartitionerOptions,
-    document_to_element_list,
-)
+from unstructured.documents.html import HTMLDocument, HtmlPartitionerOptions
 from unstructured.file_utils.file_conversion import convert_file_to_html_text
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
 from unstructured.partition.common import get_last_modified_date, get_last_modified_date_from_file
@@ -103,7 +99,7 @@ def partition_html(
 
     elements = list(
         apply_lang_metadata(
-            document_to_element_list(document, last_modified=opts.last_modified, **kwargs),
+            document.elements,
             languages=languages,
             detect_language_per_element=detect_language_per_element,
         )

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -105,11 +105,6 @@ def partition_html(
         )
     )
 
-    # Note(yuming): Rip off page_number metadata fields here until we have a better way to handle
-    # page counting for html files.
-    for e in elements:
-        e.metadata.page_number = None
-
     return elements
 
 


### PR DESCRIPTION
**Summary**
Pagination of HTML documents is currently unused. The `Page` class and concept were deeply embedding in the legacy organization of HTML partitioning code due to the legacy `Document` (= pages of elements) domain model. Remove this concept from the code such that elements are available directly from the partitioner.

**Additional Context**
- Pagination can be re-added later if we decide we want it again. A re-implementation would be much simpler and much lower impact to the structure of the code and introduce much less additional complexity, similar to the approach we take in `partition_docx()`.