### PR TITLE
build(deps): version bumps for 2024-06-17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,14 +116,14 @@ jobs:
     - name: Test
       env:
         UNS_API_KEY: ${{ secrets.UNS_API_KEY }}
-        TESSERACT_VERSION : "5.3.4"
+        TESSERACT_VERSION : "5.4.1"
       run: |
         source .venv/bin/activate
         sudo apt-get update
         sudo apt-get install -y libmagic-dev poppler-utils libreoffice
         sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
         sudo apt-get update
-        sudo apt-get install -y tesseract-ocr=5.3.4 tesseract-ocr-kor
+        sudo apt-get install -y tesseract-ocr tesseract-ocr-kor
         tesseract --version
         installed_tesseract_version=$(tesseract --version | grep -oP '(?<=tesseract )\d+\.\d+\.\d+')
         if [ "$installed_tesseract_version" != "${{env.TESSERACT_VERSION}}" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         sudo apt-get install -y libmagic-dev poppler-utils libreoffice
         sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
         sudo apt-get update
-        sudo apt-get install -y tesseract-ocr tesseract-ocr-kor
+        sudo apt-get install -y tesseract-ocr=5.3.4 tesseract-ocr-kor
         tesseract --version
         installed_tesseract_version=$(tesseract --version | grep -oP '(?<=tesseract )\d+\.\d+\.\d+')
         if [ "$installed_tesseract_version" != "${{env.TESSERACT_VERSION}}" ]; then

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -85,7 +85,9 @@ soupsieve==2.5
 tabulate==0.9.0
     # via -r ./base.in
 tqdm==4.66.4
-    # via nltk
+    # via
+    #   -r ./base.in
+    #   nltk
 typing-extensions==4.12.2
     # via
     #   -r ./base.in

--- a/requirements/deps/constraints.txt
+++ b/requirements/deps/constraints.txt
@@ -54,7 +54,9 @@ unstructured-client<=0.18.0
 fsspec==2024.5.0
 
 # python 3.12 support
-numpy>=1.26.0
+# NOTE(robinson) - pinned due to a feature being deprecated in the latest version. plan to
+# investigate and remove pin
+numpy==1.26.4
 wrapt>=1.14.0
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -80,7 +80,7 @@ exceptiongroup==1.2.1
     #   anyio
 executing==2.0.1
     # via stack-data
-fastjsonschema==2.19.1
+fastjsonschema==2.20.0
     # via nbformat
 filelock==3.15.1
     # via virtualenv

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -64,7 +64,7 @@ grpcio==1.64.1
     #   grpcio-status
 grpcio-status==1.62.2
     # via google-api-core
-huggingface-hub==0.23.3
+huggingface-hub==0.23.4
     # via
     #   timm
     #   tokenizers
@@ -189,7 +189,7 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pycocotools==2.0.7
+pycocotools==2.0.8
     # via
     #   -c ././deps/constraints.txt
     #   effdet

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -27,7 +27,7 @@ fsspec==2024.5.0
     #   -c ././deps/constraints.txt
     #   huggingface-hub
     #   torch
-huggingface-hub==0.23.3
+huggingface-hub==0.23.4
     # via
     #   tokenizers
     #   transformers

--- a/requirements/ingest/chroma.txt
+++ b/requirements/ingest/chroma.txt
@@ -72,7 +72,7 @@ h11==0.14.0
     # via uvicorn
 httptools==0.6.1
     # via uvicorn
-huggingface-hub==0.23.3
+huggingface-hub==0.23.4
     # via tokenizers
 humanfriendly==10.0
     # via coloredlogs
@@ -147,7 +147,7 @@ opentelemetry-util-http==0.46b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
-orjson==3.10.4
+orjson==3.10.5
     # via chromadb
 overrides==7.7.0
     # via chromadb
@@ -219,7 +219,7 @@ starlette==0.37.2
     # via fastapi
 sympy==1.12.1
     # via onnxruntime
-tenacity==8.3.0
+tenacity==8.4.1
     # via chromadb
 tokenizers==0.19.1
     # via chromadb

--- a/requirements/ingest/confluence.txt
+++ b/requirements/ingest/confluence.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/confluence.in
 #
-atlassian-python-api==3.41.13
+atlassian-python-api==3.41.14
     # via -r ./ingest/confluence.in
 beautifulsoup4==4.12.3
     # via

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -90,7 +90,7 @@ numpy==1.26.4
     #   -c ./ingest/../deps/constraints.txt
     #   langchain
     #   langchain-community
-orjson==3.10.4
+orjson==3.10.5
     # via langsmith
 packaging==23.2
     # via
@@ -130,7 +130,7 @@ sqlalchemy==2.0.30
     # via
     #   langchain
     #   langchain-community
-tenacity==8.3.0
+tenacity==8.4.1
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -47,7 +47,7 @@ fsspec==2024.5.0
     #   torch
 huggingface==0.0.1
     # via -r ./ingest/embed-huggingface.in
-huggingface-hub==0.23.3
+huggingface-hub==0.23.4
     # via
     #   sentence-transformers
     #   tokenizers
@@ -112,7 +112,7 @@ numpy==1.26.4
     #   scipy
     #   sentence-transformers
     #   transformers
-orjson==3.10.4
+orjson==3.10.5
     # via langsmith
 packaging==23.2
     # via
@@ -167,7 +167,7 @@ sqlalchemy==2.0.30
     #   langchain-community
 sympy==1.12.1
     # via torch
-tenacity==8.3.0
+tenacity==8.4.1
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -100,7 +100,7 @@ numpy==1.26.4
     #   langchain-community
 openai==1.34.0
     # via -r ./ingest/embed-openai.in
-orjson==3.10.4
+orjson==3.10.5
     # via langsmith
 packaging==23.2
     # via
@@ -141,7 +141,7 @@ sqlalchemy==2.0.30
     # via
     #   langchain
     #   langchain-community
-tenacity==8.3.0
+tenacity==8.4.1
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-vertexai.txt
+++ b/requirements/ingest/embed-vertexai.txt
@@ -141,7 +141,7 @@ numpy==1.26.4
     #   langchain
     #   langchain-community
     #   shapely
-orjson==3.10.4
+orjson==3.10.5
     # via langsmith
 packaging==23.2
     # via
@@ -210,7 +210,7 @@ sqlalchemy==2.0.30
     # via
     #   langchain
     #   langchain-community
-tenacity==8.3.0
+tenacity==8.4.1
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-voyageai.txt
+++ b/requirements/ingest/embed-voyageai.txt
@@ -68,7 +68,7 @@ numpy==1.26.4
     #   -c ./ingest/../deps/constraints.txt
     #   langchain
     #   voyageai
-orjson==3.10.4
+orjson==3.10.5
     # via langsmith
 packaging==23.2
     # via
@@ -94,7 +94,7 @@ requests==2.32.3
     #   voyageai
 sqlalchemy==2.0.30
     # via langchain
-tenacity==8.3.0
+tenacity==8.4.1
     # via
     #   langchain
     #   langchain-core

--- a/requirements/ingest/jira.txt
+++ b/requirements/ingest/jira.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/jira.in
 #
-atlassian-python-api==3.41.13
+atlassian-python-api==3.41.14
     # via -r ./ingest/jira.in
 beautifulsoup4==4.12.3
     # via

--- a/requirements/ingest/slack.txt
+++ b/requirements/ingest/slack.txt
@@ -4,5 +4,5 @@
 #
 #    pip-compile ./ingest/slack.in
 #
-slack-sdk==3.28.0
+slack-sdk==3.29.0
     # via -r ./ingest/slack.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -37,7 +37,7 @@ coverage[toml]==7.5.3
     #   pytest-cov
 exceptiongroup==1.2.1
     # via pytest
-flake8==7.0.0
+flake8==7.1.0
     # via
     #   -r ./test.in
     #   flake8-print
@@ -92,7 +92,7 @@ platformdirs==3.10.0
     #   black
 pluggy==1.5.0
     # via pytest
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via
     #   flake8
     #   flake8-print
@@ -132,7 +132,7 @@ rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
-ruff==0.4.8
+ruff==0.4.9
     # via -r ./test.in
 six==1.16.0
     # via


### PR DESCRIPTION
### Summary

Version bumps for the week of 2024-06-17. There is a now a pin on `numpy` due to a breaking change in the latest version that we'll need to investigate and remove in a subsequent PR.