### PR TITLE
bugfix/isolate ingest v2 dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.14.10-dev4
+## 0.14.10-dev5
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.10-dev4"  # pragma: no cover
+__version__ = "0.14.10-dev5"  # pragma: no cover

--- a/unstructured/ingest/v2/cli/base/dest.py
+++ b/unstructured/ingest/v2/cli/base/dest.py
@@ -4,9 +4,9 @@ from typing import Optional, Type
 
 import click
 
-from unstructured.ingest.cli.utils import conform_click_options
 from unstructured.ingest.v2.cli.base.cmd import BaseCmd
 from unstructured.ingest.v2.cli.interfaces import CliConfig
+from unstructured.ingest.v2.cli.utils import conform_click_options
 from unstructured.ingest.v2.logger import logger
 
 

--- a/unstructured/ingest/v2/cli/base/src.py
+++ b/unstructured/ingest/v2/cli/base/src.py
@@ -4,7 +4,6 @@ from typing import Optional, Type
 
 import click
 
-from unstructured.ingest.cli.utils import Group, conform_click_options
 from unstructured.ingest.v2.cli.base.cmd import BaseCmd
 from unstructured.ingest.v2.cli.configs import (
     ChunkerCliConfig,
@@ -13,6 +12,7 @@ from unstructured.ingest.v2.cli.configs import (
     ProcessorCliConfig,
 )
 from unstructured.ingest.v2.cli.interfaces import CliConfig
+from unstructured.ingest.v2.cli.utils import Group, conform_click_options
 from unstructured.ingest.v2.logger import logger
 
 

--- a/unstructured/ingest/v2/cli/cmds/chroma.py
+++ b/unstructured/ingest/v2/cli/cmds/chroma.py
@@ -2,9 +2,9 @@ from dataclasses import dataclass
 
 import click
 
-from unstructured.ingest.cli.interfaces import Dict
 from unstructured.ingest.v2.cli.base import DestCmd
 from unstructured.ingest.v2.cli.interfaces import CliConfig
+from unstructured.ingest.v2.cli.utils import Dict
 from unstructured.ingest.v2.processes.connectors.chroma import CONNECTOR_TYPE
 
 

--- a/unstructured/ingest/v2/cli/configs/partition.py
+++ b/unstructured/ingest/v2/cli/configs/partition.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 
 import click
 
-from unstructured.ingest.cli.interfaces import DelimitedString, Dict
 from unstructured.ingest.v2.cli.interfaces import CliConfig
+from unstructured.ingest.v2.cli.utils import DelimitedString, Dict
 
 
 @dataclass

--- a/unstructured/ingest/v2/processes/connectors/__init__.py
+++ b/unstructured/ingest/v2/processes/connectors/__init__.py
@@ -1,1 +1,46 @@
 from __future__ import annotations
+
+from unstructured.ingest.v2.processes.connector_registry import (
+    add_destination_entry,
+    add_source_entry,
+)
+
+from .astra import CONNECTOR_TYPE as ASTRA_CONNECTOR_TYPE
+from .astra import astra_destination_entry
+from .chroma import CONNECTOR_TYPE as CHROMA_CONNECTOR_TYPE
+from .chroma import chroma_destination_entry
+from .elasticsearch import CONNECTOR_TYPE as ELASTICSEARCH_CONNECTOR_TYPE
+from .elasticsearch import elasticsearch_destination_entry, elasticsearch_source_entry
+from .google_drive import CONNECTOR_TYPE as GOOGLE_DRIVE_CONNECTOR_TYPE
+from .google_drive import google_drive_source_entry
+from .local import CONNECTOR_TYPE as LOCAL_CONNECTOR_TYPE
+from .local import local_destination_entry, local_source_entry
+from .onedrive import CONNECTOR_TYPE as ONEDRIVE_CONNECTOR_TYPE
+from .onedrive import onedrive_source_entry
+from .opensearch import CONNECTOR_TYPE as OPENSEARCH_CONNECTOR_TYPE
+from .opensearch import opensearch_destination_entry, opensearch_source_entry
+from .weaviate import CONNECTOR_TYPE as WEAVIATE_CONNECTOR_TYPE
+from .weaviate import weaviate_destination_entry
+
+add_destination_entry(destination_type=ASTRA_CONNECTOR_TYPE, entry=astra_destination_entry)
+
+add_destination_entry(destination_type=CHROMA_CONNECTOR_TYPE, entry=chroma_destination_entry)
+
+add_source_entry(source_type=ELASTICSEARCH_CONNECTOR_TYPE, entry=elasticsearch_source_entry)
+add_destination_entry(
+    destination_type=ELASTICSEARCH_CONNECTOR_TYPE, entry=elasticsearch_destination_entry
+)
+
+add_source_entry(source_type=GOOGLE_DRIVE_CONNECTOR_TYPE, entry=google_drive_source_entry)
+
+add_source_entry(source_type=LOCAL_CONNECTOR_TYPE, entry=local_source_entry)
+add_destination_entry(destination_type=LOCAL_CONNECTOR_TYPE, entry=local_destination_entry)
+
+add_source_entry(source_type=ONEDRIVE_CONNECTOR_TYPE, entry=onedrive_source_entry)
+
+add_source_entry(source_type=OPENSEARCH_CONNECTOR_TYPE, entry=opensearch_source_entry)
+add_destination_entry(
+    destination_type=OPENSEARCH_CONNECTOR_TYPE, entry=opensearch_destination_entry
+)
+
+add_destination_entry(destination_type=WEAVIATE_CONNECTOR_TYPE, entry=weaviate_destination_entry)

--- a/unstructured/ingest/v2/processes/connectors/__init__.py
+++ b/unstructured/ingest/v2/processes/connectors/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import unstructured.ingest.v2.processes.connectors.fsspec  # noqa: F401
 from unstructured.ingest.v2.processes.connector_registry import (
     add_destination_entry,
     add_source_entry,

--- a/unstructured/ingest/v2/processes/connectors/astra.py
+++ b/unstructured/ingest/v2/processes/connectors/astra.py
@@ -20,7 +20,6 @@ from unstructured.ingest.v2.interfaces import (
 from unstructured.ingest.v2.logger import logger
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
-    add_destination_entry,
 )
 from unstructured.utils import requires_dependencies
 
@@ -143,13 +142,10 @@ class AstraUploader(Uploader):
             collection.insert_many(chunk)
 
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        connection_config=AstraConnectionConfig,
-        upload_stager_config=AstraUploadStagerConfig,
-        upload_stager=AstraUploadStager,
-        uploader_config=AstraUploaderConfig,
-        uploader=AstraUploader,
-    ),
+astra_destination_entry = DestinationRegistryEntry(
+    connection_config=AstraConnectionConfig,
+    upload_stager_config=AstraUploadStagerConfig,
+    upload_stager=AstraUploadStager,
+    uploader_config=AstraUploaderConfig,
+    uploader=AstraUploader,
 )

--- a/unstructured/ingest/v2/processes/connectors/chroma.py
+++ b/unstructured/ingest/v2/processes/connectors/chroma.py
@@ -23,7 +23,6 @@ from unstructured.ingest.v2.interfaces import (
 from unstructured.ingest.v2.logger import logger
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
-    add_destination_entry,
 )
 from unstructured.staging.base import flatten_dict
 from unstructured.utils import requires_dependencies
@@ -197,13 +196,10 @@ class ChromaUploader(Uploader):
             self.upsert_batch(collection, self.prepare_chroma_list(chunk))
 
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        connection_config=ChromaConnectionConfig,
-        uploader=ChromaUploader,
-        uploader_config=ChromaUploaderConfig,
-        upload_stager=ChromaUploadStager,
-        upload_stager_config=ChromaUploadStagerConfig,
-    ),
+chroma_destination_entry = DestinationRegistryEntry(
+    connection_config=ChromaConnectionConfig,
+    uploader=ChromaUploader,
+    uploader_config=ChromaUploaderConfig,
+    upload_stager=ChromaUploadStager,
+    upload_stager_config=ChromaUploadStagerConfig,
 )

