### PR TITLE
feat: filter ingest step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.0-dev16
+## 0.15.0-dev17
 
 ### Enhancements
 

--- a/test_unstructured_ingest/src/s3.sh
+++ b/test_unstructured_ingest/src/s3.sh
@@ -36,6 +36,7 @@ PYTHONPATH=${PYTHONPATH:-.} "$RUN_SCRIPT" \
   --verbose \
   --remote-url s3://utic-dev-tech-fixtures/small-pdf-set/ \
   --anonymous \
+  --max-file-size 6164770 \
   --work-dir "$WORK_DIR"
 
 set +e

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.0-dev16"  # pragma: no cover
+__version__ = "0.15.0-dev17"  # pragma: no cover

--- a/unstructured/ingest/v2/cli/base/src.py
+++ b/unstructured/ingest/v2/cli/base/src.py
@@ -8,6 +8,7 @@ from unstructured.ingest.v2.cli.base.cmd import BaseCmd
 from unstructured.ingest.v2.cli.configs import (
     ChunkerCliConfig,
     EmbedderCliConfig,
+    FilterCliConfig,
     PartitionerCliConfig,
     ProcessorCliConfig,
 )
@@ -26,6 +27,7 @@ class SrcCmd(BaseCmd):
             ProcessorCliConfig,
             PartitionerCliConfig,
             EmbedderCliConfig,
+            FilterCliConfig,
             ChunkerCliConfig,
         ]
     )

--- a/unstructured/ingest/v2/cli/cmds/fsspec/fsspec.py
+++ b/unstructured/ingest/v2/cli/cmds/fsspec/fsspec.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 import click
 
 from unstructured.ingest.v2.cli.interfaces import CliConfig
-from unstructured.ingest.v2.cli.utils import DelimitedString
 
 
 @dataclass
@@ -64,13 +63,6 @@ class FsspecCliIndexerConfig(FsspecCliFileConfig):
                     default=False,
                     help="Recursively download files in their respective folders "
                     "otherwise stop at the files in provided folder level.",
-                ),
-                click.Option(
-                    ["--file-glob"],
-                    default=None,
-                    type=DelimitedString(),
-                    help="A comma-separated list of file globs to limit which types of "
-                    "local files are accepted, e.g. '*.html,*.txt'",
                 ),
             ]
         )

--- a/unstructured/ingest/v2/cli/cmds/local.py
+++ b/unstructured/ingest/v2/cli/cmds/local.py
@@ -4,7 +4,6 @@ import click
 
 from unstructured.ingest.v2.cli.base import DestCmd, SrcCmd
 from unstructured.ingest.v2.cli.interfaces import CliConfig
-from unstructured.ingest.v2.cli.utils import DelimitedString
 from unstructured.ingest.v2.processes.connectors.local import CONNECTOR_TYPE
 
 
@@ -18,13 +17,6 @@ class LocalCliIndexerConfig(CliConfig):
                 required=True,
                 type=click.Path(file_okay=True, dir_okay=True, exists=True),
                 help="Path to the location in the local file system that will be processed.",
