### PR TITLE
bugfix: Recursively extracts text from a pdfminer layout object 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Features
 
 * **Mark ingest as deprecated** Begin sunset of ingest code in this repo as it's been moved to a dedicated repo.
-
 * **Add `pdf_hi_res_max_pages` argument for partitioning, which allows rejecting PDF files that exceed this page number limit, when the `high_res` strategy is chosen.** By default, it will allow parsing PDF files with an unlimited number of pages.
 
 ### Fixes
@@ -19,6 +18,7 @@
 * **Textual content retrieved from a URL with gzip transport compression now partitions correctly.** Resolves a bug where a textual file-type (such as Markdown) retrieved by passing a URL to `partition()` would raise when `gzip` compression was used for transport by the server.
 * **A DOCX, PPTX, or XLSX content-type asserted on partition is confirmed or fixed.** Resolves a bug where calling `partition()` with a swapped MS-Office `content_type` would cause the file-type to be misidentified. A DOCX, PPTX, or XLSX MIME-type received by `partition()` is now checked for accuracy and corrected if the file is for a different MS-Office 2007+ type.
 * **DOC, PPT, XLS, and MSG files are now auto-detected correctly.** Resolves a bug where DOC, PPT, and XLS files were auto-detected as MSG files under certain circumstances.
+* **Recursively extracts text from a pdfminer layout object.** Addresses an issue where PDFMiner's layout analysis algorithm incorrectly aggregates multiple text sections, encapsulating them within objects such as `LTFigure` or `LTRect` instead of `LTTextBox`.
 
 ## 0.15.0
 
@@ -97,7 +97,6 @@
 ### Features
 
 * **Expose conversion functions for tables** Adds public functions to convert tables from HTML to the Deckerd format and back
-
 * **Adds Kafka Source and Destination** New source and destination connector added to all CLI ingest commands to support reading from and writing to Kafka streams. Also supports Confluent Kafka.
 
 ### Fixes
@@ -144,7 +143,7 @@
 
 * **Move logger error to debug level when PDFminer fails to extract text** which includes error message for Invalid dictionary construct.
 * **Add support for Pinecone serverless** Adds Pinecone serverless to the connector tests. Pinecone
-    serverless will work version versions >=0.14.2, but hadn't been tested until now.
+  serverless will work version versions >=0.14.2, but hadn't been tested until now.
 
 ### Features
 
@@ -227,6 +226,7 @@
 * **Add GLOBAL_WORKING_DIR and GLOBAL_WORKING_PROCESS_DIR** configuration parameteres to control temporary storage.
 
 ### Features
+
 * **Add form extraction basics (document elements and placeholder code in partition)**. This is to lay the ground work for the future. Form extraction models are not currently available in the library. An attempt to use this functionality will end in a `NotImplementedError`.
 
 ### Fixes
@@ -404,8 +404,8 @@
 ### Enhancements
 
 ### Features
-* Add `date_from_file_object` parameter to partition. If True and if file is provided via `file` parameter it will cause partition to infer last modified date from `file`'s content. If False, last modified metadata will be `None`.
 
+* Add `date_from_file_object` parameter to partition. If True and if file is provided via `file` parameter it will cause partition to infer last modified date from `file`'s content. If False, last modified metadata will be `None`.
 * **Header and footer detection for fast strategy** `partition_pdf` with `fast` strategy now
   detects elements that are in the top or bottom 5 percent of the page as headers and footers.
 * **Add parent_element to overlapping case output** Adds parent_element to the output for `identify_overlapping_or_nesting_case` and `catch_overlapping_and_nested_bboxes` functions.
@@ -423,7 +423,6 @@
 * **Improved documentation**. Fixed broken links and improved readability on `Key Concepts` page.
 * **Rename `OpenAiEmbeddingConfig` to `OpenAIEmbeddingConfig`.**
 * **Fix partition_json() doesn't chunk.** The `@add_chunking_strategy` decorator was missing from `partition_json()` such that pre-partitioned documents serialized to JSON did not chunk when a chunking-strategy was specified.
