### PR TITLE
Improve pdfminer embedded image extraction in `pdf` partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Enhancements
 
+* **Improve `pdfminer` embedded `image` extraction to exclude text elements and produce more accurate bounding boxes.** This results in cleaner, more precise element extraction in `pdf` partitioning.
+
 ### Features
 
 * **Mark ingest as deprecated** Begin sunset of ingest code in this repo as it's been moved to a dedicated repo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.1-dev7
+## 0.15.1-dev8
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.1-dev7"  # pragma: no cover
+__version__ = "0.15.1-dev8"  # pragma: no cover

--- a/unstructured/partition/pdf_image/pdfminer_processing.py
+++ b/unstructured/partition/pdf_image/pdfminer_processing.py
@@ -5,7 +5,7 @@ from pdfminer.utils import open_filename
 from unstructured.documents.elements import ElementType
 from unstructured.partition.pdf_image.pdf_image_utils import remove_control_characters
 from unstructured.partition.pdf_image.pdfminer_utils import (
-    extract_text_and_image_objects,
+    extract_image_objects,
     open_pdfminer_pages_generator,
     rect_to_bbox,
 )
@@ -51,30 +51,26 @@ def process_data_with_pdfminer(
     for page, page_layout in open_pdfminer_pages_generator(file):
         height = page_layout.height
 
-        layout: List["TextRegion"] = []
+        layout: list["TextRegion"] = []
         for obj in page_layout:
-            inner_objects = extract_text_and_image_objects(obj)
-            for inner_obj in inner_objects:
-                x1, y1, x2, y2 = rect_to_bbox(inner_obj.bbox, height)
+            x1, y1, x2, y2 = rect_to_bbox(obj.bbox, height)
 
-                if hasattr(inner_obj, "get_text"):
-                    _text = inner_obj.get_text()
-                    element_class = EmbeddedTextRegion  # type: ignore
-                else:
-                    _text = None
-                    element_class = ImageTextRegion
-
-                text_region = element_class.from_coords(
-                    x1 * coef,
-                    y1 * coef,
-                    x2 * coef,
-                    y2 * coef,
-                    text=_text,
-                    source=Source.PDFMINER,
+            if hasattr(obj, "get_text"):
+                _text = obj.get_text()
+                text_region = _create_text_region(
+                    x1, y1, x2, y2, coef, _text, Source.PDFMINER, EmbeddedTextRegion
                 )
-
                 if text_region.bbox is not None and text_region.bbox.area > 0:
                     layout.append(text_region)
+            else:
+                inner_image_objects = extract_image_objects(obj)
+                for img_obj in inner_image_objects:
+                    new_x1, new_y1, new_x2, new_y2 = rect_to_bbox(img_obj.bbox, height)
+                    text_region = _create_text_region(
+                        new_x1, new_y1, new_x2, new_y2, coef, None, Source.PDFMINER, ImageTextRegion
+                    )
+                    if text_region.bbox is not None and text_region.bbox.area > 0:
+                        layout.append(text_region)
 
         # NOTE(christine): always do the basic sort first for deterministic order across
         # python versions.
@@ -86,6 +82,18 @@ def process_data_with_pdfminer(
         layouts.append(layout)
 
     return layouts
+
+
+def _create_text_region(x1, y1, x2, y2, coef, text, source, region_class):
+    """Creates a text region of the specified class with scaled coordinates."""
+    return region_class.from_coords(
+        x1 * coef,
+        y1 * coef,
+        x2 * coef,
+        y2 * coef,
+        text=text,
+        source=source,
+    )
 
 
 @requires_dependencies("unstructured_inference")

--- a/unstructured/partition/pdf_image/pdfminer_utils.py
+++ b/unstructured/partition/pdf_image/pdfminer_utils.py
@@ -1,8 +1,8 @@
 import tempfile
-from typing import Any, BinaryIO, List, Tuple
+from typing import BinaryIO, List, Tuple
 
 from pdfminer.converter import PDFPageAggregator
-from pdfminer.layout import LAParams, LTComponent, LTContainer, LTImage
+from pdfminer.layout import LAParams, LTContainer, LTImage, LTItem
 from pdfminer.pdfinterp import PDFPageInterpreter, PDFResourceManager
 from pdfminer.pdfpage import PDFPage
 from pdfminer.pdfparser import PSSyntaxError
@@ -20,27 +20,15 @@ def init_pdfminer():
     return device, interpreter
 
 
-def extract_text_and_image_objects(parent_object) -> List[LTComponent]:
-    """
-    Recursively extract text and image objects from a given parent object in a PDF document.
-
-    This function navigates through the PDF's layout tree and collects objects that contain text
-    (objects with a 'get_text' method) or are images (instances of LTImage).
-
-    Args:
-        parent_object: The root object from which to start the extraction. This could be an
-                       instance of LTContainer, LTText, LTImage, or any other pdfminer layout object.
-
-    Returns:
-        A list of LTComponent objects which are either text-containing objects or images.
-    """
+def extract_image_objects(parent_object: LTItem) -> List[LTImage]:
+    """Recursively extracts image objects from a given parent object in a PDF document."""
     objects = []
 
-    if hasattr(parent_object, "get_text") or isinstance(parent_object, LTImage):
+    if isinstance(parent_object, LTImage):
         objects.append(parent_object)
     elif isinstance(parent_object, LTContainer):
         for child in parent_object:
-            objects.extend(extract_text_and_image_objects(child))
+            objects.extend(extract_image_objects(child))
 
     return objects
 

--- a/unstructured/partition/pdf_image/pdfminer_utils.py
+++ b/unstructured/partition/pdf_image/pdfminer_utils.py
@@ -45,41 +45,6 @@ def extract_text_and_image_objects(parent_object) -> List[LTComponent]:
     return objects
 
 
-def get_images_from_pdf_element(layout_object: Any) -> List[LTImage]:
-    """
-    Recursively extracts LTImage objects from a PDF layout element.
-
-    This function takes a PDF layout element (could be LTImage or LTContainer) and recursively
-    extracts all LTImage objects contained within it.
-
-    Parameters:
-    - layout_object (Any): The PDF layout element to extract images from.
-
-    Returns:
-    - List[LTImage]: A list of LTImage objects extracted from the layout object.
-
-    Note:
-    - This function recursively traverses through the layout_object to find and accumulate all
-     LTImage objects.
-    - If the input layout_object is an LTImage, it will be included in the returned list.
-    - If the input layout_object is an LTContainer, the function will recursively search its
-     children for LTImage objects.
-    - If the input layout_object is neither LTImage nor LTContainer, an empty list will be
-     returned.
-    """
-
-    # recursively locate Image objects in layout_object
-    if isinstance(layout_object, LTImage):
-        return [layout_object]
-    if isinstance(layout_object, LTContainer):
-        img_list: List[LTImage] = []
-        for child in layout_object:
-            img_list = img_list + get_images_from_pdf_element(child)
-        return img_list
-    else:
-        return []
-
-
 def rect_to_bbox(
     rect: Tuple[float, float, float, float],
     height: float,


### PR DESCRIPTION
### Summary
This PR addresses an issue in `pdfminer` library's embedded image extraction process. Previously, some extracted "images" were incorrect, including embedded text elements, resulting in oversized bounding boxes. This update refines the extraction process to focus on actual images with more accurate, smaller bounding boxes. 

### Testing
PDF: [test_pdfminer_text_extraction.pdf](https://github.com/user-attachments/files/16448213/test_pdfminer_text_extraction.pdf)

```
elements = partition_pdf(
    filename="test_pdfminer_text_extraction",
    strategy=strategy,
    languages=["chi_sim"],
    analysis=True,
)
```
**Results**
- this `PR`
![page1_layout_pdfminer](https://github.com/user-attachments/assets/098e0a1f-fdad-4627-a881-cbafd71ce5a0)
![page1_layout_final](https://github.com/user-attachments/assets/6dc89180-36ac-424a-99de-63810ebf8958)
- `main` branch
![page1_layout_pdfminer](https://github.com/user-attachments/assets/8228995a-2ef1-4b76-9758-b8015c224e6d)
![page1_layout_final](https://github.com/user-attachments/assets/68d43d7b-7270-4f58-8360-dc76bd0df78f)