### PR TITLE
feat(docx): differentiate no-file from not-ZIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
-## 0.14.9-dev6
+## 0.14.9-dev7
 
 ### Enhancements
 
-* **Added visualization and OD model result dump for PDF** In PDF `hi_res` strategy the `analysis` parameter can be used
-  to visualize the result of the OD model and dump the result to a file.
-  Additionally, the visualization of bounding boxes of each layout source is rendered and saved
-  for each page.
+* **Added visualization and OD model result dump for PDF** In PDF `hi_res` strategy the `analysis` parameter can be used to visualize the result of the OD model and dump the result to a file. Additionally, the visualization of bounding boxes of each layout source is rendered and saved for each page.
+* **`partition_docx()` distinguishes "file not found" from "not a ZIP archive" error.** `partition_docx()` now provides different error messages for "file not found" and "file is not a ZIP archive (and therefore not a DOCX file)". This aids diagnosis since these two conditions generally point in different directions as to the cause and fix.
 
 ### Features
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.9-dev6"  # pragma: no cover
+__version__ = "0.14.9-dev7"  # pragma: no cover

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import html
 import io
 import itertools
+import os
 import tempfile
+import zipfile
 from typing import IO, Any, Iterator, Optional, Protocol, Type
 
 # -- CT_* stands for "complex-type", an XML element type in docx parlance --
@@ -155,7 +157,7 @@ def partition_docx(
         Assign this number to the first page of this document and increment the page number from
         there.
     """
-    opts = DocxPartitionerOptions(
+    opts = DocxPartitionerOptions.load(
         date_from_file_object=date_from_file_object,
         file=file,
         file_path=filename,
@@ -213,6 +215,11 @@ class DocxPartitionerOptions:
         self._strategy = strategy
         # -- options object maintains page-number state --
         self._page_counter = starting_page_number
+
+    @classmethod
+    def load(cls, **kwargs: Any) -> DocxPartitionerOptions:
+        """Construct and validate an instance."""
+        return cls(**kwargs)._validate()
 
     @classmethod
     def register_picture_partitioner(cls, picture_partitioner: PicturePartitionerT):
@@ -358,12 +365,26 @@ class DocxPartitionerOptions:
             self._file.seek(0)
             return io.BytesIO(self._file.read())
 
-        if self._file:
-            return self._file
+        assert self._file is not None  # -- assured by `._validate()` --
+        return self._file
 
-        raise ValueError(
-            "No DOCX document specified, either `filename` or `file` argument must be provided"
-        )
+    def _validate(self) -> DocxPartitionerOptions:
+        """Raise on first invalide option, return self otherwise."""
+        # -- provide distinguished error between "file-not-found" and "not-a-DOCX-file" --
+        if self._file_path:
+            if not os.path.isfile(self._file_path):
+                raise FileNotFoundError(f"no such file or directory: {repr(self._file_path)}")
+            if not zipfile.is_zipfile(self._file_path):
+                raise ValueError(f"not a ZIP archive (so not a DOCX file): {repr(self._file_path)}")
+        elif self._file:
+            if not zipfile.is_zipfile(self._file):
+                raise ValueError(f"not a ZIP archive (so not a DOCX file): {repr(self._file)}")
+        else:
+            raise ValueError(
+                "no DOCX document specified, either `filename` or `file` argument must be provided"
+            )
+
+        return self
 
 
 class _DocxPartitioner:


### PR DESCRIPTION
**Summary**
The `python-docx` error `docx.opc.exceptions.PackageNotFoundError` arises both when no file exists at the given path and when the file exists but is not a ZIP archive (and so is not a DOCX file).

This ambiguity is unwelcome when diagnosing the error as the two possible conditions generally indicate a different course of action to resolve the error.

Add detailed validation to `DocxPartitionerOptions` to distinguish these two and provide more precise exception messages.

**Additional Context**
- `python-pptx` shares the same OPC-Package (file) loading code used by `python-docx`, so the same ambiguity will be present in `python-pptx`.
- It would be preferable for this distinguished exception behavior to be upstream in `python-docx` and `python-pptx`. If we're willing to take the version bump it might be worth considering doing that instead.