### PR TITLE
rfctr(part): remove double-decoration 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.14-dev7
+## 0.15.14-dev8
 
 ### Enhancements
 
@@ -13,6 +13,7 @@
 * **Fix occasional `KeyError` when mapping parent ids to hash ids.** Occasionally the input elements into `assign_and_map_hash_ids` can contain duplicated element instances, which lead to error when mapping parent id.
 * **Allow empty text files.** Fixes an issue where text files with only white space would fail to be partitioned.
 * **Remove double-decoration for CSV, DOC, ODT partitioners.** Refactor these partitioners to use the new `@apply_metadata()` decorator and only decorate the principal partitioner (CSV and DOCX in this case); remove decoration from delegating partitioners.
+* **Remove double-decoration for PPT, PPTX, TSV, XLSX, and XML partitioners.** Refactor these partitioners to use the new `@apply_metadata()` decorator and only decorate the principal partitioner; remove decoration from delegating partitioners.
 
 ## 0.15.13
 

--- a/test_unstructured/partition/test_ppt.py
+++ b/test_unstructured/partition/test_ppt.py
@@ -30,11 +30,6 @@ def test_partition_ppt_from_filename():
         assert {element.metadata.detection_origin for element in elements} == {"pptx"}
 
 
-def test_partition_ppt_from_filename_with_metadata_filename():
-    elements = partition_ppt(example_doc_path("fake-power-point.ppt"), metadata_filename="test")
-    assert all(element.metadata.filename == "test" for element in elements)
-
-
 def test_partition_ppt_raises_with_missing_file():
     with pytest.raises(ValueError):
         partition_ppt(example_doc_path("doesnt-exist.ppt"))
@@ -65,6 +60,38 @@ def test_partition_ppt_raises_with_both_specified():
 def test_partition_ppt_raises_when_neither_file_path_or_file_is_provided():
     with pytest.raises(ValueError):
         partition_ppt()
+
+
+# -- .metadata.filename --------------------------------------------------------------------------
+
+
+def test_partition_ppt_from_filename_gets_filename_from_filename_arg():
+    elements = partition_ppt(example_doc_path("fake-power-point.ppt"))
+
+    assert len(elements) > 0
+    assert all(e.metadata.filename == "fake-power-point.ppt" for e in elements)
+
+
+def test_partition_ppt_from_file_gets_filename_None():
+    with open(example_doc_path("fake-power-point.ppt"), "rb") as f:
+        elements = partition_ppt(file=f)
+
+    assert len(elements) > 0
+    assert all(e.metadata.filename is None for e in elements)
+
+
+def test_partition_ppt_from_filename_prefers_metadata_filename():
+    elements = partition_ppt(example_doc_path("fake-power-point.ppt"), metadata_filename="test")
+
+    assert len(elements) > 0
+    assert all(element.metadata.filename == "test" for element in elements)
+
+
+def test_partition_ppt_from_file_prefers_metadata_filename():
+    with open(example_doc_path("fake-power-point.ppt"), "rb") as f:
+        elements = partition_ppt(file=f, metadata_filename="test")
+
+    assert all(e.metadata.filename == "test" for e in elements)
 
 
 # -- .metadata.last_modified ---------------------------------------------------------------------

--- a/test_unstructured/partition/test_xml.py
+++ b/test_unstructured/partition/test_xml.py
@@ -114,6 +114,18 @@ def test_partition_xml_from_file_rb_with_tags_raises_encoding_error():
             )
 
 
