### PR TITLE
build: Fix build reproducibility.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ rst_reqs = load_requirements("requirements/extra-pandoc.in")
 tsv_reqs = load_requirements("requirements/extra-csv.in")
 xlsx_reqs = load_requirements("requirements/extra-xlsx.in")
 
-all_doc_reqs = list(
+all_doc_reqs = sorted(
     set(
         csv_reqs
         + docx_reqs


### PR DESCRIPTION
Without going the extra length of exporting `PYTHONHASHSEED=0` or
similar, the built sdist and wheel for a given version of the project
would have inconsistent random ordering of extras_require entries
between builds.

This was observed attempting to lock a VCS requirement on this project
here: https://github.com/pantsbuild/pants/discussions/21145
On the bright side, it led to Pex fixing its building and locking code
to be robust to this sort of (unintended) bad behavior:
https://github.com/pex-tool/pex/pull/2554