--- a/unstructured/ingest/v2/processes/connectors/elasticsearch.py
+++ b/unstructured/ingest/v2/processes/connectors/elasticsearch.py
@@ -31,8 +31,6 @@ from unstructured.ingest.v2.logger import logger
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
-    add_destination_entry,
-    add_source_entry,
 )
 from unstructured.staging.base import flatten_dict
 from unstructured.utils import requires_dependencies
@@ -386,24 +384,18 @@ class ElasticsearchUploader(Uploader):
                     )
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        connection_config=ElasticsearchConnectionConfig,
-        indexer=ElasticsearchIndexer,
-        indexer_config=ElasticsearchIndexerConfig,
-        downloader=ElasticsearchDownloader,
-        downloader_config=ElasticsearchDownloaderConfig,
-    ),
+elasticsearch_source_entry = SourceRegistryEntry(
+    connection_config=ElasticsearchConnectionConfig,
+    indexer=ElasticsearchIndexer,
+    indexer_config=ElasticsearchIndexerConfig,
+    downloader=ElasticsearchDownloader,
+    downloader_config=ElasticsearchDownloaderConfig,
 )
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        connection_config=ElasticsearchConnectionConfig,
-        upload_stager_config=ElasticsearchUploadStagerConfig,
-        upload_stager=ElasticsearchUploadStager,
-        uploader_config=ElasticsearchUploaderConfig,
-        uploader=ElasticsearchUploader,
-    ),
+elasticsearch_destination_entry = DestinationRegistryEntry(
+    connection_config=ElasticsearchConnectionConfig,
+    upload_stager_config=ElasticsearchUploadStagerConfig,
+    upload_stager=ElasticsearchUploadStager,
+    uploader_config=ElasticsearchUploaderConfig,
+    uploader=ElasticsearchUploader,
 )