-
 
 ## 0.12.4
 
@@ -452,7 +451,6 @@
 * **Fix remove Vectara requirements from setup.py - there are no dependencies **
 * **Add title to Vectara upload - was not separated out from initial connector **
 * **Fix change OpenSearch port to fix potential conflict with Elasticsearch in ingest test **
-
 
 ## 0.12.3
 
@@ -506,6 +504,7 @@
 * **Install Kapa AI chatbot.** Added Kapa.ai website widget on the documentation.
 
 ### Features
+
 * **MongoDB Source Connector.** New source connector added to all CLI ingest commands to support downloading/partitioning files from MongoDB.
 * **Add OpenSearch source and destination connectors.** OpenSearch, a fork of Elasticsearch, is a popular storage solution for various functionality such as search, or providing intermediary caches within data pipelines. Feature: Added OpenSearch source connector to support downloading/partitioning files. Added OpenSearch destination connector to be able to ingest documents from any supported source, embed them and write the embeddings / documents into OpenSearch.
 
@@ -684,8 +683,8 @@
 * **Import tables_agent from inference** so that we don't have to initialize a global table agent in unstructured OCR again
 * **Fix empty table is identified as bulleted-table.** A table with no text content was mistakenly identified as a bulleted-table and processed by the wrong branch of the initial HTML partitioner.
 * **Fix partition_html() emits empty (no text) tables.** A table with cells nested below a `<thead>` or `<tfoot>` element was emitted as a table element having no text and unparseable HTML in `element.metadata.text_as_html`. Do not emit empty tables to the element stream.
-* **Fix HTML `element.metadata.text_as_html` contains spurious <br> elements in invalid locations.** The HTML generated for the `text_as_html` metadata for HTML tables contained `<br>` elements invalid locations like between `<table>` and `<tr>`. Change the HTML generator such that these do not appear.
-* **Fix HTML table cells enclosed in <thead> and <tfoot> elements are dropped.** HTML table cells nested in a `<thead>` or `<tfoot>` element were not detected and the text in those cells was omitted from the table element text and `.text_as_html`. Detect table rows regardless of the semantic tag they may be nested in.
+* **Fix HTML `element.metadata.text_as_html` contains spurious `<br>` elements in invalid locations.** The HTML generated for the `text_as_html` metadata for HTML tables contained `<br>` elements invalid locations like between `<table>` and `<tr>`. Change the HTML generator such that these do not appear.
+* **Fix HTML table cells enclosed in `<thead>` and `<tfoot>` elements are dropped.** HTML table cells nested in a `<thead>` or `<tfoot>` element were not detected and the text in those cells was omitted from the table element text and `.text_as_html`. Detect table rows regardless of the semantic tag they may be nested in.
 * **Remove whitespace padding from `.text_as_html`.** `tabulate` inserts padding spaces to achieve visual alignment of columns in HTML tables it generates. Add our own HTML generator to do this simple job and omit that padding as well as newlines ("\n") used for human readability.
 * **Fix local connector with absolute input path** When passed an absolute filepath for the input document path, the local connector incorrectly writes the output file to the input file directory. This fixes such that the output in this case is written to `output-dir/input-filename.json`
 
@@ -753,8 +752,8 @@
 * **Update `ocr_only` strategy in `partition_pdf()`** Adds the functionality to get accurate coordinate data when partitioning PDFs and Images with the `ocr_only` strategy.
 
 ### Fixes
-* **Fixed SharePoint permissions for the fetching to be opt-in** Problem: Sharepoint permissions were trying to be fetched even when no reletad cli params were provided, and this gave an error due to values for those keys not existing. Fix: Updated getting keys to be with .get() method and changed the "skip-check" to check individual cli params rather than checking the existance of a config object.
 
