### PR TITLE
bugfix: google drive connector metadata safegaurds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.0-dev14
+## 0.15.0-dev15
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.0-dev14"  # pragma: no cover
+__version__ = "0.15.0-dev15"  # pragma: no cover

--- a/unstructured/ingest/v2/processes/connectors/google_drive.py
+++ b/unstructured/ingest/v2/processes/connectors/google_drive.py
@@ -129,15 +129,15 @@ class GoogleDriveIndexer(Indexer):
     def map_file_data(f: dict) -> FileData:
         file_id = f["id"]
         filename = f.pop("name")
-        url = f.pop("webContentLink")
+        url = f.pop("webContentLink", None)
         version = f.pop("version", None)
         permissions = f.pop("permissions", None)
-        date_created_str = f.pop("createdTime")
-        date_created_dt = parser.parse(date_created_str)
-        date_modified_str = f.pop("modifiedTime")
+        date_created_str = f.pop("createdTime", None)
+        date_created_dt = parser.parse(date_created_str) if date_created_str else None
+        date_modified_str = f.pop("modifiedTime", None)
         parent_path = f.pop("parent_path", None)
         parent_root_path = f.pop("parent_root_path", None)
-        date_modified_dt = parser.parse(date_modified_str)
+        date_modified_dt = parser.parse(date_modified_str) if date_modified_str else None
         if (
             parent_path
             and isinstance(parent_path, str)


### PR DESCRIPTION
### Description

At times, the google drive response doens't have some of the metadata we're grabbing to populate the `FileData` metadata. This is fine, but without the added safegaurds, this can cause a `KeyError`.