--- a/unstructured/ingest/v2/processes/connectors/fsspec/__init__.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/__init__.py
@@ -1,1 +1,37 @@
 from __future__ import annotations
+
+from unstructured.ingest.v2.processes.connector_registry import (
+    add_destination_entry,
+    add_source_entry,
+)
+
+from .azure import CONNECTOR_TYPE as AZURE_CONNECTOR_TYPE
+from .azure import azure_destination_entry, azure_source_entry
+from .box import CONNECTOR_TYPE as BOX_CONNECTOR_TYPE
+from .box import box_destination_entry, box_source_entry
+from .dropbox import CONNECTOR_TYPE as DROPBOX_CONNECTOR_TYPE
+from .dropbox import dropbox_destination_entry, dropbox_source_entry
+from .gcs import CONNECTOR_TYPE as GCS_CONNECTOR_TYPE
+from .gcs import gcs_destination_entry, gcs_source_entry
+from .s3 import CONNECTOR_TYPE as S3_CONNECTOR_TYPE
+from .s3 import s3_destination_entry, s3_source_entry
+from .sftp import CONNECTOR_TYPE as SFTP_CONNECTOR_TYPE
+from .sftp import sftp_destination_entry, sftp_source_entry
+
+add_source_entry(source_type=AZURE_CONNECTOR_TYPE, entry=azure_source_entry)
+add_destination_entry(destination_type=AZURE_CONNECTOR_TYPE, entry=azure_destination_entry)
+
+add_source_entry(source_type=BOX_CONNECTOR_TYPE, entry=box_source_entry)
+add_destination_entry(destination_type=BOX_CONNECTOR_TYPE, entry=box_destination_entry)
+
+add_source_entry(source_type=DROPBOX_CONNECTOR_TYPE, entry=dropbox_source_entry)
+add_destination_entry(destination_type=DROPBOX_CONNECTOR_TYPE, entry=dropbox_destination_entry)
+
+add_source_entry(source_type=GCS_CONNECTOR_TYPE, entry=gcs_source_entry)
+add_destination_entry(destination_type=GCS_CONNECTOR_TYPE, entry=gcs_destination_entry)
+
+add_source_entry(source_type=S3_CONNECTOR_TYPE, entry=s3_source_entry)
+add_destination_entry(destination_type=S3_CONNECTOR_TYPE, entry=s3_destination_entry)
+
+add_source_entry(source_type=SFTP_CONNECTOR_TYPE, entry=sftp_source_entry)
+add_destination_entry(destination_type=SFTP_CONNECTOR_TYPE, entry=sftp_destination_entry)

