### PR TITLE
fix: update base image SHA for amd64 wolfi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.14.8-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
 ## 0.14.7
 
 ### Enhancements

--- a/Dockerfile-amd64
+++ b/Dockerfile-amd64
@@ -1,4 +1,4 @@
-FROM quay.io/unstructured-io/base-images:wolfi-base@sha256:863fd5b87e780dacec62b97c2db2aeda7f770fcf9b045b29f53ec1ddbe607b4d
+FROM quay.io/unstructured-io/base-images:wolfi-base@sha256:7c3af225a39f730f4feee705df6cd8d1570739dc130456cf589ac53347da0f1d as base
 
 USER root
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.7"  # pragma: no cover
+__version__ = "0.14.8-dev0"  # pragma: no cover


### PR DESCRIPTION
This PR aims to fix a `test_dockerfile` job [failure](https://github.com/Unstructured-IO/unstructured/actions/runs/9613636416/job/26517074221?pr=3234) in CI after `base-images` repo update.