### PR TITLE
fix: Table metric typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 0.15.12-dev0
+## 0.15.12-dev1
 
 ### Enhancements
 
 ### Features
 
 ### Fixes
+
+* **Fixed table accuracy metric** Table accuracy was incorrectly using column content difference in calculating row accuracy.
 
 ## 0.15.11
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.12-dev0"  # pragma: no cover
+__version__ = "0.15.12-dev1"  # pragma: no cover

--- a/unstructured/metrics/table/table_alignment.py
+++ b/unstructured/metrics/table/table_alignment.py
@@ -176,5 +176,5 @@ class TableAlignment:
             "col_index_acc": round(np.mean(col_index_acc), 2),
             "row_index_acc": round(np.mean(row_index_acc), 2),
             "col_content_acc": round(np.mean(content_diff_cols) / 100.0, 2),
-            "row_content_acc": round(np.mean(content_diff_cols) / 100.0, 2),
+            "row_content_acc": round(np.mean(content_diff_rows) / 100.0, 2),
         }


### PR DESCRIPTION
It looks like we puts columns when we meant rows in one of the table metrics. @pravin-unstructured  flagged this.