### PR TITLE
Fix blocking async interfaces for v2 ingest framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.9-dev8
+## 0.14.9-dev9
 
 ### Enhancements
 
@@ -11,6 +11,8 @@
 
 * **Fix a bug where multiple `soffice` processes could be attempted** Add a wait mechanism in `convert_office_doc` so that the function first checks if another `soffice` is running already: if yes wait till the other process finishes or till the wait timeout before spawning a subprocess to run `soffice`
 * **`partition()` now forwards `strategy` arg to `partition_docx()`, `partition_pptx()`, and their brokering partitioners for DOC, ODT, and PPT formats.** A `strategy` argument passed to `partition()` (or the default value "auto" assigned by `partition()`) is now forwarded to `partition_docx()`, `partition_pptx()`, and their brokering partitioners when those filetypes are detected.
+
+* Fix blocking async interfaces for v2 ingest framework
 
 ## 0.14.8
 

--- a/unstructured/ingest/v2/interfaces/downloader.py
+++ b/unstructured/ingest/v2/interfaces/downloader.py
@@ -7,6 +7,7 @@ from unstructured.ingest.enhanced_dataclass import EnhancedDataClassJsonMixin
 from unstructured.ingest.v2.interfaces.connector import BaseConnector
 from unstructured.ingest.v2.interfaces.file_data import FileData
 from unstructured.ingest.v2.interfaces.process import BaseProcess
+from unstructured.utils import run_func_async
 
 
 @dataclass
@@ -53,4 +54,4 @@ class Downloader(BaseProcess, BaseConnector, ABC):
         pass
 
     async def run_async(self, file_data: FileData, **kwargs: Any) -> download_responses:
-        return self.run(file_data=file_data, **kwargs)
+        return await run_func_async(self.run, file_data=file_data, **kwargs)

--- a/unstructured/ingest/v2/interfaces/process.py
+++ b/unstructured/ingest/v2/interfaces/process.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
+from unstructured.utils import run_func_async
+
 
 @dataclass
 class BaseProcess(ABC):
@@ -13,7 +15,7 @@ class BaseProcess(ABC):
         pass
 
     async def run_async(self, **kwargs: Any) -> Any:
-        return self.run(**kwargs)
+        return await run_func_async(self.run, **kwargs)
 
     def check_connection(self):
         # If the process requires external connections, run a quick check

--- a/unstructured/ingest/v2/interfaces/upload_stager.py
+++ b/unstructured/ingest/v2/interfaces/upload_stager.py
@@ -6,6 +6,7 @@ from typing import Any, TypeVar
 from unstructured.ingest.enhanced_dataclass import EnhancedDataClassJsonMixin
 from unstructured.ingest.v2.interfaces.file_data import FileData
 from unstructured.ingest.v2.interfaces.process import BaseProcess
+from unstructured.utils import run_func_async
 
 
 @dataclass
@@ -39,7 +40,8 @@ class UploadStager(BaseProcess, ABC):
         output_filename: str,
         **kwargs: Any
     ) -> Path:
