### PR TITLE
build(deps): bump cryptography version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -92,7 +92,7 @@ python-magic==0.4.27
     # via -r ./base.in
 python-oxmsg==0.0.1
     # via -r ./base.in
-rapidfuzz==3.9.6
+rapidfuzz==3.9.7
     # via -r ./base.in
 regex==2024.7.24
     # via nltk
@@ -133,7 +133,7 @@ typing-inspect==0.9.0
     # via
     #   dataclasses-json
     #   unstructured-client
-unstructured-client==0.25.5
+unstructured-client==0.25.7
     # via -r ./base.in
 urllib3==1.26.20
     # via

--- a/requirements/extra-paddleocr.txt
+++ b/requirements/extra-paddleocr.txt
@@ -60,7 +60,7 @@ imgaug==0.4.0
     # via unstructured-paddleocr
 importlib-resources==6.4.4
     # via matplotlib
-kiwisolver==1.4.5
+kiwisolver==1.4.7
     # via matplotlib
 lazy-loader==0.4
     # via scikit-image
@@ -127,7 +127,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
 pyyaml==6.0.2
     # via unstructured-paddleocr
-rapidfuzz==3.9.6
+rapidfuzz==3.9.7
     # via
     #   -c ./base.txt
     #   unstructured-paddleocr
@@ -157,7 +157,7 @@ sniffio==1.3.1
     #   -c ./base.txt
     #   anyio
     #   httpx
-tifffile==2024.8.28
+tifffile==2024.8.30
     # via scikit-image
 tqdm==4.66.5
     # via

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -12,7 +12,7 @@ certifi==2024.8.30
     # via
     #   -c ./base.txt
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via
@@ -23,7 +23,7 @@ coloredlogs==15.0.1
     # via onnxruntime
 contourpy==1.3.0
     # via matplotlib
-cryptography==43.0.0
+cryptography==43.0.1
     # via pdfminer-six
 cycler==0.12.1
     # via matplotlib
@@ -40,7 +40,7 @@ flatbuffers==24.3.25
     # via onnxruntime
 fonttools==4.53.1
     # via matplotlib
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via
     #   huggingface-hub
     #   torch
@@ -81,7 +81,7 @@ iopath==0.1.10
     # via layoutparser
 jinja2==3.1.4
     # via torch
-kiwisolver==1.4.5
+kiwisolver==1.4.7
     # via matplotlib
 layoutparser==0.3.4
     # via unstructured-inference
@@ -119,7 +119,7 @@ onnx==1.16.2
     # via
     #   -r ./extra-pdf-image.in
     #   unstructured-inference
-onnxruntime==1.19.0
+onnxruntime==1.19.2
     # via unstructured-inference
 opencv-python==4.10.0.84
     # via
@@ -148,7 +148,7 @@ pdfplumber==0.11.4
     # via layoutparser
 pi-heif==0.18.0
     # via -r ./extra-pdf-image.in
-pikepdf==9.2.0
+pikepdf==9.2.1
     # via -r ./extra-pdf-image.in
 pillow==10.4.0
     # via
@@ -210,7 +210,7 @@ pyyaml==6.0.2
     #   omegaconf
     #   timm
     #   transformers
-rapidfuzz==3.9.6
+rapidfuzz==3.9.7
     # via
     #   -c ./base.txt
     #   unstructured-inference
@@ -226,7 +226,7 @@ requests==2.32.3
     #   transformers
 rsa==4.9
     # via google-auth
-safetensors==0.4.4
+safetensors==0.4.5
     # via
     #   timm
     #   transformers
@@ -248,13 +248,13 @@ tokenizers==0.19.1
     # via
     #   -c ././deps/constraints.txt
     #   transformers
-torch==2.4.0
+torch==2.4.1
     # via
     #   effdet
     #   timm
     #   torchvision
     #   unstructured-inference
-torchvision==0.19.0
+torchvision==0.19.1
     # via
     #   effdet
     #   timm

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -21,7 +21,7 @@ filelock==3.15.4
     #   huggingface-hub
     #   torch
     #   transformers
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via
     #   huggingface-hub
     #   torch
@@ -74,7 +74,7 @@ requests==2.32.3
     #   transformers
 sacremoses==0.1.1
     # via -r ./huggingface.in
