### PR TITLE
Remove clean_bullets from partition_docx

### DIFF
--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -27,7 +27,6 @@ from tabulate import tabulate
 from typing_extensions import TypeAlias
 
 from unstructured.chunking import add_chunking_strategy
-from unstructured.cleaners.core import clean_bullets
 from unstructured.documents.elements import (
     Address,
     Element,
@@ -474,7 +473,7 @@ class _DocxPartitioner:
         # NOTE(scanny) - a list-item gets some special treatment, mutating the text to remove a
         # bullet-character if present.
         if self._is_list_item(paragraph):
-            clean_text = clean_bullets(text).strip()
+            clean_text = text.strip()
             if clean_text:
                 yield ListItem(
                     text=clean_text,


### PR DESCRIPTION
Removing clean_bullets from partition_docx.
Fixes #3463.
Should I even strip?