+# -- .metadata.filetype --------------------------------------------------------------------------
+
+
+def test_partition_xml_gets_the_XML_mime_type_in_metadata_filetype():
+    XML_MIME_TYPE = "application/xml"
+    elements = partition_xml(example_doc_path("factbook.xml"))
+    assert all(e.metadata.filetype == XML_MIME_TYPE for e in elements), (
+        f"Expected all elements to have '{XML_MIME_TYPE}' as their filetype, but got:"
+        f" {repr(elements[0].metadata.filetype)}"
+    )
+
+
 # -- .metadata.last_modified ---------------------------------------------------------------------
 
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.14-dev7"  # pragma: no cover
+__version__ = "0.15.14-dev8"  # pragma: no cover

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -20,6 +20,7 @@ DETECTION_ORIGIN: str = "csv"
 @add_chunking_strategy
 def partition_csv(
     filename: str | None = None,
+    *,
     file: IO[bytes] | None = None,
     encoding: str | None = None,
     include_header: bool = False,

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -21,6 +21,7 @@ DETECTION_ORIGIN: str = "tsv"
 @add_chunking_strategy
 def partition_tsv(
     filename: Optional[str] = None,
+    *,
     file: Optional[IO[bytes]] = None,
     include_header: bool = False,
     **kwargs: Any,

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -6,36 +6,23 @@ import pandas as pd
 from lxml.html.soupparser import fromstring as soupparser_fromstring
 
 from unstructured.chunking import add_chunking_strategy
-from unstructured.documents.elements import (
-    Element,
-    ElementMetadata,
-    Table,
-    process_metadata,
-)
-from unstructured.file_utils.filetype import add_metadata_with_filetype
+from unstructured.documents.elements import Element, ElementMetadata, Table
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import (
     exactly_one,
     spooled_to_bytes_io_if_needed,
 )
-from unstructured.partition.common.lang import apply_lang_metadata
-from unstructured.partition.common.metadata import get_last_modified_date
+from unstructured.partition.common.metadata import apply_metadata, get_last_modified_date
 
 DETECTION_ORIGIN: str = "tsv"
 
 
-@process_metadata()
-@add_metadata_with_filetype(FileType.TSV)
+@apply_metadata(FileType.TSV)
 @add_chunking_strategy
 def partition_tsv(
     filename: Optional[str] = None,
     file: Optional[IO[bytes]] = None,
-    metadata_filename: Optional[str] = None,
-    metadata_last_modified: Optional[str] = None,
     include_header: bool = False,
-    languages: Optional[list[str]] = ["auto"],
-    # NOTE (jennings) partition_tsv generates a single TableElement
-    # so detect_language_per_element is not included as a param
     **kwargs: Any,
 ) -> list[Element]:
     """Partitions TSV files into document elements.
@@ -48,16 +35,8 @@ def partition_tsv(
         A file-like object using "rb" mode --> open(filename, "rb").
     include_header
         Determines whether or not header info info is included in text and medatada.text_as_html.
-    metadata_last_modified
-        The day of the last modification.
-    languages
-        User defined value for `metadata.languages` if provided. Otherwise language is detected
-        using naive Bayesian filter via `langdetect`. Multiple languages indicates text could be
-        in either language.
     """
     exactly_one(filename=filename, file=file)
-
-    last_modified = get_last_modified_date(filename) if filename else None
 
     header = 0 if include_header else None
 
@@ -75,14 +54,9 @@ def partition_tsv(
 
     metadata = ElementMetadata(
         text_as_html=html_text,
-        filename=metadata_filename or filename,
-        last_modified=metadata_last_modified or last_modified,
-        languages=languages,
+        filename=filename,
+        last_modified=get_last_modified_date(filename) if filename else None,
     )
     metadata.detection_origin = DETECTION_ORIGIN
 
-    elements = apply_lang_metadata(
-        [Table(text=text, metadata=metadata)],
-        languages=languages,
-    )
-    return list(elements)
+    return [Table(text=text, metadata=metadata)]

--- a/unstructured/partition/xml.py
+++ b/unstructured/partition/xml.py
@@ -2,92 +2,34 @@ from __future__ import annotations
 
 import copy
 from io import BytesIO
-from typing import IO, Any, Iterator, Optional, cast
+from typing import IO, Any, Iterator, cast
 
 from lxml import etree
 
 from unstructured.chunking import add_chunking_strategy
-from unstructured.documents.elements import (
-    Element,
-    ElementMetadata,
-    Text,
-    process_metadata,
-)
+from unstructured.documents.elements import Element, ElementMetadata, Text
 from unstructured.file_utils.encoding import read_txt_file
-from unstructured.file_utils.filetype import add_metadata_with_filetype
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import (
     exactly_one,
     spooled_to_bytes_io_if_needed,
 )
-from unstructured.partition.common.lang import apply_lang_metadata
-from unstructured.partition.common.metadata import get_last_modified_date
+from unstructured.partition.common.metadata import apply_metadata, get_last_modified_date
 from unstructured.partition.text import element_from_text
 
 DETECTION_ORIGIN: str = "xml"
 
 
-def get_leaf_elements(
-    filename: Optional[str] = None,
-    file: Optional[IO[bytes]] = None,
-    text: Optional[str] = None,
-    xml_path: Optional[str] = None,
-) -> Iterator[Optional[str]]:
-    """Get leaf elements from the XML tree defined in filename, file, or text."""
-    exactly_one(filename=filename, file=file, text=text)
-    if filename:
-        return _get_leaf_elements(filename, xml_path=xml_path)
-    elif file:
-        return _get_leaf_elements(file=spooled_to_bytes_io_if_needed(file), xml_path=xml_path)
-    else:
-        b = BytesIO(bytes(cast(str, text), encoding="utf-8"))
-        return _get_leaf_elements(b, xml_path=xml_path)
-
-
-def _get_leaf_elements(
-    file: str | IO[bytes],
-    xml_path: Optional[str] = None,
-) -> Iterator[Optional[str]]:
-    """Parse the XML tree in a memory efficient manner if possible."""
-    element_stack: list[etree._Element] = []  # pyright: ignore[reportPrivateUsage]
-
-    element_iterator = etree.iterparse(file, events=("start", "end"), resolve_entities=False)
-    # NOTE(alan) If xml_path is used for filtering, I've yet to find a good way to stream
-    # elements through in a memory efficient way, so we bite the bullet and load it all into
-    # memory.
-    if xml_path is not None:
-        _, element = next(element_iterator)
-        compiled_path = etree.XPath(xml_path)
-        element_iterator = (("end", el) for el in compiled_path(element))
-
-    for event, element in element_iterator:
-        if event == "start":
-            element_stack.append(element)
-
-        if event == "end":
-            if element.text is not None and element.text.strip():
-                yield element.text
-
-            element.clear()
-
-        while element_stack and element_stack[-1].getparent() is None:
-            element_stack.pop()
-
-
-@process_metadata()
-@add_metadata_with_filetype(FileType.XML)
+@apply_metadata(FileType.XML)
 @add_chunking_strategy
 def partition_xml(
-    filename: Optional[str] = None,
-    file: Optional[IO[bytes]] = None,
-    text: Optional[str] = None,
+    filename: str | None = None,
+    *,
+    file: IO[bytes] | None = None,
+    text: str | None = None,
+    encoding: str | None = None,
     xml_keep_tags: bool = False,
-    xml_path: Optional[str] = None,
-    metadata_filename: Optional[str] = None,
-    encoding: Optional[str] = None,
-    metadata_last_modified: Optional[str] = None,
-    languages: Optional[list[str]] = ["auto"],
-    detect_language_per_element: bool = False,
+    xml_path: str | None = None,
     **kwargs: Any,
 ) -> list[Element]:
     """Partitions an XML document into its document elements.
@@ -100,32 +42,20 @@ def partition_xml(
         A file-like object using "rb" mode --> open(filename, "rb").
     text
         The text of the XML file.
+    encoding
+        The encoding method used to decode the text input. If None, utf-8 will be used.
     xml_keep_tags
         If True, will retain the XML tags in the output. Otherwise it will simply extract
         the text from within the tags.
     xml_path
         The xml_path to use for extracting the text. Only used if xml_keep_tags=False.
-    encoding
-        The encoding method used to decode the text input. If None, utf-8 will be used.
-    metadata_last_modified
-        The day of the last modification.
-    languages
-        User defined value for `metadata.languages` if provided. Otherwise language is detected
-        using naive Bayesian filter via `langdetect`. Multiple languages indicates text could be
-        in either language.
-        Additional Parameters:
-            detect_language_per_element
-                Detect language per element instead of at the document level.
     """
     exactly_one(filename=filename, file=file, text=text)
 
     elements: list[Element] = []
 
-    last_modification_date = get_last_modified_date(filename) if filename else None
-
     metadata = ElementMetadata(
-        filename=metadata_filename or filename,
-        last_modified=metadata_last_modified or last_modification_date,
+        filename=filename, last_modified=get_last_modified_date(filename) if filename else None
     )
     metadata.detection_origin = DETECTION_ORIGIN
 
@@ -153,11 +83,48 @@ def partition_xml(
                 element.metadata = copy.deepcopy(metadata)
                 elements.append(element)
 
-    elements = list(
-        apply_lang_metadata(
-            elements=elements,
-            languages=languages,
-            detect_language_per_element=detect_language_per_element,
-        ),
-    )
     return elements
+
+
+def get_leaf_elements(
+    filename: str | None, file: IO[bytes] | None, text: str | None, xml_path: str | None
+) -> Iterator[str | None]:
+    """Get leaf elements from the XML tree defined in filename, file, or text."""
+    exactly_one(filename=filename, file=file, text=text)
+    if filename:
+        return _get_leaf_elements(filename, xml_path=xml_path)
+    elif file:
+        return _get_leaf_elements(file=spooled_to_bytes_io_if_needed(file), xml_path=xml_path)
+    else:
+        b = BytesIO(bytes(cast(str, text), encoding="utf-8"))
+        return _get_leaf_elements(b, xml_path=xml_path)
+
+
+def _get_leaf_elements(
+    file: str | IO[bytes],
+    xml_path: str | None,
+) -> Iterator[str | None]:
+    """Parse the XML tree in a memory efficient manner if possible."""
+    element_stack: list[etree._Element] = []  # pyright: ignore[reportPrivateUsage]
+
+    element_iterator = etree.iterparse(file, events=("start", "end"), resolve_entities=False)
+    # NOTE(alan) If xml_path is used for filtering, I've yet to find a good way to stream
+    # elements through in a memory efficient way, so we bite the bullet and load it all into
+    # memory.
+    if xml_path is not None:
+        _, element = next(element_iterator)
+        compiled_path = etree.XPath(xml_path)
+        element_iterator = (("end", el) for el in compiled_path(element))
+
+    for event, element in element_iterator:
+        if event == "start":
+            element_stack.append(element)
+
+        if event == "end":
+            if element.text is not None and element.text.strip():
+                yield element.text
+
+            element.clear()
+
+        while element_stack and element_stack[-1].getparent() is None:
+            element_stack.pop()


### PR DESCRIPTION
**Summary**
Install new `@apply_metadata()` on PPTX, TSV, XLSX, and XML and remove decoration from PPT.

**Additional Context**
- Alphabetical order turns out to be hard, so this is the remaining "easy" delegating partitioner and the remaining principal partitioners.
- Replace use of `@process_metadata()` and `@add_metadata_with_filetype()` decorators with `@apply_metadata()` on principal partitioners (those that do not delegate to other partitioners.
- Remove all decorators from delegating partitioners (PPT in this case); this removes the "double-decorating".