### PR TITLE
Suppress nltk.download output logs

### DIFF
--- a/unstructured/nlp/tokenize.py
+++ b/unstructured/nlp/tokenize.py
@@ -20,7 +20,7 @@ def _download_nltk_package_if_not_present(package_name: str, package_category: s
     try:
         nltk.find(f"{package_category}/{package_name}")
     except LookupError:
-        nltk.download(package_name)
+        nltk.download(package_name, quiet=True)
 
 
 @lru_cache(maxsize=CACHE_MAX_SIZE)


### PR DESCRIPTION
The download logs interfere with observability logs and don't add any meaningful information to most apps, so added the change.
- Also, found a similar [issue](https://github.com/Unstructured-IO/unstructured/issues/2267) someone raised as well 