### PR TITLE
build(deps): bump protobuf pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.13-dev0
+## 0.15.13-dev1
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.15.13-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
 ## 0.15.12
 
 ### Enhancements

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,7 +44,7 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.2
     # via unstructured-client
-idna==3.8
+idna==3.10
     # via
     #   anyio
     #   httpx

--- a/requirements/deps/constraints.txt
+++ b/requirements/deps/constraints.txt
@@ -3,10 +3,11 @@
 # extras. Putting a dependency here will only affect dependency sets that contain them -- in other
 # words, if something does not require a constraint, it will not be installed.
 ####################################################################################################
-# consistency with local-inference-pin
-protobuf<4.24
+# (jennings): Versions greater than 5.0 create dependency conflicts with other packages
+protobuf<5.0
+# TODO: Constriant due to multiple versions being installed during pip-compile
 grpcio>=1.65.5
-# TODO: Pinned in transformers package, remove when that gets updated
+# TODO: Pinned in transformers package, remove when that gets updated (https://github.com/huggingface/transformers/blob/main/setup.py)
 tokenizers>=0.19,<0.20
 # TODO: Constaint due to boto, with python before 3.10 not requiring openssl 1.1.1, remove when that gets
 # updated or we drop support for 3.9

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,7 +17,7 @@ distlib==0.3.8
     # via virtualenv
 filelock==3.16.0
     # via virtualenv
-identify==2.6.0
+identify==2.6.1
     # via pre-commit
 importlib-metadata==8.5.0
     # via
@@ -32,7 +32,7 @@ packaging==24.1
     #   build
 pip-tools==7.4.1
     # via -r ./dev.in
-platformdirs==4.3.2
+platformdirs==4.3.3
     # via
     #   -c ./test.txt
     #   virtualenv
@@ -55,7 +55,7 @@ virtualenv==20.26.4
     # via pre-commit
 wheel==0.44.0
     # via pip-tools
-zipp==3.20.1
+zipp==3.20.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/extra-markdown.txt
+++ b/requirements/extra-markdown.txt
@@ -10,5 +10,5 @@ importlib-metadata==8.5.0
     #   markdown
 markdown==3.7
     # via -r ./extra-markdown.in
-zipp==3.20.1
+zipp==3.20.2
     # via importlib-metadata

--- a/requirements/extra-paddleocr.txt
+++ b/requirements/extra-paddleocr.txt
@@ -46,7 +46,7 @@ httpx==0.27.2
     # via
     #   -c ./base.txt
     #   paddlepaddle
-idna==3.8
+idna==3.10
     # via
     #   -c ./base.txt
     #   anyio
@@ -113,7 +113,7 @@ pillow==10.4.0
     #   pdf2image
     #   scikit-image
     #   unstructured-paddleocr
-protobuf==4.23.4
+protobuf==4.25.4
     # via
     #   -c ././deps/constraints.txt
     #   paddlepaddle
@@ -175,5 +175,5 @@ urllib3==1.26.20
     #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   requests
-zipp==3.20.1
+zipp==3.20.2
     # via importlib-resources

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -71,7 +71,7 @@ huggingface-hub==0.24.7
     #   unstructured-inference
 humanfriendly==10.0
     # via coloredlogs
-idna==3.8
+idna==3.10
     # via
     #   -c ./base.txt
     #   requests
@@ -166,7 +166,7 @@ proto-plus==1.24.0
     # via
     #   google-api-core
     #   google-cloud-vision
-protobuf==4.23.4
+protobuf==4.25.4
     # via
     #   -c ././deps/constraints.txt
     #   google-api-core
@@ -288,5 +288,5 @@ wrapt==1.16.0
     # via
     #   -c ./base.txt
     #   deprecated
-zipp==3.20.1
+zipp==3.20.2
     # via importlib-resources

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -29,7 +29,7 @@ huggingface-hub==0.24.7
     # via
     #   tokenizers
     #   transformers
-idna==3.8
+idna==3.10
     # via
     #   -c ./base.txt
     #   requests

