### PR TITLE
rfctr(part): remove double-decoration 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.14-dev6
+## 0.15.14-dev7
 
 ### Enhancements
 
@@ -12,6 +12,7 @@
 * **Remove "unused" `date_from_file_object` parameter.** As part of simplifying partitioning parameter set, remove `date_from_file_object` parameter. A file object does not have a last-modified date attribute so can never give a useful value. When a file-object is used as the document source (such as in Unstructured API) the last-modified date must come from the `metadata_last_modified` argument.
 * **Fix occasional `KeyError` when mapping parent ids to hash ids.** Occasionally the input elements into `assign_and_map_hash_ids` can contain duplicated element instances, which lead to error when mapping parent id.
 * **Allow empty text files.** Fixes an issue where text files with only white space would fail to be partitioned.
+* **Remove double-decoration for CSV, DOC, ODT partitioners.** Refactor these partitioners to use the new `@apply_metadata()` decorator and only decorate the principal partitioner (CSV and DOCX in this case); remove decoration from delegating partitioners.
 
 ## 0.15.13
 

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -222,8 +222,6 @@ class Describe_CsvPartitioningContext:
             file_path=example_doc_path("stanley-cups.csv"),
             file=None,
             encoding=None,
-            metadata_file_path=None,
-            metadata_last_modified=None,
             include_header=True,
             infer_table_structure=True,
         )
@@ -235,8 +233,6 @@ class Describe_CsvPartitioningContext:
                 file_path=None,
                 file=None,
                 encoding=None,
-                metadata_file_path=None,
-                metadata_last_modified=None,
                 include_header=True,
                 infer_table_structure=True,
             )
@@ -272,22 +268,19 @@ class Describe_CsvPartitioningContext:
     ):
         assert _CsvPartitioningContext(include_header=include_header).header == expected_value
 
-    # -- .last_modified --------------------------
+    # -- .last_modified -----------------------------------------
 
-    def it_gets_the_last_modified_date_of_the_document_from_the_caller_when_provided(self):
-        ctx = _CsvPartitioningContext(metadata_last_modified="2024-08-04T13:12:35")
-        assert ctx.last_modified == "2024-08-04T13:12:35"
-
-    def and_it_falls_back_to_the_last_modified_date_of_the_file_when_a_path_is_provided(
+    def it_gets_last_modified_from_the_filesystem_when_a_path_is_provided(
         self, get_last_modified_date_: Mock
     ):
-        get_last_modified_date_.return_value = "2024-08-04T02:23:53"
+        filesystem_last_modified = "2024-08-04T02:23:53"
+        get_last_modified_date_.return_value = filesystem_last_modified
         ctx = _CsvPartitioningContext(file_path="a/b/document.csv")
 
         last_modified = ctx.last_modified
 
         get_last_modified_date_.assert_called_once_with("a/b/document.csv")
-        assert last_modified == "2024-08-04T02:23:53"
+        assert last_modified == filesystem_last_modified
 
     def and_it_falls_back_to_None_for_the_last_modified_date_when_file_path_is_not_provided(self):
         file = io.BytesIO(b"abcdefg")

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -462,10 +462,7 @@ def test_partition_docx_respects_languages_arg():
 def test_partition_docx_raises_TypeError_for_invalid_languages():
     with pytest.raises(TypeError):
         filename = example_doc_path("handbook-1p.docx")
-        partition_docx(
-            filename=filename,
-            languages="eng",  # pyright: ignore[reportArgumentType]
-        )
+        partition_docx(filename=filename, languages="eng")
 
 
 # ------------------------------------------------------------------------------------------------
@@ -703,8 +700,6 @@ def opts_args() -> dict[str, Any]:
         "file_path": None,
         "include_page_breaks": True,
         "infer_table_structure": True,
-        "metadata_file_path": None,
-        "metadata_last_modified": None,
         "strategy": None,
     }
 
@@ -805,15 +800,7 @@ class DescribeDocxPartitionerOptions:
 
     # -- .last_modified --------------------------
 