-safetensors==0.4.4
+safetensors==0.4.5
     # via transformers
 sentencepiece==0.2.0
     # via -r ./huggingface.in
@@ -88,7 +88,7 @@ tokenizers==0.19.1
     # via
     #   -c ././deps/constraints.txt
     #   transformers
-torch==2.4.0
+torch==2.4.1
     # via -r ./huggingface.in
 tqdm==4.66.5
     # via

--- a/requirements/ingest/airtable.txt
+++ b/requirements/ingest/airtable.txt
@@ -22,9 +22,9 @@ inflection==0.5.1
     # via pyairtable
 pyairtable==2.3.3
     # via -r ./ingest/airtable.in
-pydantic==2.8.2
+pydantic==2.9.0
     # via pyairtable
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 requests==2.32.3
     # via
@@ -36,6 +36,8 @@ typing-extensions==4.12.2
     #   pyairtable
     #   pydantic
     #   pydantic-core
+tzdata==2024.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   -c ./ingest/../base.txt

--- a/requirements/ingest/azure.txt
+++ b/requirements/ingest/azure.txt
@@ -31,7 +31,7 @@ certifi==2024.8.30
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via
     #   azure-datalake-store
     #   cryptography
@@ -39,7 +39,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -49,7 +49,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via
     #   -r ./ingest/azure.in
     #   adlfs
@@ -99,5 +99,5 @@ urllib3==1.26.20
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   requests
-yarl==1.9.4
+yarl==1.9.11
     # via aiohttp

--- a/requirements/ingest/box.txt
+++ b/requirements/ingest/box.txt
@@ -14,15 +14,15 @@ certifi==2024.8.30
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via boxsdk
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via
     #   -r ./ingest/box.in
     #   boxfs

--- a/requirements/ingest/chroma.txt
+++ b/requirements/ingest/chroma.txt
@@ -55,13 +55,13 @@ exceptiongroup==1.2.2
     # via
     #   -c ./ingest/../base.txt
     #   anyio
-fastapi==0.112.2
+fastapi==0.113.0
     # via chromadb
 filelock==3.15.4
     # via huggingface-hub
 flatbuffers==24.3.25
     # via onnxruntime
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via huggingface-hub
 google-auth==2.34.0
     # via kubernetes
@@ -122,7 +122,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-onnxruntime==1.19.0
+onnxruntime==1.19.2
     # via chromadb
 opentelemetry-api==1.27.0
     # via
@@ -172,7 +172,7 @@ packaging==24.1
     #   build
     #   huggingface-hub
     #   onnxruntime
-posthog==3.6.0
+posthog==3.6.3
     # via chromadb
 protobuf==4.23.4
     # via
@@ -186,11 +186,11 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pydantic==2.8.2
+pydantic==2.9.0
     # via
     #   chromadb
     #   fastapi
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 pypika==0.48.9
     # via chromadb
@@ -231,7 +231,7 @@ sniffio==1.3.1
     #   -c ./ingest/../base.txt
     #   anyio
     #   httpx
-starlette==0.38.2
+starlette==0.38.4
     # via fastapi
 sympy==1.13.2
     # via onnxruntime
@@ -268,6 +268,8 @@ typing-extensions==4.12.2
     #   starlette
     #   typer
     #   uvicorn
+tzdata==2024.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   -c ./ingest/../base.txt

--- a/requirements/ingest/databricks-volumes.txt
+++ b/requirements/ingest/databricks-volumes.txt
@@ -14,7 +14,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-databricks-sdk==0.31.1
+databricks-sdk==0.32.0
     # via -r ./ingest/databricks-volumes.in
 google-auth==2.34.0
     # via databricks-sdk

--- a/requirements/ingest/delta-table.in
+++ b/requirements/ingest/delta-table.in
@@ -1,4 +1,4 @@
 -c ../deps/constraints.txt
 -c ../base.txt
-deltalake
+deltalake<=0.19.1
 fsspec

--- a/requirements/ingest/delta-table.txt
+++ b/requirements/ingest/delta-table.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/delta-table.in
 #
-deltalake==0.19.2
+deltalake==0.19.1
     # via -r ./ingest/delta-table.in
 fsspec==2024.9.0
     # via -r ./ingest/delta-table.in