+* **Fixed SharePoint permissions for the fetching to be opt-in** Problem: Sharepoint permissions were trying to be fetched even when no reletad cli params were provided, and this gave an error due to values for those keys not existing. Fix: Updated getting keys to be with .get() method and changed the "skip-check" to check individual cli params rather than checking the existance of a config object.
 * **Fixes issue where tables from markdown documents were being treated as text** Problem: Tables from markdown documents were being treated as text, and not being extracted as tables. Solution: Enable the `tables` extension when instantiating the `python-markdown` object. Importance: This will allow users to extract structured data from tables in markdown documents.
 * **Fix wrong logger for paddle info** Replace the logger from unstructured-inference with the logger from unstructured for paddle_ocr.py module.
 * **Fix ingest pipeline to be able to use chunking and embedding together** Problem: When ingest pipeline was using chunking and embedding together, embedding outputs were empty and the outputs of chunking couldn't be re-read into memory and be forwarded to embeddings. Fix: Added CompositeElement type to TYPE_TO_TEXT_ELEMENT_MAP to be able to process CompositeElements with unstructured.staging.base.isd_to_elements
@@ -807,7 +806,7 @@
 ### Features
 
 * **Table OCR refactor** support Table OCR with pre-computed OCR data to ensure we only do one OCR for entrie document. User can specify
-ocr agent tesseract/paddle in environment variable `OCR_AGENT` for OCRing the entire document.
+  ocr agent tesseract/paddle in environment variable `OCR_AGENT` for OCRing the entire document.
 * **Adds accuracy function** The accuracy scoring was originally an option under `calculate_edit_distance`. For easy function call, it is now a wrapper around the original function that calls edit_distance and return as "score".
 * **Adds HuggingFaceEmbeddingEncoder** The HuggingFace Embedding Encoder uses a local embedding model as opposed to using an API.
 * **Add AWS bedrock embedding connector** `unstructured.embed.bedrock` now provides a connector to use AWS bedrock's `titan-embed-text` model to generate embeddings for elements. This features requires valid AWS bedrock setup and an internet connectionto run.
@@ -838,7 +837,7 @@ ocr agent tesseract/paddle in environment variable `OCR_AGENT` for OCRing the en
 ### Fixes
 
 * **Fix paddle model file not discoverable** Fixes issue where ocr_models/paddle_ocr.py file is not discoverable on PyPI by adding
-an `__init__.py` file under the folder.
+  an `__init__.py` file under the folder.
 * **Chipper v2 Fixes** Includes fix for a memory leak and rare last-element bbox fix. (unstructured-inference==0.7.7)
 * **Fix image resizing issue** Includes fix related to resizing images in the tables pipeline. (unstructured-inference==0.7.6)
 
@@ -900,12 +899,13 @@ an `__init__.py` file under the folder.
 * **Applies `max_characters=<n>` argument to all element types in `add_chunking_strategy` decorator** Previously this argument was only utilized in chunking Table elements and now applies to all partitioned elements if `add_chunking_strategy` decorator is utilized, further preparing the elements for downstream processing.
 * **Add common retry strategy utilities for unstructured-ingest** Dynamic retry strategy with exponential backoff added to Notion source connector.
 *
+
 ### Features
 
 * **Adds `bag_of_words` and `percent_missing_text` functions** In order to count the word frequencies in two input texts and calculate the percentage of text missing relative to the source document.
 * **Adds `edit_distance` calculation metrics** In order to benchmark the cleaned, extracted text with unstructured, `edit_distance` (`Levenshtein distance`) is included.
 * **Adds detection_origin field to metadata** Problem: Currently isn't an easy way to find out how an element was created. With this change that information is added. Importance: With this information the developers and users are now able to know how an element was created to make decisions on how to use it. In order tu use this feature
-setting UNSTRUCTURED_INCLUDE_DEBUG_METADATA=true is needed.
+  setting UNSTRUCTURED_INCLUDE_DEBUG_METADATA=true is needed.
 * **Adds a function that calculates frequency of the element type and its depth** To capture the accuracy of element type extraction, this function counts the occurrences of each unique element type with its depth for use in element metrics.
 
 ### Fixes
