### PR TITLE
build(deps): bump unstructured.paddleocr to 2.8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,18 @@
 
 ### Fixes
 
-* **Fix NLTK data download path to prevent nested directories**. Resolved an issue where a nested "nltk_data" directory was created within the parent "nltk_data" directory when it already existed. This fix prevents errors in checking for existing downloads and loading models from NLTK data.
 * **Minify text_as_html from DOCX.** Previously `.metadata.text_as_html` for DOCX tables was "bloated" with whitespace and noise elements introduced by `tabulate` that produced over-chunking and lower "semantic density" of elements. Reduce HTML to minimum character count without preserving all text.
 * **Fall back to filename extension-based file-type detection for unidentified OLE files.** Resolves a problem where a DOC file that could not be detected as such by `filetype` was incorrectly identified as a MSG file.
+
+## 0.15.7
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* **Fix NLTK data download path to prevent nested directories**. Resolved an issue where a nested "nltk_data" directory was created within the parent "nltk_data" directory when it already existed. This fix prevents errors in checking for existing downloads and loading models from NLTK data.
 
 ## 0.15.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.15.8-dev3
+## 0.15.8-dev4
 
 ### Enhancements
+
+* **Bump unstructured.paddleocr to 2.8.1.0.**
 
 ### Features
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,7 +43,7 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via unstructured-client
-idna==3.7
+idna==3.8
     # via
     #   anyio
     #   httpx

--- a/requirements/deps/constraints.txt
+++ b/requirements/deps/constraints.txt
@@ -27,9 +27,6 @@ tokenizers>=0.19,<0.20
 pycocotools>=2.0.7
 # NOTE(crag): python3.8-python3.11 compat (if it ends up being required)
 torch>2
-# pinned in unstructured paddleocr
-opencv-python==4.8.0.76
-opencv-contrib-python==4.8.0.76
 platformdirs==3.10.0
 
 # TODO: Constaint due to boto, with python before 3.10 not requiring openssl 1.1.1, remove when that gets

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -68,7 +68,7 @@ filelock==3.15.4
     # via virtualenv
 identify==2.6.0
     # via pre-commit
-idna==3.7
+idna==3.8
     # via
     #   -c ./base.txt
     #   -c ./test.txt
@@ -94,7 +94,7 @@ ipython-genutils==0.2.0
     # via
     #   nbclassic
     #   notebook
-ipywidgets==8.1.3
+ipywidgets==8.1.5
     # via jupyter
 jedi==0.19.1
     # via ipython
@@ -140,7 +140,7 @@ jupyter-server-terminals==0.5.3
     # via jupyter-server
 jupyterlab-pygments==0.3.0
     # via nbconvert
-jupyterlab-widgets==3.0.11
+jupyterlab-widgets==3.0.13
     # via ipywidgets
 markupsafe==2.1.5
     # via
@@ -256,7 +256,7 @@ pyyaml==6.0.2
     #   -c ./test.txt
     #   jupyter-events
     #   pre-commit
-pyzmq==26.1.1
+pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -352,7 +352,7 @@ wheel==0.44.0
     # via
     #   -c ././deps/constraints.txt
     #   pip-tools
-widgetsnbextension==4.0.11
+widgetsnbextension==4.0.13
     # via ipywidgets
 zipp==3.20.0
     # via importlib-metadata

--- a/requirements/extra-paddleocr.in
+++ b/requirements/extra-paddleocr.in
@@ -2,4 +2,4 @@
 -c base.txt
 
 paddlepaddle==3.0.0b1
-unstructured.paddleocr==2.8.0.1
+unstructured.paddleocr==2.8.1.0

--- a/requirements/extra-paddleocr.txt
+++ b/requirements/extra-paddleocr.txt
@@ -10,10 +10,6 @@ anyio==4.4.0
     #   httpx
 astor==0.8.1
     # via paddlepaddle
-attrdict==2.0.1
-    # via unstructured-paddleocr
-cachetools==5.5.0
-    # via premailer
 certifi==2024.7.4
     # via
     #   -c ././deps/constraints.txt
@@ -27,18 +23,12 @@ charset-normalizer==3.3.2
     #   requests
 contourpy==1.2.1
     # via matplotlib
-cssselect==1.2.0
-    # via premailer
-cssutils==2.11.1
-    # via premailer
 cycler==0.12.1
     # via matplotlib
 cython==3.0.11
     # via unstructured-paddleocr
 decorator==5.1.1
     # via paddlepaddle
