### PR TITLE
chore: fix tests breaking on main

### DIFF
--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -360,8 +360,8 @@ def test_partition_multiple_via_api_valid_request_data_kwargs():
         filenames=filenames,
         strategy="auto",
         api_key=get_api_key(),
-        # The url has changed since the 06/24 API release while the sdk defaults to the old url
-        api_url="https://api.unstructuredapp.io/general/v0/general",
+        # NOTE(crag): point to freemium API for now
+        api_url="https://api.unstructured.io/general/v0/general",
     )
     assert isinstance(elements, list)
 

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -106,6 +106,7 @@ def test_partition_via_api_raises_with_bad_response(request: FixtureRequest):
 
 
 @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_with_no_strategy():
     test_file = example_doc_path("pdf/loremipsum-flat.pdf")
     elements_no_strategy = partition_via_api(
@@ -145,6 +146,7 @@ def test_partition_via_api_with_no_strategy():
 
 
 @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_with_image_hi_res_strategy_includes_coordinates():
     # coordinates not included by default to limit payload size
     elements = partition_via_api(
@@ -159,6 +161,7 @@ def test_partition_via_api_with_image_hi_res_strategy_includes_coordinates():
 
 
 @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_image_block_extraction():
     elements = partition_via_api(
         filename=example_doc_path("pdf/embedded-images-tables.pdf"),
@@ -352,7 +355,8 @@ def get_api_key():
 
 
 @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
-def test_partition_multiple_via_api_valid_request_data_kwargs(:
+@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
+def test_partition_multiple_via_api_valid_request_data_kwargs():
     filenames = [
         example_doc_path("fake-text.txt"),
         example_doc_path("fake-email.txt"),

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -103,7 +103,6 @@ def test_partition_via_api_raises_with_bad_response(request: FixtureRequest):
 
 
 @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
-@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_with_no_strategy():
     elements_no_strategy = partition_via_api(
         filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
@@ -130,7 +129,6 @@ def test_partition_via_api_with_no_strategy():
 
 
 @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
-@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_with_image_hi_res_strategy_includes_coordinates():
     # coordinates not included by default to limit payload size
     elements = partition_via_api(
@@ -146,7 +144,6 @@ def test_partition_via_api_with_image_hi_res_strategy_includes_coordinates():
 
 
 @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
-@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_valid_request_data_kwargs():
     elements = partition_via_api(
         filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
@@ -160,7 +157,6 @@ def test_partition_via_api_valid_request_data_kwargs():
 
 
 @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
-@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_image_block_extraction():
     elements = partition_via_api(
         filename=example_doc_path("pdf/embedded-images-tables.pdf"),
@@ -354,7 +350,6 @@ def get_api_key():
 
 
 @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
-@pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_multiple_via_api_valid_request_data_kwargs():
     filenames = [
         example_doc_path("pdf/layout-parser-paper-fast.pdf"),

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -106,7 +106,7 @@ def test_partition_via_api_raises_with_bad_response(request: FixtureRequest):
 @pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_with_no_strategy():
     elements_no_strategy = partition_via_api(
-        filename=example_doc_path("layout-parser-paper-fast.pdf"),
+        filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
         strategy="auto",
         api_key=get_api_key(),
         # The url has changed since the 06/24 API release while the sdk defaults to the old url
@@ -114,7 +114,7 @@ def test_partition_via_api_with_no_strategy():
         skip_infer_table_types=["pdf"],
     )
     elements_hi_res = partition_via_api(
-        filename=example_doc_path("layout-parser-paper-fast.pdf"),
+        filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
         strategy="hi_res",
         api_key=get_api_key(),
         # The url has changed since the 06/24 API release while the sdk defaults to the old url
@@ -134,7 +134,7 @@ def test_partition_via_api_with_no_strategy():
 def test_partition_via_api_with_image_hi_res_strategy_includes_coordinates():
     # coordinates not included by default to limit payload size
     elements = partition_via_api(
-        filename=example_doc_path("layout-parser-paper-fast.pdf"),
+        filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
         strategy="hi_res",
         coordinates="true",
         api_key=get_api_key(),
@@ -149,7 +149,7 @@ def test_partition_via_api_with_image_hi_res_strategy_includes_coordinates():
 @pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_valid_request_data_kwargs():
     elements = partition_via_api(
-        filename=example_doc_path("layout-parser-paper-fast.pdf"),
+        filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
         strategy="fast",
         api_key=get_api_key(),
         # The url has changed since the 06/24 API release while the sdk defaults to the old url
@@ -163,7 +163,7 @@ def test_partition_via_api_valid_request_data_kwargs():
 @pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_via_api_image_block_extraction():
     elements = partition_via_api(
-        filename=example_doc_path("embedded-images-tables.pdf"),
+        filename=example_doc_path("pdf/embedded-images-tables.pdf"),
         strategy="hi_res",
         extract_image_block_types=["image", "table"],
         api_key=get_api_key(),
@@ -357,8 +357,8 @@ def get_api_key():
 @pytest.mark.skipif(skip_not_on_main, reason="Skipping test run outside of main branch")
 def test_partition_multiple_via_api_valid_request_data_kwargs():
     filenames = [
-        example_doc_path("layout-parser-paper-fast.pdf"),
-        example_doc_path("layout-parser-paper-fast.jpg"),
+        example_doc_path("pdf/layout-parser-paper-fast.pdf"),
+        example_doc_path("img/layout-parser-paper-fast.jpg"),
     ]
 
     elements = partition_multiple_via_api(

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -18,6 +18,9 @@ from ..unit_utils import ANY, FixtureRequest, example_doc_path, method_mock
 
 DIRECTORY = pathlib.Path(__file__).parent.resolve()
 
+# NOTE(crag): point to freemium API for now
+API_URL = "https://api.unstructured.io/general/v0/general"
+
 is_in_ci = os.getenv("CI", "").lower() not in {"", "false", "f", "0"}
 skip_not_on_main = os.getenv("GITHUB_REF_NAME", "").lower() != "main"
 
@@ -102,22 +105,31 @@ def test_partition_via_api_raises_with_bad_response(request: FixtureRequest):
     partition_mock_.assert_called_once()
 
 
-@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
 def test_partition_via_api_with_no_strategy():
+    test_file = example_doc_path("pdf/loremipsum-flat.pdf")
     elements_no_strategy = partition_via_api(
-        filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
+        filename=test_file,
         strategy="auto",
         api_key=get_api_key(),
         # The url has changed since the 06/24 API release while the sdk defaults to the old url
-        api_url="https://api.unstructuredapp.io/general/v0/general",
+        api_url=API_URL,
         skip_infer_table_types=["pdf"],
     )
     elements_hi_res = partition_via_api(
-        filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
+        filename=test_file,
         strategy="hi_res",
         api_key=get_api_key(),
         # The url has changed since the 06/24 API release while the sdk defaults to the old url
-        api_url="https://api.unstructuredapp.io/general/v0/general",
+        api_url=API_URL,
+        skip_infer_table_types=["pdf"],
+    )
+    elements_fast_res = partition_via_api(
+        filename=test_file,
+        strategy="fast",
+        api_key=get_api_key(),
+        # The url has changed since the 06/24 API release while the sdk defaults to the old url
+        api_url=API_URL,
         skip_infer_table_types=["pdf"],
     )
 
@@ -125,38 +137,28 @@ def test_partition_via_api_with_no_strategy():
     # elements_hi_res[3].text =
     #     'LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis'
     # while elements_no_strategy[3].text = ']' (as of this writing)
-    assert elements_no_strategy[3].text != elements_hi_res[3].text
+    assert len(elements_no_strategy) == len(elements_hi_res)
+    assert len(elements_hi_res) != len(elements_fast_res)
+
+    # NOTE(crag): slightly out scope assertion, but avoid extra API call
+    assert elements_hi_res[0].metadata.coordinates is None
 
 
-@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
 def test_partition_via_api_with_image_hi_res_strategy_includes_coordinates():
     # coordinates not included by default to limit payload size
     elements = partition_via_api(
-        filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
+        filename=example_doc_path("pdf/fake-memo.pdf"),
         strategy="hi_res",
         coordinates="true",
         api_key=get_api_key(),
-        # The url has changed since the 06/24 API release while the sdk defaults to the old url
-        api_url="https://api.unstructuredapp.io/general/v0/general",
+        api_url=API_URL,
     )
 
     assert elements[0].metadata.coordinates is not None
 
 
-@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
-def test_partition_via_api_valid_request_data_kwargs():
-    elements = partition_via_api(
-        filename=example_doc_path("pdf/layout-parser-paper-fast.pdf"),
-        strategy="fast",
-        api_key=get_api_key(),
-        # The url has changed since the 06/24 API release while the sdk defaults to the old url
-        api_url="https://api.unstructuredapp.io/general/v0/general",
-    )
-
-    assert isinstance(elements, list)
-
-
-@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
 def test_partition_via_api_image_block_extraction():
     elements = partition_via_api(
         filename=example_doc_path("pdf/embedded-images-tables.pdf"),
@@ -164,7 +166,7 @@ def test_partition_via_api_image_block_extraction():
         extract_image_block_types=["image", "table"],
         api_key=get_api_key(),
         # The url has changed since the 06/24 API release while the sdk defaults to the old url
-        api_url="https://api.unstructuredapp.io/general/v0/general",
+        api_url=API_URL,
     )
     image_elements = [el for el in elements if el.category == ElementType.IMAGE]
     for el in image_elements:
@@ -349,24 +351,26 @@ def get_api_key():
     return api_key
 
 
-@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
 def test_partition_multiple_via_api_valid_request_data_kwargs():
     filenames = [
-        example_doc_path("pdf/layout-parser-paper-fast.pdf"),
-        example_doc_path("img/layout-parser-paper-fast.jpg"),
+        example_doc_path("fake-text.txt"),
+        example_doc_path("fake-email.txt"),
     ]
 
-    elements = partition_multiple_via_api(
+    list_of_lists_of_elements = partition_multiple_via_api(
         filenames=filenames,
-        strategy="auto",
+        strategy="fast",
         api_key=get_api_key(),
-        # NOTE(crag): point to freemium API for now
-        api_url="https://api.unstructured.io/general/v0/general",
+        api_url=API_URL,
     )
-    assert isinstance(elements, list)
+    # assert there is a list of elements for each file
+    assert len(list_of_lists_of_elements) == 2
+    assert isinstance(list_of_lists_of_elements[0], list)
+    assert isinstance(list_of_lists_of_elements[1], list)
 
 
-@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
 def test_partition_multiple_via_api_invalid_request_data_kwargs():
     filenames = [
         example_doc_path("pdf/layout-parser-paper-fast.pdf"),
@@ -378,7 +382,7 @@ def test_partition_multiple_via_api_invalid_request_data_kwargs():
             strategy="not_a_strategy",
             api_key=get_api_key(),
             # The url has changed since the 06/24 API release while the sdk defaults to the old url
-            api_url="https://api.unstructuredapp.io/general/v0/general",
+            api_url=API_URL,
         )
 
 

--- a/test_unstructured/partition/test_api.py
+++ b/test_unstructured/partition/test_api.py
@@ -105,7 +105,7 @@ def test_partition_via_api_raises_with_bad_response(request: FixtureRequest):
     partition_mock_.assert_called_once()
 
 
-# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
 def test_partition_via_api_with_no_strategy():
     test_file = example_doc_path("pdf/loremipsum-flat.pdf")
     elements_no_strategy = partition_via_api(
@@ -144,7 +144,7 @@ def test_partition_via_api_with_no_strategy():
     assert elements_hi_res[0].metadata.coordinates is None
 
 
-# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
 def test_partition_via_api_with_image_hi_res_strategy_includes_coordinates():
     # coordinates not included by default to limit payload size
     elements = partition_via_api(
@@ -158,7 +158,7 @@ def test_partition_via_api_with_image_hi_res_strategy_includes_coordinates():
     assert elements[0].metadata.coordinates is not None
 
 
-# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
 def test_partition_via_api_image_block_extraction():
     elements = partition_via_api(
         filename=example_doc_path("pdf/embedded-images-tables.pdf"),
@@ -351,8 +351,8 @@ def get_api_key():
     return api_key
 
 
-# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
-def test_partition_multiple_via_api_valid_request_data_kwargs():
+@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+def test_partition_multiple_via_api_valid_request_data_kwargs(:
     filenames = [
         example_doc_path("fake-text.txt"),
         example_doc_path("fake-email.txt"),
@@ -370,7 +370,7 @@ def test_partition_multiple_via_api_valid_request_data_kwargs():
     assert isinstance(list_of_lists_of_elements[1], list)
 
 
-# @pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
+@pytest.mark.skipif(not is_in_ci, reason="Skipping test run outside of CI")
 def test_partition_multiple_via_api_invalid_request_data_kwargs():
     filenames = [
         example_doc_path("pdf/layout-parser-paper-fast.pdf"),


### PR DESCRIPTION
Fix API tests (really more like integration tests) that run only on main. Also use less compute intensive files to speedup test time and remove a useless test.

Tests in `test_unstructured/partition/test_api.py` pass, temporarily running outside of main per per screenshot:
![image](https://github.com/user-attachments/assets/f15d440a-2574-40f2-98b4-adf57fbae704)

https://github.com/Unstructured-IO/unstructured/actions/runs/10754098974/job/29824415513