### PR TITLE
rfctr(html): refine HTML parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
+## 0.14.11-dev0
+
+### Enhancements
+
+* **Refine HTML parser to accommodate block element nested in phrasing.** HTML parser no longer raises on a block element (e.g. `<p>`, `<div>`) nested inside a phrasing element (e.g. `<strong>` or `<cite>`). Instead it breaks the phrasing run (and therefore element) at the block-item start and begins a new phrasing run after the block-item. This is consistent with how the browser determines element boundaries in this situation.
+
+### Features
+
+### Fixes
+
 ## 0.14.10
 
 ### Enhancements
 
-* **Update unstructured-client dependency** Change unstructured-client dependency pin back to
-  greater than min version and updated tests that were failing given the update.
+* **Update unstructured-client dependency** Change unstructured-client dependency pin back to greater than min version and updated tests that were failing given the update.
 * **`.doc` files are now supported in the `arm64` image.**. `libreoffice24` is added to the `arm64` image, meaning `.doc` files are now supported. We have follow on work planned to investigate adding `.ppt` support for `arm64` as well.
-* Add table detection metrics: recall, precision and f1
-* Remove unused _with_spans metrics
+* **Add table detection metrics: recall, precision and f1.**
+* **Remove unused _with_spans metrics.**
 
 ### Features
 

