### PR TITLE
Refactor image block extraction in `pdf` partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.2-dev6
+## 0.15.2-dev7
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.2-dev7
+## 0.15.2-dev8
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Enhancements
 
+* **Improve directory handling when extracting image blocks**. The `figures` directory is no longer created when the `extract_image_block_to_payload` parameter is set to `True`.
+
 ### Features
 
 * **Added per-class Object Detection metrics in the evaluation**. The metrics include average precision, precision, recall, and f1-score for each class in the dataset.

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.2-dev6"  # pragma: no cover
+__version__ = "0.15.2-dev7"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.2-dev7"  # pragma: no cover
+__version__ = "0.15.2-dev8"  # pragma: no cover

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -139,13 +139,14 @@ def save_elements(
     a specified directory or embedded into the element's payload as a base64-encoded string.
     """
 
-    if not output_dir_path:
-        if env_config.GLOBAL_WORKING_DIR_ENABLED:
-            output_dir_path = str(Path(env_config.GLOBAL_WORKING_PROCESS_DIR) / "figures")
-        else:
-            output_dir_path = str(Path.cwd() / "figures")
-
+    # Determine the output directory path
     if not extract_image_block_to_payload:
+        output_dir_path = output_dir_path or (
+            str(Path(env_config.GLOBAL_WORKING_PROCESS_DIR) / "figures")
+            if env_config.GLOBAL_WORKING_DIR_ENABLED
+            else str(Path.cwd() / "figures")
+        )
+
         os.makedirs(output_dir_path, exist_ok=True)
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -144,7 +144,9 @@ def save_elements(
             output_dir_path = str(Path(env_config.GLOBAL_WORKING_PROCESS_DIR) / "figures")
         else:
             output_dir_path = str(Path.cwd() / "figures")
-    os.makedirs(output_dir_path, exist_ok=True)
+
+    if not extract_image_block_to_payload:
+        os.makedirs(output_dir_path, exist_ok=True)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         if is_image:
@@ -193,11 +195,6 @@ def save_elements(
 
             figure_number += 1
             try:
-                basename = "table" if el.category == ElementType.TABLE else "figure"
-                output_f_path = os.path.join(
-                    output_dir_path,
-                    f"{basename}-{metadata_page_number}-{figure_number}.jpg",
-                )
                 image_path = image_paths[page_index]
                 image = Image.open(image_path)
                 cropped_image = image.crop(padded_bbox)
@@ -209,6 +206,11 @@ def save_elements(
                     el.metadata.image_base64 = img_base64_str
                     el.metadata.image_mime_type = "image/jpeg"
                 else:
+                    basename = "table" if el.category == ElementType.TABLE else "figure"
+                    output_f_path = os.path.join(
+                        output_dir_path,
+                        f"{basename}-{metadata_page_number}-{figure_number}.jpg",
+                    )
                     write_image(cropped_image, output_f_path)
                     # add image path to element metadata
                     el.metadata.image_path = output_f_path


### PR DESCRIPTION
Closes [#3503](https://github.com/Unstructured-IO/unstructured/issues/3503).

### Summary
This PR prevents creation of `figures` directory for saving image blocks (`Image`, `Table`) when `extract_image_block_to_payload` parameter is set to True

### Testing

```
elements = partition_image(
    filename="example-docs/img/embedded-images-tables.jpg",
    strategy="hi_res",
    extract_image_block_types=["Image", "Table"],
    extract_image_block_to_payload=True,
)
```
**Results:**
- `Main` Branch: `figures` directory is created.
- `PR`: `figures` directory is not created.