--- a/unstructured/ingest/v2/processes/connectors/fsspec/azure.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/azure.py
@@ -9,8 +9,6 @@ from unstructured.ingest.v2.interfaces import DownloadResponse, FileData, Upload
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
-    add_destination_entry,
-    add_source_entry,
 )
 from unstructured.ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecAccessConfig,
@@ -131,22 +129,16 @@ class AzureUploader(FsspecUploader):
         return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        indexer=AzureIndexer,
-        indexer_config=AzureIndexerConfig,
-        downloader=AzureDownloader,
-        downloader_config=AzureDownloaderConfig,
-        connection_config=AzureConnectionConfig,
-    ),
+azure_source_entry = SourceRegistryEntry(
+    indexer=AzureIndexer,
+    indexer_config=AzureIndexerConfig,
+    downloader=AzureDownloader,
+    downloader_config=AzureDownloaderConfig,
+    connection_config=AzureConnectionConfig,
 )
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        uploader=AzureUploader,
-        uploader_config=AzureUploaderConfig,
-        connection_config=AzureConnectionConfig,
-    ),
+azure_destination_entry = DestinationRegistryEntry(
+    uploader=AzureUploader,
+    uploader_config=AzureUploaderConfig,
+    connection_config=AzureConnectionConfig,
 )

--- a/unstructured/ingest/v2/processes/connectors/fsspec/box.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/box.py
@@ -9,8 +9,6 @@ from unstructured.ingest.v2.interfaces import DownloadResponse, FileData, Upload
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
-    add_destination_entry,
-    add_source_entry,
 )
 from unstructured.ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecAccessConfig,
@@ -118,22 +116,16 @@ class BoxUploader(FsspecUploader):
         return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        indexer=BoxIndexer,
-        indexer_config=BoxIndexerConfig,
-        downloader=BoxDownloader,
-        downloader_config=BoxDownloaderConfig,
-        connection_config=BoxConnectionConfig,
-    ),
+box_source_entry = SourceRegistryEntry(
+    indexer=BoxIndexer,
+    indexer_config=BoxIndexerConfig,
+    downloader=BoxDownloader,
+    downloader_config=BoxDownloaderConfig,
+    connection_config=BoxConnectionConfig,
 )
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        uploader=BoxUploader,
-        uploader_config=BoxUploaderConfig,
-        connection_config=BoxConnectionConfig,
-    ),
+box_destination_entry = DestinationRegistryEntry(
+    uploader=BoxUploader,
+    uploader_config=BoxUploaderConfig,
+    connection_config=BoxConnectionConfig,
 )

--- a/unstructured/ingest/v2/processes/connectors/fsspec/dropbox.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/dropbox.py
@@ -9,8 +9,6 @@ from unstructured.ingest.v2.interfaces import DownloadResponse, FileData, Upload
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
-    add_destination_entry,
-    add_source_entry,
 )
 from unstructured.ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecAccessConfig,
@@ -117,22 +115,16 @@ class DropboxUploader(FsspecUploader):
         return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        indexer=DropboxIndexer,