--- a/test_unstructured/partition/html/test_parser.py
+++ b/test_unstructured/partition/html/test_parser.py
@@ -12,7 +12,6 @@ from lxml import etree
 
 from unstructured.documents.elements import Address, Element, ListItem, NarrativeText, Text, Title
 from unstructured.partition.html.parser import (
-    Anchor,
     Annotation,
     DefaultElement,
     Flow,
@@ -20,7 +19,10 @@ from unstructured.partition.html.parser import (
     RemovedPhrasing,
     TextSegment,
     _consolidate_annotations,
+    _ElementAccumulator,
     _normalize_text,
+    _PhraseAccumulator,
+    _PreElementAccumulator,
     html_parser,
 )
 
@@ -29,27 +31,21 @@ from unstructured.partition.html.parser import (
 # -- _consolidate_annotations() ------------------
 
 
-def it_gathers_annotations_from_text_segments():
-    text_segments = [
-        TextSegment(
-            " Ford Prefect ",
-            {
-                "link_texts": "Ford Prefect",
-                "link_url": "https://wikipedia/Ford_Prefect",
-                "emphasized_text_contents": "Ford Prefect",
-                "emphasized_text_tags": "b",
-            },
-        ),
-        TextSegment(
-            " alien  encounter",
-            {
-                "emphasized_text_contents": "alien encounter",
-                "emphasized_text_tags": "bi",
-            },
-        ),
+def it_consolidates_annotations_from_multiple_text_segments():
+    annotations = [
+        {
+            "link_texts": "Ford Prefect",
+            "link_url": "https://wikipedia/Ford_Prefect",
+            "emphasized_text_contents": "Ford Prefect",
+            "emphasized_text_tags": "b",
+        },
+        {
+            "emphasized_text_contents": "alien encounter",
+            "emphasized_text_tags": "bi",
+        },
     ]
 
-    annotations = _consolidate_annotations(text_segments)
+    annotations = _consolidate_annotations(annotations)
 
     assert annotations == {
         # -- each distinct key gets a list of values --
@@ -87,6 +83,263 @@ def it_gathers_annotations_from_text_segments():
 )
 def test_normalize_text_produces_normalized_text(text: str, expected_value: str):
     assert _normalize_text(text) == expected_value
+
+
+# -- PHRASING ACCUMULATORS -----------------------------------------------------------------------
+
+
+class Describe_PhraseAccumulator:
+    """Isolated unit-test suite for `unstructured.partition.html.parser._PhraseAccumulator`."""
+
+    def it_is_empty_on_construction(self):
+        accum = _PhraseAccumulator()
+
+        phrase_iter = accum.flush()
+
+        with pytest.raises(StopIteration):
+            next(phrase_iter)
+
+    # -- .add() -----------------------------------------------------------
+
+    def it_accumulates_text_segments(self):
+        accum = _PhraseAccumulator()
+
+        accum.add(TextSegment("Ford... you're turning ", {}))
+        accum.add(TextSegment("into a penguin.", {}))
+        phrase_iter = accum.flush()
+
+        phrase = next(phrase_iter)
+        assert phrase == (
+            TextSegment("Ford... you're turning ", {}),
+            TextSegment("into a penguin.", {}),
+        )
+
+        with pytest.raises(StopIteration):
+            next(phrase_iter)
+
+    # -- .flush() ---------------------------------------------------------
+
+    def it_generates_zero_phrases_on_flush_when_empty(self):
+        accum = _PhraseAccumulator()
+
+        phrase_iter = accum.flush()
+
+        with pytest.raises(StopIteration):
+            next(phrase_iter)
+
+
+class Describe_ElementAccumulator:
+    """Isolated unit-test suite for `unstructured.partition.html.parser._ElementAccumulator`."""
+
+    def it_is_empty_on_construction(self, html_element: etree.ElementBase):
+        accum = _ElementAccumulator(html_element)
+
+        element_iter = accum.flush(None)
+
+        with pytest.raises(StopIteration):
+            next(element_iter)
+
+    # -- .add() -----------------------------------------------------------
+
+    def it_accumulates_text_segments(self, html_element: etree.ElementBase):
+        accum = _ElementAccumulator(html_element)
+
+        accum.add(TextSegment("Ford... you're turning ", {}))
+        accum.add(TextSegment("into a penguin.", {}))
+        element_iter = accum.flush(None)
+
+        element = next(element_iter)
+        assert element == NarrativeText("Ford... you're turning into a penguin.")
+
+        with pytest.raises(StopIteration):
+            next(element_iter)
+
+    # -- .flush() ---------------------------------------------------------
+
+    def it_generates_zero_elements_when_empty(self, html_element: etree.ElementBase):
+        accum = _ElementAccumulator(html_element)
+
+        element_iter = accum.flush(None)
+
+        with pytest.raises(StopIteration):
+            next(element_iter)
+
+    def and_it_generates_zero_elements_when_all_its_text_segments_are_whitespace_only(
+        self, html_element: etree.ElementBase
+    ):
+        accum = _ElementAccumulator(html_element)
+        accum.add(TextSegment(" \n   \t \n", {}))
+        accum.add(TextSegment("   \n", {}))
+
+        with pytest.raises(StopIteration):
+            next(accum.flush(None))
+
+    def and_it_generates_zero_elements_when_there_is_only_one_non_whitespace_character(
+        self, html_element: etree.ElementBase
+    ):
+        accum = _ElementAccumulator(html_element)
+        accum.add(TextSegment(" \n   \t \n", {}))
+        accum.add(TextSegment(" X \n", {}))
+
+        with pytest.raises(StopIteration):
+            next(accum.flush(None))
+
+    def it_normalizes_the_text_of_its_text_segments_on_flush(self, html_element: etree.ElementBase):
+        accum = _ElementAccumulator(html_element)
+        accum.add(TextSegment(" \n  Ford...   you're \t turning\n", {}))
+        accum.add(TextSegment("into a   penguin.\n", {}))
+
+        (element,) = accum.flush(None)
+
+        assert element.text == "Ford... you're turning into a penguin."
+
+    def it_creates_a_document_element_of_the_specified_type(self, html_element: etree.ElementBase):
+        accum = _ElementAccumulator(html_element)
+        accum.add(TextSegment("Ford... you're turning into a penguin.", {}))
+
+        (element,) = accum.flush(ListItem)
+
+        assert element == ListItem("Ford... you're turning into a penguin.")
+
+    def but_it_derives_the_element_type_from_the_text_when_none_is_specified(
+        self, html_element: etree.ElementBase
+    ):
+        accum = _ElementAccumulator(html_element)
+        accum.add(TextSegment("Ford... you're turning into a penguin.", {}))
+
+        (element,) = accum.flush(None)
+
+        assert element == NarrativeText("Ford... you're turning into a penguin.")
+
+    def it_removes_an_explicit_leading_bullet_character_from_a_list_item(
+        self, html_element: etree.ElementBase
+    ):
+        accum = _ElementAccumulator(html_element)
+        accum.add(TextSegment("* turning into a penguin", {}))
+
+        (element,) = accum.flush(None)
+
+        assert element == ListItem("turning into a penguin")
+
+    def it_applies_category_depth_metadata(self):
+        html_element = etree.fromstring("<h3>About fish</h3>", html_parser).xpath(".//h3")[0]
+        accum = _ElementAccumulator(html_element)
+        accum.add(TextSegment("Thanks for all those!", {}))
+
+        (element,) = accum.flush(Title)
+
+        e = element.to_dict()
+        e.pop("element_id")
+        assert e == {
+            "metadata": {"category_depth": 2},
+            "text": "Thanks for all those!",
+            "type": "Title",
+        }
+
+    def and_it_consolidates_annotations_into_metadata(self, html_element: etree.ElementBase):
+        accum = _ElementAccumulator(html_element)
+        accum.add(
+            TextSegment(
+                "\n    Ford...",
+                {
+                    "emphasized_text_contents": "Ford",
+                    "emphasized_text_tags": "b",
+                },
+            )
+        )
+        accum.add(TextSegment(" you're turning into a ", {}))
+        accum.add(
+            TextSegment(
+                "penguin",
+                {
+                    "emphasized_text_contents": "penguin",
+                    "emphasized_text_tags": "i",
+                },
+            )
+        )
+        accum.add(TextSegment(".\n", {}))
+
+        (element,) = accum.flush(NarrativeText)
+
+        e = element.to_dict()
+        e.pop("element_id")
+        assert e == {
+            "metadata": {
+                "emphasized_text_contents": [
+                    "Ford",
+                    "penguin",
+                ],
+                "emphasized_text_tags": [
+                    "b",
+                    "i",
+                ],
+            },
+            "text": "Ford... you're turning into a penguin.",
+            "type": "NarrativeText",
+        }
+
+    # -- ._category_depth() -----------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("html_text", "tag", "ElementCls", "expected_value"),
+        [
+            ("<p>Ford... you're turning into a penguin. Stop it.<p>", "p", Text, None),
+            ("<p>* thanks for all the fish.</p>", "p", ListItem, 0),
+            ("<li>thanks for all the fish.</li>", "li", ListItem, 0),
+            ("<ul><li>So long</li><li>and thanks for all the fish.</li></ul>", "li", ListItem, 1),
+            ("<dl><dd>So long<ol><li>and thanks for the fish.</li></ol></ul>", "li", ListItem, 2),
+            ("<p>Examples</p>", "p", Title, 0),
+            ("<h1>Examples</h1>", "h1", Title, 0),
+            ("<h2>Examples</h2>", "h2", Title, 1),
+            ("<h3>Examples</h3>", "h3", Title, 2),
+            ("<h4>Examples</h4>", "h4", Title, 3),
+            ("<h5>Examples</h5>", "h5", Title, 4),
+            ("<h6>Examples</h6>", "h6", Title, 5),
+        ],
+    )
+    def it_computes_the_category_depth_to_help(
+        self, html_text: str, tag: str, ElementCls: type[Element], expected_value: int | None
+    ):
+        e = etree.fromstring(html_text, html_parser).xpath(f".//{tag}")[0]
+        accum = _ElementAccumulator(e)
+        assert accum._category_depth(ElementCls) == expected_value
+
+    # -- ._normalized_text ------------------------------------------------
+
+    def it_computes_the_normalized_text_of_its_text_segments_to_help(
+        self, html_element: etree.ElementBase
+    ):
+        accum = _ElementAccumulator(html_element)
+        accum.add(TextSegment(" \n  Ford...   you're \t turning\n", {}))
+        accum.add(TextSegment("into a   penguin.\n", {}))
+
+        assert accum._normalized_text == "Ford... you're turning into a penguin."
+
+    # -- fixtures --------------------------------------------------------------------------------
+
+    @pytest.fixture()
+    def html_element(self) -> etree.ElementBase:
+        return etree.fromstring("<p/>", html_parser).xpath(".//p")[0]
+
+
+class Describe_PreElementAccumulator:
+    """Isolated unit-test suite for `unstructured.partition.html.parser._PreElementAccumulator`."""
+
+    def it_computes_the_normalized_text_of_its_text_segments_to_help(self):
+        html_element = etree.fromstring("<p/>", html_parser).xpath(".//p")[0]
+        accum = _PreElementAccumulator(html_element)
+        accum.add(TextSegment("\n\n", {}))
+        accum.add(TextSegment("    The panel lit up\n", {}))
+        accum.add(TextSegment("    with the words 'Please do not press\n", {}))
+        accum.add(TextSegment("    this button again'\n\n", {}))
+
+        # -- note single leading and trailing newline stripped --
+        assert accum._normalized_text == (
+            "\n"
+            "    The panel lit up\n"
+            "    with the words 'Please do not press\n"
+            "    this button again'\n"
+        )
 
 
 # -- FLOW (BLOCK-ITEM) ELEMENTS ------------------------------------------------------------------
@@ -159,31 +412,6 @@ class DescribeFlow:
         }
         with pytest.raises(StopIteration):
             e = next(elements)
-
-    # -- ._category_depth() -----------------------------------------------
-
-    @pytest.mark.parametrize(
-        ("html_text", "tag", "ElementCls", "expected_value"),
-        [
-            ("<p>Ford... you're turning into a penguin. Stop it.<p>", "p", Text, None),
-            ("<p>* thanks for all the fish.</p>", "p", ListItem, 0),
-            ("<li>thanks for all the fish.</li>", "li", ListItem, 0),
-            ("<ul><li>So long</li><li>and thanks for all the fish.</li></ul>", "li", ListItem, 1),
-            ("<dl><dd>So long<ol><li>and thanks for the fish.</li></ol></ul>", "li", ListItem, 2),
-            ("<p>Examples</p>", "p", Title, 0),
-            ("<h1>Examples</h1>", "h1", Title, 0),
-            ("<h2>Examples</h2>", "h2", Title, 1),
-            ("<h3>Examples</h3>", "h3", Title, 2),
-            ("<h4>Examples</h4>", "h4", Title, 3),
-            ("<h5>Examples</h5>", "h5", Title, 4),
-            ("<h6>Examples</h6>", "h6", Title, 5),
-        ],
-    )
-    def it_computes_the_category_depth_to_help(
-        self, html_text: str, tag: str, ElementCls: type[Element], expected_value: int | None
-    ):
-        e = etree.fromstring(html_text, html_parser).xpath(f".//{tag}")[0]
-        assert e._category_depth(ElementCls) == expected_value
 
     # -- ._element_from_text_or_tail() ------------------------------------
 
@@ -392,11 +620,15 @@ class DescribePhrasing:
     The `Phrasing` class provides most behaviors for phrasing (inline) elements.
     """
 
+    # -- .is_phrasing -----------------------------------------------------
+
     def it_knows_it_is_a_phrasing_element(self):
         b = etree.fromstring("<b>Hello</b>", html_parser).xpath(".//b")[0]
 
         assert isinstance(b, Phrasing)
         assert b.is_phrasing is True
+
+    # -- .iter_text_segments() --------------------------------------------
 
     @pytest.mark.parametrize(
         ("html_text", "expected_value"),
@@ -428,24 +660,574 @@ class DescribePhrasing:
         e = etree.fromstring(html_text, html_parser).xpath(".//body")[0][0]
         assert list(e.iter_text_segments()) == expected_value
 
+    @pytest.mark.parametrize(
+        ("html_text", "expected_value"),
+        [
+            # -- Phrasing with nested block but no text or tail produces only element for block --
+            ("<strong><p>aaa</p></strong>", [Title("aaa")]),
+            # -- Phrasing with text produces annotated text-segment for the text --
+            (
+                "<strong>aaa<p>bbb</p></strong>",
+                [
+                    TextSegment(
+                        "aaa", {"emphasized_text_contents": "aaa", "emphasized_text_tags": "b"}
+                    ),
+                    Title("bbb"),
+                ],
+            ),
+            # -- Phrasing with tail produces annotated text-segment for the tail --
+            (
+                "<strong><p>aaa</p>bbb</strong>",
+                [
+                    Title("aaa"),
+                    TextSegment(
+                        "bbb", {"emphasized_text_contents": "bbb", "emphasized_text_tags": "b"}
+                    ),
+                ],
+            ),
+            # -- Phrasing with text, nested block, and tail produces all three --
+            (
+                "<strong>aaa<p>bbb</p>ccc</strong>",
+                [
+                    TextSegment(
+                        "aaa", {"emphasized_text_contents": "aaa", "emphasized_text_tags": "b"}
+                    ),
+                    Title("bbb"),
+                    TextSegment(
+                        "ccc", {"emphasized_text_contents": "ccc", "emphasized_text_tags": "b"}
+                    ),
+                ],
+            ),
+        ],
+    )
+    def but_it_can_also_generate_an_element_when_it_has_a_nested_block_element(
+        self, html_text: str, expected_value: list[TextSegment | Element]
+    ):
+        e = etree.fromstring(html_text, html_parser).xpath(".//body")[0][0]
+        assert list(e.iter_text_segments()) == expected_value
+
+    # -- ._annotation() ---------------------------------------------------
+
     def it_forms_its_annotations_from_emphasis(self):
-        cite = etree.fromstring("<cite>  rhombus </cite>", html_parser).xpath(".//cite")[0]
-        assert cite._annotation(cite.text, "bi") == {
-            "emphasized_text_contents": "rhombus",
+        cite = etree.fromstring("<cite/>", html_parser).xpath(".//cite")[0]
+        assert cite._annotation("\n  foobar\n  ", "bi") == {
+            "emphasized_text_contents": "foobar",
             "emphasized_text_tags": "bi",
         }
 
-    def but_not_when_text_is_empty_or_whitespace(self):
-        cite = etree.fromstring("<cite>   </cite>", html_parser).xpath(".//cite")[0]
-        assert cite._annotation(cite.text, "bi") == {}
+    @pytest.mark.parametrize("text", ["", "\n  \t  "])
+    def but_not_when_text_is_empty_or_whitespace(self, text: str):
+        cite = etree.fromstring("<cite/>", html_parser).xpath(".//cite")[0]
+        assert cite._annotation(text, "bi") == {}
 
     def and_not_when_there_is_no_emphasis(self):
-        cite = etree.fromstring("<cite>rhombus</cite>", html_parser).xpath(".//cite")[0]
-        assert cite._annotation(cite.text, "") == {}
+        cite = etree.fromstring("<cite/>", html_parser).xpath(".//cite")[0]
+        assert cite._annotation("foobar", "") == {}
 
-    def it_uses_the_enclosing_emphasis_as_the_default_inside_emphasis(self):
-        abbr = etree.fromstring("<abbr>LLM</abbr>", html_parser).xpath(".//abbr")[0]
-        assert abbr._inside_emphasis("xyz") == "xyz"
+    # -- ._inside_emphasis() ----------------------------------------------
+
+    @pytest.mark.parametrize("enclosing_emphasis", ["", "b", "bi"])
+    def it_uses_the_enclosing_emphasis_as_the_default_inside_emphasis(
+        self, enclosing_emphasis: str
+    ):
+        """Inside emphasis is applied to text inside the phrasing element (but not its tail).
+
+        The `._inside_emphasis()` method is overridden by Bold and Italic classes which add their
+        specific emphasis characters.
+        """
+        abbr = etree.fromstring("<abbr/>", html_parser).xpath(".//abbr")[0]
+        assert abbr._inside_emphasis(enclosing_emphasis) == enclosing_emphasis
+
+    # -- ._iter_child_text_segments() -------------------------------------
+
+    @pytest.mark.parametrize(
+        ("html_text", "expected_value"),
+        [
+            # -- a phrasing element with no children produces no text segments
+            # -- (element text is handled elsewhere)
+            ("<abbr>aaa</abbr>", []),
+            # -- child phrasing element produces text-segment for its text --
+            ("<bdi>x<bdo>bbb</bdo></bdi>", [TextSegment("bbb", {})]),
+            # -- and also for its tail when it has one --
+            ("<bdi>x<bdo>bbb</bdo>ccc</bdi>", [TextSegment("bbb", {}), TextSegment("ccc", {})]),
+            # -- nested phrasing recursively each produce a segment for text and tail, in order --
+            (
+                "<big>xxx<cite>aaa<code>bbb<data>ccc</data>ddd</code>eee</cite>fff</big>",
+                [
+                    TextSegment("aaa", {}),
+                    TextSegment("bbb", {}),
+                    TextSegment("ccc", {}),
+                    TextSegment("ddd", {}),
+                    TextSegment("eee", {}),
+                    TextSegment("fff", {}),
+                ],
+            ),
+        ],
+    )
+    def it_generates_text_segments_for_its_children_and_their_tails(
+        self, html_text: str, expected_value: list[TextSegment]
+    ):
+        e = etree.fromstring(html_text, html_parser).xpath(".//body")[0][0]
+        assert list(e._iter_child_text_segments("")) == expected_value
+
+    @pytest.mark.parametrize(
+        ("html_text", "inside_emphasis", "expected_value"),
+        [
+            # -- a phrasing element with no block children produces no elements --
+            ("<dfn></dfn>", "", []),
+            # -- a child block element produces an element --
+            ("<kbd><p>aaa</p></kbd>", "", [Title("aaa")]),
+            # -- a child block element with a tail also produces a text-segment for the tail --
+            ("<kbd><p>aaa</p>bbb</kbd>", "", [Title("aaa"), TextSegment("bbb", {})]),
+            # -- and also text-segments for phrasing following the tail --
+            (
+                "<kbd><p>aaa</p>bbb<mark>ccc</mark>ddd</kbd>",
+                "",
+                [
+                    Title("aaa"),
+                    TextSegment("bbb", {}),
+                    TextSegment("ccc", {}),
+                    TextSegment("ddd", {}),
+                ],
+            ),
+            # -- and emphasis is applied before and after block-item --
+            (
+                "<strong><q>aaa</q><p>bbb</p>ccc<s>ddd</s>eee</strong>",
+                "b",
+                [
+                    TextSegment(
+                        "aaa", {"emphasized_text_contents": "aaa", "emphasized_text_tags": "b"}
+                    ),
+                    Title("bbb"),
+                    TextSegment(
+                        "ccc", {"emphasized_text_contents": "ccc", "emphasized_text_tags": "b"}
+                    ),
+                    TextSegment(
+                        "ddd", {"emphasized_text_contents": "ddd", "emphasized_text_tags": "b"}
+                    ),
+                    TextSegment(
+                        "eee", {"emphasized_text_contents": "eee", "emphasized_text_tags": "b"}
+                    ),
+                ],
+            ),
+        ],
+    )
+    def and_it_generates_elements_for_its_block_children(
+        self, html_text: str, inside_emphasis: str, expected_value: list[TextSegment | Element]
+    ):
+        e = etree.fromstring(html_text, html_parser).xpath(".//body")[0][0]
+        assert list(e._iter_child_text_segments(inside_emphasis)) == expected_value
+
+    # -- ._iter_text_segments_from_block_tail_and_phrasing() --------------
+
+    @pytest.mark.parametrize(
+        ("html_text", "emphasis", "expected_value"),
+        [
+            # -- no tail and no contiguous phrasing produces no text-segments --
+            ("<cite><p/></cite>", "", []),
+            # -- tail produces a text-segment --
+            ("<cite><p/>aaa</cite>", "", [TextSegment("aaa", {})]),
+            # -- contiguous phrasing produces a text-segment --
+            ("<cite><p/><s>aaa</s></cite>", "", [TextSegment("aaa", {})]),
+            # -- tail of contiguous phrasing also produces a text-segment --
+            ("<bdi><p/><s>aaa</s>bbb</bdi>", "", [TextSegment("aaa", {}), TextSegment("bbb", {})]),
+            # -- nested phrasing produces a text-segment --
+            (
+                "<sub><p/>aaa<s>bbb<q>ccc</q>ddd</s>eee</sub>",
+                "",
+                [
+                    TextSegment("aaa", {}),
+                    TextSegment("bbb", {}),
+                    TextSegment("ccc", {}),
+                    TextSegment("ddd", {}),
+                    TextSegment("eee", {}),
+                ],
+            ),
+            # -- and emphasis is added to each text-segment when specified --
+            (
+                "<strong><p/>aaa<s>bbb<i>ccc</i>ddd</s>eee</strong>",
+                "b",
+                [
+                    TextSegment(
+                        "aaa", {"emphasized_text_contents": "aaa", "emphasized_text_tags": "b"}
+                    ),
+                    TextSegment(
+                        "bbb", {"emphasized_text_contents": "bbb", "emphasized_text_tags": "b"}
+                    ),
+                    TextSegment(
+                        "ccc", {"emphasized_text_contents": "ccc", "emphasized_text_tags": "bi"}
+                    ),
+                    TextSegment(
+                        "ddd", {"emphasized_text_contents": "ddd", "emphasized_text_tags": "b"}
+                    ),
+                    TextSegment(
+                        "eee", {"emphasized_text_contents": "eee", "emphasized_text_tags": "b"}
+                    ),
+                ],
+            ),
+            # -- a block item nested in contiguous phrasing produces an Element --
+            (
+                "<cite><p/>aaa<abbr>bbb<p>ccc</p>ddd</abbr>eee</cite>",
+                "",
+                [
+                    TextSegment("aaa", {}),
+                    TextSegment("bbb", {}),
+                    Title("ccc"),
+                    TextSegment("ddd", {}),
+                    TextSegment("eee", {}),
+                ],
+            ),
+        ],
+    )
+    def it_generates_text_segments_from_the_tail_and_contiguous_phrasing(
+        self, html_text: str, emphasis: str, expected_value: list[TextSegment | Element]
+    ):
+        e = etree.fromstring(html_text, html_parser).xpath(".//body")[0][0]
+        p = e.xpath("./p")[0]
+        tail = p.tail or ""
+        q = deque(e[1:])
+
+        assert (
+            list(e._iter_text_segments_from_block_tail_and_phrasing(tail, q, emphasis))
+            == expected_value
+        )
+
+
+class DescribeAnchor:
+    """Isolated unit-test suite for `unstructured.partition.html.parser.Anchor`.
+
+    The `Anchor` class is used for `<a>` tags and provides link metadata.
+    """
+
+    # -- .iter_text_segments() --------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("html_text", "emphasis", "expected_value"),
+        [
+            # -- produces no text-segment or annotation for anchor.text when there is none --
+            ('<a href="http://abc.com"></a>', "", []),
+            # -- but it produces a text-segment for the tail if there is one --
+            ('<a href="http://abc.com"></a> long tail ', "", [TextSegment(" long tail ", {})]),
+            # -- produces text-segment but no annotation for anchor.text when it is whitespace --
+            ('<a href="http://abc.com">  </a>', "", [TextSegment("  ", {})]),
+            # -- produces text-segment and annotation for anchor text. Note `link_texts:`
+            # -- annotation value is whitespace-normalized but text-segment text is not.
+            (
+                '<a href="http://abc.com"> click here </a>',
+                "",
+                [
+                    TextSegment(
+                        " click here ",
+                        {"link_texts": ["click here"], "link_urls": ["http://abc.com"]},
+                    )
+                ],
+            ),
+            # -- produces text-segment for both text and tail when present --
+            (
+                '<a href="http://abc.com"> click here </a> long tail',
+                "",
+                [
+                    TextSegment(
+                        " click here ",
+                        {"link_texts": ["click here"], "link_urls": ["http://abc.com"]},
+                    ),
+                    TextSegment(" long tail", {}),
+                ],
+            ),
+            # -- nested phrasing inside <a> element is handled as expected --
+            (
+                '<p>I am <a href="http://eie.io">one <u>with<i> the</i></u> Force</a>.</p>',
+                "",
+                [
+                    TextSegment(
+                        "one with the Force",
+                        {
+                            "emphasized_text_contents": ["the"],
+                            "emphasized_text_tags": ["i"],
+                            "link_texts": ["one with the Force"],
+                            "link_urls": ["http://eie.io"],
+                        },
+                    ),
+                    TextSegment(".", {}),
+                ],
+            ),
+            # -- enclosing_emphasis is applied to all segments --
+            (
+                '<p>I am <strong><a href="http://eie.io">one with</a> the Force.</strong></p>',
+                "b",
+                [
+                    TextSegment(
+                        "one with",
+                        {
+                            "emphasized_text_contents": ["one with"],
+                            "emphasized_text_tags": ["b"],
+                            "link_texts": ["one with"],
+                            "link_urls": ["http://eie.io"],
+                        },
+                    ),
+                    TextSegment(
+                        " the Force.",
+                        {
+                            "emphasized_text_contents": "the Force.",
+                            "emphasized_text_tags": "b",
+                        },
+                    ),
+                ],
+            ),
+        ],
+    )
+    def it_generates_link_annotated_text_segments_for_its_text_and_a_tail_text_segment(
+        self, html_text: str, emphasis: str, expected_value: list[TextSegment]
+    ):
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+        assert list(a.iter_text_segments(emphasis)) == expected_value
+
+    def it_generates_enclosed_block_items_as_separate_elements(self):
+        html_text = """<a href="http://eie.io">I am <p>one with</p> the Force.</a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+
+        assert list(a.iter_text_segments("b")) == [
+            TextSegment(
+                "I am ",
+                {
+                    "emphasized_text_contents": ["I am"],
+                    "emphasized_text_tags": ["b"],
+                    "link_texts": ["I am"],
+                    "link_urls": ["http://eie.io"],
+                },
+            ),
+            Title("one with"),
+            TextSegment(
+                " the Force.",
+                {
+                    "emphasized_text_contents": "the Force.",
+                    "emphasized_text_tags": "b",
+                },
+            ),
+        ]
+
+    def and_it_annotates_first_enclosed_block_Element_when_no_non_whitespace_phrase_appears_first(
+        self,
+    ):
+        html_text = """<a href="http://eie.io"> \n <p>I am one with</p> the Force.</a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+
+        actual = list(a.iter_text_segments("i"))
+
+        assert actual == [
+            TextSegment(" \n ", {}),
+            NarrativeText("I am one with"),
+            TextSegment(
+                " the Force.",
+                {
+                    "emphasized_text_contents": "the Force.",
+                    "emphasized_text_tags": "i",
+                },
+            ),
+        ]
+        element = actual[1]
+        assert element.metadata.link_texts == ["I am one with"]
+        assert element.metadata.link_urls == ["http://eie.io"]
+
+    # -- ._iter_phrases_and_elements() ------------------------------------
+
+    def it_divides_the_anchor_contents_but_not_tail_into_phrases_and_elements(self):
+        html_text = """
+          <a href="http://eie.io">But always <p>see first.</p> Otherwise you </a> will only see
+        """
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+
+        assert list(a._iter_phrases_and_elements(emphasis="")) == [
+            (TextSegment("But always ", {}),),
+            NarrativeText("see first."),
+            (TextSegment(" Otherwise you ", {}),),
+        ]
+
+    # -- ._iter_phrasing() ------------------------------------------------
+
+    def it_generates_zero_items_when_both_text_and_q_are_empty(self):
+        html_text = """<a href="http://eie.io"></a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+
+        with pytest.raises(StopIteration):
+            next(a._iter_phrasing(text="", q=deque([]), emphasis=""))
+
+    def it_generates_a_phrase_when_only_text_is_present(self):
+        html_text = """<a href="http://eie.io">\n  But always see first.\n</a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+
+        assert list(a._iter_phrasing(text=a.text, q=deque(a), emphasis="")) == [
+            (TextSegment("\n  But always see first.\n", {}),)
+        ]
+
+    def and_it_generates_a_phrase_when_that_text_is_followed_by_a_phrasing_element(self):
+        html_text = """<a href="http://eie.io">But always <b>see <i>first</i></b>. Otherwise</a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+
+        assert list(a._iter_phrasing(text=a.text, q=deque(a), emphasis="")) == [
+            (
+                TextSegment("But always ", {}),
+                TextSegment(
+                    "see ",
+                    {
+                        "emphasized_text_contents": "see",
+                        "emphasized_text_tags": "b",
+                    },
+                ),
+                TextSegment(
+                    "first",
+                    {
+                        "emphasized_text_contents": "first",
+                        "emphasized_text_tags": "bi",
+                    },
+                ),
+                TextSegment(". Otherwise", {}),
+            )
+        ]
+
+    def it_ends_the_phrase_at_the_end_of_the_element(self):
+        html_text = """<a href="http://eie.io">But always see first.</a> Otherwise you will """
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+
+        assert list(a._iter_phrasing(text=a.text, q=deque(a), emphasis="")) == [
+            (TextSegment("But always see first.", {}),)
+        ]
+
+    def but_it_ends_at_a_block_element_if_one_occurs_first(self):
+        html_text = """<a href="http://eie.io">But always see first. <p>Otherwise you </p> </a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+
+        assert list(a._iter_phrasing(text=a.text, q=deque(a), emphasis="")) == [
+            (TextSegment("But always see first. ", {}),)
+        ]
+
+    def it_generates_an_element_for_a_block_item_nested_inside_phrasing(self):
+        html_text = """
+          <a href="http://eie.io">But <strong>always <p>see first.</p>Otherwise</strong> you </a>
+        """
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+
+        assert list(a._iter_phrasing(text=a.text, q=deque(a), emphasis="")) == [
+            (
+                TextSegment("But ", {}),
+                TextSegment(
+                    "always ",
+                    {
+                        "emphasized_text_contents": "always",
+                        "emphasized_text_tags": "b",
+                    },
+                ),
+            ),
+            NarrativeText("see first."),
+            (
+                TextSegment(
+                    "Otherwise",
+                    {
+                        "emphasized_text_contents": "Otherwise",
+                        "emphasized_text_tags": "b",
+                    },
+                ),
+                TextSegment(" you ", {}),
+            ),
+        ]
+
+    # -- ._link_annotate_element() ----------------------------------------
+
+    def it_adds_link_metadata_to_an_element_to_help(self):
+        html_text = """<a href="http://eie.io"></a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+        element = Text("aaa")
+
+        e = a._link_annotate_element(element)
+
+        assert e is element
+        assert e.metadata.link_texts == ["aaa"]
+        assert e.metadata.link_urls == ["http://eie.io"]
+
+    def and_it_preserves_any_existing_link_metadata_on_the_element(self):
+        # -- nested anchors shouldn't be possible but easier to test than prove it can't happen --
+        html_text = """<a href="http://eie.io"></a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+        element = Text("bbb")
+        element.metadata.link_texts = ["abc"]
+        element.metadata.link_urls = ["http://abc.com"]
+
+        e = a._link_annotate_element(element)
+
+        assert e is element
+        assert e.metadata.link_texts == ["abc", "bbb"]
+        assert e.metadata.link_urls == ["http://abc.com", "http://eie.io"]
+
+    def but_not_when_the_text_is_empty(self):
+        html_text = """<a href="http://eie.io"/>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+        element = Text("")
+
+        e = a._link_annotate_element(element)
+
+        assert e is element
+        assert e.metadata.link_texts is None
+        assert e.metadata.link_urls is None
+
+    def and_not_when_there_is_no_url(self):
+        html_text = """<a/>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+        element = Text("zzz")
+
+        e = a._link_annotate_element(element)
+
+        assert e is element
+        assert e.metadata.link_texts is None
+        assert e.metadata.link_urls is None
+
+    # -- ._link_text_segment() --------------------------------------------
+
+    def it_consolidates_a_phrase_into_a_single_link_annotated_TextSegment_to_help(self):
+        html_text = """<a href="http://eie.io"></a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+        phrase = (
+            TextSegment(
+                "Otherwise you will only ",
+                {
+                    "emphasized_text_contents": ["Otherwise"],
+                    "emphasized_text_tags": ["i"],
+                },
+            ),
+            TextSegment(
+                "see what you were expecting.\n",
+                {
+                    "emphasized_text_contents": "expecting",
+                    "emphasized_text_tags": "b",
+                },
+            ),
+        )
+
+        link_text_segment = a._link_text_segment(phrase)
+
+        assert link_text_segment == TextSegment(
+            "Otherwise you will only see what you were expecting.\n",
+            {
+                "emphasized_text_contents": ["Otherwise", "expecting"],
+                "emphasized_text_tags": ["i", "b"],
+                "link_texts": ["Otherwise you will only see what you were expecting."],
+                "link_urls": ["http://eie.io"],
+            },
+        )
+
+    @pytest.mark.parametrize("text", ["", " \n \t "])
+    def but_not_when_the_text_is_empty_or_whitespace_only(self, text: str):
+        html_text = """<a href="http://eie.io"></a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+        phrase = (TextSegment(text, {}), TextSegment(text, {}), TextSegment(text, {}))
+
+        assert a._link_text_segment(phrase) is None
+
+    def and_not_when_the_anchor_has_no_href_url(self):
+        html_text = """<a>foobar</a>"""
+        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
+        phrase = (TextSegment("Otherwise", {}), TextSegment(" you will", {}))
+
+        assert a._link_text_segment(phrase) is None
 
 
 class DescribeBold:
@@ -593,124 +1375,6 @@ class DescribeRemovedPhrasing:
         assert isinstance(label, RemovedPhrasing)
         assert label.is_phrasing is True
         assert text_segment.text == "\n  Like vastly, hugely big.\n"
-
-
-# -- DUAL-ROLE ELEMENTS --------------------------------------------------------------------------
-
-
-class DescribeAnchor:
-    """Isolated unit-test suite for `unstructured.partition.html.parser.Anchor`.
-
-    The `Anchor` class is used for `<a>` tags and provides link metadata.
-    """
-
-    # -- .is_phrasing -----------------------------------------------------
-
-    @pytest.mark.parametrize(
-        ("html_text", "expected_value"),
-        [
-            # -- an empty <a> identifies as phrasing --
-            ('<a href="http://eie.io"></a>', True),
-            # -- an <a> with text but no children identifies as phrasing --
-            ('<a href="http://eie.io">“O Deep Thought computer," he said,</a>', True),
-            # -- an <a> with no text and only phrasing children identifies as phrasing --
-            ('<a href="http://eie.io"><i>“O Deep Thought computer,"</i></a>', True),
-            # -- an <a> with both text and phrasing children identifies as phrasing --
-            ('<a href="http://eie.io">“O <b>Deep Thought</b> computer,"</a>', True),
-            # -- but an <a> with a block-item child does not --
-            ('<a href="http://eie.io"><p>“O Deep Thought computer,"</p></a>', False),
-            # -- and an <a> with both text and a block-item child does not --
-            ('<a href="http://eie.io">“O Deep Thought computer,"<div>he said,</div></a>', False),
-            # -- and an <a> with text and both block and phrasing children does not --
-            ('<a href="http://eie.io">“O <b>Deep</b> Thought <div>computer," he</div></a>', False),
-        ],
-    )
-    def it_determines_whether_it_is_phrasing_dynamically(
-        self, html_text: str, expected_value: bool
-    ):
-        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
-
-        assert isinstance(a, Anchor)
-        assert a.is_phrasing is expected_value
-
-    # -- .iter_elements() -------------------------------------------------
-
-    def it_can_also_act_as_a_block_item(self):
-        html_text = """
-        <div>
-          <a href="http://eie.io">
-            O Deep Thought computer, he said,
-            <div>The task we have designed you to perform is this.</div>
-            <p>We want you to tell us.... he paused,</p>
-          </a>
-        </div>
-        """
-        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
-
-        elements = a.iter_elements()
-
-        assert [e.text for e in elements] == [
-            "O Deep Thought computer, he said,",
-            "The task we have designed you to perform is this.",
-            "We want you to tell us.... he paused,",
-        ]
-
-    # -- .iter_text_segments() --------------------------------------------
-
-    @pytest.mark.parametrize(
-        ("html_text", "expected_value"),
-        [
-            # -- produces no text-segment or annotation for anchor.text when there is none --
-            ('<a href="http://abc.com"></a>', []),
-            # -- but it produces a text-segment for the tail if there is one --
-            ('<a href="http://abc.com"></a> long tail ', [TextSegment(" long tail ", {})]),
-            # -- produces text-segment but no annotation for anchor.text when it is whitespace --
-            ('<a href="http://abc.com">  </a>', [TextSegment("  ", {})]),
-            # -- produces text-segment and annotation for anchor text
-            # -- Note link-texts annotation is whitespace-normalized but text-segment text is not.
-            (
-                '<a href="http://abc.com"> click here </a>',
-                [
-                    TextSegment(
-                        " click here ",
-                        {"link_texts": ["click here"], "link_urls": ["http://abc.com"]},
-                    )
-                ],
-            ),
-            # -- produces text-segment for both text and tail when present --
-            (
-                '<a href="http://abc.com"> click here </a> long tail',
-                [
-                    TextSegment(
-                        " click here ",
-                        {"link_texts": ["click here"], "link_urls": ["http://abc.com"]},
-                    ),
-                    TextSegment(" long tail", {}),
-                ],
-            ),
-            # -- nested phrasing inside <a> element is handled as expected --
-            (
-                '<p>I am <a href="http://eie.io">one <u>with<i> the</i></u> Force</a>.</p>',
-                [
-                    TextSegment(
-                        "one with the Force",
-                        {
-                            "emphasized_text_contents": ["the"],
-                            "emphasized_text_tags": ["i"],
-                            "link_texts": ["one with the Force"],
-                            "link_urls": ["http://eie.io"],
-                        },
-                    ),
-                    TextSegment(".", {}),
-                ],
-            ),
-        ],
-    )
-    def it_generates_link_annotated_text_segments_for_its_text_and_a_tail_text_segment(
-        self, html_text: str, expected_value: list[TextSegment]
-    ):
-        a = etree.fromstring(html_text, html_parser).xpath(".//a")[0]
-        assert list(a.iter_text_segments()) == expected_value
 
 
 # -- DEFAULT ELEMENT -----------------------------------------------------------------------------

--- a/typings/lxml/etree/__init__.pyi
+++ b/typings/lxml/etree/__init__.pyi
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ._classlookup import ElementBase as ElementBase
 from ._classlookup import ElementDefaultClassLookup as ElementDefaultClassLookup
+from ._cleanup import strip_elements as strip_elements
 from ._element import _Element as _Element
 from ._element import _ElementTree as _ElementTree
 from ._module_func import fromstring as fromstring

--- a/typings/lxml/etree/_cleanup.pyi
+++ b/typings/lxml/etree/_cleanup.pyi
@@ -1,0 +1,21 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import Collection, overload
+
+from .._types import _ElementOrTree, _TagSelector
+
+@overload
+def strip_elements(
+    __tree_or_elem: _ElementOrTree,
+    *tag_names: _TagSelector,
+    with_tail: bool = True,
+) -> None: ...
+@overload
+def strip_elements(
+    __tree_or_elem: _ElementOrTree,
+    __tag: Collection[_TagSelector],
+    /,
+    with_tail: bool = True,
+) -> None: ...

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.14.10"  # pragma: no cover
+__version__ = "0.14.11-dev0"  # pragma: no cover


### PR DESCRIPTION
**Note**
This refines the new HTML parser but _does not install it_. This is why no changes to ingest test expectations or other unit-tests are required here. Installing the new parser will happen in the next PR #3218.

**Summary**
The initial version of the parser (purposely) raised on a block element nested inside a phrasing element. While such nesting is not valid according to the HTML Standard, it is accepted by the browser and does happen in the wild.

The refinements here handle this situation similarly to how the browser does, breaking phrasing at the block element boundaries and starting it up again after the block element.

Unfortunately this adds complexity to the parser, but it makes the parser robust against pretty much any HTML we're likely to encounter and partitions it consistent with how it would be rendered in the browser.
