### PR TITLE
bugfix [OSS-67]: update import of pinecone exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixes
 
-* **Update import of Pinecone exception**
+* **Update import of Pinecone exception** Adds compatibility for pinecone-client>=5.0.0
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 0.15.1-dev0
+## 0.15.1-dev1
 
 ### Enhancements
 
 ### Features
 
 ### Fixes
+
+* **Update import of Pinecone exception**
 
 ## 0.15.0
 

--- a/requirements/deps/constraints.txt
+++ b/requirements/deps/constraints.txt
@@ -65,7 +65,3 @@ importlib-metadata==7.1.0
 # NOTE(robinson) - due to failure in this job
 # https://github.com/Unstructured-IO/unstructured/actions/runs/10044201938/job/27762303563?pr=3427
 cryptography<43.0.0
-
-# NOTE - robinson) - due to failure in this job
-# https://github.com/Unstructured-IO/unstructured/actions/runs/10045984678/job/27768160933?pr=3427
-pinecone-client<5.0.0

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -66,7 +66,7 @@ grpcio==1.65.1
     #   grpcio-status
 grpcio-status==1.62.2
     # via google-api-core
-huggingface-hub==0.24.0
+huggingface-hub==0.24.1
     # via
     #   timm
     #   tokenizers
@@ -153,7 +153,7 @@ pdfminer-six==20231228
     #   pdfplumber
 pdfplumber==0.11.2
     # via layoutparser
-pikepdf==9.0.0
+pikepdf==9.1.0
     # via -r ./extra-pdf-image.in
 pillow==10.4.0
     # via
@@ -279,7 +279,7 @@ tqdm==4.66.4
     #   huggingface-hub
     #   iopath
     #   transformers
-transformers==4.42.4
+transformers==4.43.1
     # via unstructured-inference
 typing-extensions==4.12.2
     # via

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -27,7 +27,7 @@ fsspec==2024.5.0
     #   -c ././deps/constraints.txt
     #   huggingface-hub
     #   torch
-huggingface-hub==0.24.0
+huggingface-hub==0.24.1
     # via
     #   tokenizers
     #   transformers
@@ -99,7 +99,7 @@ tqdm==4.66.4
     #   huggingface-hub
     #   sacremoses
     #   transformers
-transformers==4.42.4
+transformers==4.43.1
     # via -r ./huggingface.in
 typing-extensions==4.12.2
     # via

--- a/requirements/ingest/chroma.txt
+++ b/requirements/ingest/chroma.txt
@@ -37,9 +37,9 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-chroma-hnswlib==0.7.5
+chroma-hnswlib==0.7.6
     # via chromadb
-chromadb==0.5.4
+chromadb==0.5.5
     # via -r ./ingest/chroma.in
 click==8.1.7
     # via
@@ -89,7 +89,7 @@ httpx==0.27.0
     # via
     #   -c ./ingest/../base.txt
     #   chromadb
-huggingface-hub==0.24.0
+huggingface-hub==0.24.1
     # via tokenizers
 humanfriendly==10.0
     # via coloredlogs

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -55,13 +55,13 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.10
+langchain==0.2.11
     # via langchain-community
-langchain-community==0.2.9
+langchain-community==0.2.10
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/embed-aws-bedrock.in
-langchain-core==0.2.22
+langchain-core==0.2.23
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -47,7 +47,7 @@ fsspec==2024.5.0
     #   torch
 huggingface==0.0.1
     # via -r ./ingest/embed-huggingface.in
-huggingface-hub==0.24.0
+huggingface-hub==0.24.1
     # via
     #   sentence-transformers
     #   tokenizers
@@ -67,13 +67,13 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.10
+langchain==0.2.11
     # via langchain-community
-langchain-community==0.2.9
+langchain-community==0.2.10
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/embed-huggingface.in
-langchain-core==0.2.22
+langchain-core==0.2.23
     # via
     #   langchain
     #   langchain-community
@@ -186,7 +186,7 @@ tqdm==4.66.4
     #   huggingface-hub
     #   sentence-transformers
     #   transformers
-transformers==4.42.4
+transformers==4.43.1
     # via sentence-transformers
 typing-extensions==4.12.2
     # via

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -72,13 +72,13 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.10
+langchain==0.2.11
     # via langchain-community
-langchain-community==0.2.9
+langchain-community==0.2.10
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/embed-openai.in
-langchain-core==0.2.22
+langchain-core==0.2.23
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-vertexai.txt
+++ b/requirements/ingest/embed-vertexai.txt
@@ -64,7 +64,7 @@ google-cloud-core==2.4.1
     #   google-cloud-storage
 google-cloud-resource-manager==1.12.4
     # via google-cloud-aiplatform
-google-cloud-storage==2.17.0
+google-cloud-storage==2.18.0
     # via
     #   google-cloud-aiplatform
     #   langchain-google-vertexai
