### PR TITLE
fix(auto): partition() passes strategy to DOC,ODT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.9-dev4
+## 0.14.9-dev5
 
 ### Enhancements
 
@@ -7,6 +7,7 @@
 ### Fixes
 
 * **Fix a bug where multiple `soffice` processes could be attempted** Add a wait mechanism in `convert_office_doc` so that the function first checks if another `soffice` is running already: if yes wait till the other process finishes or till the wait timeout before spawning a subprocess to run `soffice`
+* **`partition()` now forwards `strategy` arg to `partition_docx()`, `partition_pptx()`, and their brokering partitioners for DOC, ODT, and PPT formats.** A `strategy` argument passed to `partition()` (or the default value "auto" assigned by `partition()`) is now forwarded to `partition_docx()`, `partition_pptx()`, and their brokering partitioners when those filetypes are detected.
 
 ## 0.14.8
 
@@ -20,7 +21,6 @@
 
 * **Bump unstructured-inference==0.7.36** Fix `ValueError` when converting cells to html.
 * **`partition()` now forwards `strategy` arg to `partition_docx()`, `partition_ppt()`, and `partition_pptx()`.** A `strategy` argument passed to `partition()` (or the default value "auto" assigned by `partition()`) is now forwarded to `partition_docx()`, `partition_ppt()`, and `partition_pptx()` when those filetypes are detected.
-
 * **Fix missing sensitive field markers** for embedders
 
 ## 0.14.7

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.9-dev4"  # pragma: no cover
+__version__ = "0.14.9-dev5"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -316,6 +316,7 @@ def partition(
             languages=languages,
             detect_language_per_element=detect_language_per_element,
             starting_page_number=starting_page_number,
+            strategy=strategy,
             **kwargs,
         )
     elif filetype == FileType.DOCX:
@@ -339,6 +340,7 @@ def partition(
             languages=languages,
             detect_language_per_element=detect_language_per_element,
             starting_page_number=starting_page_number,
+            strategy=strategy,
             **kwargs,
         )
     elif filetype == FileType.EML:


### PR DESCRIPTION
**Summary**
Remedy gap where `strategy` argument passed to `partition()` was not forwarded to `partition_doc()` or `partition_odt()` and so was not making its way to `partition_docx()`.