-    def it_gets_the_last_modified_date_of_the_document_from_the_caller_when_provided(
-        self, opts_args: dict[str, Any]
-    ):
-        opts_args["metadata_last_modified"] = "2024-03-05T17:02:53"
-        opts = DocxPartitionerOptions(**opts_args)
-
-        assert opts.last_modified == "2024-03-05T17:02:53"
-
-    def and_it_falls_back_to_the_last_modified_date_of_the_file_when_a_path_is_provided(
+    def it_gets_last_modified_from_the_filesystem_when_file_path_is_provided(
         self, opts_args: dict[str, Any], get_last_modified_date_: Mock
     ):
         opts_args["file_path"] = "a/b/document.docx"
@@ -836,21 +823,11 @@ class DescribeDocxPartitionerOptions:
 
     # -- .metadata_file_path ---------------------
 
-    def it_uses_the_user_provided_file_path_in_the_metadata_when_provided(
-        self, opts_args: dict[str, Any]
-    ):
-        opts_args["file_path"] = "x/y/z.docx"
-        opts_args["metadata_file_path"] = "a/b/c.docx"
-        opts = DocxPartitionerOptions(**opts_args)
-
-        assert opts.metadata_file_path == "a/b/c.docx"
-
     @pytest.mark.parametrize("file_path", ["u/v/w.docx", None])
-    def and_it_falls_back_to_the_document_file_path_otherwise(
+    def it_uses_the_file_path_argument_when_provided(
         self, file_path: str | None, opts_args: dict[str, Any]
     ):
         opts_args["file_path"] = file_path
-        opts_args["metadata_file_path"] = None
         opts = DocxPartitionerOptions(**opts_args)
 
         assert opts.metadata_file_path == file_path

--- a/test_unstructured/partition/test_odt.py
+++ b/test_unstructured/partition/test_odt.py
@@ -1,20 +1,30 @@
+# pyright: reportPrivateUsage=false
+
 """Test suite for `unstructured.partition.odt` module."""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterator
 
 import pytest
 from pytest_mock import MockFixture
 
 from test_unstructured.unit_utils import (
+    ANY,
     FixtureRequest,
     assert_round_trips_through_JSON,
     example_doc_path,
-    function_mock,
+    method_mock,
 )
 from unstructured.chunking.basic import chunk_elements
-from unstructured.documents.elements import CompositeElement, Table, TableChunk, Title
+from unstructured.documents.elements import (
+    CompositeElement,
+    Element,
+    Table,
+    TableChunk,
+    Text,
+    Title,
+)
 from unstructured.partition.docx import partition_docx
 from unstructured.partition.odt import partition_odt
 from unstructured.partition.utils.constants import UNSTRUCTURED_INCLUDE_DEBUG_METADATA
@@ -66,15 +76,35 @@ def test_partition_odt_from_file():
 # -- .metadata.filename --------------------------------------------------------------------------
 
 
+def test_partition_odt_from_filename_gets_the_ODT_filename_in_metadata_not_the_DOCX_filename():
+    elements = partition_odt(example_doc_path("simple.odt"))
+    assert all(e.metadata.filename == "simple.odt" for e in elements), (
+        f"Expected all elements to have 'simple.odt' as their filename, but got:"
+        f" {repr(elements[0].metadata.filename)}"
+    )
+
+
 def test_partition_odt_from_filename_with_metadata_filename():
     elements = partition_odt(example_doc_path("fake.odt"), metadata_filename="test")
-    assert all(element.metadata.filename == "test" for element in elements)
+    assert all(e.metadata.filename == "test" for e in elements)
 
 
 def test_partition_odt_from_file_with_metadata_filename():
     with open(example_doc_path("fake.odt"), "rb") as f:
         elements = partition_odt(file=f, metadata_filename="test")
-    assert all(element.metadata.filename == "test" for element in elements)
+    assert all(e.metadata.filename == "test" for e in elements)
+
+
+# -- .metadata.filetype --------------------------------------------------------------------------
+
+
+def test_partition_odt_gets_the_ODT_MIME_type_in_metadata_filetype():
+    ODT_MIME_TYPE = "application/vnd.oasis.opendocument.text"
+    elements = partition_odt(example_doc_path("simple.odt"))
+    assert all(e.metadata.filetype == ODT_MIME_TYPE for e in elements), (
+        f"Expected all elements to have '{ODT_MIME_TYPE}' as their filetype, but got:"
+        f" {repr(elements[0].metadata.filetype)}"
+    )
 
 
 # -- .metadata.text_as_html ----------------------------------------------------------------------
@@ -130,7 +160,7 @@ def test_partition_odt_prefers_metadata_last_modified_when_provided(mocker: Mock
     assert all(e.metadata.last_modified == metadata_last_modified for e in elements)
 
 
-# -- language-recognition metadata ---------------------------------------------------------------
+# -- .metadata.languages -------------------------------------------------------------------------
 
 
 def test_partition_odt_adds_languages_metadata():
@@ -156,20 +186,27 @@ def test_partition_odt_respects_detect_language_per_element_arg():
 
 @pytest.mark.parametrize(
     ("kwargs", "expected_value"),
-    [({}, None), ({"strategy": None}, None), ({"strategy": "hi_res"}, "hi_res")],
+    [({}, "hi_res"), ({"strategy": None}, "hi_res"), ({"strategy": "auto"}, "auto")],
 )
 def test_partition_odt_forwards_strategy_arg_to_partition_docx(
     request: FixtureRequest, kwargs: dict[str, Any], expected_value: str | None
 ):
-    partition_docx_ = function_mock(request, "unstructured.partition.odt.partition_docx")
+    from unstructured.partition.docx import _DocxPartitioner
 
-    partition_odt(example_doc_path("simple.odt"), **kwargs)
+    def fake_iter_document_elements(self: _DocxPartitioner) -> Iterator[Element]:
+        yield Text(f"strategy == {self._opts.strategy}")
 
-    call_kwargs = partition_docx_.call_args.kwargs
-    # -- `strategy` keyword-argument appeared in the call --
-    assert "strategy" in call_kwargs
-    # -- `strategy` argument was passed with the expected value --
-    assert call_kwargs["strategy"] == expected_value
+    _iter_elements_ = method_mock(
+        request,
+        _DocxPartitioner,
+        "_iter_document_elements",
+        side_effect=fake_iter_document_elements,
+    )
+
+    (element,) = partition_odt(example_doc_path("simple.odt"), **kwargs)
+
+    _iter_elements_.assert_called_once_with(ANY)
+    assert element.text == f"strategy == {expected_value}"
 
 
 def test_partition_odt_round_trips_through_json():

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.14-dev6"  # pragma: no cover
+__version__ = "0.15.14-dev7"  # pragma: no cover

--- a/unstructured/partition/doc.py
+++ b/unstructured/partition/doc.py
@@ -4,32 +4,24 @@ import os
 import tempfile
 from typing import IO, Any, Optional
 
-from unstructured.chunking import add_chunking_strategy
-from unstructured.documents.elements import Element, process_metadata
-from unstructured.file_utils.filetype import add_metadata_with_filetype
+from unstructured.documents.elements import Element
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import convert_office_doc, exactly_one
 from unstructured.partition.common.metadata import get_last_modified_date
 from unstructured.partition.docx import partition_docx
 
 
-@process_metadata()
-@add_metadata_with_filetype(FileType.DOC)
-@add_chunking_strategy
 def partition_doc(
     filename: Optional[str] = None,
     file: Optional[IO[bytes]] = None,
-    include_page_breaks: bool = True,
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
     libre_office_filter: Optional[str] = "MS Word 2007 XML",
-    languages: Optional[list[str]] = ["auto"],
-    detect_language_per_element: bool = False,
-    starting_page_number: int = 1,
-    strategy: Optional[str] = None,
     **kwargs: Any,
 ) -> list[Element]:
     """Partitions Microsoft Word Documents in .doc format into its document elements.
+
+    All parameters available on `partition_docx()` are also available here.
 
     Parameters
     ----------
@@ -96,13 +88,10 @@ def partition_doc(
         # -- resulting elements are not double-chunked.
         elements = partition_docx(
             filename=target_file_path,
-            detect_language_per_element=detect_language_per_element,
-            include_page_breaks=include_page_breaks,
-            languages=languages,
-            metadata_filename=metadata_filename,
+            metadata_filename=metadata_filename or filename,
+            metadata_file_type=FileType.DOC,
             metadata_last_modified=metadata_last_modified or last_modified,
-            starting_page_number=starting_page_number,
-            strategy=strategy,
+            **kwargs,
         )
 
     # -- Remove temporary document.docx path from metadata when necessary. Note `metadata_filename`

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -7,7 +7,7 @@ import itertools
 import os
 import tempfile
 import zipfile
-from typing import IO, Any, Iterator, Optional, Protocol, Type
+from typing import IO, Any, Iterator, Protocol, Type
 
 # -- CT_* stands for "complex-type", an XML element type in docx parlance --
 import docx
@@ -104,17 +104,17 @@ class PicturePartitionerT(Protocol):
 @add_metadata_with_filetype(FileType.DOCX)
 @add_chunking_strategy
 def partition_docx(
-    filename: Optional[str] = None,
+    filename: str | None = None,
     *,
     detect_language_per_element: bool = False,
-    file: Optional[IO[bytes]] = None,
+    file: IO[bytes] | None = None,
     include_page_breaks: bool = True,
     infer_table_structure: bool = True,
-    languages: Optional[list[str]] = ["auto"],
-    metadata_filename: Optional[str] = None,
-    metadata_last_modified: Optional[str] = None,
+    languages: list[str] | None = ["auto"],
+    metadata_filename: str | None = None,
+    metadata_last_modified: str | None = None,
     starting_page_number: int = 1,
-    strategy: Optional[str] = None,
+    strategy: str | None = None,
     **kwargs: Any,
 ) -> list[Element]:
     """Partitions Microsoft Word Documents in .docx format into its document elements.
@@ -191,8 +191,8 @@ class DocxPartitionerOptions:
         file_path: str | None,
         include_page_breaks: bool,
         infer_table_structure: bool,
-        metadata_file_path: Optional[str],
-        metadata_last_modified: Optional[str],
+        metadata_file_path: str | None,
+        metadata_last_modified: str | None,
         starting_page_number: int = 1,
         strategy: str | None = None,
     ):
@@ -244,7 +244,7 @@ class DocxPartitionerOptions:
         return self._infer_table_structure
 
     @lazyproperty
-    def last_modified(self) -> Optional[str]:
+    def last_modified(self) -> str | None:
         """The best last-modified date available, None if no sources are available."""
         # -- Value explicitly specified by caller takes precedence. This is used for example when
         # -- this file was converted from another format, and any last-modified date for the file
@@ -267,7 +267,7 @@ class DocxPartitionerOptions:
         return self._metadata_file_path or self._file_path
 
     @property
-    def metadata_page_number(self) -> Optional[int]:
+    def metadata_page_number(self) -> int | None:
         """The current page number to report in metadata, or None if we can't really tell.
 
         Page numbers are not added to element metadata if we can't find any page-breaks in the
@@ -923,7 +923,7 @@ class _DocxPartitioner:
         # Other styles
         return 0
 
-    def _parse_paragraph_text_for_element_type(self, paragraph: Paragraph) -> Optional[Type[Text]]:
+    def _parse_paragraph_text_for_element_type(self, paragraph: Paragraph) -> Type[Text] | None:
         """Attempt to differentiate the element-type by inspecting the raw text."""
         text = paragraph.text.strip()
 
@@ -940,7 +940,7 @@ class _DocxPartitioner:
 
         return None
 
-    def _style_based_element_type(self, paragraph: Paragraph) -> Optional[Type[Text]]:
+    def _style_based_element_type(self, paragraph: Paragraph) -> Type[Text] | None:
         """Element-type for `paragraph` based on its paragraph-style.
 
         Returns `None` when the style doesn't tell us anything useful, including when it

--- a/unstructured/partition/odt.py
+++ b/unstructured/partition/odt.py
@@ -4,9 +4,7 @@ import os
 import tempfile
 from typing import IO, Any, Optional, cast
 
-from unstructured.chunking import add_chunking_strategy
-from unstructured.documents.elements import Element, process_metadata
-from unstructured.file_utils.filetype import add_metadata_with_filetype
+from unstructured.documents.elements import Element
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import exactly_one
 from unstructured.partition.common.metadata import get_last_modified_date
@@ -14,23 +12,17 @@ from unstructured.partition.docx import partition_docx
 from unstructured.utils import requires_dependencies
 
 
-@process_metadata()
-@add_metadata_with_filetype(FileType.ODT)
-@add_chunking_strategy
 def partition_odt(
     filename: Optional[str] = None,
     *,
     file: Optional[IO[bytes]] = None,
-    detect_language_per_element: bool = False,
-    infer_table_structure: bool = True,
-    languages: Optional[list[str]] = ["auto"],
     metadata_filename: Optional[str] = None,
     metadata_last_modified: Optional[str] = None,
-    starting_page_number: int = 1,
-    strategy: Optional[str] = None,
     **kwargs: Any,
 ) -> list[Element]:
     """Partitions Open Office Documents in .odt format into its document elements.
+
+    All parameters that are available on `partition_docx()` are also available here.
 
     Parameters
     ----------
@@ -61,13 +53,10 @@ def partition_odt(
         docx_path = _convert_odt_to_docx(target_dir, filename, file)
         elements = partition_docx(
             filename=docx_path,
-            detect_language_per_element=detect_language_per_element,
-            infer_table_structure=infer_table_structure,
-            languages=languages,
-            metadata_filename=metadata_filename,
+            metadata_filename=metadata_filename or filename,
+            metadata_file_type=FileType.ODT,
             metadata_last_modified=metadata_last_modified or last_modified,
-            starting_page_number=starting_page_number,
-            strategy=strategy,
+            **kwargs,
         )
 
     return elements


### PR DESCRIPTION
**Summary**
Install new `@apply_metadata()` on CSV and DOCX and remove decoration from DOC and ODT.

**Additional Context**
- Working in alphabetical order and keeping PR size manageable, replace use of `@process_metadata()` and `@add_metadata_with_filetype()` decorators with `@apply_metadata()` on principal partitioners (those that do not delegate to other partitioners.
- Remove all decorators from delegating partitioners (DOC and ODT in this case); this removes the "double-decorating".