@@ -915,10 +915,9 @@ setting UNSTRUCTURED_INCLUDE_DEBUG_METADATA=true is needed.
 * **Fixes category_depth None value for Title elements** Problem: `Title` elements from `chipper` get `category_depth`= None even when `Headline` and/or `Subheadline` elements are present in the same page. Fix: all `Title` elements with `category_depth` = None should be set to have a depth of 0 instead iff there are `Headline` and/or `Subheadline` element-types present. Importance: `Title` elements should be equivalent html `H1` when nested headings are present; otherwise, `category_depth` metadata can result ambiguous within elements in a page.
 * **Tweak `xy-cut` ordering output to be more column friendly** This results in the order of elements more closely reflecting natural reading order which benefits downstream applications. While element ordering from `xy-cut` is usually mostly correct when ordering multi-column documents, sometimes elements from a RHS column will appear before elements in a LHS column. Fix: add swapped `xy-cut` ordering by sorting by X coordinate first and then Y coordinate.
 * **Fixes badly initialized Formula** Problem: YoloX contain new types of elements, when loading a document that contain formulas a new element of that class
-should be generated, however the Formula class inherits from Element instead of Text. After this change the element is correctly created with the correct class
-allowing the document to be loaded. Fix: Change parent class for Formula to Text. Importance: Crucial to be able to load documents that contain formulas.
+  should be generated, however the Formula class inherits from Element instead of Text. After this change the element is correctly created with the correct class
+  allowing the document to be loaded. Fix: Change parent class for Formula to Text. Importance: Crucial to be able to load documents that contain formulas.
 * **Fixes pdf uri error** An error was encountered when URI type of `GoToR` which refers to pdf resources outside of its own was detected since no condition catches such case. The code is fixing the issue by initialize URI before any condition check.
-
 
 ## 0.10.19
 
@@ -928,7 +927,7 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 * **bump `unstructured-inference` to `0.6.6`** The updated version of `unstructured-inference` makes table extraction in `hi_res` mode configurable to fine tune table extraction performance; it also improves element detection by adding a deduplication post processing step in the `hi_res` partitioning of pdfs and images.
 * **Detect text in HTML Heading Tags as Titles** This will increase the accuracy of hierarchies in HTML documents and provide more accurate element categorization. If text is in an HTML heading tag and is not a list item, address, or narrative text, categorize it as a title.
 * **Update python-based docs** Refactor docs to use the actual unstructured code rather than using the subprocess library to run the cli command itself.
-* **Adds Table support for the `add_chunking_strategy` decorator to partition functions.** In addition to combining elements under Title elements, user's can now specify the `max_characters=<n>` argument to chunk Table elements into TableChunk elements with `text` and `text_as_html` of length <n> characters. This means partitioned Table results are ready for use in downstream applications without any post processing.
+* **Adds Table support for the `add_chunking_strategy` decorator to partition functions.** In addition to combining elements under Title elements, user's can now specify the `max_characters=<n>` argument to chunk Table elements into TableChunk elements with `text` and `text_as_html` of length `<n>` characters. This means partitioned Table results are ready for use in downstream applications without any post processing.
 * **Expose endpoint url for s3 connectors** By allowing for the endpoint url to be explicitly overwritten, this allows for any non-AWS data providers supporting the s3 protocol to be supported (i.e. minio).
 
 ### Features
@@ -995,7 +994,6 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 * ***Fixes an issue that caused a partition error for some PDF's.** Fixes GH Issue 1460 by bypassing a coordinate check if an element has invalid coordinates.
 
 ## 0.10.15
-
 
 ### Enhancements
 
@@ -1070,7 +1068,6 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 * Add Jira Connector to be able to pull issues from a Jira organization
 * Add `clean_ligatures` function to expand ligatures in text
 
