### PR TITLE
rfctr(html): drop convert_and_partition_html()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.7-dev2
+## 0.14.7-dev3
 
 ### Enhancements
 

--- a/test_unstructured/partition/test_common.py
+++ b/test_unstructured/partition/test_common.py
@@ -568,6 +568,43 @@ def test_ocr_data_to_elements(
         )
 
 
+class Describe_get_last_modified:
+    """Isolated unit-tests for `unstructured.partition.common.get_last_modified()."""
+
+    def it_pulls_last_modified_from_the_filesystem_when_a_path_is_provided(
+        self, file_and_last_modified: tuple[str, str]
+    ):
+        file_path, last_modified = file_and_last_modified
+        last_modified_date = common.get_last_modified(str(file_path), None, False)
+        assert last_modified_date == last_modified
+
+    def and_it_pulls_last_modified_from_the_file_like_object_when_one_is_provided(
+        self, file_and_last_modified: tuple[str, str]
+    ):
+        file_path, last_modified = file_and_last_modified
+        with open(file_path, "rb") as f:
+            last_modified_date = common.get_last_modified(None, f, True)
+        assert last_modified_date == last_modified
+
+    def but_not_when_date_from_file_object_is_False(self, file_and_last_modified: tuple[str, str]):
+        file_path, _ = file_and_last_modified
+        with open(file_path, "rb") as f:
+            last_modified_date = common.get_last_modified(None, f, False)
+        assert last_modified_date is None
+
+    # -- fixtures --------------------------------------------------------------------------------
+
+    @pytest.fixture()
+    def file_and_last_modified(self, tmp_path: pathlib.Path) -> tuple[str, str]:
+        modified_timestamp = dt.datetime(
+            year=2024, month=6, day=14, hour=15, minute=39, second=25
+        ).timestamp()
+        file_path = tmp_path / "some_file.txt"
+        file_path.write_text("abcdefg")
+        os.utime(file_path, (modified_timestamp, modified_timestamp))
+        return str(file_path), "2024-06-14T15:39:25"
+
+
 class Describe_get_last_modified_date:
     def it_gets_the_modified_time_of_a_file_identified_by_a_path(self, tmp_path: pathlib.Path):
         modified_timestamp = dt.datetime(

--- a/test_unstructured/partition/test_doc.py
+++ b/test_unstructured/partition/test_doc.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pathlib
-import tempfile
 from typing import Any
 
 import pytest
@@ -133,11 +132,10 @@ def test_partition_doc_from_file_prefers_metadata_filename_when_provided():
 # -- .metadata.last_modified ---------------------------------------------------------------------
 
 
-def test_partition_doc_from_filename_pulls_last_modified_from_filesystem(mocker: MockFixture):
+def test_partition_doc_pulls_last_modified_from_filesystem(mocker: MockFixture):
     filesystem_last_modified = "2029-07-05T09:24:28"
     mocker.patch(
-        "unstructured.partition.doc.get_last_modified_date",
-        return_value=filesystem_last_modified,
+        "unstructured.partition.doc.get_last_modified", return_value=filesystem_last_modified
     )
 
     elements = partition_doc(example_doc_path("fake.doc"))
@@ -145,73 +143,18 @@ def test_partition_doc_from_filename_pulls_last_modified_from_filesystem(mocker:
     assert all(e.metadata.last_modified == filesystem_last_modified for e in elements)
 
 
-def test_partition_doc_from_filename_prefers_metadata_last_modified_when_provided(
+def test_partition_doc_prefers_metadata_last_modified_when_provided(
     mocker: MockFixture,
 ):
     filesystem_last_modified = "2029-07-05T09:24:28"
     metadata_last_modified = "2020-07-05T09:24:28"
     mocker.patch(
-        "unstructured.partition.doc.get_last_modified_date", return_value=filesystem_last_modified
+        "unstructured.partition.doc.get_last_modified", return_value=filesystem_last_modified
     )
 
     elements = partition_doc(
         example_doc_path("simple.doc"), metadata_last_modified=metadata_last_modified
     )
-
-    assert all(e.metadata.last_modified == metadata_last_modified for e in elements)
-
-
-def test_partition_doc_from_file_suppresses_last_modified_from_file_by_default(mocker: MockFixture):
-    modified_date_on_file = "2029-07-05T09:24:28"
-    mocker.patch(
-        "unstructured.partition.doc.get_last_modified_date_from_file",
-        return_value=modified_date_on_file,
-    )
-
-    with open(example_doc_path("simple.doc"), "rb") as f:
-        elements = partition_doc(file=f)
-
-    assert all(e.metadata.last_modified is None for e in elements)
-
-
-def test_partition_doc_from_file_pulls_last_modified_from_file_when_date_from_file_obj_arg_is_True(
-    mocker: MockFixture,
-):
-    modified_date_on_file = "2024-05-01T09:24:28"
-    mocker.patch(
-        "unstructured.partition.doc.get_last_modified_date_from_file",
-        return_value=modified_date_on_file,
-    )
-
-    with open(example_doc_path("simple.doc"), "rb") as f:
-        elements = partition_doc(file=f, date_from_file_object=True)
-
-    assert all(e.metadata.last_modified == modified_date_on_file for e in elements)
-
-
-def test_partition_doc_from_file_gets_None_last_modified_when_file_has_no_last_modified():
-    with open(example_doc_path("simple.doc"), "rb") as f:
-        sf = tempfile.SpooledTemporaryFile()
-        sf.write(f.read())
-        sf.seek(0)
-        elements = partition_doc(file=sf, date_from_file_object=True)
-
-    assert all(e.metadata.last_modified is None for e in elements)
-
-
-def test_partition_doc_from_file_prefers_metadata_last_modified_when_provided(mocker: MockFixture):
-    """Even when `date_from_file_object` arg is `True`."""
-    last_modified_on_file = "2029-07-05T09:24:28"
-    metadata_last_modified = "2020-07-05T09:24:28"
-    mocker.patch(
-        "unstructured.partition.doc.get_last_modified_date_from_file",
-        return_value=last_modified_on_file,
-    )
-
-    with open(example_doc_path("simple.doc"), "rb") as f:
-        elements = partition_doc(
-            file=f, metadata_last_modified=metadata_last_modified, date_from_file_object=True
-        )
 
     assert all(e.metadata.last_modified == metadata_last_modified for e in elements)
 

--- a/test_unstructured/partition/test_odt.py
+++ b/test_unstructured/partition/test_odt.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import tempfile
 from typing import Any
 
 import pytest
@@ -120,10 +119,10 @@ def test_partition_odt_suppresses_text_as_html_when_infer_table_structure_is_Fal
 # -- .metadata.last_modified ---------------------------------------------------------------------
 
 
-def test_partition_odt_from_filename_pulls_last_modified_from_filesystem(mocker: MockFixture):
+def test_partition_odt_pulls_last_modified_from_filesystem(mocker: MockFixture):
     filesystem_last_modified = "2029-07-05T09:24:28"
     mocker.patch(
-        "unstructured.partition.odt.get_last_modified_date", return_value=filesystem_last_modified
+        "unstructured.partition.odt.get_last_modified", return_value=filesystem_last_modified
     )
 
     elements = partition_odt(example_doc_path("fake.odt"))
@@ -131,72 +130,16 @@ def test_partition_odt_from_filename_pulls_last_modified_from_filesystem(mocker:
     assert all(e.metadata.last_modified == filesystem_last_modified for e in elements)
 
 
-def test_partition_odt_from_filename_prefers_metadata_last_modified_when_provided(
-    mocker: MockFixture,
-):
+def test_partition_odt_prefers_metadata_last_modified_when_provided(mocker: MockFixture):
     filesystem_last_modified = "2029-07-05T09:24:28"
     metadata_last_modified = "2020-07-05T09:24:28"
     mocker.patch(
-        "unstructured.partition.doc.get_last_modified_date", return_value=filesystem_last_modified
+        "unstructured.partition.odt.get_last_modified", return_value=filesystem_last_modified
     )
 
     elements = partition_odt(
         example_doc_path("simple.odt"), metadata_last_modified=metadata_last_modified
     )
-
-    assert all(e.metadata.last_modified == metadata_last_modified for e in elements)
-
-
-def test_partition_odt_from_file_suppresses_last_modified_from_file_by_default(mocker: MockFixture):
-    modified_date_on_file = "2029-07-05T09:24:28"
-    mocker.patch(
-        "unstructured.partition.odt.get_last_modified_date_from_file",
-        return_value=modified_date_on_file,
-    )
-
-    with open(example_doc_path("simple.odt"), "rb") as f:
-        elements = partition_odt(file=f)
-
-    assert all(e.metadata.last_modified is None for e in elements)
-
-
-def test_partition_odt_from_file_pulls_last_modified_from_file_when_date_from_file_obj_arg_is_True(
-    mocker: MockFixture,
-):
-    modified_date_on_file = "2024-05-01T09:24:28"
-    mocker.patch(
-        "unstructured.partition.odt.get_last_modified_date_from_file",
-        return_value=modified_date_on_file,
-    )
-
-    with open(example_doc_path("simple.odt"), "rb") as f:
-        elements = partition_odt(file=f, date_from_file_object=True)
-
-    assert all(e.metadata.last_modified == modified_date_on_file for e in elements)
-
-
-def test_partition_odt_from_file_gets_None_last_modified_when_file_has_no_last_modified():
-    with open(example_doc_path("simple.odt"), "rb") as f:
-        sf = tempfile.SpooledTemporaryFile()
-        sf.write(f.read())
-        sf.seek(0)
-        elements = partition_odt(file=sf, date_from_file_object=True)
-
-    assert all(e.metadata.last_modified is None for e in elements)
-
-
-def test_partition_odt_from_file_prefers_metadata_last_modified_when_provided(mocker: MockFixture):
-    """Even when `date_from_file_object` arg is `True`."""
-    modified_date_on_file = "2029-07-05T09:24:28"
-    metadata_last_modified = "2020-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.odt.get_last_modified_date_from_file",
-        return_value=modified_date_on_file,
-    )
-
-    with open(example_doc_path("fake.odt"), "rb") as f:
-        elements = partition_odt(file=f, metadata_last_modified=metadata_last_modified)
 
     assert all(e.metadata.last_modified == metadata_last_modified for e in elements)
 

--- a/test_unstructured/partition/test_org.py
+++ b/test_unstructured/partition/test_org.py
@@ -1,4 +1,6 @@
-from tempfile import SpooledTemporaryFile
+from __future__ import annotations
+
+from pytest_mock import MockFixture
 
 from test_unstructured.unit_utils import assert_round_trips_through_JSON, example_doc_path
 from unstructured.chunking.title import chunk_by_title
@@ -36,11 +38,9 @@ def test_partition_org_from_file_with_metadata_filename(filename="example-docs/R
     assert elements[0].metadata.filename == "test"
 
 
-def test_partition_org_from_filename_exclude_metadata(filename="example-docs/README.org"):
-    elements = partition_org(filename=filename, include_metadata=False)
-
-    for i in range(len(elements)):
-        assert elements[i].metadata.to_dict() == {}
+def test_partition_org_from_filename_exclude_metadata():
+    elements = partition_org("example-docs/README.org", include_metadata=False)
+    assert all(e.metadata.to_dict() == {} for e in elements)
 
 
 def test_partition_org_from_file_exclude_metadata(filename="example-docs/README.org"):
@@ -51,110 +51,26 @@ def test_partition_org_from_file_exclude_metadata(filename="example-docs/README.
         assert elements[i].metadata.to_dict() == {}
 
 
-def test_partition_org_metadata_date(
-    mocker,
-    filename="example-docs/README.org",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-
+def test_partition_org_pulls_last_modified_from_filesystem(mocker: MockFixture):
+    filesystem_last_modified = "2024-06-14T16:01:29"
     mocker.patch(
-        "unstructured.partition.html.get_last_modified_date",
-        return_value=mocked_last_modification_date,
+        "unstructured.partition.org.get_last_modified", return_value=filesystem_last_modified
     )
+
+    elements = partition_org("example-docs/README.org")
+
+    assert elements[0].metadata.last_modified == filesystem_last_modified
+
+
+def test_partition_org_prefers_metadata_last_modified(mocker: MockFixture):
+    metadata_last_modified = "2024-06-14T16:01:29"
+    mocker.patch("unstructured.partition.org.get_last_modified", return_value="2029-07-05T09:24:28")
 
     elements = partition_org(
-        filename=filename,
+        "example-docs/README.org", metadata_last_modified=metadata_last_modified
     )
 
-    assert elements[0].metadata.last_modified == mocked_last_modification_date
-
-
-def test_partition_org_with_custom_metadata_date(
-    mocker,
-    filename="example-docs/README.org",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-    expected_last_modification_date = "2020-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date",
-        return_value=mocked_last_modification_date,
-    )
-
-    elements = partition_org(
-        filename=filename,
-        metadata_last_modified=expected_last_modification_date,
-    )
-
-    assert elements[0].metadata.last_modified == expected_last_modification_date
-
-
-def test_partition_org_from_file_metadata_date(
-    mocker,
-    filename="example-docs/README.org",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date_from_file",
-        return_value=mocked_last_modification_date,
-    )
-
-    with open(filename, "rb") as f:
-        elements = partition_org(
-            file=f,
-        )
-
-    assert elements[0].metadata.last_modified is None
-
-
-def test_partition_org_from_file_explicit_get_metadata_date(
-    mocker,
-    filename="example-docs/README.org",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date_from_file",
-        return_value=mocked_last_modification_date,
-    )
-
-    with open(filename, "rb") as f:
-        elements = partition_org(file=f, date_from_file_object=True)
-
-    assert elements[0].metadata.last_modified == mocked_last_modification_date
-
-
-def test_partition_org_from_file_with_custom_metadata_date(
-    mocker,
-    filename="example-docs/README.org",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-    expected_last_modification_date = "2020-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date_from_file",
-        return_value=mocked_last_modification_date,
-    )
-
-    with open(filename, "rb") as f:
-        elements = partition_org(file=f, metadata_last_modified=expected_last_modification_date)
-
-    assert elements[0].metadata.last_modified == expected_last_modification_date
-
-
-def test_partition_org_from_file_without_metadata_date(
-    filename="example-docs/README.org",
-):
-    """Test partition_org() with file that are not possible to get last modified date"""
-
-    with open(filename, "rb") as f:
-        sf = SpooledTemporaryFile()
-        sf.write(f.read())
-        sf.seek(0)
-        elements = partition_org(file=sf, date_from_file_object=True)
-
-    assert elements[0].metadata.last_modified is None
+    assert all(e.metadata.last_modified == metadata_last_modified for e in elements)
 
 
 def test_partition_org_with_json():

--- a/test_unstructured/partition/test_rst.py
+++ b/test_unstructured/partition/test_rst.py
@@ -1,4 +1,6 @@
-from tempfile import SpooledTemporaryFile
+from __future__ import annotations
+
+from pytest_mock import MockFixture
 
 from test_unstructured.unit_utils import assert_round_trips_through_JSON, example_doc_path
 from unstructured.chunking.title import chunk_by_title
@@ -62,110 +64,26 @@ def test_partition_rst_from_file_exclude_metadata(filename="example-docs/README.
         assert elements[i].metadata.to_dict() == {}
 
 
-def test_partition_rst_metadata_date(
-    mocker,
-    filename="example-docs/README.rst",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-
+def test_partition_rst_pulls_last_modified_from_filesystem(mocker: MockFixture):
+    filesystem_last_modified = "2024-06-14T16:01:29"
     mocker.patch(
-        "unstructured.partition.html.get_last_modified_date",
-        return_value=mocked_last_modification_date,
+        "unstructured.partition.rst.get_last_modified", return_value=filesystem_last_modified
     )
+
+    elements = partition_rst("example-docs/README.rst")
+
+    assert elements[0].metadata.last_modified == filesystem_last_modified
+
+
+def test_partition_rst_prefers_metadata_last_modified(mocker: MockFixture):
+    metadata_last_modified = "2024-06-14T16:01:29"
+    mocker.patch("unstructured.partition.rst.get_last_modified", return_value="2029-07-05T09:24:28")
 
     elements = partition_rst(
-        filename=filename,
+        "example-docs/README.rst", metadata_last_modified=metadata_last_modified
     )
 
-    assert elements[0].metadata.last_modified == mocked_last_modification_date
-
-
-def test_partition_rst_with_custom_metadata_date(
-    mocker,
-    filename="example-docs/README.rst",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-    expected_last_modification_date = "2020-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date",
-        return_value=mocked_last_modification_date,
-    )
-
-    elements = partition_rst(
-        filename=filename,
-        metadata_last_modified=expected_last_modification_date,
-    )
-
-    assert elements[0].metadata.last_modified == expected_last_modification_date
-
-
-def test_partition_rst_from_file_metadata_date(
-    mocker,
-    filename="example-docs/README.rst",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date_from_file",
-        return_value=mocked_last_modification_date,
-    )
-
-    with open(filename, "rb") as f:
-        elements = partition_rst(
-            file=f,
-        )
-
-    assert elements[0].metadata.last_modified is None
-
-
-def test_partition_rst_from_file_explicit_get_metadata_date(
-    mocker,
-    filename="example-docs/README.rst",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date_from_file",
-        return_value=mocked_last_modification_date,
-    )
-
-    with open(filename, "rb") as f:
-        elements = partition_rst(file=f, date_from_file_object=True)
-
-    assert elements[0].metadata.last_modified == mocked_last_modification_date
-
-
-def test_partition_rst_from_file_with_custom_metadata_date(
-    mocker,
-    filename="example-docs/README.rst",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-    expected_last_modification_date = "2020-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date_from_file",
-        return_value=mocked_last_modification_date,
-    )
-
-    with open(filename, "rb") as f:
-        elements = partition_rst(file=f, metadata_last_modified=expected_last_modification_date)
-
-    assert elements[0].metadata.last_modified == expected_last_modification_date
-
-
-def test_partition_rst_from_file_without_metadata_date(
-    filename="example-docs/README.rst",
-):
-    """Test partition_rst() with file that are not possible to get last modified date"""
-
-    with open(filename, "rb") as f:
-        sf = SpooledTemporaryFile()
-        sf.write(f.read())
-        sf.seek(0)
-        elements = partition_rst(file=sf, date_from_file_object=True)
-
-    assert elements[0].metadata.last_modified is None
+    assert all(e.metadata.last_modified == metadata_last_modified for e in elements)
 
 
 def test_partition_rst_with_json():

--- a/test_unstructured/partition/test_rtf.py
+++ b/test_unstructured/partition/test_rtf.py
@@ -1,4 +1,6 @@
-from tempfile import SpooledTemporaryFile
+from __future__ import annotations
+
+from pytest_mock import MockFixture
 
 from test_unstructured.unit_utils import assert_round_trips_through_JSON, example_doc_path
 from unstructured.chunking.title import chunk_by_title
@@ -59,113 +61,26 @@ def test_partition_rtf_from_file_exclude_metadata():
         assert elements[i].metadata.to_dict() == {}
 
 
-def test_partition_rtf_metadata_date(
-    mocker,
-    filename="example-docs/fake-doc.rtf",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-
+def test_partition_rtf_pulls_last_modified_from_filesystem(mocker: MockFixture):
+    filesystem_last_modified = "2024-06-14T16:01:29"
     mocker.patch(
-        "unstructured.partition.html.get_last_modified_date",
-        return_value=mocked_last_modification_date,
+        "unstructured.partition.rtf.get_last_modified", return_value=filesystem_last_modified
     )
+
+    elements = partition_rtf("example-docs/fake-doc.rtf")
+
+    assert elements[0].metadata.last_modified == filesystem_last_modified
+
+
+def test_partition_rtf_prefers_metadata_last_modified(mocker: MockFixture):
+    metadata_last_modified = "2024-06-14T16:01:29"
+    mocker.patch("unstructured.partition.rtf.get_last_modified", return_value="2029-07-05T09:24:28")
 
     elements = partition_rtf(
-        filename=filename,
+        "example-docs/fake-doc.rtf", metadata_last_modified=metadata_last_modified
     )
 
-    assert elements[0].metadata.last_modified == mocked_last_modification_date
-
-
-def test_partition_rtf_with_custom_metadata_date(
-    mocker,
-    filename="example-docs/fake-doc.rtf",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-    expected_last_modification_date = "2020-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date",
-        return_value=mocked_last_modification_date,
-    )
-
-    elements = partition_rtf(
-        filename=filename,
-        metadata_last_modified=expected_last_modification_date,
-    )
-
-    assert elements[0].metadata.last_modified == expected_last_modification_date
-
-
-def test_partition_rtf_from_file_metadata_date(
-    mocker,
-    filename="example-docs/fake-doc.rtf",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date_from_file",
-        return_value=mocked_last_modification_date,
-    )
-
-    with open(filename, "rb") as f:
-        elements = partition_rtf(
-            file=f,
-        )
-
-    assert elements[0].metadata.last_modified is None
-
-
-def test_partition_rtf_from_file_explicit_get_metadata_date(
-    mocker,
-    filename="example-docs/fake-doc.rtf",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date_from_file",
-        return_value=mocked_last_modification_date,
-    )
-
-    with open(filename, "rb") as f:
-        elements = partition_rtf(
-            file=f,
-            date_from_file_object=True,
-        )
-
-    assert elements[0].metadata.last_modified == mocked_last_modification_date
-
-
-def test_partition_rtf_from_file_with_custom_metadata_date(
-    mocker,
-    filename="example-docs/fake-doc.rtf",
-):
-    mocked_last_modification_date = "2029-07-05T09:24:28"
-    expected_last_modification_date = "2020-07-05T09:24:28"
-
-    mocker.patch(
-        "unstructured.partition.html.get_last_modified_date_from_file",
-        return_value=mocked_last_modification_date,
-    )
-
-    with open(filename, "rb") as f:
-        elements = partition_rtf(file=f, metadata_last_modified=expected_last_modification_date)
-
-    assert elements[0].metadata.last_modified == expected_last_modification_date
-
-
-def test_partition_rtf_from_file_without_metadata_date(
-    filename="example-docs/fake-doc.rtf",
-):
-    """Test partition_rtf() with file that are not possible to get last modified date"""
-
-    with open(filename, "rb") as f:
-        sf = SpooledTemporaryFile()
-        sf.write(f.read())
-        sf.seek(0)
-        elements = partition_rtf(file=sf, date_from_file_object=True)
-
-    assert elements[0].metadata.last_modified is None
+    assert all(e.metadata.last_modified == metadata_last_modified for e in elements)
 
 
 def test_partition_rtf_with_json():

--- a/typings/pypandoc/__init__.pyi
+++ b/typings/pypandoc/__init__.pyi
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 import pathlib
 
 def convert_file(
-    source_file: str, to: str, format: str | None, outputfile: str | pathlib.Path | None
+    source_file: str, to: str, format: str | None, outputfile: str | pathlib.Path | None = None
 ) -> str: ...
+def get_pandoc_formats() -> tuple[list[str], list[str]]: ...
+def get_pandoc_version() -> str: ...

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.7-dev2"  # pragma: no cover
+__version__ = "0.14.7-dev3"  # pragma: no cover

--- a/unstructured/file_utils/file_conversion.py
+++ b/unstructured/file_utils/file_conversion.py
@@ -1,24 +1,24 @@
+from __future__ import annotations
+
 import tempfile
-from typing import IO, Optional
+from typing import IO
 
 from unstructured.partition.common import exactly_one
-from unstructured.utils import dependency_exists, requires_dependencies
-
-if dependency_exists("pypandoc"):
-    import pypandoc
+from unstructured.utils import requires_dependencies
 
 
 @requires_dependencies(["pypandoc"])
 def convert_file_to_text(filename: str, source_format: str, target_format: str) -> str:
     """Uses pandoc to convert the source document to a raw text string."""
+    import pypandoc
+
     try:
         text = pypandoc.convert_file(filename, target_format, format=source_format)
     except FileNotFoundError as err:
         msg = (
-            "Error converting the file to text. Ensure you have the pandoc "
-            "package installed on your system. Install instructions are available at "
-            "https://pandoc.org/installing.html. The original exception text was:\n"
-            f"{err}"
+            f"Error converting the file to text. Ensure you have the pandoc package installed on"
+            f" your system. Installation instructions are available at"
+            f" https://pandoc.org/installing.html. The original exception text was:\n{err}"
         )
         raise FileNotFoundError(msg)
     except RuntimeError as err:
@@ -36,39 +36,32 @@ def convert_file_to_text(filename: str, source_format: str, target_format: str) 
         msg = (
             f"{err}\n\n{additional_info}\n\n"
             f"Current version of pandoc: {pypandoc.get_pandoc_version()}\n"
-            "Make sure you have the right version installed in your system. "
-            "Please, follow the pandoc installation instructions "
-            "in README.md to install the right version."
+            "Make sure you have the right version installed in your system. Please follow the"
+            " pandoc installation instructions in README.md to install the right version."
         )
         raise RuntimeError(msg)
 
     return text
 
 
-def convert_file_to_html_text(
-    source_format: str,
-    filename: Optional[str] = None,
-    file: Optional[IO[bytes]] = None,
+def convert_file_to_html_text_using_pandoc(
+    source_format: str, filename: str | None = None, file: IO[bytes] | None = None
 ) -> str:
-    """Converts a document to HTML raw text. Enables the doucment to be
-    processed using the partition_html function."""
+    """Converts a document to HTML raw text.
+
+    Enables the doucment to be processed using `partition_html()`.
+    """
     exactly_one(filename=filename, file=file)
 
     if file is not None:
         with tempfile.NamedTemporaryFile() as tmp:
             tmp.write(file.read())
             tmp.flush()
-
-            html_text = convert_file_to_text(
-                filename=tmp.name,
-                source_format=source_format,
-                target_format="html",
+            return convert_file_to_text(
+                filename=tmp.name, source_format=source_format, target_format="html"
             )
-    elif filename is not None:
-        html_text = convert_file_to_text(
-            filename=filename,
-            source_format=source_format,
-            target_format="html",
-        )
 
-    return html_text
+    assert filename is not None
+    return convert_file_to_text(
+        filename=filename, source_format=source_format, target_format="html"
+    )

--- a/unstructured/partition/common.py
+++ b/unstructured/partition/common.py
@@ -66,6 +66,19 @@ HIERARCHY_RULE_SET = {
 }
 
 
+def get_last_modified(
+    filename: str | None, file: IO[bytes] | None, date_from_file_object: bool
+) -> str | None:
+    """Determine best available last-modified date from file or filename."""
+    if filename is not None:
+        return get_last_modified_date(filename)
+
+    if file is not None:
+        return get_last_modified_date_from_file(file) if date_from_file_object else None
+
+    return None
+
+
 def get_last_modified_date(filename: str) -> Optional[str]:
     """Modification time of file at path `filename`, if it exists.
 

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -10,8 +10,7 @@ from unstructured.file_utils.filetype import FileType, add_metadata_with_filetyp
 from unstructured.partition.common import (
     convert_office_doc,
     exactly_one,
-    get_last_modified_date,
-    get_last_modified_date_from_file,
+    get_last_modified,
 )
 from unstructured.partition.docx import partition_docx
 
@@ -23,11 +22,9 @@ def partition_doc(
     filename: Optional[str] = None,
     file: Optional[IO[bytes]] = None,
     include_page_breaks: bool = True,
-    include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     libre_office_filter: Optional[str] = "MS Word 2007 XML",
-    chunking_strategy: Optional[str] = None,
     languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
@@ -106,7 +103,6 @@ def partition_doc(
         elements = partition_docx(
             filename=target_file_path,
             detect_language_per_element=detect_language_per_element,
-            include_metadata=include_metadata,
             include_page_breaks=include_page_breaks,
             languages=languages,
             metadata_filename=metadata_filename,
@@ -122,16 +118,3 @@ def partition_doc(
             element.metadata.filename = metadata_filename
 
     return elements
-
-
-def get_last_modified(
-    filename: str | None, file: IO[bytes] | None, date_from_file_object: bool
-) -> str | None:
-    """Determine best available last-modified date from partitioner document-source."""
-    if filename is not None:
-        return get_last_modified_date(filename)
-
-    if file is not None:
-        return get_last_modified_date_from_file(file) if date_from_file_object else None
-
-    return None

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -4,9 +4,10 @@ from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
+from unstructured.file_utils.file_conversion import convert_file_to_html_text_using_pandoc
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.html import convert_and_partition_html
-from unstructured.partition.lang import apply_lang_metadata
+from unstructured.partition.common import exactly_one, get_last_modified
+from unstructured.partition.html import partition_html
 
 DETECTION_ORIGIN: str = "epub"
 
@@ -16,12 +17,10 @@ DETECTION_ORIGIN: str = "epub"
 @add_chunking_strategy
 def partition_epub(
     filename: Optional[str] = None,
+    *,
     file: Optional[IO[bytes]] = None,
-    include_page_breaks: bool = False,
-    include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
-    chunking_strategy: Optional[str] = None,
     languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
@@ -36,8 +35,6 @@ def partition_epub(
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
-    include_page_breaks
-        If True, the output will include page breaks if the filetype supports it
     metadata_last_modified
         The last modified date for the document.
     languages
@@ -51,24 +48,20 @@ def partition_epub(
         Applies only when providing file via `file` parameter. If this option is True, attempt
         infer last_modified metadata from bytes, otherwise set it to None.
     """
+    exactly_one(filename=filename, file=file)
 
-    elements = convert_and_partition_html(
-        filename=filename,
-        file=file,
-        include_page_breaks=include_page_breaks,
+    html_text = convert_file_to_html_text_using_pandoc(
+        source_format="epub", filename=filename, file=file
+    )
+
+    return partition_html(
+        text=html_text,
+        encoding="unicode",
         metadata_filename=metadata_filename,
-        metadata_last_modified=metadata_last_modified,
-        source_format="epub",
-        detection_origin=DETECTION_ORIGIN,
-        date_from_file_object=date_from_file_object,
-    )
-
-    elements = list(
-        apply_lang_metadata(
-            elements,
-            languages=languages,
-            detect_language_per_element=detect_language_per_element,
+        metadata_last_modified=(
+            metadata_last_modified or get_last_modified(filename, file, date_from_file_object)
         ),
+        languages=languages,
+        detect_language_per_element=detect_language_per_element,
+        detection_origin=DETECTION_ORIGIN,
     )
-
-    return elements

--- a/unstructured/partition/html.py
+++ b/unstructured/partition/html.py
@@ -5,9 +5,7 @@ from typing import IO, Any, Optional
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.documents.html import HTMLDocument, HtmlPartitionerOptions
-from unstructured.file_utils.file_conversion import convert_file_to_html_text
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.common import get_last_modified_date, get_last_modified_date_from_file
 from unstructured.partition.lang import apply_lang_metadata
 
 
@@ -50,7 +48,6 @@ def partition_html(
     ssl_verify
         If the URL parameter is set, determines whether or not SSL verification is performed
         on the HTTP request.
-
     date_from_file_object
         Applies only when providing file via `file` parameter. If this option is True, attempt
         infer last_modified metadata from bytes, otherwise set it to None.
@@ -106,71 +103,3 @@ def partition_html(
     )
 
     return elements
-
-
-def convert_and_partition_html(
-    source_format: str,
-    filename: Optional[str] = None,
-    file: Optional[IO[bytes]] = None,
-    include_page_breaks: bool = False,
-    metadata_filename: Optional[str] = None,
-    metadata_last_modified: Optional[str] = None,
-    languages: Optional[list[str]] = ["auto"],
-    detect_language_per_element: bool = False,
-    detection_origin: Optional[str] = None,
-    date_from_file_object: bool = False,
-) -> list[Element]:
-    """Converts a document to HTML and then partitions it using partition_html. Works with
-    any file format support by pandoc.
-
-    Parameters
-    ----------
-    source_format
-        The format of the source document, i.e. rst
-    filename
-        A string defining the target filename path.
-    file
-        A file-like object using "rb" mode --> open(filename, "rb").
-    include_page_breaks
-        If True, the output will include page breaks if the filetype supports it.
-    metadata_filename
-        The filename to use in element metadata.
-    metadata_last_modified
-        The last modified date for the document.
-    languages
-        User defined value for `metadata.languages` if provided. Otherwise language is detected
-        using naive Bayesian filter via `langdetect`. Multiple languages indicates text could be
-        in either language.
-        Additional Parameters:
-            detect_language_per_element
-                Detect language per element instead of at the document level.
-    date_from_file_object
-        Applies only when providing file via `file` parameter. If this option is True, attempt
-        infer last_modified metadata from bytes, otherwise set it to None.
-    """
-
-    last_modification_date = None
-    if filename:
-        last_modification_date = get_last_modified_date(filename)
-    elif file:
-        last_modification_date = (
-            get_last_modified_date_from_file(file) if date_from_file_object else None
-        )
-    html_text = convert_file_to_html_text(
-        source_format=source_format,
-        filename=filename,
-        file=file,
-    )
-    # NOTE(robinson) - pypandoc returns a text string with unicode encoding
-    # ref: https://github.com/JessicaTegner/pypandoc#usage
-    return partition_html(
-        text=html_text,
-        source_format=source_format,
-        include_page_breaks=include_page_breaks,
-        encoding="unicode",
-        metadata_filename=metadata_filename,
-        metadata_last_modified=metadata_last_modified or last_modification_date,
-        languages=languages,
-        detect_language_per_element=detect_language_per_element,
-        detection_origin=detection_origin,
-    )

--- a/unstructured/partition/odt.py
+++ b/unstructured/partition/odt.py
@@ -7,11 +7,7 @@ from typing import IO, Any, Optional, cast
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.common import (
-    exactly_one,
-    get_last_modified_date,
-    get_last_modified_date_from_file,
-)
+from unstructured.partition.common import exactly_one, get_last_modified
 from unstructured.partition.docx import partition_docx
 from unstructured.utils import requires_dependencies
 
@@ -61,12 +57,6 @@ def partition_odt(
         infer last_modified metadata from the file-like object, otherwise set it to None.
     """
 
-    last_modification_date = (
-        get_last_modified_date(filename)
-        if filename
-        else get_last_modified_date_from_file(file) if file and date_from_file_object else None
-    )
-
     with tempfile.TemporaryDirectory() as target_dir:
         docx_path = _convert_odt_to_docx(target_dir, filename, file)
         elements = partition_docx(
@@ -75,7 +65,9 @@ def partition_odt(
             infer_table_structure=infer_table_structure,
             languages=languages,
             metadata_filename=metadata_filename,
-            metadata_last_modified=metadata_last_modified or last_modification_date,
+            metadata_last_modified=(
+                metadata_last_modified or get_last_modified(filename, file, date_from_file_object)
+            ),
             starting_page_number=starting_page_number,
             strategy=strategy,
         )

--- a/unstructured/partition/org.py
+++ b/unstructured/partition/org.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import IO, Optional
+from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element
+from unstructured.file_utils.file_conversion import convert_file_to_html_text_using_pandoc
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.html import convert_and_partition_html
+from unstructured.partition.common import exactly_one, get_last_modified
+from unstructured.partition.html import partition_html
 
 DETECTION_ORIGIN: str = "org"
 
@@ -14,15 +16,14 @@ DETECTION_ORIGIN: str = "org"
 @add_chunking_strategy
 def partition_org(
     filename: Optional[str] = None,
+    *,
     file: Optional[IO[bytes]] = None,
-    include_page_breaks: bool = False,
-    include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
-    chunking_strategy: Optional[str] = None,
     languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
+    **kwargs: Any,
 ) -> list[Element]:
     """Partitions an org document. The document is first converted to HTML and then
     partitioned using partition_html.
@@ -33,8 +34,6 @@ def partition_org(
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
-    include_page_breaks
-        If True, the output will include page breaks if the filetype supports it
     metadata_last_modified
         The last modified date for the document.
     languages
@@ -48,16 +47,20 @@ def partition_org(
         Applies only when providing file via `file` parameter. If this option is True, attempt
         infer last_modified metadata from bytes, otherwise set it to None.
     """
+    exactly_one(filename=filename, file=file)
 
-    return convert_and_partition_html(
-        source_format="org",
-        filename=filename,
-        file=file,
-        include_page_breaks=include_page_breaks,
+    html_text = convert_file_to_html_text_using_pandoc(
+        source_format="org", filename=filename, file=file
+    )
+
+    return partition_html(
+        text=html_text,
+        encoding="unicode",
         metadata_filename=metadata_filename,
-        metadata_last_modified=metadata_last_modified,
+        metadata_last_modified=(
+            metadata_last_modified or get_last_modified(filename, file, date_from_file_object)
+        ),
         languages=languages,
         detect_language_per_element=detect_language_per_element,
         detection_origin=DETECTION_ORIGIN,
-        date_from_file_object=date_from_file_object,
     )

--- a/unstructured/partition/rst.py
+++ b/unstructured/partition/rst.py
@@ -4,8 +4,10 @@ from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
+from unstructured.file_utils.file_conversion import convert_file_to_html_text_using_pandoc
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.html import convert_and_partition_html
+from unstructured.partition.common import exactly_one, get_last_modified
+from unstructured.partition.html import partition_html
 
 DETECTION_ORIGIN: str = "rst"
 
@@ -15,12 +17,10 @@ DETECTION_ORIGIN: str = "rst"
 @add_chunking_strategy
 def partition_rst(
     filename: Optional[str] = None,
+    *,
     file: Optional[IO[bytes]] = None,
-    include_page_breaks: bool = False,
-    include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
-    chunking_strategy: Optional[str] = None,
     languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
@@ -35,8 +35,6 @@ def partition_rst(
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
-    include_page_breaks
-        If True, the output will include page breaks if the filetype supports it.
     metadata_last_modified
         The last modified date for the document.
     languages
@@ -50,16 +48,20 @@ def partition_rst(
         Applies only when providing file via `file` parameter. If this option is True, attempt
         infer last_modified metadata from bytes, otherwise set it to None.
     """
+    exactly_one(filename=filename, file=file)
 
-    return convert_and_partition_html(
-        source_format="rst",
-        filename=filename,
-        file=file,
-        include_page_breaks=include_page_breaks,
+    html_text = convert_file_to_html_text_using_pandoc(
+        source_format="rst", filename=filename, file=file
+    )
+
+    return partition_html(
+        text=html_text,
+        encoding="unicode",
         metadata_filename=metadata_filename,
-        metadata_last_modified=metadata_last_modified,
+        metadata_last_modified=(
+            metadata_last_modified or get_last_modified(filename, file, date_from_file_object)
+        ),
         languages=languages,
         detect_language_per_element=detect_language_per_element,
         detection_origin=DETECTION_ORIGIN,
-        date_from_file_object=date_from_file_object,
     )

--- a/unstructured/partition/rtf.py
+++ b/unstructured/partition/rtf.py
@@ -4,8 +4,10 @@ from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.documents.elements import Element, process_metadata
+from unstructured.file_utils.file_conversion import convert_file_to_html_text_using_pandoc
 from unstructured.file_utils.filetype import FileType, add_metadata_with_filetype
-from unstructured.partition.html import convert_and_partition_html
+from unstructured.partition.common import exactly_one, get_last_modified
+from unstructured.partition.html import partition_html
 
 DETECTION_ORIGIN: str = "rtf"
 
@@ -15,12 +17,10 @@ DETECTION_ORIGIN: str = "rtf"
 @add_chunking_strategy
 def partition_rtf(
     filename: Optional[str] = None,
+    *,
     file: Optional[IO[bytes]] = None,
-    include_page_breaks: bool = False,
-    include_metadata: bool = True,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
-    chunking_strategy: Optional[str] = None,
     languages: Optional[list[str]] = ["auto"],
     detect_language_per_element: bool = False,
     date_from_file_object: bool = False,
@@ -35,8 +35,6 @@ def partition_rtf(
         A string defining the target filename path.
     file
         A file-like object using "rb" mode --> open(filename, "rb").
-    include_page_breaks
-        If True, the output will include page breaks if the filetype supports it
     metadata_last_modified
         The last modified date for the document.
     languages
@@ -50,16 +48,20 @@ def partition_rtf(
         Applies only when providing file via `file` parameter. If this option is True, attempt
         infer last_modified metadata from bytes, otherwise set it to None.
     """
+    exactly_one(filename=filename, file=file)
 
-    return convert_and_partition_html(
-        source_format="rtf",
-        filename=filename,
-        file=file,
-        include_page_breaks=include_page_breaks,
+    html_text = convert_file_to_html_text_using_pandoc(
+        source_format="rtf", filename=filename, file=file
+    )
+
+    return partition_html(
+        text=html_text,
+        encoding="unicode",
         metadata_filename=metadata_filename,
-        metadata_last_modified=metadata_last_modified,
+        metadata_last_modified=(
+            metadata_last_modified or get_last_modified(filename, file, date_from_file_object)
+        ),
         languages=languages,
         detect_language_per_element=detect_language_per_element,
         detection_origin=DETECTION_ORIGIN,
-        date_from_file_object=date_from_file_object,
     )


### PR DESCRIPTION
**Summary**
Remove `unstructured.partition.html.convert_and_partition_html()`. Move file-type conversion (to HTML) responsibility to each brokering partitioner that uses that strategy and let them call `partition_html()` for themselves with the result.

**Additional Context**

Rationale:
- `partition_html()` does not want or need to know which partitioners might broker partitioning to it.
- Different brokering partitioners have their own methods to convert their format to HTML and quirks that may be involved for their format. Avoid coupling them so they can evolve independently.
- The core of the conversion work is already encapsulated in `unstructured.partition.common.convert_file_to_html_text_using_pandoc()`.
- `convert_and_partition_html()` represents an additional brokering layer with the entailed complexities of an additional site for default parameter values to be (mis-)applied and/or dropped and is an additional location for new parameters to be added.