-        indexer_config=DropboxIndexerConfig,
-        downloader=DropboxDownloader,
-        downloader_config=DropboxDownloaderConfig,
-        connection_config=DropboxConnectionConfig,
-    ),
+dropbox_source_entry = SourceRegistryEntry(
+    indexer=DropboxIndexer,
+    indexer_config=DropboxIndexerConfig,
+    downloader=DropboxDownloader,
+    downloader_config=DropboxDownloaderConfig,
+    connection_config=DropboxConnectionConfig,
 )
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        uploader=DropboxUploader,
-        uploader_config=DropboxUploaderConfig,
-        connection_config=DropboxConnectionConfig,
-    ),
+dropbox_destination_entry = DestinationRegistryEntry(
+    uploader=DropboxUploader,
+    uploader_config=DropboxUploaderConfig,
+    connection_config=DropboxConnectionConfig,
 )

--- a/unstructured/ingest/v2/processes/connectors/fsspec/gcs.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/gcs.py
@@ -10,8 +10,6 @@ from unstructured.ingest.v2.interfaces import DownloadResponse, FileData, Upload
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
-    add_destination_entry,
-    add_source_entry,
 )
 from unstructured.ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecAccessConfig,
@@ -128,22 +126,16 @@ class GcsUploader(FsspecUploader):
         return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        indexer=GcsIndexer,
-        indexer_config=GcsIndexerConfig,
-        downloader=GcsDownloader,
-        downloader_config=GcsDownloaderConfig,
-        connection_config=GcsConnectionConfig,
-    ),
+gcs_source_entry = SourceRegistryEntry(
+    indexer=GcsIndexer,
+    indexer_config=GcsIndexerConfig,
+    downloader=GcsDownloader,
+    downloader_config=GcsDownloaderConfig,
+    connection_config=GcsConnectionConfig,
 )
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        uploader=GcsUploader,
-        uploader_config=GcsUploaderConfig,
-        connection_config=GcsConnectionConfig,
-    ),
+gcs_destination_entry = DestinationRegistryEntry(
+    uploader=GcsUploader,
+    uploader_config=GcsUploaderConfig,
+    connection_config=GcsConnectionConfig,
 )

--- a/unstructured/ingest/v2/processes/connectors/fsspec/s3.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/s3.py
@@ -10,8 +10,6 @@ from unstructured.ingest.v2.interfaces import DownloadResponse, FileData, Upload
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
-    add_destination_entry,
-    add_source_entry,
 )
 from unstructured.ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecAccessConfig,
@@ -143,22 +141,16 @@ class S3Uploader(FsspecUploader):
         return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        indexer=S3Indexer,
-        indexer_config=S3IndexerConfig,
-        downloader=S3Downloader,
-        downloader_config=S3DownloaderConfig,
-        connection_config=S3ConnectionConfig,
-    ),
+s3_source_entry = SourceRegistryEntry(
+    indexer=S3Indexer,
+    indexer_config=S3IndexerConfig,
+    downloader=S3Downloader,
+    downloader_config=S3DownloaderConfig,
+    connection_config=S3ConnectionConfig,
 )
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        uploader=S3Uploader,
-        uploader_config=S3UploaderConfig,
-        connection_config=S3ConnectionConfig,
-    ),
+s3_destination_entry = DestinationRegistryEntry(
+    uploader=S3Uploader,
+    uploader_config=S3UploaderConfig,
+    connection_config=S3ConnectionConfig,
 )

--- a/unstructured/ingest/v2/processes/connectors/fsspec/sftp.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/sftp.py
@@ -11,8 +11,6 @@ from unstructured.ingest.v2.interfaces import DownloadResponse, FileData, Upload
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
-    add_destination_entry,
-    add_source_entry,
 )
 from unstructured.ingest.v2.processes.connectors.fsspec.fsspec import (
     FsspecAccessConfig,
@@ -153,22 +151,16 @@ class SftpUploader(FsspecUploader):
         return await super().run_async(path=path, file_data=file_data, **kwargs)
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        indexer=SftpIndexer,
-        indexer_config=SftpIndexerConfig,
-        downloader=SftpDownloader,
-        downloader_config=SftpDownloaderConfig,
-        connection_config=SftpConnectionConfig,
-    ),
+sftp_source_entry = SourceRegistryEntry(
+    indexer=SftpIndexer,
+    indexer_config=SftpIndexerConfig,
+    downloader=SftpDownloader,
+    downloader_config=SftpDownloaderConfig,
+    connection_config=SftpConnectionConfig,
 )
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        uploader=SftpUploader,
-        uploader_config=SftpUploaderConfig,
-        connection_config=SftpConnectionConfig,
-    ),
+sftp_destination_entry = DestinationRegistryEntry(
+    uploader=SftpUploader,
+    uploader_config=SftpUploaderConfig,
+    connection_config=SftpConnectionConfig,
 )

