### PR TITLE
fix: dropbox source connector file path bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * **Fix passing parameters to python-client** - Remove parsing list arguments to strings in passing arguments to python-client in Ingest workflow and `partition_via_api`
 * **table metric bug fix** get_element_level_alignment()now will find all the matched indices in predicted table data instead of only returning the first match in the case of multiple matches for the same gt string.
 * **fsspec connector path/permissions bug** V2 fsspec connectors were failing when defined relative filepaths had leading slash. This strips that slash to guarantee the relative path never has it.
-* **Dropbox connector internal file path bugs** Dropbox source connector currently raises exceptions when indexing files due to two issues: a path formatting idiosyncracy of the Dropbox library and a divergence in the definition of the Dropbox libraries fs.info method, expecting a 'url' parameter rather than 'path'.
+* **Dropbox connector internal file path bugs** Dropbox source connector currently raises exceptions when indexing files due to two issues: a path formatting idiosyncrasy of the Dropbox library and a divergence in the definition of the Dropbox libraries fs.info method, expecting a 'url' parameter rather than 'path'.
 
 ## 0.14.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.6-dev3
+## 0.14.6-dev4
 
 ### Enhancements
 
@@ -6,9 +6,9 @@
 
 ### Fixes
 * **Fix passing parameters to python-client** - Remove parsing list arguments to strings in passing arguments to python-client in Ingest workflow and `partition_via_api`
-
 * **table metric bug fix** get_element_level_alignment()now will find all the matched indices in predicted table data instead of only returning the first match in the case of multiple matches for the same gt string.
 * **fsspec connector path/permissions bug** V2 fsspec connectors were failing when defined relative filepaths had leading slash. This strips that slash to guarantee the relative path never has it.
+* **Dropbox connector internal file path bugs** Dropbox source connector currently raises exceptions when indexing files due to two issues: a path formatting idiosyncracy of the Dropbox library and a divergence in the definition of the Dropbox libraries fs.info method, expecting a 'url' parameter rather than 'path'.
 
 ## 0.14.5
 