--- a/requirements/ingest/airtable.txt
+++ b/requirements/ingest/airtable.txt
@@ -14,7 +14,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/astradb.txt
+++ b/requirements/ingest/astradb.txt
@@ -56,7 +56,7 @@ httpx[http2]==0.27.2
     #   astrapy
 hyperframe==6.0.1
     # via h2
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio

--- a/requirements/ingest/azure-cognitive-search.txt
+++ b/requirements/ingest/azure-cognitive-search.txt
@@ -6,7 +6,7 @@
 #
 azure-common==1.1.28
     # via azure-search-documents
-azure-core==1.30.2
+azure-core==1.31.0
     # via azure-search-documents
 azure-search-documents==11.5.1
     # via -r ./ingest/azure-cognitive-search.in
@@ -18,7 +18,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/azure.txt
+++ b/requirements/ingest/azure.txt
@@ -16,7 +16,7 @@ async-timeout==4.0.3
     # via aiohttp
 attrs==24.2.0
     # via aiohttp
-azure-core==1.30.2
+azure-core==1.31.0
     # via
     #   adlfs
     #   azure-identity
@@ -53,7 +53,7 @@ fsspec==2024.9.0
     # via
     #   -r ./ingest/azure.in
     #   adlfs
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -76,7 +76,9 @@ portalocker==2.10.1
 pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.9.0
-    # via msal
+    # via
+    #   msal
+    #   pyjwt
 requests==2.32.3
     # via
     #   -c ./ingest/../base.txt

--- a/requirements/ingest/box.txt
+++ b/requirements/ingest/box.txt
@@ -26,7 +26,7 @@ fsspec==2024.9.0
     # via
     #   -r ./ingest/box.in
     #   boxfs
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/chroma.in
+++ b/requirements/ingest/chroma.in
@@ -1,6 +1,6 @@
 -c ../deps/constraints.txt
 -c ../base.txt
-chromadb
+chromadb>0.4.14
 importlib-metadata>=8.2.0
 # Future releases adds in typer-cli which breaks the resolution of typer as a library
 typer<=0.9.0

--- a/requirements/ingest/chroma.txt
+++ b/requirements/ingest/chroma.txt
@@ -49,7 +49,7 @@ exceptiongroup==1.2.2
     # via
     #   -c ./ingest/../base.txt
     #   anyio
-fastapi==0.114.1
+fastapi==0.114.2
     # via chromadb
 filelock==3.16.0
     # via huggingface-hub
@@ -77,7 +77,7 @@ huggingface-hub==0.24.7
     # via tokenizers
 humanfriendly==10.0
     # via coloredlogs
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -130,9 +130,9 @@ packaging==24.1
     #   build
     #   huggingface-hub
     #   onnxruntime
-posthog==3.6.5
+posthog==3.6.6
     # via chromadb
-protobuf==4.23.4
+protobuf==4.25.4
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   googleapis-common-protos
@@ -245,7 +245,7 @@ wrapt==1.16.0
     #   -c ./ingest/../base.txt
     #   deprecated
     #   opentelemetry-instrumentation
-zipp==3.20.1
+zipp==3.20.2
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/ingest/clarifai.txt
+++ b/requirements/ingest/clarifai.txt
@@ -24,7 +24,7 @@ grpcio==1.66.1
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   clarifai-grpc
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -45,7 +45,7 @@ pillow==10.4.0
     # via clarifai
 prompt-toolkit==3.0.47
     # via inquirerpy
-protobuf==4.23.4
+protobuf==4.25.4
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   clarifai-grpc

--- a/requirements/ingest/confluence.txt
+++ b/requirements/ingest/confluence.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/confluence.in
 #
-atlassian-python-api==3.41.15
+atlassian-python-api==3.41.16
     # via -r ./ingest/confluence.in
 beautifulsoup4==4.12.3
     # via
@@ -20,7 +20,7 @@ charset-normalizer==3.3.2
     #   requests
 deprecated==1.2.14
     # via atlassian-python-api
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/databricks-volumes.txt
+++ b/requirements/ingest/databricks-volumes.txt
@@ -18,7 +18,7 @@ databricks-sdk==0.32.1
     # via -r ./ingest/databricks-volumes.in
 google-auth==2.34.0
     # via databricks-sdk
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/discord.txt
+++ b/requirements/ingest/discord.txt
@@ -20,7 +20,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   yarl

