### PR TITLE
fix(file): no default OLE subtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.8-dev2
+## 0.15.8-dev3
 
 ### Enhancements
 
@@ -8,6 +8,7 @@
 
 * **Fix NLTK data download path to prevent nested directories**. Resolved an issue where a nested "nltk_data" directory was created within the parent "nltk_data" directory when it already existed. This fix prevents errors in checking for existing downloads and loading models from NLTK data.
 * **Minify text_as_html from DOCX.** Previously `.metadata.text_as_html` for DOCX tables was "bloated" with whitespace and noise elements introduced by `tabulate` that produced over-chunking and lower "semantic density" of elements. Reduce HTML to minimum character count without preserving all text.
+* **Fall back to filename extension-based file-type detection for unidentified OLE files.** Resolves a problem where a DOC file that could not be detected as such by `filetype` was incorrectly identified as a MSG file.
 
 ## 0.15.6
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.8-dev2"  # pragma: no cover
+__version__ = "0.15.8-dev3"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -476,13 +476,14 @@ class _OleFileDifferentiator:
         if not self._is_ole_file(self._ctx):
             return None
 
-        # -- `filetype` lib is better at legacy MS-Office files than `libmagic`, so rely on it to
-        # -- differentiate those. Note it doesn't detect MSG type though, so we assume any OLE file
-        # -- that is not a legacy MS-Office type to be a MSG file.
+        # -- `filetype` lib is better at legacy MS-Office files than `libmagic`, so we rely on it
+        # -- to differentiate those. Note `filetype` doesn't detect MSG type and won't always
+        # -- detect DOC, PPT, or XLS, returning `None` instead. We let those fall through and we
+        # -- rely on filename-extension to identify those.
         with self._ctx.open() as file:
             mime_type = ft.guess_mime(file)
 
-        return FileType.from_mime_type(mime_type or "application/vnd.ms-outlook")
+        return FileType.from_mime_type(mime_type) if mime_type else None
 
     @staticmethod
     def _is_ole_file(ctx: _FileTypeDetectionContext) -> bool:


### PR DESCRIPTION
**Summary**
Do not assume MSG format when an OLE "container" file cannot be differentiated into DOC, PPT, XLS, or MSG. Fall back to extention-based identification in that case.

**Additional Context**
DOC, MSG, PPT, and XLS are all OLE files. An OLE file is, very roughly, a Microsoft-proprietary Zip format which "contains" a filesystem of discrete files and directories.

An OLE "container" is easily identified by inspecting the first 8 bytes of the file, so all we need to do is differentiate between the four subtypes we can process. The `filetype` module does a good job of this but it not perfect and does not identify MSG files.

Previously we assumed MSG format when none of DOC, PPT, or XLS was detected, but we discovered that `filetype` is not completely reliable at detecting these types.

Change the behavior to remove the assumption of MSG format. `_OleFileDifferentiator` returns `None` in this case and filetype detection falls back to use filename-extension.

Note a file with no filename and no metadata_filename or an incorrect extension will not be correctly identified in this case, however we're assuming for now that will be rare in practice.