--- a/test_unstructured_ingest/expected-structured-output/dropbox/handbook-1p.docx.json
+++ b/test_unstructured_ingest/expected-structured-output/dropbox/handbook-1p.docx.json
@@ -1,301 +1,301 @@
 [
   {
+    "type": "Header",
     "element_id": "3cea98cfe0d578669abe2c435f9f50da",
+    "text": "US Trustee Handbook",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "header_footer_type": "primary",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "US Trustee Handbook",
-    "type": "Header"
-  },
-  {
-    "element_id": "5209312022a75a31d95385fdccff68fa",
-    "metadata": {
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
         "record_locator": {
           "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "5209312022a75a31d95385fdccff68fa",
+    "text": "CHAPTER 1",
+    "metadata": {
       "emphasized_text_contents": [
         "CHAPTER 1"
       ],
       "emphasized_text_tags": [
         "b"
       ],
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "CHAPTER 1",
-    "type": "Title"
-  },
-  {
-    "element_id": "22a23e29022f32945965002cd734a8f0",
-    "metadata": {
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
         "record_locator": {
           "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "22a23e29022f32945965002cd734a8f0",
+    "text": "INTRODUCTION",
+    "metadata": {
       "emphasized_text_contents": [
         "INTRODUCTION"
       ],
       "emphasized_text_tags": [
         "b"
       ],
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "INTRODUCTION",
-    "type": "Title"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "Title",
     "element_id": "4c175cf543957acc4420221de28d3fca",
+    "text": "CHAPTER 1 \u2013 INTRODUCTION",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "CHAPTER 1 – INTRODUCTION",
-    "type": "Title"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "Title",
     "element_id": "77022a5264f552b223538977cd40f640",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "languages": [
-        "eng"
-      ]
-    },
     "text": "A.\tPURPOSE",
-    "type": "Title"
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "NarrativeText",
     "element_id": "8e9d0514cc08b3b0898cd4f165d8d188",
+    "text": "The United States Trustee appoints and supervises standing trustees and monitors and supervises cases under chapter 13 of title 11 of the United States Code.  28 U.S.C. \u00a7 586(b).  The Handbook, issued as part of our duties under 28 U.S.C. \u00a7 586, establishes or clarifies the position of the United States Trustee Program (Program) on the duties owed by a standing trustee to the debtors, creditors, other parties in interest, and the United States Trustee.  The Handbook does not present a full and complete statement of the law; it should not be used as a substitute for legal research and analysis.  The standing trustee must be familiar with relevant provisions of the Bankruptcy Code, Federal Rules of Bankruptcy Procedure (Rules), any local bankruptcy rules, and case law.  11 U.S.C. \u00a7 321, 28 U.S.C. \u00a7 586, 28 C.F.R. \u00a7 58.6(a)(3).  Standing trustees are encouraged to follow Practice Tips identified in this Handbook but these are not considered mandatory.",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "The United States Trustee appoints and supervises standing trustees and monitors and supervises cases under chapter 13 of title 11 of the United States Code.  28 U.S.C. § 586(b).  The Handbook, issued as part of our duties under 28 U.S.C. § 586, establishes or clarifies the position of the United States Trustee Program (Program) on the duties owed by a standing trustee to the debtors, creditors, other parties in interest, and the United States Trustee.  The Handbook does not present a full and complete statement of the law; it should not be used as a substitute for legal research and analysis.  The standing trustee must be familiar with relevant provisions of the Bankruptcy Code, Federal Rules of Bankruptcy Procedure (Rules), any local bankruptcy rules, and case law.  11 U.S.C. § 321, 28 U.S.C. § 586, 28 C.F.R. § 58.6(a)(3).  Standing trustees are encouraged to follow Practice Tips identified in this Handbook but these are not considered mandatory.",
-    "type": "NarrativeText"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "NarrativeText",
     "element_id": "6647ac00520f9b8dcf37f1625d008a69",
+    "text": "Nothing in this Handbook should be construed to excuse the standing trustee from complying with all duties imposed by the Bankruptcy Code and Rules, local rules, and orders of the court.  The standing trustee should notify the United States Trustee whenever the provision of the Handbook conflicts with the local rules or orders of the court.  The standing trustee is accountable for all duties set forth in this Handbook, but need not personally perform any duty unless otherwise indicated.  All statutory references in this Handbook refer to the Bankruptcy Code, 11 U.S.C. \u00a7 101 et seq., unless otherwise indicated.",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "Nothing in this Handbook should be construed to excuse the standing trustee from complying with all duties imposed by the Bankruptcy Code and Rules, local rules, and orders of the court.  The standing trustee should notify the United States Trustee whenever the provision of the Handbook conflicts with the local rules or orders of the court.  The standing trustee is accountable for all duties set forth in this Handbook, but need not personally perform any duty unless otherwise indicated.  All statutory references in this Handbook refer to the Bankruptcy Code, 11 U.S.C. § 101 et seq., unless otherwise indicated.",
-    "type": "NarrativeText"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "NarrativeText",
     "element_id": "60220f2162f5d83e2af6fc8d144bd429",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "languages": [
-        "eng"
-      ]
-    },
     "text": "This Handbook does not create additional rights against the standing trustee or United States Trustee in favor of other parties.",
-    "type": "NarrativeText"
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "Title",
     "element_id": "e341ffc123dd2827638aba18149c4175",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "languages": [
-        "eng"
-      ]
-    },
     "text": "B.\tROLE OF THE UNITED STATES TRUSTEE",
-    "type": "Title"
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "NarrativeText",
     "element_id": "3a6e7cf9f42299fd056a5a7a1279753a",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "languages": [
-        "eng"
-      ]
-    },
     "text": "The Bankruptcy Reform Act of 1978 removed the bankruptcy judge from the responsibilities for daytoday administration of cases.  Debtors, creditors, and third parties with adverse interests to the trustee were concerned that the court, which previously appointed and supervised the trustee, would not impartially adjudicate their rights as adversaries of that trustee. To address these concerns, judicial and administrative functions within the bankruptcy system were bifurcated.",
-    "type": "NarrativeText"
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "NarrativeText",
     "element_id": "4a3de42983fb56345c598326c3732769",
+    "text": "Many administrative functions formerly performed by the court were placed within the Department of Justice through the creation of the Program.  Among the administrative functions assigned to the United States Trustee were the appointment and supervision of chapter 13 trustees./  This Handbook is issued under the authority of the Program\u2019s enabling statutes. ",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "Many administrative functions formerly performed by the court were placed within the Department of Justice through the creation of the Program.  Among the administrative functions assigned to the United States Trustee were the appointment and supervision of chapter 13 trustees./  This Handbook is issued under the authority of the Program’s enabling statutes. ",
-    "type": "NarrativeText"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "Title",
     "element_id": "1b11ebe52652656e0ed8c12e5969de9b",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "languages": [
-        "eng"
-      ]
-    },
     "text": "C.\tSTATUTORY DUTIES OF A STANDING TRUSTEE\t",
-    "type": "Title"
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "NarrativeText",
     "element_id": "5820e4e6e72ffc7a9f962983c727f9a9",
+    "text": "The standing trustee has a fiduciary responsibility to the bankruptcy estate.  The standing trustee is more than a mere disbursing agent.  The standing trustee must be personally involved in the trustee operation.  If the standing trustee is or becomes unable to perform the duties and responsibilities of a standing trustee, the standing trustee must immediately advise the United States Trustee.  28 U.S.C. \u00a7 586(b), 28 C.F.R. \u00a7 58.4(b) referencing 28 C.F.R. \u00a7 58.3(b).",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "The standing trustee has a fiduciary responsibility to the bankruptcy estate.  The standing trustee is more than a mere disbursing agent.  The standing trustee must be personally involved in the trustee operation.  If the standing trustee is or becomes unable to perform the duties and responsibilities of a standing trustee, the standing trustee must immediately advise the United States Trustee.  28 U.S.C. § 586(b), 28 C.F.R. § 58.4(b) referencing 28 C.F.R. § 58.3(b).",
-    "type": "NarrativeText"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "NarrativeText",
     "element_id": "3bbf318afaf932ebb9f5e9cf1b74efa2",
+    "text": "Although this Handbook is not intended to be a complete statutory reference, the standing trustee\u2019s primary statutory duties are set forth in 11 U.S.C. \u00a7 1302, which incorporates by reference some of the duties of chapter 7 trustees found in 11 U.S.C. \u00a7 704.  These duties include, but are not limited to, the following:",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "Although this Handbook is not intended to be a complete statutory reference, the standing trustee’s primary statutory duties are set forth in 11 U.S.C. § 1302, which incorporates by reference some of the duties of chapter 7 trustees found in 11 U.S.C. § 704.  These duties include, but are not limited to, the following:",
-    "type": "NarrativeText"
-  },
-  {
-    "element_id": "64a3d9e381082c0d1977ae11f4c40cf1",
-    "metadata": {
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
         "record_locator": {
           "protocol": "dropbox",
-          "remote_file_path": "/test-input/handbook-1p.docx"
-        },
-        "url": "dropbox:///test-input/handbook-1p.docx",
-        "version": "43605171787078892967774639504094681027"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
+  },
+  {
+    "type": "Footer",
+    "element_id": "64a3d9e381082c0d1977ae11f4c40cf1",
+    "text": "Copyright",
+    "metadata": {
       "header_footer_type": "primary",
       "languages": [
         "eng"
-      ]
-    },
-    "text": "Copyright",
-    "type": "Footer"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "data_source": {
+        "url": "dropbox:///test-input/handbook-1p.docx",
+        "version": "134700592086487568162605251521926324397",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   }
 ]

--- a/test_unstructured_ingest/expected-structured-output/dropbox/nested-1/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/dropbox/nested-1/ideas-page.html.json
@@ -1,22 +1,22 @@
 [
   {
+    "type": "Table",
     "element_id": "32bc8af17151389d3e80f65036f8e65b",
+    "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/nested-1/ideas-page.html"
-        },
-        "url": "dropbox:///test-input/nested-1/ideas-page.html",
-        "version": "280041656934077002038318439395031104600"
-      },
-      "filetype": "text/html",
+      "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>",
       "languages": [
         "eng"
       ],
-      "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>"
-    },
-    "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",
-    "type": "Table"
+      "filetype": "text/html",
+      "data_source": {
+        "url": "dropbox:///test-input/nested-1/ideas-page.html",
+        "version": "67356979305728150851855820427694668063",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   }
 ]

--- a/test_unstructured_ingest/expected-structured-output/dropbox/nested-2/ideas-page.html.json
+++ b/test_unstructured_ingest/expected-structured-output/dropbox/nested-2/ideas-page.html.json
@@ -1,22 +1,22 @@
 [
   {
+    "type": "Table",
     "element_id": "32bc8af17151389d3e80f65036f8e65b",
+    "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/nested-2/ideas-page.html"
-        },
-        "url": "dropbox:///test-input/nested-2/ideas-page.html",
-        "version": "199529738485760976214264649588985968756"
-      },
-      "filetype": "text/html",
+      "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>",
       "languages": [
         "eng"
       ],
-      "text_as_html": "<table><tr><td></td><td></td><td>January 2023 ( Someone fed my essays into GPT to make something that could answer<br/>questions based on them, then asked it where good ideas come from.  The<br/>answer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,<br/>or missing, or broken? You can see anomalies in everyday life (much<br/>of standup comedy is based on this), but the best place to look for<br/>them is at the frontiers of knowledge. Knowledge grows fractally.<br/>From a distance its edges look smooth, but when you learn enough<br/>to get close to one, you&#x27;ll notice it&#x27;s full of gaps. These gaps<br/>will seem obvious; it will seem inexplicable that no one has tried<br/>x or wondered about y. In the best case, exploring such gaps yields<br/>whole new fractal buds.</td></tr></table>"
-    },
-    "text": "January 2023 ( Someone fed my essays into GPT to make something that could answer\nquestions based on them, then asked it where good ideas come from.  The\nanswer was ok, but not what I would have said. This is what I would have said.) The way to get new ideas is to notice anomalies: what seems strange,\nor missing, or broken? You can see anomalies in everyday life (much\nof standup comedy is based on this), but the best place to look for\nthem is at the frontiers of knowledge. Knowledge grows fractally.\nFrom a distance its edges look smooth, but when you learn enough\nto get close to one, you'll notice it's full of gaps. These gaps\nwill seem obvious; it will seem inexplicable that no one has tried\nx or wondered about y. In the best case, exploring such gaps yields\nwhole new fractal buds.",
-    "type": "Table"
+      "filetype": "text/html",
+      "data_source": {
+        "url": "dropbox:///test-input/nested-2/ideas-page.html",
+        "version": "145453788782335405288844961545898675998",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   }
 ]