--- a/requirements/ingest/dropbox.txt
+++ b/requirements/ingest/dropbox.txt
@@ -20,7 +20,7 @@ fsspec==2024.9.0
     # via
     #   -r ./ingest/dropbox.in
     #   dropboxdrivefs
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/elasticsearch.txt
+++ b/requirements/ingest/elasticsearch.txt
@@ -26,7 +26,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   yarl

--- a/requirements/ingest/embed-aws-bedrock.txt
+++ b/requirements/ingest/embed-aws-bedrock.txt
@@ -65,7 +65,7 @@ httpx==0.27.2
     # via
     #   -c ./ingest/../base.txt
     #   langsmith
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -80,18 +80,18 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.16
+langchain==0.3.0
     # via langchain-community
-langchain-community==0.2.16
+langchain-community==0.3.0
     # via -r ./ingest/embed-aws-bedrock.in
-langchain-core==0.2.39
+langchain-core==0.3.0
     # via
     #   langchain
     #   langchain-community
     #   langchain-text-splitters
-langchain-text-splitters==0.2.4
+langchain-text-splitters==0.3.0
     # via langchain
-langsmith==0.1.118
+langsmith==0.1.120
     # via
     #   langchain
     #   langchain-community
@@ -125,12 +125,17 @@ pydantic==2.9.1
     #   langchain
     #   langchain-core
     #   langsmith
+    #   pydantic-settings
 pydantic-core==2.23.3
     # via pydantic
+pydantic-settings==2.5.2
+    # via langchain-community
 python-dateutil==2.9.0.post0
     # via
     #   -c ./ingest/../base.txt
     #   botocore
+python-dotenv==1.0.1
+    # via pydantic-settings
 pyyaml==6.0.2
     # via
     #   langchain

--- a/requirements/ingest/embed-huggingface.txt
+++ b/requirements/ingest/embed-huggingface.txt
@@ -51,7 +51,7 @@ huggingface-hub==0.24.7
     #   sentence-transformers
     #   tokenizers
     #   transformers
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -67,11 +67,11 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain-core==0.2.39
+langchain-core==0.3.0
     # via langchain-huggingface
-langchain-huggingface==0.0.3
+langchain-huggingface==0.1.0
     # via -r ./ingest/embed-huggingface.in
-langsmith==0.1.118
+langsmith==0.1.120
     # via langchain-core
 markupsafe==2.1.5
     # via jinja2

--- a/requirements/ingest/embed-mixedbreadai.txt
+++ b/requirements/ingest/embed-mixedbreadai.txt
@@ -31,7 +31,7 @@ httpx==0.27.2
     # via
     #   -c ./ingest/../base.txt
     #   mixedbread-ai
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio

--- a/requirements/ingest/embed-octoai.txt
+++ b/requirements/ingest/embed-octoai.txt
@@ -39,7 +39,7 @@ httpx==0.27.2
     # via
     #   -c ./ingest/../base.txt
     #   openai
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -47,7 +47,7 @@ idna==3.8
     #   requests
 jiter==0.5.0
     # via openai
-openai==1.44.1
+openai==1.45.0
     # via -r ./ingest/embed-octoai.in
 pydantic==2.9.1
     # via openai

--- a/requirements/ingest/embed-openai.txt
+++ b/requirements/ingest/embed-openai.txt
@@ -40,7 +40,7 @@ httpx==0.27.2
     #   -c ./ingest/../base.txt
     #   langsmith
     #   openai
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -52,13 +52,13 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain-core==0.2.39
+langchain-core==0.3.0
     # via langchain-openai
-langchain-openai==0.1.23
+langchain-openai==0.2.0
     # via -r ./ingest/embed-openai.in
-langsmith==0.1.118
+langsmith==0.1.120
     # via langchain-core
-openai==1.44.1
+openai==1.45.0
     # via langchain-openai
 orjson==3.10.7
     # via langsmith

