### PR TITLE
Roman/bugfix conflicting event loop ingest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
         AZURE_SEARCH_ENDPOINT: ${{ secrets.AZURE_SEARCH_ENDPOINT }}
         AZURE_SEARCH_API_KEY: ${{ secrets.AZURE_SEARCH_API_KEY }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        OCTOAI_API_KEY: ${{ secrets.OCTOAI_API_KEY }}
         PINECONE_API_KEY: ${{secrets.PINECONE_API_KEY}}
         TABLE_OCR: "tesseract"
         OCR_AGENT: "unstructured.partition.utils.ocr_models.tesseract_ocr.OCRAgentTesseract"

--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -95,6 +95,7 @@ jobs:
           AZURE_SEARCH_ENDPOINT: ${{ secrets.AZURE_SEARCH_ENDPOINT }}
           AZURE_SEARCH_API_KEY: ${{ secrets.AZURE_SEARCH_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OCTOAI_API_KEY: ${{ secrets.OCTOAI_API_KEY }}
           TABLE_OCR: "tesseract"
           OCR_AGENT: "unstructured.partition.utils.ocr_models.tesseract_ocr.OCRAgentTesseract"
           OVERWRITE_FIXTURES: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.14.9-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
 ## 0.14.8
 
 ### Enhancements

--- a/scripts/elasticsearch-test-helpers/destination_connector/elasticsearch_elements_mappings.json
+++ b/scripts/elasticsearch-test-helpers/destination_connector/elasticsearch_elements_mappings.json
@@ -12,7 +12,9 @@
       },
       "embeddings": {
          "type": "dense_vector",
-         "dims": 384
+         "dims": 384,
+         "index": "true",
+         "similarity": "cosine"
       },
       "metadata": {
          "type": "object",

--- a/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
+++ b/scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-import sys
+from time import sleep, time
 from typing import List
 
+import click
 from elasticsearch import Elasticsearch
 from es_cluster_config import (
     CLUSTER_URL,
@@ -12,8 +13,6 @@ from es_cluster_config import (
 )
 
 from unstructured.embed.huggingface import HuggingFaceEmbeddingConfig, HuggingFaceEmbeddingEncoder
-
-N_ELEMENTS = 1404
 
 
 def embeddings_for_text(text: str) -> List[float]:
@@ -39,32 +38,96 @@ def query(client: Elasticsearch, search_text: str):
     return client.search(index=INDEX_NAME, body=query)
 
 
-if __name__ == "__main__":
+def validate_count(client: Elasticsearch, num_elements: int):
+    print(f"Validating that the count of documents in index {INDEX_NAME} is {num_elements}")
+    count = int(client.cat.count(index=INDEX_NAME, format="json")[0]["count"])
+    consistent = False
+    consistent_count = 1
+    desired_consistent_count = 5
+    timeout = 60
+    sleep_interval = 1
+    start_time = time()
+    print(f"initial count returned: {count}")
+    while not consistent and time() - start_time < timeout:
+        new_count = int(client.cat.count(index=INDEX_NAME, format="json")[0]["count"])
+        print(f"latest count returned: {new_count}")
+        if new_count == count:
+            consistent_count += 1
+        else:
+            count = new_count
+            consistent_count = 1
+        sleep(sleep_interval)
+        if consistent_count >= desired_consistent_count:
+            consistent = True
+    if not consistent:
+        raise TimeoutError(f"failed to get consistent count after {timeout}s")
+    assert count == num_elements, (
+        f"Elasticsearch dest check failed: got {count} items in index, "
+        f"expected {num_elements} items in index."
+    )
+    print(f"Elasticsearch destination test was successful with {count} items being uploaded.")
+
+
+def get_embeddings_len(client: Elasticsearch) -> int:
+    res = client.search(index=INDEX_NAME, size=1, query={"match_all": {}})
+    return len(res["hits"]["hits"][0]["_source"]["embeddings"])
+
+
+def validate_embeddings(client: Elasticsearch, embeddings: list[float]):
+    # Query the index using the appropriate embedding vector for given query text
+    # Verify that the top 1 result matches the expected chunk by checking the start text
+    print("Testing query to the embedded index.")
+    es_embeddings_len = get_embeddings_len(client=client)
+    assert len(embeddings) == es_embeddings_len, (
+        f"length of embeddings ({len(embeddings)}) doesn't "
+        f"match what exists in Elasticsearch ({es_embeddings_len})"
+    )
+    query_string = {
+        "field": "embeddings",
+        "query_vector": embeddings,
+        "k": 10,
+        "num_candidates": 10,
+    }
+    query_response = client.search(index=INDEX_NAME, knn=query_string)
+    response_found = query_response["hits"]["hits"][0]["_source"]
+    assert response_found["embeddings"] == embeddings
+    print("Query to the embedded index was successful and returned the expected result.")
+
+
+def validate(num_elements: int, embeddings: list[float]):
     print(f"Checking contents of index" f"{INDEX_NAME} at {CLUSTER_URL}")
 
     print("Connecting to the Elasticsearch cluster.")
     client = Elasticsearch(CLUSTER_URL, basic_auth=(USER, PASSWORD), request_timeout=30)
     print(client.info())
+    validate_count(client=client, num_elements=num_elements)
+    validate_embeddings(client=client, embeddings=embeddings)
 
-    count = int(client.cat.count(index=INDEX_NAME, format="json")[0]["count"])
+
+def parse_embeddings(embeddings_str: str) -> list[float]:
+    if embeddings_str.startswith("["):
+        embeddings_str = embeddings_str[1:]
+    if embeddings_str.endswith("]"):
+        embeddings_str = embeddings_str[:-1]
+    embeddings_split = embeddings_str.split(",")
+    embeddings_split = [e.strip() for e in embeddings_split]
+    return [float(e) for e in embeddings_split]
+
+
+@click.command()
+@click.option(
+    "--num-elements", type=int, required=True, help="The expected number of elements to exist"
+)
+@click.option("--embeddings", type=str, required=True, help="List of embeddings to test")
+def run_validation(num_elements: int, embeddings: str):
     try:
-        assert count == N_ELEMENTS
-    except AssertionError:
-        sys.exit(
-            "Elasticsearch dest check failed:"
-            f"got {count} items in index, expected {N_ELEMENTS} items in index."
-        )
-    print(f"Elasticsearch destination test was successful with {count} items being uploaded.")
+        parsed_embeddings = parse_embeddings(embeddings_str=embeddings)
+    except ValueError as e:
+        raise TypeError(
+            f"failed to parse embeddings string into list of float: {embeddings}"
+        ) from e
+    validate(num_elements=num_elements, embeddings=parsed_embeddings)
 
-    # Query the index using the appropriate embedding vector for given query text
-    # Verify that the top 1 result matches the expected chunk by checking the start text
-    print("Testing query to the embedded index.")
-    query_text = (
-        "A gathering of Russian nobility and merchants in historic uniforms, "
-        "discussing the Emperor's manifesto with a mix of solemn anticipation "
-        "and everyday concerns, while Pierre, dressed in a tight nobleman's uniform, "
-        "ponders the French Revolution and social contracts amidst the crowd."
-    )
-    query_response = query(client, query_text)
-    assert query_response["hits"]["hits"][0]["_source"]["text"].startswith("CHAPTER XXII")
-    print("Query to the embedded index was successful and returned the expected result.")
+
+if __name__ == "__main__":
+    run_validation()

--- a/test_unstructured_ingest/dest/elasticsearch.sh
+++ b/test_unstructured_ingest/dest/elasticsearch.sh
@@ -59,4 +59,9 @@ PYTHONPATH=. ./unstructured/ingest/main.py \
   --batch-size-bytes 15000000 \
   --num-threads "$max_processes"
 
-PYTHONPATH=. scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py
+desired_count=$(cat "$WORK_DIR"/upload_stage/* | jq 'length')
+desired_embeddings=$(cat "$WORK_DIR"/upload_stage/* | jq '.[0]._source.embeddings' | tr -d '\n')
+
+PYTHONPATH=. scripts/elasticsearch-test-helpers/destination_connector/test-ingest-elasticsearch-output.py \
+  --num-elements "$desired_count" \
+  --embeddings "$desired_embeddings"

--- a/test_unstructured_ingest/src/local-embed-bedrock.sh
+++ b/test_unstructured_ingest/src/local-embed-bedrock.sh
@@ -19,6 +19,11 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  echo "Skipping local bedrock ingest test because AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY env var is not set."
+  exit 8
+fi
+
 RUN_SCRIPT=${RUN_SCRIPT:-./unstructured/ingest/main.py}
 PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
   local \

--- a/test_unstructured_ingest/src/local-embed-octoai.sh
+++ b/test_unstructured_ingest/src/local-embed-octoai.sh
@@ -20,6 +20,11 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+if [ -z "$OCTOAI_API_KEY" ]; then
+  echo "Skipping local octioai ingest test because the OCTOAI_API_KEY env var is not set."
+  exit 8
+fi
+
 RUN_SCRIPT=${RUN_SCRIPT:-./unstructured/ingest/main.py}
 PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
   local \

--- a/test_unstructured_ingest/src/local-embed-octoai.sh
+++ b/test_unstructured_ingest/src/local-embed-octoai.sh
@@ -21,7 +21,7 @@ function cleanup() {
 trap cleanup EXIT
 
 if [ -z "$OCTOAI_API_KEY" ]; then
-  echo "Skipping local octioai ingest test because the OCTOAI_API_KEY env var is not set."
+  echo "Skipping local octoai ingest test because the OCTOAI_API_KEY env var is not set."
   exit 8
 fi
 

--- a/test_unstructured_ingest/src/local-embed-vertexai.sh
+++ b/test_unstructured_ingest/src/local-embed-vertexai.sh
@@ -20,6 +20,11 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+if [ -z "$GCP_INGEST_SERVICE_KEY" ]; then
+  echo "Skipping local vertexai ingest test because the GCP_INGEST_SERVICE_KEY env var is not set."
+  exit 8
+fi
+
 RUN_SCRIPT=${RUN_SCRIPT:-./unstructured/ingest/main.py}
 PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
   local \

--- a/test_unstructured_ingest/src/local-embed-voyageai.sh
+++ b/test_unstructured_ingest/src/local-embed-voyageai.sh
@@ -20,6 +20,11 @@ function cleanup() {
 }
 trap cleanup EXIT
 
+if [ -z "$VOYAGE_API_KEY" ]; then
+  echo "Skipping local voyageai ingest test because the VOYAGE_API_KEY env var is not set."
+  exit 8
+fi
+
 RUN_SCRIPT=${RUN_SCRIPT:-./unstructured/ingest/main.py}
 PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
   local \

--- a/test_unstructured_ingest/test-help.sh
+++ b/test_unstructured_ingest/test-help.sh
@@ -4,11 +4,9 @@ set -u -o pipefail -e
 
 RUN_SCRIPT=${RUN_SCRIPT:-./unstructured/ingest/main.py}
 sources=$(PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" --help | sed -e '1,/Commands/ d' | awk '{NF=1}1')
-first_source=$(echo "$sources" | head -1)
-destinations=$(PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" "$first_source" --help | sed -e '1,/Destinations/ d' | awk '{NF=1}1')
 echo "Checking all source: $sources"
-echo "Checking all destinations: $destinations"
 for src in $sources; do
+  destinations=$(PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" "$src" --help | sed -e '1,/Destinations/ d' | awk '{NF=1}1')
   for dest in $destinations; do
     echo "Checking $src -> $dest"
     PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" "$src" "$dest" --help

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.8"  # pragma: no cover
+__version__ = "0.14.9-dev0"  # pragma: no cover

--- a/unstructured/ingest/cli/cli.py
+++ b/unstructured/ingest/cli/cli.py
@@ -21,17 +21,12 @@ def get_cmd() -> click.Command:
     dest_dict = {d.name: d for d in dest}
     for s in src_v2:
         src_dict[s.name] = s
-    # TODO Remove custom logic around v2 connectors once all connectors migrated:
-    #  Inject the v2 connectors to override the existing v1 connectors
-    #  If a v2 source connector is used, only a v2 destination connector can be associated
+    for d in dest_v2:
+        dest_dict[d.name] = d
     # Add all subcommands
-    for src_key, src_subcommand in src_dict.items():
+    for src_subcommand in src_dict.values():
         # Add all destination subcommands
-        if src_key in [s.name for s in src_v2]:
-            for dest_subcommand in dest_v2:
-                src_subcommand.add_command(dest_subcommand)
-        else:
-            for dest_subcommand in dest_dict.values():
-                src_subcommand.add_command(dest_subcommand)
+        for dest_subcommand in dest_dict.values():
+            src_subcommand.add_command(dest_subcommand)
         cmd.add_command(src_subcommand)
     return cmd

--- a/unstructured/ingest/cli/cli.py
+++ b/unstructured/ingest/cli/cli.py
@@ -21,12 +21,17 @@ def get_cmd() -> click.Command:
     dest_dict = {d.name: d for d in dest}
     for s in src_v2:
         src_dict[s.name] = s
-    for d in dest_v2:
-        dest_dict[d.name] = d
+    # TODO Remove custom logic around v2 connectors once all connectors migrated:
+    #  Inject the v2 connectors to override the existing v1 connectors
+    #  If a v2 source connector is used, only a v2 destination connector can be associated
     # Add all subcommands
-    for src_subcommand in src_dict.values():
+    for src_key, src_subcommand in src_dict.items():
         # Add all destination subcommands
-        for dest_subcommand in dest_dict.values():
-            src_subcommand.add_command(dest_subcommand)
+        if src_key in [s.name for s in src_v2]:
+            for dest_subcommand in dest_v2:
+                src_subcommand.add_command(dest_subcommand)
+        else:
+            for dest_subcommand in dest_dict.values():
+                src_subcommand.add_command(dest_subcommand)
         cmd.add_command(src_subcommand)
     return cmd

--- a/unstructured/ingest/v2/examples/example_elasticsearch.py
+++ b/unstructured/ingest/v2/examples/example_elasticsearch.py
@@ -1,0 +1,48 @@
+import os
+from pathlib import Path
+
+from unstructured.ingest.v2.interfaces import ProcessorConfig
+from unstructured.ingest.v2.logger import logger
+from unstructured.ingest.v2.pipeline.pipeline import Pipeline
+from unstructured.ingest.v2.processes.chunker import ChunkerConfig
+from unstructured.ingest.v2.processes.connectors.elasticsearch import (
+    ElasticsearchAccessConfig,
+    ElasticsearchConnectionConfig,
+    ElasticsearchUploaderConfig,
+    ElasticsearchUploadStagerConfig,
+)
+from unstructured.ingest.v2.processes.connectors.local import (
+    LocalConnectionConfig,
+    LocalDownloaderConfig,
+    LocalIndexerConfig,
+)
+from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
+
+base_path = Path(__file__).parent.parent.parent.parent.parent
+docs_path = base_path / "example-docs"
+work_dir = base_path / "tmp_ingest"
+output_path = work_dir / "output"
+download_path = work_dir / "download"
+
+if __name__ == "__main__":
+    logger.info(f"Writing all content in: {work_dir.resolve()}")
+    index_name = "ingest-test-destination"
+    Pipeline.from_configs(
+        context=ProcessorConfig(work_dir=str(work_dir.resolve())),
+        indexer_config=LocalIndexerConfig(
+            input_path=str(docs_path.resolve()) + "/book-war-and-peace-1p.txt"
+        ),
+        downloader_config=LocalDownloaderConfig(download_dir=download_path),
+        source_connection_config=LocalConnectionConfig(),
+        partitioner_config=PartitionerConfig(strategy="fast"),
+        chunker_config=ChunkerConfig(chunking_strategy="by_title"),
+        embedder_config=EmbedderConfig(embedding_provider="langchain-huggingface"),
+        destination_connection_config=ElasticsearchConnectionConfig(
+            access_config=ElasticsearchAccessConfig(password=os.getenv("ELASTIC_PASSWORD")),
+            username=os.getenv("ELASTIC_USERNAME"),
+            hosts=["http://localhost:9200"],
+        ),
+        uploader_config=ElasticsearchUploaderConfig(index_name=index_name),
+        stager_config=ElasticsearchUploadStagerConfig(index_name=index_name),
+    ).run()

--- a/unstructured/ingest/v2/interfaces/processor.py
+++ b/unstructured/ingest/v2/interfaces/processor.py
@@ -34,3 +34,15 @@ class ProcessorConfig(EnhancedDataClassJsonMixin):
     def __post_init__(self):
         if self.max_connections is not None:
             self.semaphore = Semaphore(self.max_connections)
+
+    @property
+    def mp_supported(self) -> bool:
+        return not self.disable_parallelism and self.num_processes > 1
+
+    @property
+    def async_supported(self) -> bool:
+        if self.disable_parallelism:
+            return False
+        if self.max_connections is not None and isinstance(self.max_connections, int):
+            return self.max_connections > 1
+        return True

--- a/unstructured/ingest/v2/pipeline/pipeline.py
+++ b/unstructured/ingest/v2/pipeline/pipeline.py
@@ -64,7 +64,12 @@ class Pipeline:
         self.downloader_step = DownloadStep(process=downloader, context=self.context)
         self.partitioner_step = PartitionStep(process=partitioner, context=self.context)
         self.chunker_step = ChunkStep(process=chunker, context=self.context) if chunker else None
+
+        # TODO: support initialize() call from each step process
+        # Potential long call to download embedder models:
+        embedder.config.get_embedder().initialize()
         self.embedder_step = EmbedStep(process=embedder, context=self.context) if embedder else None
+
         self.stager_step = UploadStageStep(process=stager, context=self.context) if stager else None
         self.uploader_step = UploadStep(process=uploader, context=self.context)
         if self.context.uncompress:

--- a/unstructured/ingest/v2/pipeline/pipeline.py
+++ b/unstructured/ingest/v2/pipeline/pipeline.py
@@ -65,11 +65,11 @@ class Pipeline:
         self.partitioner_step = PartitionStep(process=partitioner, context=self.context)
         self.chunker_step = ChunkStep(process=chunker, context=self.context) if chunker else None
 
+        self.embedder_step = EmbedStep(process=embedder, context=self.context) if embedder else None
         # TODO: support initialize() call from each step process
         # Potential long call to download embedder models:
-        if embedder and embedder.config:
+        if self.embedder_step.process and embedder.config:
             embedder.config.get_embedder().initialize()
-        self.embedder_step = EmbedStep(process=embedder, context=self.context) if embedder else None
 
         self.stager_step = UploadStageStep(process=stager, context=self.context) if stager else None
         self.uploader_step = UploadStep(process=uploader, context=self.context)

--- a/unstructured/ingest/v2/pipeline/pipeline.py
+++ b/unstructured/ingest/v2/pipeline/pipeline.py
@@ -67,8 +67,8 @@ class Pipeline:
 
         self.embedder_step = EmbedStep(process=embedder, context=self.context) if embedder else None
         # TODO: support initialize() call from each step process
-        # Potential long call to download embedder models:
-        if self.embedder_step.process and embedder.config:
+        # Potential long call to download embedder models, run before any fanout:
+        if embedder and embedder.config:
             embedder.config.get_embedder().initialize()
 
         self.stager_step = UploadStageStep(process=stager, context=self.context) if stager else None

--- a/unstructured/ingest/v2/pipeline/pipeline.py
+++ b/unstructured/ingest/v2/pipeline/pipeline.py
@@ -67,7 +67,8 @@ class Pipeline:
 
         # TODO: support initialize() call from each step process
         # Potential long call to download embedder models:
-        embedder.config.get_embedder().initialize()
+        if embedder and embedder.config:
+            embedder.config.get_embedder().initialize()
         self.embedder_step = EmbedStep(process=embedder, context=self.context) if embedder else None
 
         self.stager_step = UploadStageStep(process=stager, context=self.context) if stager else None

--- a/unstructured/ingest/v2/pipeline/pipeline.py
+++ b/unstructured/ingest/v2/pipeline/pipeline.py
@@ -108,8 +108,11 @@ class Pipeline:
             f"Running local pipline: {self} with configs: "
             f"{sterilize_dict(self.context.to_dict(redact_sensitive=True))}"
         )
-        manager = mp.Manager()
-        self.context.status = manager.dict()
+        if self.context.mp_supported:
+            manager = mp.Manager()
+            self.context.status = manager.dict()
+        else:
+            self.context.status = {}
 
         # Index into data source
         indices = self.indexer_step.run()

--- a/unstructured/ingest/v2/pipeline/steps/upload.py
+++ b/unstructured/ingest/v2/pipeline/steps/upload.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, TypedDict
 from unstructured.ingest.v2.interfaces import FileData
 from unstructured.ingest.v2.interfaces.uploader import UploadContent, Uploader
 from unstructured.ingest.v2.logger import logger
-from unstructured.ingest.v2.pipeline.interfaces import PipelineStep, iterable_input
+from unstructured.ingest.v2.pipeline.interfaces import PipelineStep, iterable_input, timed
 from unstructured.ingest.v2.pipeline.utils import sterilize_dict
 
 STEP_ID = "upload"
@@ -44,18 +44,12 @@ class UploadStep(PipelineStep):
     def process_whole(self, iterable: iterable_input):
         self.run(contents=iterable)
 
-    async def _process_async(self, iterable: iterable_input):
-        return await asyncio.gather(*[self.run_async(**i) for i in iterable])
-
-    def process_async(self, iterable: iterable_input):
-        logger.info("processing content async")
-        return asyncio.run(self._process_async(iterable=iterable))
-
+    @timed
     def __call__(self, iterable: iterable_input):
         logger.info(
             f"Calling {self.__class__.__name__} " f"with {len(iterable)} docs",  # type: ignore
         )
-        if self.process.is_async():
+        if self.process.is_async() and self.process.is_async():
             self.process_async(iterable=iterable)
         else:
             self.process_whole(iterable=iterable)

--- a/unstructured/ingest/v2/pipeline/steps/upload.py
+++ b/unstructured/ingest/v2/pipeline/steps/upload.py
@@ -49,7 +49,7 @@ class UploadStep(PipelineStep):
         logger.info(
             f"Calling {self.__class__.__name__} " f"with {len(iterable)} docs",  # type: ignore
         )
-        if self.process.is_async() and self.process.is_async():
+        if self.process.is_async():
             self.process_async(iterable=iterable)
         else:
             self.process_whole(iterable=iterable)

--- a/unstructured/ingest/v2/processes/chunker.py
+++ b/unstructured/ingest/v2/processes/chunker.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any, Optional
 
@@ -29,7 +29,7 @@ class ChunkerConfig(EnhancedDataClassJsonMixin):
     def to_chunking_kwargs(self) -> dict[str, Any]:
         return {
             "chunking_strategy": self.chunking_strategy,
-            "combine_text_under_n_chars": self.chunk_combine_text_under_n_chars,
+            "combine_under_n_chars": self.chunk_combine_text_under_n_chars,
             "max_characters": self.chunk_max_characters,
             "include_orig_elements": self.chunk_include_orig_elements,
             "multipage_sections": self.chunk_multipage_sections,
@@ -71,13 +71,24 @@ class Chunker(BaseProcess, ABC):
             server_url=self.config.chunking_endpoint,
         )
         partition_request = self.config.to_chunking_kwargs()
+        possible_fields = [f.name for f in fields(PartitionParameters)]
+        filtered_partition_request = {
+            k: v for k, v in partition_request.items() if k in possible_fields
+        }
+        if len(filtered_partition_request) == len(partition_request):
+            logger.debug(
+                "Following fields were omitted due to not being "
+                "supported by the currently used unstructured client: {}".format(
+                    ", ".join([v for v in partition_request if v not in filtered_partition_request])
+                )
+            )
         with open(elements_filepath, "rb") as f:
             files = Files(
                 content=f.read(),
                 file_name=str(elements_filepath.resolve()),
             )
-            partition_request["files"] = files
-        partition_params = PartitionParameters(**partition_request)
+            filtered_partition_request["files"] = files
+        partition_params = PartitionParameters(**filtered_partition_request)
         resp = client.general.partition(partition_params)
         elements_raw = resp.elements or []
         elements = dict_to_elements(elements_raw)

--- a/unstructured/ingest/v2/processes/chunker.py
+++ b/unstructured/ingest/v2/processes/chunker.py
@@ -75,7 +75,7 @@ class Chunker(BaseProcess, ABC):
         filtered_partition_request = {
             k: v for k, v in partition_request.items() if k in possible_fields
         }
-        if len(filtered_partition_request) == len(partition_request):
+        if len(filtered_partition_request) != len(partition_request):
             logger.debug(
                 "Following fields were omitted due to not being "
                 "supported by the currently used unstructured client: {}".format(

--- a/unstructured/ingest/v2/processes/connectors/elasticsearch.py
+++ b/unstructured/ingest/v2/processes/connectors/elasticsearch.py
@@ -8,8 +8,8 @@ from time import time
 from typing import TYPE_CHECKING, Any, Generator, Optional
 
 from unstructured.documents.elements import DataSourceMetadata
-from unstructured.ingest.enhanced_dataclass import enhanced_field
-from unstructured.ingest.error import SourceConnectionNetworkError
+from unstructured.ingest.enhanced_dataclass import EnhancedDataClassJsonMixin, enhanced_field
+from unstructured.ingest.error import SourceConnectionError, SourceConnectionNetworkError
 from unstructured.ingest.utils.data_prep import generator_batching_wbytes
 from unstructured.ingest.v2.interfaces import (
     AccessConfig,
@@ -52,6 +52,15 @@ class ElasticsearchAccessConfig(AccessConfig):
 
 
 @dataclass
+class ElasticsearchClientInput(EnhancedDataClassJsonMixin):
+    hosts: Optional[str] = None
+    cloud_id: Optional[str] = None
+    ca_certs: Optional[str] = None
+    basic_auth: Optional[tuple[str, str]] = None
+    api_key: Optional[str] = enhanced_field(sensitive=True, default=None)
+
+
+@dataclass
 class ElasticsearchConnectionConfig(ConnectionConfig):
     hosts: Optional[list[str]] = None
     username: Optional[str] = None
@@ -64,28 +73,42 @@ class ElasticsearchConnectionConfig(ConnectionConfig):
         # Update auth related fields to conform to what the SDK expects based on the
         # supported methods:
         # https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html
-        client_kwargs = {}
+        client_input = ElasticsearchClientInput()
         if self.hosts:
-            client_kwargs["hosts"] = self.hosts
+            client_input.hosts = self.hosts
         if self.cloud_id:
-            client_kwargs["cloud_id"] = self.cloud_id
+            client_input.cloud_id = self.cloud_id
         if self.ca_certs:
-            client_kwargs["ca_certs"] = self.ca_certs
+            client_input.ca_certs = self.ca_certs
         if self.access_config.password and (
             self.cloud_id or self.ca_certs or self.access_config.ssl_assert_fingerprint
         ):
-            client_kwargs["basic_auth"] = ("elastic", self.access_config.password)
+            client_input.basic_auth = ("elastic", self.access_config.password)
         elif not self.cloud_id and self.username and self.access_config.password:
-            client_kwargs["basic_auth"] = (self.username, self.access_config.password)
+            client_input.basic_auth = (self.username, self.access_config.password)
         elif self.access_config.api_key and self.api_key_id:
-            client_kwargs["api_key"] = (self.api_key_id, self.access_config.api_key)
+            client_input.api_key = (self.api_key_id, self.access_config.api_key)
+        logger.debug(
+            f"Elasticsearch client inputs mapped to: {client_input.to_dict(redact_sensitive=True)}"
+        )
+        client_kwargs = client_input.to_dict(redact_sensitive=False)
+        client_kwargs = {k: v for k, v in client_kwargs.items() if v is not None}
         return client_kwargs
 
     @requires_dependencies(["elasticsearch"], extras="elasticsearch")
     def get_client(self) -> "ElasticsearchClient":
         from elasticsearch import Elasticsearch as ElasticsearchClient
 
-        return ElasticsearchClient(**self.get_client_kwargs())
+        client = ElasticsearchClient(**self.get_client_kwargs())
+        self.check_connection(client=client)
+        return client
+
+    def check_connection(self, client: "ElasticsearchClient"):
+        try:
+            client.perform_request("HEAD", "/", headers={"accept": "application/json"})
+        except Exception as e:
+            logger.error(f"failed to validate connection: {e}", exc_info=True)
+            raise SourceConnectionError(f"failed to validate connection: {e}")
 
 
 @dataclass

--- a/unstructured/ingest/v2/processes/connectors/elasticsearch.py
+++ b/unstructured/ingest/v2/processes/connectors/elasticsearch.py
@@ -88,6 +88,8 @@ class ElasticsearchConnectionConfig(ConnectionConfig):
             client_input.basic_auth = (self.username, self.access_config.password)
         elif self.access_config.api_key and self.api_key_id:
             client_input.api_key = (self.api_key_id, self.access_config.api_key)
+        elif self.access_config.api_key:
+            client_input.api_key = self.access_config.api_key
         logger.debug(
             f"Elasticsearch client inputs mapped to: {client_input.to_dict(redact_sensitive=True)}"
         )

--- a/unstructured/ingest/v2/processes/connectors/elasticsearch.py
+++ b/unstructured/ingest/v2/processes/connectors/elasticsearch.py
@@ -64,9 +64,11 @@ class ElasticsearchConnectionConfig(ConnectionConfig):
         # Update auth related fields to conform to what the SDK expects based on the
         # supported methods:
         # https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html
-        client_kwargs = {
-            "hosts": self.hosts,
-        }
+        client_kwargs = {}
+        if self.hosts:
+            client_kwargs["hosts"] = self.hosts
+        if self.cloud_id:
+            client_kwargs["cloud_id"] = self.cloud_id
         if self.ca_certs:
             client_kwargs["ca_certs"] = self.ca_certs
         if self.access_config.password and (

--- a/unstructured/ingest/v2/processes/connectors/elasticsearch.py
+++ b/unstructured/ingest/v2/processes/connectors/elasticsearch.py
@@ -310,11 +310,10 @@ class ElasticsearchUploader(Uploader):
                 elements = json.load(elements_file)
                 elements_dict.extend(elements)
         logger.info(
-            f"writing document batches to destination"
-            f" index named {self.upload_config.index_name}"
-            f" at {self.connection_config.hosts}"
-            f" with batch size (in bytes) {self.upload_config.batch_size_bytes}"
-            f" with {self.upload_config.thread_count} (number of) threads"
+            f"writing {len(elements_dict)} elements via document batches to destination "
+            f"index named {self.upload_config.index_name} at {self.connection_config.hosts} with "
+            f"batch size (in bytes) {self.upload_config.batch_size_bytes} with "
+            f"{self.upload_config.thread_count} (number of) threads"
         )
         from elasticsearch.helpers import parallel_bulk
 

--- a/unstructured/ingest/v2/processes/connectors/elasticsearch.py
+++ b/unstructured/ingest/v2/processes/connectors/elasticsearch.py
@@ -334,9 +334,10 @@ class ElasticsearchUploader(Uploader):
             with open(content.path) as elements_file:
                 elements = json.load(elements_file)
                 elements_dict.extend(elements)
+        upload_destination = self.connection_config.hosts or self.connection_config.cloud_id
         logger.info(
             f"writing {len(elements_dict)} elements via document batches to destination "
-            f"index named {self.upload_config.index_name} at {self.connection_config.hosts} with "
+            f"index named {self.upload_config.index_name} at {upload_destination} with "
             f"batch size (in bytes) {self.upload_config.batch_size_bytes} with "
             f"{self.upload_config.thread_count} (number of) threads"
         )

--- a/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -246,7 +246,7 @@ class FsspecDownloader(Downloader):
 
     def get_download_path(self, file_data: FileData) -> Path:
         return (
-            self.download_config.download_dir / Path(file_data.source_identifiers.relative_path)
+            self.download_dir / Path(file_data.source_identifiers.relative_path)
             if self.download_config
             else Path(file_data.source_identifiers.rel_path)
         )

--- a/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -356,4 +356,4 @@ class FsspecUploader(Uploader):
             logger.debug(f"Skipping upload of {path} to {upload_path}, file already exists")
             return
         logger.info(f"Writing local file {path_str} to {upload_path}")
-        await self.fs.upload(lpath=path_str, rpath=str(upload_path))
+        self.fs.upload(lpath=path_str, rpath=str(upload_path))

--- a/unstructured/ingest/v2/processes/partitioner.py
+++ b/unstructured/ingest/v2/processes/partitioner.py
@@ -120,7 +120,7 @@ class Partitioner(BaseProcess, ABC):
         filtered_partition_request = {
             k: v for k, v in partition_request.items() if k in possible_fields
         }
-        if len(filtered_partition_request) == len(partition_request):
+        if len(filtered_partition_request) != len(partition_request):
             logger.debug(
                 "Following fields were omitted due to not being "
                 "supported by the currently used unstructured client: {}".format(

--- a/unstructured/ingest/v2/processes/partitioner.py
+++ b/unstructured/ingest/v2/processes/partitioner.py
@@ -1,6 +1,6 @@
 import asyncio
 from abc import ABC
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -116,14 +116,25 @@ class Partitioner(BaseProcess, ABC):
         from unstructured_client.models.shared import Files, PartitionParameters
 
         partition_request = self.config.to_partition_kwargs()
+        possible_fields = [f.name for f in fields(PartitionParameters)]
+        filtered_partition_request = {
+            k: v for k, v in partition_request.items() if k in possible_fields
+        }
+        if len(filtered_partition_request) == len(partition_request):
+            logger.debug(
+                "Following fields were omitted due to not being "
+                "supported by the currently used unstructured client: {}".format(
+                    ", ".join([v for v in partition_request if v not in filtered_partition_request])
+                )
+            )
         logger.debug(f"Using hosted partitioner with kwargs: {partition_request}")
         with open(filename, "rb") as f:
             files = Files(
                 content=f.read(),
                 file_name=str(filename.resolve()),
             )
-            partition_request["files"] = files
-        partition_params = PartitionParameters(**partition_request)
+            filtered_partition_request["files"] = files
+        partition_params = PartitionParameters(**filtered_partition_request)
         return partition_params
 
     async def partition_via_api(


### PR DESCRIPTION
### Description
In use cases where an external system (such as code being run in a jupyter notebook) already has a running event loop, run the async code in a dedicated thread pool to not conflict with the existing event loop.

This also has a variety of fixes that were found when putting together a demo leveraging the elasticsearch destination connector