--- a/test_unstructured_ingest/expected-structured-output/dropbox/science-exploration-1p.pptx.json
+++ b/test_unstructured_ingest/expected-structured-output/dropbox/science-exploration-1p.pptx.json
@@ -1,262 +1,262 @@
 [
   {
+    "type": "Title",
     "element_id": "6e8d4e8762e9bec346ce9637a0efec16",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "GSFC: Sciences and Exploration Directorate",
-    "type": "Title"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "Title",
     "element_id": "4cfab7f060a22db4c90b2d0f75f72d5d",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Virtual Machine Environment Scorecard",
-    "type": "Title"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "0f0ae8b6e925e38d5882b7881568baff",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Code 600: Sciences and Exploration Directorate (SED)",
-    "type": "ListItem"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "2cee95c9665ecf4c0ef061df2c84269f",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Code 610: Earth Sciences Division",
-    "type": "ListItem"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "d462a5a89ab41204621103f923cb8816",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Code 660: Astrophysics Science Division",
-    "type": "ListItem"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "6e72804e49ae9ddb285026b56e8a7c21",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Code 670: Heliophysics Science Division",
-    "type": "ListItem"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "84304dd1bf3a8501d42c7cf06a10fc36",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Code 690: Solar System Exploration Division",
-    "type": "ListItem"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "606d67afd6257571bd3c1c9be25bf7d6",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Support offices",
-    "type": "ListItem"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "add73d98a4221ed85ac38e4b2ba85f28",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Code 603: Administration and Resources Management Office",
-    "type": "ListItem"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "f372bcfbba68a3fcbb1e3bdccd9f6c17",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Code 605: Science Proposal Support Office",
-    "type": "ListItem"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "fd7b9fb95274e0dece5aedb70e2c2296",
-    "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 1
-    },
     "text": "Code 606: Computational and Information Sciences and Technology Office  ( The SEDVME project is managed out of 606).",
-    "type": "ListItem"
+    "metadata": {
+      "page_number": 1,
+      "languages": [
+        "eng"
+      ],
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "0463455f2b596a1181ce682c503431d0",
+    "text": "Code 700: Information Technology and Communication Directorate",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "page_number": 1,
       "languages": [
         "eng"
       ],
-      "page_number": 1
-    },
-    "text": "Code 700: Information Technology and Communication Directorate",
-    "type": "ListItem"
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   },
   {
+    "type": "ListItem",
     "element_id": "ce3c2479c2f2e0f0e2ede14da592480f",
+    "text": "Project management help, CNE, Zoned Architecture, IT Security,  Production SEDVME Service Manager",
     "metadata": {
-      "data_source": {
-        "record_locator": {
-          "protocol": "dropbox",
-          "remote_file_path": "/test-input/science-exploration-1p.pptx"
-        },
-        "url": "dropbox:///test-input/science-exploration-1p.pptx",
-        "version": "23819616053480539262630762470581852076"
-      },
-      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "page_number": 1,
       "languages": [
         "eng"
       ],
-      "page_number": 1
-    },
-    "text": "Project management help, CNE, Zoned Architecture, IT Security,  Production SEDVME Service Manager",
-    "type": "ListItem"
+      "filetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "data_source": {
+        "url": "dropbox:///test-input/science-exploration-1p.pptx",
+        "version": "26035320120182381452247268381589958225",
+        "record_locator": {
+          "protocol": "dropbox",
+          "remote_file_path": "dropbox://test-input/"
+        }
+      }
+    }
   }
 ]