-            ),
-            click.Option(
-                ["--file-glob"],
-                default=None,
-                type=DelimitedString(),
-                help="A comma-separated list of file globs to limit which types of "
-                "local files are accepted, e.g. '*.html,*.txt'",
             ),
             click.Option(
                 ["--recursive"],

--- a/unstructured/ingest/v2/cli/configs/__init__.py
+++ b/unstructured/ingest/v2/cli/configs/__init__.py
@@ -1,6 +1,13 @@
 from .chunk import ChunkerCliConfig
 from .embed import EmbedderCliConfig
+from .filter import FilterCliConfig
 from .partition import PartitionerCliConfig
 from .processor import ProcessorCliConfig
 
-__all__ = ["ChunkerCliConfig", "ProcessorCliConfig", "PartitionerCliConfig", "EmbedderCliConfig"]
+__all__ = [
+    "ChunkerCliConfig",
+    "ProcessorCliConfig",
+    "PartitionerCliConfig",
+    "EmbedderCliConfig",
+    "FilterCliConfig",
+]

--- a/unstructured/ingest/v2/cli/configs/filter.py
+++ b/unstructured/ingest/v2/cli/configs/filter.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+
+import click
+
+from unstructured.ingest.v2.cli.interfaces import CliConfig
+from unstructured.ingest.v2.cli.utils import DelimitedString
+
+
+@dataclass
+class FilterCliConfig(CliConfig):
+    @staticmethod
+    def get_cli_options() -> list[click.Option]:
+        options = [
+            click.Option(
+                ["--file-glob"],
+                default=None,
+                type=DelimitedString(),
+                help="A comma-separated list of file globs to limit which types of "
+                "local files are accepted, e.g. '*.html,*.txt'",
+            ),
+            click.Option(
+                ["--max-file-size"],
+                default=None,
+                type=click.IntRange(min=1),
+                help="Max file size to process in bytes",
+            ),
+        ]
+        return options

--- a/unstructured/ingest/v2/examples/example_s3.py
+++ b/unstructured/ingest/v2/examples/example_s3.py
@@ -13,6 +13,7 @@ from unstructured.ingest.v2.processes.connectors.local import (
     LocalUploaderConfig,
 )
 from unstructured.ingest.v2.processes.embedder import EmbedderConfig
+from unstructured.ingest.v2.processes.filter import FiltererConfig
 from unstructured.ingest.v2.processes.partitioner import PartitionerConfig
 
 base_path = Path(__file__).parent.parent.parent.parent.parent
@@ -24,7 +25,9 @@ download_path = work_dir / "download"
 if __name__ == "__main__":
     logger.info(f"Writing all content in: {work_dir.resolve()}")
     Pipeline.from_configs(
-        context=ProcessorConfig(work_dir=str(work_dir.resolve())),
+        context=ProcessorConfig(
+            work_dir=str(work_dir.resolve()), disable_parallelism=True, verbose=True
+        ),
         indexer_config=S3IndexerConfig(remote_url="s3://utic-dev-tech-fixtures/small-pdf-set/"),
         downloader_config=S3DownloaderConfig(download_dir=download_path),
         source_connection_config=S3ConnectionConfig(anonymous=True),
@@ -32,4 +35,5 @@ if __name__ == "__main__":
         chunker_config=ChunkerConfig(chunking_strategy="by_title"),
         embedder_config=EmbedderConfig(embedding_provider="langchain-huggingface"),
         uploader_config=LocalUploaderConfig(output_dir=str(output_path.resolve())),
+        filterer_config=FiltererConfig(max_file_size=806400),
     ).run()

--- a/unstructured/ingest/v2/examples/example_s3.py
+++ b/unstructured/ingest/v2/examples/example_s3.py
@@ -35,5 +35,5 @@ if __name__ == "__main__":
         chunker_config=ChunkerConfig(chunking_strategy="by_title"),
         embedder_config=EmbedderConfig(embedding_provider="langchain-huggingface"),
         uploader_config=LocalUploaderConfig(output_dir=str(output_path.resolve())),
-        filterer_config=FiltererConfig(max_file_size=806400),
+        filterer_config=FiltererConfig(max_file_size=6164770),
     ).run()

--- a/unstructured/ingest/v2/interfaces/__init__.py
+++ b/unstructured/ingest/v2/interfaces/__init__.py
@@ -1,6 +1,6 @@
 from .connector import AccessConfig, BaseConnector, ConnectionConfig
 from .downloader import Downloader, DownloaderConfig, DownloadResponse, download_responses
-from .file_data import FileData, SourceIdentifiers
+from .file_data import FileData, FileDataSourceMetadata, SourceIdentifiers
 from .indexer import Indexer, IndexerConfig
 from .process import BaseProcess
 from .processor import ProcessorConfig
@@ -26,4 +26,5 @@ __all__ = [
     "AccessConfig",
     "ConnectionConfig",
     "BaseConnector",
+    "FileDataSourceMetadata",
 ]

--- a/unstructured/ingest/v2/interfaces/downloader.py
+++ b/unstructured/ingest/v2/interfaces/downloader.py
@@ -30,6 +30,11 @@ class Downloader(BaseProcess, BaseConnector, ABC):
     connector_type: str
     download_config: DownloaderConfigT
 
+    def get_download_path(self, file_data: FileData) -> Path:
+        rel_path = file_data.source_identifiers.relative_path
+        rel_path = rel_path[1:] if rel_path.startswith("/") else rel_path
+        return self.download_dir / Path(rel_path)
+
     @staticmethod
     def is_float(value: str):
         try:
@@ -67,9 +72,6 @@ class Downloader(BaseProcess, BaseConnector, ABC):
 
     def is_async(self) -> bool:
         return True
-
-    def get_download_path(self, file_data: FileData) -> Optional[Path]:
-        return None
 
     @abstractmethod
     def run(self, file_data: FileData, **kwargs: Any) -> download_responses:

--- a/unstructured/ingest/v2/interfaces/file_data.py
+++ b/unstructured/ingest/v2/interfaces/file_data.py
@@ -30,12 +30,17 @@ class SourceIdentifiers:
 
 
 @dataclass