-        return self.run(
+        return await run_func_async(
+            self.run,
             elements_filepath=elements_filepath,
             output_dir=output_dir,
             output_filename=output_filename,

--- a/unstructured/ingest/v2/interfaces/uploader.py
+++ b/unstructured/ingest/v2/interfaces/uploader.py
@@ -7,6 +7,7 @@ from unstructured.ingest.enhanced_dataclass import EnhancedDataClassJsonMixin
 from unstructured.ingest.v2.interfaces.connector import BaseConnector
 from unstructured.ingest.v2.interfaces.file_data import FileData
 from unstructured.ingest.v2.interfaces.process import BaseProcess
+from unstructured.utils import run_func_async
 
 
 @dataclass
@@ -36,4 +37,6 @@ class Uploader(BaseProcess, BaseConnector, ABC):
         pass
 
     async def run_async(self, path: Path, file_data: FileData, **kwargs: Any) -> None:
-        return self.run(contents=[UploadContent(path=path, file_data=file_data)], **kwargs)
+        return await run_func_async(
+            self.run, contents=[UploadContent(path=path, file_data=file_data)], **kwargs
+        )

--- a/unstructured/ingest/v2/processes/chunker.py
+++ b/unstructured/ingest/v2/processes/chunker.py
@@ -9,6 +9,7 @@ from unstructured.ingest.enhanced_dataclass import EnhancedDataClassJsonMixin, e
 from unstructured.ingest.v2.interfaces.process import BaseProcess
 from unstructured.ingest.v2.logger import logger
 from unstructured.staging.base import dict_to_elements, elements_from_json
+from unstructured.utils import run_func_async
 
 
 @dataclass
@@ -89,7 +90,7 @@ class Chunker(BaseProcess, ABC):
             )
             filtered_partition_request["files"] = files
         partition_params = PartitionParameters(**filtered_partition_request)
-        resp = client.general.partition(partition_params)
+        resp = await run_func_async(client.general.partition, partition_params)
         elements_raw = resp.elements or []
         elements = dict_to_elements(elements_raw)
         assign_and_map_hash_ids(elements)

--- a/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -350,7 +350,7 @@ class FsspecUploader(Uploader):
         upload_path = self.get_upload_path(file_data=file_data)
         path_str = str(path.resolve())
         # Odd that fsspec doesn't run exists() as async even when client support async
-        already_exists = self.fs.exists(path=str(upload_path))
+        already_exists = await run_func_async(self.fs.exists, path=str(upload_path))
         if already_exists and not self.upload_config.overwrite:
             logger.debug(f"Skipping upload of {path} to {upload_path}, file already exists")
             return

--- a/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -27,6 +27,7 @@ from unstructured.ingest.v2.interfaces import (
 )
 from unstructured.ingest.v2.logger import logger
 from unstructured.ingest.v2.processes.connectors.fsspec.utils import sterilize_dict
+from unstructured.utils import run_func_async
 
 if TYPE_CHECKING:
     from fsspec import AbstractFileSystem
@@ -354,4 +355,4 @@ class FsspecUploader(Uploader):
             logger.debug(f"Skipping upload of {path} to {upload_path}, file already exists")
             return
         logger.debug(f"Writing local file {path_str} to {upload_path}")
-        self.fs.upload(lpath=path_str, rpath=str(upload_path))
+        await run_func_async(self.fs.upload, lpath=path_str, rpath=str(upload_path))

--- a/unstructured/ingest/v2/processes/partitioner.py
+++ b/unstructured/ingest/v2/processes/partitioner.py
@@ -1,4 +1,3 @@
-import asyncio
 from abc import ABC
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -10,6 +9,7 @@ from unstructured.ingest.enhanced_dataclass.dataclasses import enhanced_field
 from unstructured.ingest.v2.interfaces.process import BaseProcess
 from unstructured.ingest.v2.logger import logger
 from unstructured.staging.base import elements_to_dicts, flatten_dict
+from unstructured.utils import run_func_async
 
 if TYPE_CHECKING:
     from unstructured_client import UnstructuredClient
@@ -109,8 +109,7 @@ class Partitioner(BaseProcess, ABC):
     async def call_api(self, client: "UnstructuredClient", request: "PartitionParameters"):
         # TODO when client supports async, run without using run_in_executor
         # isolate the IO heavy call
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(None, client.general.partition, request)
+        return await run_func_async(client.general.partition, request)
 
     def create_partition_parameters(self, filename: Path) -> "PartitionParameters":
         from unstructured_client.models.shared import Files, PartitionParameters

--- a/unstructured/ingest/v2/processes/uncompress.py
+++ b/unstructured/ingest/v2/processes/uncompress.py
@@ -8,6 +8,7 @@ from unstructured.ingest.enhanced_dataclass import EnhancedDataClassJsonMixin
 from unstructured.ingest.utils.compression import TAR_FILE_EXT, ZIP_FILE_EXT, uncompress_file
 from unstructured.ingest.v2.interfaces import FileData
 from unstructured.ingest.v2.interfaces.process import BaseProcess
+from unstructured.utils import run_func_async
 
 
 @dataclass
@@ -40,4 +41,4 @@ class Uncompressor(BaseProcess, ABC):
         return responses
 
     async def run_async(self, file_data: FileData, **kwargs: Any) -> list[FileData]:
-        return self.run(file_data=file_data, **kwargs)
+        return await run_func_async(self.run, file_data=file_data, **kwargs)

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -12,7 +12,7 @@ import subprocess
 import tempfile
 import threading
 from datetime import datetime
-from functools import wraps
+from functools import partial, wraps
 from itertools import combinations
 from typing import (
     TYPE_CHECKING,
@@ -832,3 +832,21 @@ class FileHandler:
         with self.lock:
             if os.path.exists(self.file_path):
                 os.remove(self.file_path)
+
+
+RunAsyncRReturn = TypeVar("RunAsyncRReturn")
+
+
+async def run_func_async(
+    func: Callable[..., RunAsyncRReturn], *args: Any, **kwargs: Any
+) -> RunAsyncRReturn:
+    """
+    Run a function asynchronously using an executor.
+
+    :param func: The function to run.
+    :param args: Positional arguments to pass to the function.
+    :param kwargs: Keyword arguments to pass to the function.
+    :return: The result of the function.
+    """
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, partial(func, *args, **kwargs))


### PR DESCRIPTION
Right now, in a lot of places, where something does not support async, we just call the sync version of it.

This is potentially dangerous and could cause us to have blocking code.

I propose we wrap all those calls in an executor so we don't get unexpected behavior.

A big place we're missing async is in all our file IO(we have a lot of it). We could use a package like aiofiles; however, I have a feeling there is just a lot of code that won't be coverable with async interfaces. If files are small, it might be okay.