--- a/test_unstructured_ingest/test-ingest-src.sh
+++ b/test_unstructured_ingest/test-ingest-src.sh
@@ -93,7 +93,6 @@ python_version=$(python --version 2>&1)
 
 tests_to_ignore=(
   'notion.sh'
-  'dropbox.sh'
 )
 
 for test in "${all_tests[@]}"; do

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.6-dev3"  # pragma: no cover
+__version__ = "0.14.6-dev4"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.6-dev4"  # pragma: no cover
+__version__ = "0.14.6-dev5"  # pragma: no cover


### PR DESCRIPTION
The Dropbox source connector currently raises exceptions when indexing files due to two issues: a path formatting idiosyncrasy of the Dropbox library and a divergence in the definition of the Dropbox libraries fs.info method, expecting a 'url' parameter rather than 'path'. 

## Changes

* add a `/` prefix to file path used by DropboxIndexer
* override the fsspec sterilize_info method in DropboxIndexer to call `self.fs.info` with `url` rather than `path`; to accommodate for the fact that `dropboxdrivefs` diverges with this signature
* remove `dropbox.sh` from ignored source tests
* update test fixtures (now that the dropbox connector has been fixed and not skipped)

## Testing
`dropbox.sh` source ingest test now succeeds (and is no longer ignored)