-et-xmlfile==1.1.0
-    # via openpyxl
 exceptiongroup==1.2.2
     # via
     #   -c ./base.txt
@@ -57,7 +47,7 @@ httpx==0.27.0
     # via
     #   -c ./base.txt
     #   paddlepaddle
-idna==3.7
+idna==3.8
     # via
     #   -c ./base.txt
     #   anyio
@@ -69,23 +59,14 @@ imageio==2.35.1
     #   scikit-image
 imgaug==0.4.0
     # via unstructured-paddleocr
-importlib-resources==6.4.3
+importlib-resources==6.4.4
     # via matplotlib
 kiwisolver==1.4.5
     # via matplotlib
-lanms-neo==1.0.2
-    # via unstructured-paddleocr
 lazy-loader==0.4
     # via scikit-image
-lxml==5.3.0
-    # via
-    #   -c ./base.txt
-    #   premailer
-    #   unstructured-paddleocr
 matplotlib==3.9.2
     # via imgaug
-more-itertools==10.4.0
-    # via cssutils
 networkx==3.2.1
     # via
     #   paddlepaddle
@@ -106,17 +87,12 @@ numpy==1.26.4
     #   shapely
     #   tifffile
     #   unstructured-paddleocr
-opencv-contrib-python==4.8.0.76
+opencv-contrib-python==4.10.0.84
+    # via unstructured-paddleocr
+opencv-python==4.10.0.84
     # via
-    #   -c ././deps/constraints.txt
-    #   unstructured-paddleocr
-opencv-python==4.8.0.76
-    # via
-    #   -c ././deps/constraints.txt
     #   imgaug
     #   unstructured-paddleocr
-openpyxl==3.1.5
-    # via unstructured-paddleocr
 opt-einsum==3.3.0
     # via paddlepaddle
 packaging==24.1
@@ -138,8 +114,6 @@ pillow==10.4.0
     #   pdf2image
     #   scikit-image
     #   unstructured-paddleocr
-premailer==3.10.0
-    # via unstructured-paddleocr
 protobuf==4.23.4
     # via
     #   -c ././deps/constraints.txt
@@ -161,7 +135,6 @@ rapidfuzz==3.9.6
 requests==2.32.3
     # via
     #   -c ./base.txt
-    #   premailer
     #   unstructured-paddleocr
 scikit-image==0.24.0
     # via
@@ -178,7 +151,6 @@ shapely==2.0.6
 six==1.16.0
     # via
     #   -c ./base.txt
-    #   attrdict
     #   imgaug
     #   python-dateutil
 sniffio==1.3.1
@@ -197,7 +169,7 @@ typing-extensions==4.12.2
     #   -c ./base.txt
     #   anyio
     #   paddlepaddle
-unstructured-paddleocr==2.8.0.1
+unstructured-paddleocr==2.8.1.0
     # via -r ./extra-paddleocr.in
 urllib3==1.26.19
     # via

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -57,7 +57,7 @@ googleapis-common-protos==1.63.2
     # via
     #   google-api-core
     #   grpcio-status
-grpcio==1.65.5
+grpcio==1.66.0
     # via
     #   -c ././deps/constraints.txt
     #   google-api-core
@@ -72,11 +72,11 @@ huggingface-hub==0.24.6
     #   unstructured-inference
 humanfriendly==10.0
     # via coloredlogs
-idna==3.7
+idna==3.8
     # via
     #   -c ./base.txt
     #   requests
-importlib-resources==6.4.3
+importlib-resources==6.4.4
     # via matplotlib
 iopath==0.1.10
     # via layoutparser
@@ -122,9 +122,8 @@ onnx==1.16.2
     #   unstructured-inference
 onnxruntime==1.19.0
     # via unstructured-inference
-opencv-python==4.8.0.76
+opencv-python==4.10.0.84
     # via
-    #   -c ././deps/constraints.txt
     #   layoutparser
     #   unstructured-inference
 packaging==24.1
@@ -269,7 +268,7 @@ tqdm==4.66.5
     #   huggingface-hub
     #   iopath
     #   transformers
-transformers==4.44.1
+transformers==4.44.2
     # via unstructured-inference
 typing-extensions==4.12.2
     # via

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -30,7 +30,7 @@ huggingface-hub==0.24.6
     # via
     #   tokenizers
     #   transformers
-idna==3.7
+idna==3.8
     # via
     #   -c ./base.txt
     #   requests