-
 ### Fixes
 
 * `partition_html` breaks on `<br>` elements.
@@ -1088,13 +1085,11 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
   * Support for yolox_quantized layout detection model (0.5.20)
 * YoloX element types added
 
-
 ### Features
 
 * Add Salesforce Connector to be able to pull Account, Case, Campaign, EmailMessage, Lead
 
 ### Fixes
-
 
 * Bump unstructured-inference
   * Avoid divide-by-zero errors swith `safe_division` (0.5.21)
@@ -1216,15 +1211,18 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 * Adds ability to reuse connections per process in unstructured-ingest
 
 ### Features
+
 * Add delta table connector
 
 ### Fixes
 
 ## 0.10.4
+
 * Pass ocr_mode in partition_pdf and set the default back to individual pages for now
 * Add diagrams and descriptions for ingest design in the ingest README
 
 ### Features
+
 * Supports multipage TIFF image partitioning
 
 ### Fixes
@@ -1232,6 +1230,7 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 ## 0.10.2
 
 ### Enhancements
+
 * Bump unstructured-inference==0.5.13:
   - Fix extracted image elements being included in layout merge, addresses the issue
     where an entire-page image in a PDF was not passed to the layout model when using hi_res.
@@ -1243,6 +1242,7 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 ## 0.10.1
 
 ### Enhancements
+
 * Bump unstructured-inference==0.5.12:
   - fix to avoid trace for certain PDF's (0.5.12)
   - better defaults for DPI for hi_res and  Chipper (0.5.11)
@@ -1293,7 +1293,6 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 * Fix email attachment filenames which had `=` in the filename itself
 
 ## 0.9.2
-
 
 ### Enhancements
 
@@ -1473,7 +1472,6 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 * Adjust encoding recognition threshold value in `detect_file_encoding`
 * Fix KeyError when `isd_to_elements` doesn't find a type
 * Fix `_output_filename` for local connector, allowing single files to be written correctly to the disk
-
 * Fix for cases where an invalid encoding is extracted from an email header.
 
 ### BREAKING CHANGES
@@ -1485,6 +1483,7 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 ### Enhancements
 
 * Adds `include_metadata` kwarg to `partition_doc`, `partition_docx`, `partition_email`, `partition_epub`, `partition_json`, `partition_msg`, `partition_odt`, `partition_org`, `partition_pdf`, `partition_ppt`, `partition_pptx`, `partition_rst`, and `partition_rtf`
+
 ### Features
 
 * Add Elasticsearch connector for ingest cli to pull specific fields from all documents in an index.
@@ -1719,9 +1718,7 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 
 ### Features
 
-
 ### Fixes
-
 
 ## 0.6.10
 
@@ -1819,7 +1816,6 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 
 ### Fixes
 
-
 ## 0.6.4
 
 ### Enhancements
@@ -1855,7 +1851,6 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 
 * Added logic to `partition_pdf` for detecting copy protected PDFs and falling back
   to the hi res strategy when necessary.
-
 
 ### Features
 
@@ -1927,8 +1922,8 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 * Added method to utils to allow date time format validation
 
 ### Features
-* Add Slack connector to pull messages for a specific channel
 
+* Add Slack connector to pull messages for a specific channel
 * Add --partition-by-api parameter to unstructured-ingest
 * Added `partition_rtf` for processing rich text files.
 * `partition` now accepts a `url` kwarg in addition to `file` and `filename`.
@@ -2058,7 +2053,7 @@ allowing the document to be loaded. Fix: Change parent class for Formula to Text
 ### Features
 
 * Add `AzureBlobStorageConnector` based on its `fsspec` implementation inheriting
-from `FsspecConnector`
+  from `FsspecConnector`
 * Add `partition_epub` for partitioning e-books in EPUB3 format.
 
 ### Fixes