--- a/requirements/ingest/embed-vertexai.txt
+++ b/requirements/ingest/embed-vertexai.txt
@@ -118,7 +118,7 @@ httpx==0.27.2
     #   langsmith
 httpx-sse==0.4.0
     # via langchain-google-vertexai
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -129,23 +129,23 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.16
+langchain==0.3.0
     # via
     #   -r ./ingest/embed-vertexai.in
     #   langchain-community
-langchain-community==0.2.16
+langchain-community==0.3.0
     # via -r ./ingest/embed-vertexai.in
-langchain-core==0.2.39
+langchain-core==0.3.0
     # via
     #   langchain
     #   langchain-community
     #   langchain-google-vertexai
     #   langchain-text-splitters
-langchain-google-vertexai==1.0.10
+langchain-google-vertexai==2.0.0
     # via -r ./ingest/embed-vertexai.in
-langchain-text-splitters==0.2.4
+langchain-text-splitters==0.3.0
     # via langchain
-langsmith==0.1.118
+langsmith==0.1.120
     # via
     #   langchain
     #   langchain-community
@@ -182,7 +182,7 @@ proto-plus==1.24.0
     #   google-api-core
     #   google-cloud-aiplatform
     #   google-cloud-resource-manager
-protobuf==4.23.4
+protobuf==4.25.4
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   google-api-core
@@ -203,13 +203,19 @@ pydantic==2.9.1
     #   google-cloud-aiplatform
     #   langchain
     #   langchain-core
+    #   langchain-google-vertexai
     #   langsmith
+    #   pydantic-settings
 pydantic-core==2.23.3
     # via pydantic
+pydantic-settings==2.5.2
+    # via langchain-community
 python-dateutil==2.9.0.post0
     # via
     #   -c ./ingest/../base.txt
     #   google-cloud-bigquery
+python-dotenv==1.0.1
+    # via pydantic-settings
 pyyaml==6.0.2
     # via
     #   langchain

--- a/requirements/ingest/embed-voyageai.txt
+++ b/requirements/ingest/embed-voyageai.txt
@@ -56,7 +56,7 @@ httpx==0.27.2
     # via
     #   -c ./ingest/../base.txt
     #   langsmith
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -67,18 +67,18 @@ jsonpatch==1.33
     # via langchain-core
 jsonpointer==3.0.0
     # via jsonpatch
-langchain==0.2.16
+langchain==0.3.0
     # via -r ./ingest/embed-voyageai.in
-langchain-core==0.2.39
+langchain-core==0.3.0
     # via
     #   langchain
     #   langchain-text-splitters
     #   langchain-voyageai
-langchain-text-splitters==0.2.4
+langchain-text-splitters==0.3.0
     # via langchain
-langchain-voyageai==0.1.1
+langchain-voyageai==0.1.2
     # via -r ./ingest/embed-voyageai.in
-langsmith==0.1.118
+langsmith==0.1.120
     # via
     #   langchain
     #   langchain-core
@@ -101,6 +101,7 @@ pydantic==2.9.1
     # via
     #   langchain
     #   langchain-core
+    #   langchain-voyageai
     #   langsmith
 pydantic-core==2.23.3
     # via pydantic

--- a/requirements/ingest/gcs.txt
+++ b/requirements/ingest/gcs.txt
@@ -67,7 +67,7 @@ google-resumable-media==2.7.2
     # via google-cloud-storage
 googleapis-common-protos==1.65.0
     # via google-api-core
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -80,7 +80,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 proto-plus==1.24.0
     # via google-api-core
-protobuf==4.23.4
+protobuf==4.25.4
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   google-api-core

--- a/requirements/ingest/github.txt
+++ b/requirements/ingest/github.txt
@@ -20,7 +20,7 @@ cryptography==43.0.1
     # via pyjwt
 deprecated==1.2.14
     # via pygithub
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/gitlab.txt
+++ b/requirements/ingest/gitlab.txt
@@ -12,11 +12,11 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
-python-gitlab==4.10.0
+python-gitlab==4.11.1
     # via -r ./ingest/gitlab.in
 requests==2.32.3
     # via

--- a/requirements/ingest/google-drive.txt
+++ b/requirements/ingest/google-drive.txt
@@ -31,13 +31,13 @@ httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
 proto-plus==1.24.0
     # via google-api-core
