### PR TITLE
docs: add link to serverless api in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `unstructured` library provides open-source components for ingesting and pre
 Looking for better performance and less setup? Check out our new [Serverless API](https://unstructured.io/api-key-hosted)!
 The Unstructured Serverless API is our most performant API yet, delivering a more responsive,
 production-grade solution to better support your business and LLM needs.
-Head to our [https://app.unstructured.io/](https://app.unstructured.io/) page to get started for
+Head to our [signup page](https://app.unstructured.io/) page to get started for
 free.
 
 ## :eight_pointed_black_star: Quick Start

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The `unstructured` library provides open-source components for ingesting and pre
 
 ## Try the Unstructured Serverless API!
 
-Looking for better performance and less setup? Check out our new [Serverless API](https://unstructured.io/api-key-hosted)!
+Looking for better pre-processing performance and less setup?
+Check out our new [Serverless API](https://unstructured.io/api-key-hosted)!
 The Unstructured Serverless API is our most performant API yet, delivering a more responsive,
 production-grade solution to better support your business and LLM needs.
 Head to our [signup page](https://app.unstructured.io/) page to get started for

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@
 
 The `unstructured` library provides open-source components for ingesting and pre-processing images and text documents, such as PDFs, HTML, Word docs, and [many more](https://docs.unstructured.io/open-source/core-functionality/partitioning). The use cases of `unstructured` revolve around streamlining and optimizing the data processing workflow for LLMs. `unstructured` modular functions and connectors form a cohesive system that simplifies data ingestion and pre-processing, making it adaptable to different platforms and efficient in transforming unstructured data into structured outputs.
 
+## Try the Unstructured Serverless API!
+
+Looking for better performance and less setup? Check out our new [Serverless API](https://unstructured.io/api-key-hosted)!
+The Unstructured Serverless API is our most performant API yet, delivering a more responsive,
+production-grade solution to better support your business and LLM needs.
+Head to our [https://app.unstructured.io/](https://app.unstructured.io/) page to get started for
+free.
+
 ## :eight_pointed_black_star: Quick Start
 
 There are several ways to use the `unstructured` library:


### PR DESCRIPTION
### Summary

Adds links to the serverless api. README updates look like the following:

<img width="904" alt="image" src="https://github.com/Unstructured-IO/unstructured/assets/1635179/fcb2b0c5-0dff-4612-8f18-62836ca6de8b">
