### PR TITLE
fix: remove mesa-gl workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,6 @@ COPY unstructured unstructured
 COPY test_unstructured test_unstructured
 COPY example-docs example-docs
 
-# NOTE(robinson) - temporary workaround to install mesa-gl 24.1.0 because
-# libgallum is missing in mesa-gl 24.2.0 from the wolfi package manager
-RUN wget "https://utic-public-cf.s3.amazonaws.com/mesa-gl-24.1.0-r0.718c913d.apk" && \
-  wget "https://utic-public-cf.s3.amazonaws.com/mesa-glapi-24.1.0-r0.4390a503.apk" && \
-  apk del mesa-gl && \
-  apk add --allow-untrusted mesa-gl-24.1.0-r0.718c913d.apk && \
-  apk add --allow-untrusted mesa-glapi-24.1.0-r0.4390a503.apk && \
-  rm mesa-gl-24.1.0-r0.718c913d.apk && \
-  rm mesa-glapi-24.1.0-r0.4390a503.apk
-
-
 RUN chown -R notebook-user:notebook-user /app && \
   apk add font-ubuntu git && \
   fc-cache -fv && \


### PR DESCRIPTION
### Summary

Removes the `mesa-gl` workaround from the `unstructured` image. This was fixed upstream in `base-images` in the PR linked below.

- https://github.com/Unstructured-IO/base-images/pull/44