-protobuf==4.23.4
+protobuf==4.25.4
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   google-api-core

--- a/requirements/ingest/jira.txt
+++ b/requirements/ingest/jira.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile ./ingest/jira.in
 #
-atlassian-python-api==3.41.15
+atlassian-python-api==3.41.16
     # via -r ./ingest/jira.in
 beautifulsoup4==4.12.3
     # via
@@ -20,7 +20,7 @@ charset-normalizer==3.3.2
     #   requests
 deprecated==1.2.14
     # via atlassian-python-api
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/notion.txt
+++ b/requirements/ingest/notion.txt
@@ -31,7 +31,7 @@ httpx==0.27.2
     # via
     #   -c ./ingest/../base.txt
     #   notion-client
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio

--- a/requirements/ingest/onedrive.txt
+++ b/requirements/ingest/onedrive.txt
@@ -24,7 +24,7 @@ cryptography==43.0.1
     # via
     #   msal
     #   pyjwt
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -37,7 +37,9 @@ office365-rest-python-client==2.5.12
 pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.9.0
-    # via msal
+    # via
+    #   msal
+    #   pyjwt
 pytz==2024.2
     # via office365-rest-python-client
 requests==2.32.3

--- a/requirements/ingest/opensearch.txt
+++ b/requirements/ingest/opensearch.txt
@@ -15,7 +15,7 @@ charset-normalizer==3.3.2
     #   requests
 events==0.5
     # via opensearch-py
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/outlook.txt
+++ b/requirements/ingest/outlook.txt
@@ -18,7 +18,7 @@ cryptography==43.0.1
     # via
     #   msal
     #   pyjwt
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -31,7 +31,9 @@ office365-rest-python-client==2.5.12
 pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.9.0
-    # via msal
+    # via
+    #   msal
+    #   pyjwt
 pytz==2024.2
     # via office365-rest-python-client
 requests==2.32.3

--- a/requirements/ingest/pinecone.txt
+++ b/requirements/ingest/pinecone.txt
@@ -10,7 +10,7 @@ certifi==2024.8.30
     #   pinecone-client
 pinecone-client==5.0.1
     # via -r ./ingest/pinecone.in
-pinecone-plugin-inference==1.0.3
+pinecone-plugin-inference==1.1.0
     # via pinecone-client
 pinecone-plugin-interface==0.0.7
     # via

--- a/requirements/ingest/qdrant.txt
+++ b/requirements/ingest/qdrant.txt
@@ -44,7 +44,7 @@ httpx[http2]==0.27.2
     #   qdrant-client
 hyperframe==6.0.1
     # via h2
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   anyio
@@ -55,7 +55,7 @@ numpy==1.26.4
     #   qdrant-client
 portalocker==2.10.1
     # via qdrant-client
-protobuf==4.23.4
+protobuf==4.25.4
     # via
     #   -c ./ingest/../deps/constraints.txt
     #   grpcio-tools

--- a/requirements/ingest/reddit.txt
+++ b/requirements/ingest/reddit.txt
@@ -12,7 +12,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/s3.txt
+++ b/requirements/ingest/s3.txt
@@ -32,7 +32,7 @@ fsspec==2024.9.0
     # via
     #   -r ./ingest/s3.in
     #   s3fs
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   yarl

--- a/requirements/ingest/salesforce.txt
+++ b/requirements/ingest/salesforce.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.3.2
     #   requests
 cryptography==43.0.1
     # via pyjwt
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -30,7 +30,7 @@ lxml==5.3.0
     #   zeep
 more-itertools==10.5.0
     # via simple-salesforce
-platformdirs==4.3.2
+platformdirs==4.3.3
     # via zeep
 pycparser==2.22
     # via cffi

--- a/requirements/ingest/sftp.txt
+++ b/requirements/ingest/sftp.txt
@@ -14,7 +14,7 @@ cryptography==43.0.1
     # via paramiko
 fsspec==2024.9.0
     # via -r ./ingest/sftp.in
-paramiko==3.4.1
+paramiko==3.5.0
     # via -r ./ingest/sftp.in
 pycparser==2.22
     # via cffi