--- a/requirements/ingest/delta-table.txt
+++ b/requirements/ingest/delta-table.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile ./ingest/delta-table.in
 #
-deltalake==0.19.1
+deltalake==0.19.2
     # via -r ./ingest/delta-table.in
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via -r ./ingest/delta-table.in
 numpy==1.26.4
     # via

--- a/requirements/ingest/discord.txt
+++ b/requirements/ingest/discord.txt
@@ -28,5 +28,5 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-yarl==1.9.4
+yarl==1.9.11
     # via aiohttp

--- a/requirements/ingest/dropbox.txt
+++ b/requirements/ingest/dropbox.txt
@@ -16,7 +16,7 @@ dropbox==12.0.2
     # via dropboxdrivefs
 dropboxdrivefs==1.4.1
     # via -r ./ingest/dropbox.in
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via
     #   -r ./ingest/dropbox.in
     #   dropboxdrivefs

--- a/requirements/ingest/elasticsearch.txt
+++ b/requirements/ingest/elasticsearch.txt
@@ -39,5 +39,5 @@ urllib3==1.26.20
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   elastic-transport
-yarl==1.9.4
+yarl==1.9.11
     # via aiohttp

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -80,20 +80,20 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.15
+langchain==0.2.16
     # via langchain-community
-langchain-community==0.2.14
+langchain-community==0.2.16
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/embed-aws-bedrock.in
-langchain-core==0.2.36
+langchain-core==0.2.38
     # via
     #   langchain
     #   langchain-community
     #   langchain-text-splitters
-langchain-text-splitters==0.2.2
+langchain-text-splitters==0.2.4
     # via langchain
-langsmith==0.1.107
+langsmith==0.1.114
     # via
     #   langchain
     #   langchain-community
@@ -122,12 +122,12 @@ packaging==24.1
     #   -c ./ingest/../base.txt
     #   langchain-core
     #   marshmallow
-pydantic==2.8.2
+pydantic==2.9.0
     # via
     #   langchain
     #   langchain-core
     #   langsmith
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 python-dateutil==2.9.0.post0
     # via
@@ -155,7 +155,7 @@ sniffio==1.3.1
     #   -c ./ingest/../base.txt
     #   anyio
     #   httpx
-sqlalchemy==2.0.32
+sqlalchemy==2.0.34
     # via
     #   langchain
     #   langchain-community
@@ -177,11 +177,13 @@ typing-inspect==0.9.0
     # via
     #   -c ./ingest/../base.txt
     #   dataclasses-json
+tzdata==2024.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   botocore
     #   requests
-yarl==1.9.4
+yarl==1.9.11
     # via aiohttp

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -29,7 +29,7 @@ filelock==3.15.4
     #   huggingface-hub
     #   torch
     #   transformers
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via
     #   huggingface-hub
     #   torch
@@ -67,11 +67,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain-core==0.2.36
+langchain-core==0.2.38
     # via langchain-huggingface
 langchain-huggingface==0.0.3
     # via -r ./ingest/embed-huggingface.in
-langsmith==0.1.107
+langsmith==0.1.114
     # via langchain-core
 markupsafe==2.1.5
     # via jinja2
@@ -96,11 +96,11 @@ packaging==24.1
     #   transformers
 pillow==10.4.0
     # via sentence-transformers
-pydantic==2.8.2
+pydantic==2.9.0
     # via
     #   langchain-core
     #   langsmith
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 pyyaml==6.0.2
     # via
@@ -117,7 +117,7 @@ requests==2.32.3
     #   huggingface-hub
     #   langsmith
     #   transformers
-safetensors==0.4.4
+safetensors==0.4.5
     # via transformers
 scikit-learn==1.5.1
     # via sentence-transformers
@@ -143,7 +143,7 @@ tokenizers==0.19.1
     #   -c ./ingest/../deps/constraints.txt
     #   langchain-huggingface
     #   transformers
-torch==2.4.0
+torch==2.4.1
     # via sentence-transformers
 tqdm==4.66.5
     # via
@@ -164,6 +164,8 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   torch
+tzdata==2024.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   -c ./ingest/../base.txt