@@ -99,7 +99,7 @@ tqdm==4.66.5
     #   huggingface-hub
     #   sacremoses
     #   transformers
-transformers==4.44.1
+transformers==4.44.2
     # via -r ./huggingface.in
 typing-extensions==4.12.2
     # via

--- a/requirements/ingest/airtable.txt
+++ b/requirements/ingest/airtable.txt
@@ -15,7 +15,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/astradb.txt
+++ b/requirements/ingest/astradb.txt
@@ -57,7 +57,7 @@ httpx[http2]==0.27.0
     #   astrapy
 hyperframe==6.0.1
     # via h2
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio

--- a/requirements/ingest/azure-cognitive-search.txt
+++ b/requirements/ingest/azure-cognitive-search.txt
@@ -19,7 +19,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/azure.txt
+++ b/requirements/ingest/azure.txt
@@ -54,7 +54,7 @@ fsspec==2024.6.1
     # via
     #   -r ./ingest/azure.in
     #   adlfs
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/box.txt
+++ b/requirements/ingest/box.txt
@@ -8,7 +8,7 @@ attrs==24.2.0
     # via boxsdk
 boxfs==0.3.0
     # via -r ./ingest/box.in
-boxsdk[jwt]==3.12.0
+boxsdk[jwt]==3.13.0
     # via boxfs
 certifi==2024.7.4
     # via
@@ -27,7 +27,7 @@ fsspec==2024.6.1
     # via
     #   -r ./ingest/box.in
     #   boxfs
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/chroma.txt
+++ b/requirements/ingest/chroma.txt
@@ -62,7 +62,7 @@ google-auth==2.34.0
     # via kubernetes
 googleapis-common-protos==1.63.2
     # via opentelemetry-exporter-otlp-proto-grpc
-grpcio==1.65.5
+grpcio==1.66.0
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   chromadb
@@ -78,7 +78,7 @@ huggingface-hub==0.24.6
     # via tokenizers
 humanfriendly==10.0
     # via coloredlogs
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -86,7 +86,7 @@ idna==3.7
     #   requests
 importlib-metadata==8.4.0
     # via -r ./ingest/chroma.in
-importlib-resources==6.4.3
+importlib-resources==6.4.4
     # via chromadb
 kubernetes==30.1.0
     # via chromadb
@@ -129,7 +129,7 @@ packaging==24.1
     #   build
     #   huggingface-hub
     #   onnxruntime
-posthog==3.5.0
+posthog==3.5.2
     # via chromadb
 protobuf==4.23.4
     # via

--- a/requirements/ingest/clarifai.txt
+++ b/requirements/ingest/clarifai.txt
@@ -21,11 +21,11 @@ contextlib2==21.6.0
     # via schema
 googleapis-common-protos==1.63.2
     # via clarifai-grpc
-grpcio==1.65.5
+grpcio==1.66.0
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   clarifai-grpc
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/confluence.txt
+++ b/requirements/ingest/confluence.txt
@@ -21,7 +21,7 @@ charset-normalizer==3.3.2
     #   requests
 deprecated==1.2.14
     # via atlassian-python-api
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/databricks-volumes.txt
+++ b/requirements/ingest/databricks-volumes.txt
@@ -19,7 +19,7 @@ databricks-sdk==0.30.0
     # via -r ./ingest/databricks-volumes.in
 google-auth==2.34.0
     # via databricks-sdk
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/discord.txt
+++ b/requirements/ingest/discord.txt
@@ -20,7 +20,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   yarl

--- a/requirements/ingest/dropbox.txt
+++ b/requirements/ingest/dropbox.txt
@@ -21,7 +21,7 @@ fsspec==2024.6.1
     # via
     #   -r ./ingest/dropbox.in
     #   dropboxdrivefs
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/elasticsearch.txt
+++ b/requirements/ingest/elasticsearch.txt
@@ -27,7 +27,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   yarl

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -66,7 +66,7 @@ httpx==0.27.0
     # via
     #   -c ./ingest/../base.txt
     #   langsmith
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -87,14 +87,14 @@ langchain-community==0.2.12
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/embed-aws-bedrock.in
-langchain-core==0.2.33
+langchain-core==0.2.34
     # via
     #   langchain
     #   langchain-community
     #   langchain-text-splitters
 langchain-text-splitters==0.2.2
     # via langchain