@@ -100,15 +100,15 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.10
+langchain==0.2.11
     # via
     #   -r ./ingest/embed-vertexai.in
     #   langchain-community
-langchain-community==0.2.9
+langchain-community==0.2.10
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/embed-vertexai.in
-langchain-core==0.2.22
+langchain-core==0.2.23
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-voyageai.txt
+++ b/requirements/ingest/embed-voyageai.txt
@@ -42,9 +42,9 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.10
+langchain==0.2.11
     # via -r ./ingest/embed-voyageai.in
-langchain-core==0.2.22
+langchain-core==0.2.23
     # via
     #   langchain
     #   langchain-text-splitters

--- a/requirements/ingest/gcs.txt
+++ b/requirements/ingest/gcs.txt
@@ -57,7 +57,7 @@ google-auth-oauthlib==1.2.1
     # via gcsfs
 google-cloud-core==2.4.1
     # via google-cloud-storage
-google-cloud-storage==2.17.0
+google-cloud-storage==2.18.0
     # via gcsfs
 google-crc32c==1.5.0
     # via

--- a/requirements/ingest/pinecone.txt
+++ b/requirements/ingest/pinecone.txt
@@ -9,12 +9,16 @@ certifi==2024.7.4
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   pinecone-client
-pinecone-client==4.1.2
+pinecone-client==5.0.0
     # via
-    #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/pinecone.in
-pinecone-plugin-interface==0.0.7
+    #   pinecone-plugin-inference
+pinecone-plugin-inference==1.0.2
     # via pinecone-client
+pinecone-plugin-interface==0.0.7
+    # via
+    #   pinecone-client
+    #   pinecone-plugin-inference
 tqdm==4.66.4
     # via
     #   -c ./ingest/../base.txt

--- a/test_unstructured_ingest/dest/chroma.sh
+++ b/test_unstructured_ingest/dest/chroma.sh
@@ -36,6 +36,7 @@ trap cleanup EXIT
 # Run chroma from different script so it can be forced into background
 scripts/chroma-test-helpers/create-and-check-chroma.sh "$DESTINATION_PATH"
 wait
+sleep 10
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
   local \

--- a/test_unstructured_ingest/dest/chroma.sh
+++ b/test_unstructured_ingest/dest/chroma.sh
@@ -36,7 +36,7 @@ trap cleanup EXIT
 # Run chroma from different script so it can be forced into background
 scripts/chroma-test-helpers/create-and-check-chroma.sh "$DESTINATION_PATH"
 wait
-sleep 10
+sleep 5
 
 PYTHONPATH=. ./unstructured/ingest/main.py \
   local \

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.1-dev0"  # pragma: no cover
+__version__ = "0.15.1-dev1"  # pragma: no cover

--- a/unstructured/ingest/connector/pinecone.py
+++ b/unstructured/ingest/connector/pinecone.py
@@ -97,7 +97,7 @@ class PineconeDestinationConnector(IngestDocSessionHandleMixin, BaseDestinationC
         index = self.pinecone_index
         try:
             response = index.upsert(batch)
-        except pinecone.exceptions.ApiException as api_error:
+        except pinecone.exceptions.PineconeApiException as api_error:
             raise WriteError(f"http error: {api_error}") from api_error
         logger.debug(f"results: {response}")
 

--- a/unstructured/ingest/connector/pinecone.py
+++ b/unstructured/ingest/connector/pinecone.py
@@ -92,12 +92,12 @@ class PineconeDestinationConnector(IngestDocSessionHandleMixin, BaseDestinationC
     @DestinationConnectionError.wrap
     @requires_dependencies(["pinecone"], extras="pinecone")
     def upsert_batch(self, batch):
-        import pinecone.core.client.exceptions
+        import pinecone.exceptions
 
         index = self.pinecone_index
         try:
             response = index.upsert(batch)
-        except pinecone.core.client.exceptions.ApiException as api_error:
+        except pinecone.exceptions.ApiException as api_error:
             raise WriteError(f"http error: {api_error}") from api_error
         logger.debug(f"results: {response}")
 

--- a/unstructured/ingest/v2/processes/connectors/pinecone.py
+++ b/unstructured/ingest/v2/processes/connectors/pinecone.py
@@ -129,7 +129,7 @@ class PineconeUploader(Uploader):
 
     @requires_dependencies(["pinecone"], extras="pinecone")
     def upsert_batch(self, batch):
-        from pinecone.core.client.exceptions import PineconeApiException
+        from pinecone.exceptions import PineconeApiException
 
         try:
             index = self.connection_config.get_index()


### PR DESCRIPTION
the pinecone python package moved their importing of PineconeApiException

Chroma `sleep` added because even thought there is a `wait`, there is still some sort of timing issue.