### PR TITLE
chore: pin upper limit for unstructured-client

### DIFF
--- a/requirements/deps/constraints.txt
+++ b/requirements/deps/constraints.txt
@@ -17,4 +17,4 @@ botocore<1.34.132
 # TODO: Constriant due to both 8.5.0 and 8.4.0 being installed during pip-compile
 importlib-metadata>=8.5.0
 # (austin): Versions below this have a different interface for passing parameters
-unstructured-client>=0.23.0
+unstructured-client>=0.23.0,<0.26.0


### PR DESCRIPTION
- 0.26.0 breaks tests and reason is unknown
- 0.26.0 introduces async request but the sync version interface still exists