### PR TITLE
Added 'inline' to content disposition check

### DIFF
--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -387,9 +387,9 @@ def partition_email(
     is_encrypted = False
     content_map: dict[str, str] = {}
     for part in msg.walk():
-        # NOTE(robinson) - content dispostiion is None for the content of the email itself.
+        # content dispostiion is None/inline for the content of the email itself.
         # Other dispositions include "attachment" for attachments
-        if part.get_content_disposition() is not None:
+        if part.get_content_disposition() not in (None, "inline"):
             continue
         content_type = part.get_content_type()
 


### PR DESCRIPTION
See discussion [here](https://github.com/Unstructured-IO/unstructured/issues/3449). This adds `inline` to the allowed list of Content Disposition values when parsing EML files.