+class FileDataSourceMetadata(DataSourceMetadata):
+    filesize_bytes: Optional[int] = None
+
+
+@dataclass
 class FileData(DataClassJsonMixin):
     identifier: str
     connector_type: str
     source_identifiers: Optional[SourceIdentifiers] = None
     doc_type: IndexDocType = field(default=IndexDocType.FILE)
-    metadata: DataSourceMetadata = field(default_factory=DataSourceMetadata)
+    metadata: FileDataSourceMetadata = field(default_factory=lambda: FileDataSourceMetadata())
     additional_metadata: dict[str, Any] = field(default_factory=dict)
     reprocess: bool = False
 

--- a/unstructured/ingest/v2/pipeline/interfaces.py
+++ b/unstructured/ingest/v2/pipeline/interfaces.py
@@ -126,6 +126,8 @@ class PipelineStep(ABC):
             logger.info(
                 f"Calling {self.__class__.__name__} " f"with {len(iterable)} docs",  # type: ignore
             )
+        else:
+            logger.info(f"Calling {self.__class__.__name__} with no inputs")
         if self.context.async_supported and self.process.is_async():
             return self.process_async(iterable=iterable)
         if self.context.mp_supported:

--- a/unstructured/ingest/v2/pipeline/pipeline.py
+++ b/unstructured/ingest/v2/pipeline/pipeline.py
@@ -194,7 +194,7 @@ class Pipeline:
             # Flatten list of lists
             downloaded_data = self.clean_results(results=downloaded_data)
 
-            # Post incompress filtering
+            # Post uncompress filtering
             downloaded_data = self.apply_filter(records=downloaded_data)
             if not downloaded_data:
                 return

--- a/unstructured/ingest/v2/pipeline/steps/download.py
+++ b/unstructured/ingest/v2/pipeline/steps/download.py
@@ -93,7 +93,7 @@ class DownloadStep(PipelineStep):
         if changed:
             logger.debug(f"Updating file data with new content: {file_data.to_dict()}")
             with file_data_path.open("w") as file:
-                json.dump(file_data, file, indent=2)
+                json.dump(file_data.to_dict(), file, indent=2)
 
     async def _run_async(self, fn: Callable, file_data_path: str) -> list[DownloadStepResponse]:
         file_data = FileData.from_file(path=file_data_path)

--- a/unstructured/ingest/v2/pipeline/steps/filter.py
+++ b/unstructured/ingest/v2/pipeline/steps/filter.py
@@ -1,0 +1,40 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from unstructured.ingest.v2.interfaces.file_data import FileData
+from unstructured.ingest.v2.logger import logger
+from unstructured.ingest.v2.pipeline.interfaces import PipelineStep
+from unstructured.ingest.v2.pipeline.utils import sterilize_dict
+from unstructured.ingest.v2.processes.filter import Filterer
+
+STEP_ID = "filter"
+
+
+@dataclass
+class FilterStep(PipelineStep):
+    process: Filterer
+    identifier: str = STEP_ID
+
+    def __post_init__(self):
+        config = (
+            sterilize_dict(self.process.config.to_dict(redact_sensitive=True))
+            if self.process.config
+            else None
+        )
+        logger.info(f"Created {self.identifier} with configs: {config}")
+
+    async def _run_async(self, fn: Callable, file_data_path: str, **kwargs) -> Optional[dict]:
+        file_data = FileData.from_file(path=file_data_path)
+        fn_kwargs = {"file_data": file_data}
+        if not asyncio.iscoroutinefunction(fn):
+            resp = fn(**fn_kwargs)
+        elif semaphore := self.context.semaphore:
+            async with semaphore:
+                resp = await fn(**fn_kwargs)
+        else:
+            resp = await fn(**fn_kwargs)
+
+        if resp:
+            return {"file_data_path": file_data_path}
+        return None

--- a/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
+++ b/unstructured/ingest/v2/processes/connectors/fsspec/fsspec.py
@@ -253,13 +253,6 @@ class FsspecDownloader(Downloader):
             **self.connection_config.get_access_config(),
         )
 
-    def get_download_path(self, file_data: FileData) -> Path:
-        return (
-            self.download_dir / Path(file_data.source_identifiers.relative_path)
-            if self.download_config
-            else Path(file_data.source_identifiers.rel_path)
-        )
-
     def run(self, file_data: FileData, **kwargs: Any) -> DownloadResponse:
         download_path = self.get_download_path(file_data=file_data)
         download_path.parent.mkdir(parents=True, exist_ok=True)

