### PR TITLE
ci: disable sharepoint ingest test

### DIFF
--- a/test_unstructured_ingest/test-ingest-src.sh
+++ b/test_unstructured_ingest/test-ingest-src.sh
@@ -54,7 +54,7 @@ all_tests=(
   'notion.sh'
   'delta-table.sh'
   'jira.sh'
-  'sharepoint.sh'
+  # 'sharepoint.sh'
   'sharepoint-with-permissions.sh'
   'hubspot.sh'
   'local-embed.sh'
@@ -68,7 +68,6 @@ all_tests=(
 )
 
 full_python_matrix_tests=(
-  # NOTE(christine): re-enable the test when the github secrets are updated
   #  'sharepoint.sh'
   'local.sh'
   'local-single-file.sh'

--- a/test_unstructured_ingest/test-ingest-src.sh
+++ b/test_unstructured_ingest/test-ingest-src.sh
@@ -68,7 +68,8 @@ all_tests=(
 )
 
 full_python_matrix_tests=(
-  'sharepoint.sh'
+# NOTE(christine): re-enable the test when the github secrets are updated
+#  'sharepoint.sh'
   'local.sh'
   'local-single-file.sh'
   'local-single-file-with-encoding.sh'

--- a/test_unstructured_ingest/test-ingest-src.sh
+++ b/test_unstructured_ingest/test-ingest-src.sh
@@ -68,8 +68,8 @@ all_tests=(
 )
 
 full_python_matrix_tests=(
-# NOTE(christine): re-enable the test when the github secrets are updated
-#  'sharepoint.sh'
+  # NOTE(christine): re-enable the test when the github secrets are updated
+  #  'sharepoint.sh'
   'local.sh'
   'local-single-file.sh'
   'local-single-file-with-encoding.sh'

--- a/test_unstructured_ingest/test-ingest-src.sh
+++ b/test_unstructured_ingest/test-ingest-src.sh
@@ -55,7 +55,7 @@ all_tests=(
   'delta-table.sh'
   'jira.sh'
   # 'sharepoint.sh'
-  'sharepoint-with-permissions.sh'
+  # 'sharepoint-with-permissions.sh'
   'hubspot.sh'
   'local-embed.sh'
   'local-embed-bedrock.sh'


### PR DESCRIPTION
Disable sharepoint ingest test to unblock development. We need to re-enable this test when the sharepoint credentials are updated.