--- a/unstructured/ingest/v2/processes/connectors/google_drive.py
+++ b/unstructured/ingest/v2/processes/connectors/google_drive.py
@@ -26,7 +26,6 @@ from unstructured.ingest.v2.interfaces import (
 from unstructured.ingest.v2.logger import logger
 from unstructured.ingest.v2.processes.connector_registry import (
     SourceRegistryEntry,
-    add_source_entry,
 )
 from unstructured.utils import requires_dependencies
 
@@ -345,13 +344,10 @@ class GoogleDriveDownloader(Downloader):
         return self._write_file(file_data=file_data, file_contents=file_contents)
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        connection_config=GoogleDriveConnectionConfig,
-        indexer_config=GoogleDriveIndexerConfig,
-        indexer=GoogleDriveIndexer,
-        downloader_config=GoogleDriveDownloaderConfig,
-        downloader=GoogleDriveDownloader,
-    ),
+google_drive_source_entry = SourceRegistryEntry(
+    connection_config=GoogleDriveConnectionConfig,
+    indexer_config=GoogleDriveIndexerConfig,
+    indexer=GoogleDriveIndexer,
+    downloader_config=GoogleDriveDownloaderConfig,
+    downloader=GoogleDriveDownloader,
 )

--- a/unstructured/ingest/v2/processes/connectors/local.py
+++ b/unstructured/ingest/v2/processes/connectors/local.py
@@ -25,8 +25,6 @@ from unstructured.ingest.v2.logger import logger
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
-    add_destination_entry,
-    add_source_entry,
 )
 
 CONNECTOR_TYPE = "local"
@@ -192,18 +190,14 @@ class LocalUploader(Uploader):
             shutil.copy(src=str(content.path), dst=str(final_path))
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        indexer=LocalIndexer,
-        indexer_config=LocalIndexerConfig,
-        downloader=LocalDownloader,
-        downloader_config=LocalDownloaderConfig,
-        connection_config=LocalConnectionConfig,
-    ),
+local_source_entry = SourceRegistryEntry(
+    indexer=LocalIndexer,
+    indexer_config=LocalIndexerConfig,
+    downloader=LocalDownloader,
+    downloader_config=LocalDownloaderConfig,
+    connection_config=LocalConnectionConfig,
 )
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(uploader=LocalUploader, uploader_config=LocalUploaderConfig),
+local_destination_entry = DestinationRegistryEntry(
+    uploader=LocalUploader, uploader_config=LocalUploaderConfig
 )

--- a/unstructured/ingest/v2/processes/connectors/onedrive.py
+++ b/unstructured/ingest/v2/processes/connectors/onedrive.py
@@ -25,7 +25,6 @@ from unstructured.ingest.v2.interfaces import (
 from unstructured.ingest.v2.logger import logger
 from unstructured.ingest.v2.processes.connector_registry import (
     SourceRegistryEntry,
-    add_source_entry,
 )
 from unstructured.utils import requires_dependencies
 
@@ -231,13 +230,10 @@ class OnedriveDownloader(Downloader):
         return DownloadResponse(file_data=file_data, path=download_path)
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        connection_config=OnedriveConnectionConfig,
-        indexer_config=OnedriveIndexerConfig,
-        indexer=OnedriveIndexer,
-        downloader_config=OnedriveDownloaderConfig,
-        downloader=OnedriveDownloader,
-    ),
+onedrive_source_entry = SourceRegistryEntry(
+    connection_config=OnedriveConnectionConfig,
+    indexer_config=OnedriveIndexerConfig,
+    indexer=OnedriveIndexer,
+    downloader_config=OnedriveDownloaderConfig,
+    downloader=OnedriveDownloader,
 )