--- a/unstructured/ingest/v2/processes/connectors/google_drive.py
+++ b/unstructured/ingest/v2/processes/connectors/google_drive.py
@@ -1,7 +1,6 @@
 import io
 import os
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator, Optional, Union
 
 from dateutil import parser
@@ -271,11 +270,6 @@ class GoogleDriveDownloader(Downloader):
         default_factory=lambda: GoogleDriveDownloaderConfig()
     )
     connector_type: str = CONNECTOR_TYPE
-
-    def get_download_path(self, file_data: FileData) -> Path:
-        rel_path = file_data.source_identifiers.relative_path
-        rel_path = rel_path[1:] if rel_path.startswith("/") else rel_path
-        return self.download_dir / Path(rel_path)
 
     @SourceConnectionNetworkError.wrap
     def _get_content(self, downloader: "MediaIoBaseDownload") -> bool:

--- a/unstructured/ingest/v2/processes/connectors/salesforce.py
+++ b/unstructured/ingest/v2/processes/connectors/salesforce.py
@@ -207,11 +207,6 @@ class SalesforceDownloader(Downloader):
     )
     connector_type: str = CONNECTOR_TYPE
 
-    def get_download_path(self, file_data: FileData) -> Path:
-        rel_path = file_data.source_identifiers.relative_path
-        rel_path = rel_path[1:] if rel_path.startswith("/") else rel_path
-        return self.download_dir / Path(rel_path)
-
     def _xml_for_record(self, record: OrderedDict) -> str:
         """Creates partitionable xml file from a record"""
         import xml.etree.ElementTree as ET

--- a/unstructured/ingest/v2/processes/connectors/sharepoint.py
+++ b/unstructured/ingest/v2/processes/connectors/sharepoint.py
@@ -339,10 +339,9 @@ class SharepointDownloader(Downloader):
     connector_type: str = CONNECTOR_TYPE
 
     def get_download_path(self, file_data: FileData) -> Path:
+        download_path = super().get_download_path(file_data=file_data)
+
         content_type = file_data.additional_metadata.get("sharepoint_content_type")
-        rel_path = file_data.source_identifiers.fullpath
-        rel_path = rel_path[1:] if rel_path.startswith("/") else rel_path
-        download_path = self.download_dir / Path(rel_path)
         if content_type == SharepointContentType.SITEPAGE.value:
             # Update output extension to html if site page
             download_path = download_path.with_suffix(".html")

--- a/unstructured/ingest/v2/processes/filter.py
+++ b/unstructured/ingest/v2/processes/filter.py
@@ -1,0 +1,54 @@
+import fnmatch
+from abc import ABC
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from unstructured.ingest.enhanced_dataclass import EnhancedDataClassJsonMixin
+from unstructured.ingest.v2.interfaces import FileData
+from unstructured.ingest.v2.interfaces.process import BaseProcess
+from unstructured.ingest.v2.logger import logger
+
+
+@dataclass
+class FiltererConfig(EnhancedDataClassJsonMixin):
+    file_glob: Optional[list[str]] = None
+    max_file_size: Optional[int] = None
+
+
+@dataclass
+class Filterer(BaseProcess, ABC):
+    config: FiltererConfig = field(default_factory=lambda: FiltererConfig())
+    filters: list[Callable[[FileData], bool]] = field(init=False, default_factory=list)
+
+    def __post_init__(self):
+        # Populate the filters based on values in config
+        if self.config.file_glob is not None:
+            self.filters.append(self.glob_filter)
+        if self.config.max_file_size:
+            self.filters.append(self.file_size_filter)
+
+    def is_async(self) -> bool:
+        return False
+
+    def file_size_filter(self, file_data: FileData) -> bool:
+        if filesize_bytes := file_data.metadata.filesize_bytes:
+            return filesize_bytes <= self.config.max_file_size
+        return True
+
+    def glob_filter(self, file_data: FileData) -> bool:
+        patterns = self.config.file_glob
+        path = file_data.source_identifiers.fullpath
+        for pattern in patterns:
+            if fnmatch.filter([path], pattern):
+                return True
+        logger.debug(f"The file {path!r} is discarded as it does not match any given glob.")
+        return False
+
+    def run(self, file_data: FileData, **kwargs: Any) -> Optional[FileData]:
+        for filter in self.filters:
+            if not filter(file_data):
+                logger.debug(
+                    f"filtered out file data due to {filter.__name__}: {file_data.identifier}"
+                )
+                return None
+        return file_data


### PR DESCRIPTION
### Description
Support filtering params, such as the current file glob, that can be run independently of the connector. As part of this expansion, a new filter was added to support filtering on file size, which also added this as a metadata field being persisted. 