-langsmith==0.1.100
+langsmith==0.1.104
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -52,7 +52,7 @@ huggingface-hub==0.24.6
     #   sentence-transformers
     #   tokenizers
     #   transformers
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -68,11 +68,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain-core==0.2.33
+langchain-core==0.2.34
     # via langchain-huggingface
 langchain-huggingface==0.0.3
     # via -r ./ingest/embed-huggingface.in
-langsmith==0.1.100
+langsmith==0.1.104
     # via langchain-core
 markupsafe==2.1.5
     # via jinja2
@@ -154,7 +154,7 @@ tqdm==4.66.5
     #   huggingface-hub
     #   sentence-transformers
     #   transformers
-transformers==4.44.1
+transformers==4.44.2
     # via
     #   langchain-huggingface
     #   sentence-transformers

--- a/requirements/ingest/embed-octoai.txt
+++ b/requirements/ingest/embed-octoai.txt
@@ -40,7 +40,7 @@ httpx==0.27.0
     # via
     #   -c ./ingest/../base.txt
     #   openai
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -41,7 +41,7 @@ httpx==0.27.0
     #   -c ./ingest/../base.txt
     #   langsmith
     #   openai
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -53,11 +53,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain-core==0.2.33
+langchain-core==0.2.34
     # via langchain-openai
 langchain-openai==0.1.22
     # via -r ./ingest/embed-openai.in
-langsmith==0.1.100
+langsmith==0.1.104
     # via langchain-core
 openai==1.42.0
     # via langchain-openai

--- a/requirements/ingest/embed-vertexai.txt
+++ b/requirements/ingest/embed-vertexai.txt
@@ -95,7 +95,7 @@ googleapis-common-protos[grpc]==1.63.2
     #   grpcio-status
 grpc-google-iam-v1==0.13.1
     # via google-cloud-resource-manager
-grpcio==1.65.5
+grpcio==1.66.0
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   google-api-core
@@ -115,8 +115,11 @@ httpcore==1.0.5
 httpx==0.27.0
     # via
     #   -c ./ingest/../base.txt
+    #   langchain-google-vertexai
     #   langsmith
-idna==3.7
+httpx-sse==0.4.0
+    # via langchain-google-vertexai
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -135,17 +138,17 @@ langchain-community==0.2.12
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/embed-vertexai.in
-langchain-core==0.2.33
+langchain-core==0.2.34
     # via
     #   langchain
     #   langchain-community
     #   langchain-google-vertexai
     #   langchain-text-splitters
-langchain-google-vertexai==1.0.8
+langchain-google-vertexai==1.0.10
     # via -r ./ingest/embed-vertexai.in
 langchain-text-splitters==0.2.2
     # via langchain
-langsmith==0.1.100
+langsmith==0.1.104
     # via
     #   langchain
     #   langchain-community

--- a/requirements/ingest/embed-voyageai.txt
+++ b/requirements/ingest/embed-voyageai.txt
@@ -57,7 +57,7 @@ httpx==0.27.0
     # via
     #   -c ./ingest/../base.txt
     #   langsmith
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -70,7 +70,7 @@ jsonpointer==3.0.0
     # via jsonpatch
 langchain==0.2.14
     # via -r ./ingest/embed-voyageai.in
-langchain-core==0.2.33
+langchain-core==0.2.34
     # via
     #   langchain
     #   langchain-text-splitters
@@ -79,7 +79,7 @@ langchain-text-splitters==0.2.2
     # via langchain
 langchain-voyageai==0.1.1
     # via -r ./ingest/embed-voyageai.in
-langsmith==0.1.100
+langsmith==0.1.104
     # via
     #   langchain
     #   langchain-core

--- a/requirements/ingest/gcs.txt
+++ b/requirements/ingest/gcs.txt
@@ -68,7 +68,7 @@ google-resumable-media==2.7.2
     # via google-cloud-storage
 googleapis-common-protos==1.63.2
     # via google-api-core
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/github.txt
+++ b/requirements/ingest/github.txt
@@ -21,7 +21,7 @@ cryptography==43.0.0
     # via pyjwt
 deprecated==1.2.14
     # via pygithub
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/gitlab.txt
+++ b/requirements/ingest/gitlab.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/google-drive.txt
+++ b/requirements/ingest/google-drive.txt
@@ -32,7 +32,7 @@ httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/jira.txt
+++ b/requirements/ingest/jira.txt
@@ -21,7 +21,7 @@ charset-normalizer==3.3.2
     #   requests
 deprecated==1.2.14
     # via atlassian-python-api
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/notion.txt
+++ b/requirements/ingest/notion.txt
@@ -32,7 +32,7 @@ httpx==0.27.0
     # via
     #   -c ./ingest/../base.txt
     #   notion-client
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio

--- a/requirements/ingest/onedrive.txt
+++ b/requirements/ingest/onedrive.txt
@@ -25,7 +25,7 @@ cryptography==43.0.0
     # via
     #   msal
     #   pyjwt
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/opensearch.txt
+++ b/requirements/ingest/opensearch.txt
@@ -16,11 +16,11 @@ charset-normalizer==3.3.2
     #   requests
 events==0.5
     # via opensearch-py
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests
-opensearch-py==2.7.0
+opensearch-py==2.7.1
     # via -r ./ingest/opensearch.in
 python-dateutil==2.9.0.post0
     # via

--- a/requirements/ingest/outlook.txt
+++ b/requirements/ingest/outlook.txt
@@ -19,7 +19,7 @@ cryptography==43.0.0
     # via
     #   msal
     #   pyjwt
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/qdrant.txt
+++ b/requirements/ingest/qdrant.txt
@@ -20,7 +20,7 @@ exceptiongroup==1.2.2
     # via
     #   -c ./ingest/../base.txt
     #   anyio
-grpcio==1.65.5
+grpcio==1.66.0
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   grpcio-tools
@@ -45,7 +45,7 @@ httpx[http2]==0.27.0
     #   qdrant-client
 hyperframe==6.0.1
     # via h2
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio

--- a/requirements/ingest/reddit.txt
+++ b/requirements/ingest/reddit.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/s3.txt
+++ b/requirements/ingest/s3.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/s3.in
 #
-aiobotocore==2.13.2
+aiobotocore==2.13.3
     # via s3fs
 aiohappyeyeballs==2.4.0
     # via aiohttp
@@ -32,7 +32,7 @@ fsspec==2024.6.1
     # via
     #   -r ./ingest/s3.in
     #   s3fs
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   yarl

--- a/requirements/ingest/salesforce.txt
+++ b/requirements/ingest/salesforce.txt
@@ -19,7 +19,7 @@ charset-normalizer==3.3.2
     #   requests
 cryptography==43.0.0
     # via pyjwt
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/sharepoint.txt
+++ b/requirements/ingest/sharepoint.txt
@@ -19,7 +19,7 @@ cryptography==43.0.0
     # via
     #   msal
     #   pyjwt
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/singlestore.txt
+++ b/requirements/ingest/singlestore.txt
@@ -15,7 +15,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/weaviate.txt
+++ b/requirements/ingest/weaviate.txt
@@ -31,7 +31,7 @@ exceptiongroup==1.2.2
     # via
     #   -c ./ingest/../base.txt
     #   anyio
-grpcio==1.65.5
+grpcio==1.66.0
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   grpcio-health-checking
@@ -53,7 +53,7 @@ httpx==0.27.0
     # via
     #   -c ./ingest/../base.txt
     #   weaviate-client
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   anyio

--- a/requirements/ingest/wikipedia.txt
+++ b/requirements/ingest/wikipedia.txt
@@ -17,7 +17,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.7
+idna==3.8
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -51,7 +51,7 @@ flake8-print==5.0.0
     # via -r ./test.in
 freezegun==1.5.1
     # via -r ./test.in
-grpcio==1.65.5
+grpcio==1.66.0
     # via
     #   -c ././deps/constraints.txt
     #   -r ./test.in
@@ -67,7 +67,7 @@ httpx==0.27.0
     # via
     #   -c ./base.txt
     #   label-studio-sdk
-idna==3.7
+idna==3.8
     # via
     #   -c ./base.txt
     #   anyio
@@ -201,7 +201,7 @@ tqdm==4.66.5
     #   nltk
 types-click==7.1.8
     # via -r ./test.in
-types-markdown==3.6.0.20240316
+types-markdown==3.7.0.20240822
     # via -r ./test.in
 types-requests==2.31.0.6
     # via -r ./test.in

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.8-dev3"  # pragma: no cover
+__version__ = "0.15.8-dev4"  # pragma: no cover


### PR DESCRIPTION
### Summary
- Bump `unstructured.paddleocr` to 2.8.1.0
- Remove `opencv-python` and `opencv-contrib-python` constraint pins
- Fix `0.15.7` changelog