@@ -2091,16 +2086,16 @@ from `FsspecConnector`
 
 * Fully move from printing to logging.
 * `unstructured-ingest` now uses a default `--download_dir` of `$HOME/.cache/unstructured/ingest`
-rather than a "tmp-ingest-" dir in the working directory.
+  rather than a "tmp-ingest-" dir in the working directory.
 
 ### Features
 
 ### Fixes
 
 * `setup_ubuntu.sh` no longer fails in some contexts by interpreting
-`DEBIAN_FRONTEND=noninteractive` as a command
+  `DEBIAN_FRONTEND=noninteractive` as a command
 * `unstructured-ingest` no longer re-downloads files when --preserve-downloads
-is used without --download-dir.
+  is used without --download-dir.
 * Fixed an issue that was causing text to be skipped in some HTML documents.
 
 ## 0.5.1
@@ -2277,7 +2272,7 @@ is used without --download-dir.
 * Add ability to extract document metadata from `.docx`, `.xlsx`, and `.jpg` files.
 * Helper functions for identifying and extracting phone numbers
 * Add new function `extract_attachment_info` that extracts and decodes the attachment
-of an email.
+  of an email.
 * Staging brick to convert a list of `Element`s to a `pandas` dataframe.
 * Add plain text functionality to `partition_email`
 

--- a/unstructured/partition/pdf_image/pdfminer_processing.py
+++ b/unstructured/partition/pdf_image/pdfminer_processing.py
@@ -34,6 +34,7 @@ def process_file_with_pdfminer(
 
 
 def extract_text_recursively(item: LTItem) -> str:
+    """Recursively extracts text from a pdfminer layout object"""
     if hasattr(item, "get_text"):
         return item.get_text()
 


### PR DESCRIPTION
The high-resolution mode of the partitioned PDF merges layouts extracted by `pdfminer` with those identified by a deep layout recognition model. During testing, I encountered issues with certain PDF files, such as the one attached below.
[test_pdfminer_text_extraction.pdf](https://github.com/user-attachments/files/16424396/test_pdfminer_text_extraction.pdf)

Upon debugging, I discovered that the problem stemmed from the layout extraction phase performed by `pdfminer`. For the first page of the PDF, `pdfminer` extracted two layout objects: one containing a few words, and another categorized as an `ImageTextRegion` with a `None` text attribute. Note that the bounding box of this `ImageTextRegion` nearly matches the entire page's bounding box.

The `merge_inferred_with_extracted_layout` function compares each extracted layout with the inferred layout. Despite the deep layout recognition model accurately predicting the correct layout, the merging rules prioritize the layout objects provided by `pdfminer`. As a result, since all inferred layouts fall within the bounding box of the large ImageTextRegion, the merge rules retain the ImageTextRegion and discard the inferred layouts. This approach is generally reasonable, as `pdfminer` is typically more reliable than deep layout and OCR models.

However, in this instance, `pdfminer` produced incorrect results. The `ImageTextRegion` contains embedded text elements, but it is classified merely as an image with no text. This issue can be attributed to the flawed design of the PDF itself. Nonetheless, it would be beneficial for our system to handle such cases more gracefully.

Since I am not very familiar with the `unstructured` source code, the temporary solution I came up with is to recursively extract text from `pdfminer` objects that are identified as having no text. If no text is found, the outcome remains unchanged. However, if sub text objects are discovered within, the merge rules will prioritize retaining the pdfminer extracted results, ultimately leading to the correct outcome.

Here are some extraction results for your reference.
- page1_layout_pdfminer
![page1_layout_pdfminer](https://github.com/user-attachments/assets/07f99450-e966-448a-9b40-9f54bdcd4e8f)
- page1_layout_od_model
![page1_layout_od_model](https://github.com/user-attachments/assets/ab80e81e-2032-4551-868e-fa9a7d9e3968)
- page1_layout_final
![page1_layout_final](https://github.com/user-attachments/assets/1e6c8d7a-3f66-47a8-a695-0f680809eee2)