--- a/requirements/ingest/embed-mixedbreadai.txt
+++ b/requirements/ingest/embed-mixedbreadai.txt
@@ -38,9 +38,9 @@ idna==3.8
     #   httpx
 mixedbread-ai==2.2.6
     # via -r ./ingest/embed-mixedbreadai.in
-pydantic==2.8.2
+pydantic==2.9.0
     # via mixedbread-ai
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 sniffio==1.3.1
     # via
@@ -54,3 +54,5 @@ typing-extensions==4.12.2
     #   mixedbread-ai
     #   pydantic
     #   pydantic-core
+tzdata==2024.1
+    # via pydantic

--- a/requirements/ingest/embed-octoai.txt
+++ b/requirements/ingest/embed-octoai.txt
@@ -49,9 +49,9 @@ jiter==0.5.0
     # via openai
 openai==1.43.0
     # via -r ./ingest/embed-octoai.in
-pydantic==2.8.2
+pydantic==2.9.0
     # via openai
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 regex==2024.7.24
     # via
@@ -80,6 +80,8 @@ typing-extensions==4.12.2
     #   openai
     #   pydantic
     #   pydantic-core
+tzdata==2024.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   -c ./ingest/../base.txt

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -52,11 +52,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain-core==0.2.36
+langchain-core==0.2.38
     # via langchain-openai
 langchain-openai==0.1.23
     # via -r ./ingest/embed-openai.in
-langsmith==0.1.107
+langsmith==0.1.114
     # via langchain-core
 openai==1.43.0
     # via langchain-openai
@@ -66,12 +66,12 @@ packaging==24.1
     # via
     #   -c ./ingest/../base.txt
     #   langchain-core
-pydantic==2.8.2
+pydantic==2.9.0
     # via
     #   langchain-core
     #   langsmith
     #   openai
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 pyyaml==6.0.2
     # via langchain-core
@@ -106,6 +106,8 @@ typing-extensions==4.12.2
     #   openai
     #   pydantic
     #   pydantic-core
+tzdata==2024.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   -c ./ingest/../base.txt

--- a/requirements/ingest/embed-vertexai.txt
+++ b/requirements/ingest/embed-vertexai.txt
@@ -65,7 +65,7 @@ google-auth==2.34.0
     #   google-cloud-core
     #   google-cloud-resource-manager
     #   google-cloud-storage
-google-cloud-aiplatform==1.64.0
+google-cloud-aiplatform==1.65.0
     # via langchain-google-vertexai
 google-cloud-bigquery==3.25.0
     # via google-cloud-aiplatform
@@ -79,7 +79,7 @@ google-cloud-storage==2.18.2
     # via
     #   google-cloud-aiplatform
     #   langchain-google-vertexai
-google-crc32c==1.5.0
+google-crc32c==1.6.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
@@ -129,15 +129,15 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.15
+langchain==0.2.16
     # via
     #   -r ./ingest/embed-vertexai.in
     #   langchain-community
-langchain-community==0.2.14
+langchain-community==0.2.16
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   -r ./ingest/embed-vertexai.in
-langchain-core==0.2.36
+langchain-core==0.2.38
     # via
     #   langchain
     #   langchain-community
@@ -145,9 +145,9 @@ langchain-core==0.2.36
     #   langchain-text-splitters
 langchain-google-vertexai==1.0.10
     # via -r ./ingest/embed-vertexai.in
-langchain-text-splitters==0.2.2
+langchain-text-splitters==0.2.4
     # via langchain
-langsmith==0.1.107
+langsmith==0.1.114
     # via
     #   langchain
     #   langchain-community
@@ -200,13 +200,13 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pydantic==2.8.2
+pydantic==2.9.0
     # via
     #   google-cloud-aiplatform
     #   langchain
     #   langchain-core
     #   langsmith
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 python-dateutil==2.9.0.post0
     # via
@@ -239,7 +239,7 @@ sniffio==1.3.1
     #   -c ./ingest/../base.txt
     #   anyio
     #   httpx
-sqlalchemy==2.0.32
+sqlalchemy==2.0.34
     # via
     #   langchain
     #   langchain-community
@@ -261,10 +261,12 @@ typing-inspect==0.9.0
     # via
     #   -c ./ingest/../base.txt
     #   dataclasses-json