--- a/requirements/ingest/sharepoint.txt
+++ b/requirements/ingest/sharepoint.txt
@@ -18,7 +18,7 @@ cryptography==43.0.1
     # via
     #   msal
     #   pyjwt
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -31,7 +31,9 @@ office365-rest-python-client==2.5.12
 pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.9.0
-    # via msal
+    # via
+    #   msal
+    #   pyjwt
 pytz==2024.2
     # via office365-rest-python-client
 requests==2.32.3

--- a/requirements/ingest/singlestore.txt
+++ b/requirements/ingest/singlestore.txt
@@ -14,7 +14,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests
@@ -55,7 +55,7 @@ urllib3==1.26.20
     #   requests
 wheel==0.44.0
     # via singlestoredb
-zipp==3.20.1
+zipp==3.20.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ingest/weaviate.txt
+++ b/requirements/ingest/weaviate.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.3.2
     #   requests
 cryptography==43.0.1
     # via authlib
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/ingest/wikipedia.txt
+++ b/requirements/ingest/wikipedia.txt
@@ -16,7 +16,7 @@ charset-normalizer==3.3.2
     # via
     #   -c ./ingest/../base.txt
     #   requests
-idna==3.8
+idna==3.10
     # via
     #   -c ./ingest/../base.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -66,7 +66,7 @@ httpx==0.27.2
     # via
     #   -c ./base.txt
     #   label-studio-sdk
-idna==3.8
+idna==3.10
     # via
     #   -c ./base.txt
     #   anyio
@@ -121,7 +121,7 @@ pathspec==0.12.1
     # via black
 pillow==10.4.0
     # via label-studio-sdk
-platformdirs==4.3.2
+platformdirs==4.3.3
     # via black
 pluggy==1.5.0
     # via pytest

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.12"  # pragma: no cover
+__version__ = "0.15.13-dev0"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.13-dev0"  # pragma: no cover
+__version__ = "0.15.13-dev1"  # pragma: no cover

--- a/unstructured/ingest/v2/processes/connectors/chroma.py
+++ b/unstructured/ingest/v2/processes/connectors/chroma.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import uuid
 from dataclasses import dataclass, field
@@ -5,6 +7,7 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from chromadb.config import Settings
 from dateutil import parser
 
 from unstructured.ingest.enhanced_dataclass import enhanced_field
@@ -28,14 +31,14 @@ from unstructured.staging.base import flatten_dict
 from unstructured.utils import requires_dependencies
 
 if TYPE_CHECKING:
-    from chromadb import Client
+    from chromadb.api import ClientAPI
 
 CONNECTOR_TYPE = "chroma"
 
 
 @dataclass
 class ChromaAccessConfig(AccessConfig):
-    settings: Optional[Dict[str, str]] = None
+    settings: Optional[Settings] = None
     headers: Optional[Dict[str, str]] = None
 
 
@@ -44,8 +47,8 @@ class ChromaConnectionConfig(ConnectionConfig):
     collection_name: str
     access_config: ChromaAccessConfig = enhanced_field(sensitive=True)
     path: Optional[str] = None
-    tenant: Optional[str] = "default_tenant"
-    database: Optional[str] = "default_database"
+    tenant: str = "default_tenant"
+    database: str = "default_database"
     host: Optional[str] = None
     port: Optional[int] = None
     ssl: bool = False
@@ -112,13 +115,13 @@ class ChromaUploader(Uploader):
     connector_type: str = CONNECTOR_TYPE
     upload_config: ChromaUploaderConfig
     connection_config: ChromaConnectionConfig
-    client: Optional["Client"] = field(init=False)
+    client: Optional[ClientAPI] = field(init=False)
 
     def __post_init__(self):
         self.client = self.create_client()
 
     @requires_dependencies(["chromadb"], extras="chroma")
-    def create_client(self) -> "Client":
+    def create_client(self) -> ClientAPI:
         import chromadb
 
         if self.connection_config.path:


### PR DESCRIPTION
Bumps max version of `protobuf<5.0` and sets min version of `chromadb>0.4.14` in `requirements/ingest/chroma.in`. Also fixes some type hints in `unstructured/ingest/v2/processes/connectors/chroma.py`