### PR TITLE
ci: update to Node 20 actions

### DIFF
--- a/.github/actions/base-cache/action.yml
+++ b/.github/actions/base-cache/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Check for/restore base cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       id: virtualenv-cache-restore
       with:
         path: |
@@ -41,7 +41,7 @@ runs:
     - name: Save Cache
       if: steps.virtualenv-cache-restore.outputs.cache-hit != 'true'
       id: virtualenv-cache-save
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: |
           .venv

--- a/.github/actions/base-ingest-cache/action.yml
+++ b/.github/actions/base-ingest-cache/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Check for/restore ingest cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       id: ingest-virtualenv-cache-restore
       with:
         path: |
@@ -40,7 +40,7 @@ runs:
     - name: Save Ingest Cache
       if: steps.ingest-virtualenv-cache-restore.outputs.cache-hit != 'true'
       id: ingest-virtualenv-cache-save
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: |
           .venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/base-cache
       with:
         python-version: ${{ matrix.python-version }}
@@ -33,9 +33,9 @@ jobs:
         python-version: ["3.9","3.10","3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Check for dependency conflicts
@@ -47,9 +47,9 @@ jobs:
         python-version: [ "3.9","3.10","3.11","3.12" ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install all extras
@@ -64,9 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, changelog]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup virtual environment
@@ -81,14 +81,14 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@master
 
   shfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup shfmt
         uses: mfinelli/setup-shfmt@v3
       - name: Run shfmt
@@ -104,9 +104,9 @@ jobs:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
     needs: [setup, lint]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup virtual environment
@@ -145,9 +145,9 @@ jobs:
       UNSTRUCTURED_HF_TOKEN: ${{ secrets.HF_TOKEN }}
     needs: [setup, lint]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup virtual environment
@@ -177,9 +177,9 @@ jobs:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
     needs: [setup, lint]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup virtual environment
@@ -204,12 +204,12 @@ jobs:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
     needs: [setup, lint, test_unit_no_extras]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache/restore@v3
+    - uses: actions/cache/restore@v4
       id: virtualenv-cache
       with:
         path: |
@@ -246,7 +246,7 @@ jobs:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
     needs: [setup]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/base-ingest-cache
         with:
           python-version: ${{ matrix.python-version }}
@@ -261,7 +261,7 @@ jobs:
       # actions/checkout MUST come before auth
       - uses: 'actions/checkout@v4'
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -289,7 +289,7 @@ jobs:
     # actions/checkout MUST come before auth
     - uses: 'actions/checkout@v4'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get full Python version
@@ -373,7 +373,7 @@ jobs:
     # actions/checkout MUST come before auth
     - uses: 'actions/checkout@v4'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get full Python version
@@ -437,7 +437,7 @@ jobs:
       NLTK_DATA: ${{ github.workspace }}/nltk_data
     needs: [setup, lint]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup virtual environment
       uses: ./.github/actions/base-cache
       with:
@@ -449,7 +449,7 @@ jobs:
         echo "SKIP_API_UNIT_FOR_BREAKING_CHANGE=true" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }}
       if: env.SKIP_API_UNIT_FOR_BREAKING_CHANGE == 'false'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup virtual environment (no cache hit)
@@ -477,9 +477,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # need to checkout otherwise paths-filter will fail on merge-queue trigger
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - if: github.ref != 'refs/heads/main'
-      uses: dorny/paths-filter@v2
+      uses: dorny/paths-filter@v3
       id: changes
       with:
         filters: |
@@ -495,7 +495,7 @@ jobs:
     runs-on: ubuntu-latest-m
     needs: [ setup, lint ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test Dockerfile
         run: |
           echo "UNS_API_KEY=${{ secrets.UNS_API_KEY }}" > uns_test_env_file

--- a/.github/workflows/release-version-alert.yml
+++ b/.github/workflows/release-version-alert.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Restore Message from Cache
         if: env.SKIP_STEPS != 'true'
         id: restore-cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with: 
           path: message_cache.txt
           key: message-cache-${{ env.MESSAGE_HASH  }}
@@ -69,7 +69,7 @@ jobs:
           cat message_cache.txt
       - name: Store Message in Cache
         if: env.SKIP_STEPS != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: message_cache.txt
           key: message-cache-${{ env.MESSAGE_HASH }}


### PR DESCRIPTION
**Summary**
Silence the long list of warnings we get in CI from using Node 16 actions by updating to Node 20 versions.