+tzdata==2024.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   requests
-yarl==1.9.4
+yarl==1.9.11
     # via aiohttp

--- a/requirements/ingest/embed-voyageai.txt
+++ b/requirements/ingest/embed-voyageai.txt
@@ -67,18 +67,18 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.15
+langchain==0.2.16
     # via -r ./ingest/embed-voyageai.in
-langchain-core==0.2.36
+langchain-core==0.2.38
     # via
     #   langchain
     #   langchain-text-splitters
     #   langchain-voyageai
-langchain-text-splitters==0.2.2
+langchain-text-splitters==0.2.4
     # via langchain
 langchain-voyageai==0.1.1
     # via -r ./ingest/embed-voyageai.in
-langsmith==0.1.107
+langsmith==0.1.114
     # via
     #   langchain
     #   langchain-core
@@ -97,12 +97,12 @@ packaging==24.1
     # via
     #   -c ./ingest/../base.txt
     #   langchain-core
-pydantic==2.8.2
+pydantic==2.9.0
     # via
     #   langchain
     #   langchain-core
     #   langsmith
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 pyyaml==6.0.2
     # via
@@ -119,7 +119,7 @@ sniffio==1.3.1
     #   -c ./ingest/../base.txt
     #   anyio
     #   httpx
-sqlalchemy==2.0.32
+sqlalchemy==2.0.34
     # via langchain
 tenacity==8.5.0
     # via
@@ -134,6 +134,8 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
+tzdata==2024.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   -c ./ingest/../base.txt
@@ -141,5 +143,5 @@ urllib3==1.26.20
     #   requests
 voyageai==0.2.3
     # via langchain-voyageai
-yarl==1.9.4
+yarl==1.9.11
     # via aiohttp

--- a/requirements/ingest/gcs.txt
+++ b/requirements/ingest/gcs.txt
@@ -36,11 +36,11 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via
     #   -r ./ingest/gcs.in
     #   gcsfs
-gcsfs==2024.6.1
+gcsfs==2024.9.0.post1
     # via -r ./ingest/gcs.in
 google-api-core==2.19.2
     # via
@@ -59,7 +59,7 @@ google-cloud-core==2.4.1
     # via google-cloud-storage
 google-cloud-storage==2.18.2
     # via gcsfs
-google-crc32c==1.5.0
+google-crc32c==1.6.0
     # via
     #   google-cloud-storage
     #   google-resumable-media
@@ -112,5 +112,5 @@ urllib3==1.26.20
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   requests
-yarl==1.9.4
+yarl==1.9.11
     # via aiohttp

--- a/requirements/ingest/github.txt
+++ b/requirements/ingest/github.txt
@@ -8,7 +8,7 @@ certifi==2024.8.30
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
@@ -16,7 +16,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via pyjwt
 deprecated==1.2.14
     # via pygithub

--- a/requirements/ingest/google-drive.txt
+++ b/requirements/ingest/google-drive.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.3.2
     #   requests
 google-api-core==2.19.2
     # via google-api-python-client
-google-api-python-client==2.143.0
+google-api-python-client==2.144.0
     # via -r ./ingest/google-drive.in
 google-auth==2.34.0
     # via

--- a/requirements/ingest/kafka.txt
+++ b/requirements/ingest/kafka.txt
@@ -4,5 +4,5 @@
 #
 #    pip-compile ./ingest/kafka.in
 #
-confluent-kafka==2.5.0
+confluent-kafka==2.5.3
     # via -r ./ingest/kafka.in

--- a/requirements/ingest/onedrive.txt
+++ b/requirements/ingest/onedrive.txt
@@ -14,13 +14,13 @@ certifi==2024.8.30
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via
     #   msal
     #   pyjwt

--- a/requirements/ingest/outlook.txt
+++ b/requirements/ingest/outlook.txt
@@ -8,13 +8,13 @@ certifi==2024.8.30
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via
     #   msal
     #   pyjwt

--- a/requirements/ingest/qdrant.txt
+++ b/requirements/ingest/qdrant.txt
@@ -59,9 +59,9 @@ protobuf==4.23.4
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   grpcio-tools
-pydantic==2.8.2
+pydantic==2.9.0
     # via qdrant-client
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 qdrant-client==1.11.1
     # via -r ./ingest/qdrant.in
