### PR TITLE
added note about nltk issue in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ elements = partition(filename="example-docs/eml/fake-email.eml")
 print("\n\n".join([str(el) for el in elements]))
 ```
 
+If you face `nltk` related issue, install it again and download `nltk_data`
+```python
+!pip install --upgrade nltk
+
+import nltk
+nltk.download('all')
+```
+
 ### Installation Instructions for Local Development
 
 The following instructions are intended to help you get up and running with `unstructured`


### PR DESCRIPTION
Faced issue on fresh install about nltk tokenizer not available. Adding a note on readme should help first time user. 
```
!pip install --upgrade nltk

# import nltk
# nltk.download('all')
```