--- a/unstructured/ingest/v2/processes/connectors/opensearch.py
+++ b/unstructured/ingest/v2/processes/connectors/opensearch.py
@@ -13,8 +13,6 @@ from unstructured.ingest.v2.logger import logger
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
     SourceRegistryEntry,
-    add_destination_entry,
-    add_source_entry,
 )
 from unstructured.ingest.v2.processes.connectors.elasticsearch import (
     ElasticsearchDownloader,
@@ -139,23 +137,19 @@ class OpenSearchUploader(ElasticsearchUploader):
         return parallel_bulk
 
 
-add_source_entry(
-    source_type=CONNECTOR_TYPE,
-    entry=SourceRegistryEntry(
-        connection_config=OpenSearchConnectionConfig,
-        indexer=OpenSearchIndexer,
-        indexer_config=ElasticsearchIndexerConfig,
-        downloader=OpenSearchDownloader,
-        downloader_config=ElasticsearchDownloaderConfig,
-    ),
+opensearch_source_entry = SourceRegistryEntry(
+    connection_config=OpenSearchConnectionConfig,
+    indexer=OpenSearchIndexer,
+    indexer_config=ElasticsearchIndexerConfig,
+    downloader=OpenSearchDownloader,
+    downloader_config=ElasticsearchDownloaderConfig,
 )
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        connection_config=OpenSearchConnectionConfig,
-        upload_stager_config=ElasticsearchUploadStagerConfig,
-        upload_stager=ElasticsearchUploadStager,
-        uploader_config=ElasticsearchUploaderConfig,
-        uploader=OpenSearchUploader,
-    ),
+
+
+opensearch_destination_entry = DestinationRegistryEntry(
+    connection_config=OpenSearchConnectionConfig,
+    upload_stager_config=ElasticsearchUploadStagerConfig,
+    upload_stager=ElasticsearchUploadStager,
+    uploader_config=ElasticsearchUploaderConfig,
+    uploader=OpenSearchUploader,
 )

--- a/unstructured/ingest/v2/processes/connectors/weaviate.py
+++ b/unstructured/ingest/v2/processes/connectors/weaviate.py
@@ -20,7 +20,6 @@ from unstructured.ingest.v2.interfaces import (
 from unstructured.ingest.v2.logger import logger
 from unstructured.ingest.v2.processes.connector_registry import (
     DestinationRegistryEntry,
-    add_destination_entry,
 )
 
 if TYPE_CHECKING:
@@ -224,13 +223,10 @@ class WeaviateUploader(Uploader):
                 )
 
 
-add_destination_entry(
-    destination_type=CONNECTOR_TYPE,
-    entry=DestinationRegistryEntry(
-        connection_config=WeaviateConnectionConfig,
-        uploader=WeaviateUploader,
-        uploader_config=WeaviateUploaderConfig,
-        upload_stager=WeaviateUploadStager,
-        upload_stager_config=WeaviateUploadStagerConfig,
-    ),
+weaviate_destination_entry = DestinationRegistryEntry(
+    connection_config=WeaviateConnectionConfig,
+    uploader=WeaviateUploader,
+    uploader_config=WeaviateUploaderConfig,
+    upload_stager=WeaviateUploadStager,
+    upload_stager_config=WeaviateUploadStagerConfig,
 )


### PR DESCRIPTION
### Description
This PR handles two things:
* Exposing all the connectors via the connector registries by simply importing the connector module. This should be safe assuming all connector specific dependencies themselves are imported in the methods where they are used and wrapped in `@requires_dependencies` decorator
* Remove any import that pulls from the v2 ingest.cli package