@@ -76,6 +76,8 @@ typing-extensions==4.12.2
     #   anyio
     #   pydantic
     #   pydantic-core
+tzdata==2024.1
+    # via pydantic
 urllib3==1.26.20
     # via
     #   -c ./ingest/../base.txt

--- a/requirements/ingest/s3.txt
+++ b/requirements/ingest/s3.txt
@@ -12,7 +12,7 @@ aiohttp==3.10.5
     # via
     #   aiobotocore
     #   s3fs
-aioitertools==0.11.0
+aioitertools==0.12.0
     # via aiobotocore
 aiosignal==1.3.1
     # via aiohttp
@@ -28,7 +28,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via
     #   -r ./ingest/s3.in
     #   s3fs
@@ -46,7 +46,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ./ingest/../base.txt
     #   botocore
-s3fs==2024.6.1
+s3fs==2024.9.0
     # via -r ./ingest/s3.in
 six==1.16.0
     # via
@@ -66,5 +66,5 @@ wrapt==1.16.0
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   aiobotocore
-yarl==1.9.4
+yarl==1.9.11
     # via aiohttp

--- a/requirements/ingest/salesforce.txt
+++ b/requirements/ingest/salesforce.txt
@@ -10,13 +10,13 @@ certifi==2024.8.30
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via pyjwt
 idna==3.8
     # via
@@ -28,7 +28,7 @@ lxml==5.3.0
     # via
     #   -c ./ingest/../base.txt
     #   zeep
-more-itertools==10.4.0
+more-itertools==10.5.0
     # via simple-salesforce
 platformdirs==3.10.0
     # via

--- a/requirements/ingest/sftp.txt
+++ b/requirements/ingest/sftp.txt
@@ -6,13 +6,13 @@
 #
 bcrypt==4.2.0
     # via paramiko
-cffi==1.17.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-cryptography==43.0.0
+cryptography==43.0.1
     # via paramiko
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via -r ./ingest/sftp.in
 paramiko==3.4.1
     # via -r ./ingest/sftp.in

--- a/requirements/ingest/sharepoint.txt
+++ b/requirements/ingest/sharepoint.txt
@@ -8,13 +8,13 @@ certifi==2024.8.30
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via
     #   msal
     #   pyjwt

--- a/requirements/ingest/singlestore.txt
+++ b/requirements/ingest/singlestore.txt
@@ -38,7 +38,7 @@ requests==2.32.3
     # via
     #   -c ./ingest/../base.txt
     #   singlestoredb
-singlestoredb==1.6.2
+singlestoredb==1.6.3
     # via -r ./ingest/singlestore.in
 sqlparams==6.1.0
     # via singlestoredb

--- a/requirements/ingest/weaviate.txt
+++ b/requirements/ingest/weaviate.txt
@@ -10,13 +10,13 @@ certifi==2024.8.30
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via authlib
 idna==3.8
     # via
@@ -33,7 +33,7 @@ urllib3==1.26.20
     #   -c ./ingest/../base.txt
     #   -c ./ingest/../deps/constraints.txt
     #   requests
-validators==0.33.0
+validators==0.34.0
     # via weaviate-client
 weaviate-client==3.26.7
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -131,11 +131,11 @@ pycodestyle==2.12.1
     # via
     #   flake8
     #   flake8-print
-pydantic==2.8.2
+pydantic==2.9.0
     # via
     #   -r ./test.in
     #   label-studio-sdk
-pydantic-core==2.20.1
+pydantic-core==2.23.2
     # via pydantic
 pyflakes==3.2.0
     # via
@@ -218,7 +218,9 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
 tzdata==2024.1
-    # via pandas
+    # via
+    #   pandas
+    #   pydantic
 ujson==5.10.0
     # via label-studio-sdk
 urllib3==1.26.20
@@ -236,7 +238,7 @@ wrapt==1.16.0
     #   vcrpy
 xmljson==0.2.1
     # via label-studio-sdk
-yarl==1.9.4
+yarl==1.9.11
     # via vcrpy
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
### Summary

Bumps to the latest version of the `cryptography` library to address `GHSA-h4gh-qq45-vh27`.