### PR TITLE
ML-405/ML-427 - OntologyElement improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ### Enhancements
 
+* **`value` attribute in `<input/>` element is parsed to `OntologyElement.text` in ontology**
+* **`id` and `class` attributes removed from Table subtags in HTML partitioning**
+* **cleaned `to_html` and newly introduced `to_text` in `OntologyElement`**
+
 ### Features
 
 ### Fixes
-
-* **`value` attribute in `<input/>` element is parsed to `OntologyElement.text` in ontology**
 
 
 ## 0.16.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.16.4-dev1
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* **`value` attribute in `<input/>` element is parsed to `OntologyElement.text` in ontology**
+
+
 ## 0.16.3
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.16.4-dev1
+## 0.16.4-dev0
 
 ### Enhancements
 

--- a/test_unstructured/documents/unstructured_json_output/example.json
+++ b/test_unstructured/documents/unstructured_json_output/example.json
@@ -78,9 +78,9 @@
             "filename": "example.pdf",
             "page_number": 1,
             "parent_id": "592422373ed741b68a077e2003f8ed81",
-            "text_as_html": "<table class=\"Table\" id=\"dc3792d4422e444f90876b56d0cfb20d\"> <thead class=\"TableHeader\" id=\"50a5548a87e84024af590b3d2830d140\"> <tr class=\"TableRow\" id=\"5e473d7742474412be72dc4e2c45bd4a\"> <th class=\"TableCellHeader\" id=\"01800309aa42411c98ae30f85b23f399\">Description </th><th class=\"TableCellHeader\" id=\"c2765b63d08946a2851955e79e301de4\">Row header </th></tr></thead><tbody class=\"TableBody\" id=\"e0a9a8ffdd7148ad8b4a274b073d340a\"> <tr class=\"TableRow\" id=\"77e829974632455191330b0b8545d1e3\"> <td class=\"TableCell\" id=\"7fee12d4c5554b7da778d6f8fdec8a57\">Value description </td><td class=\"TableCell\" id=\"5a7a33b0c57b4eb881a35bce9f87c831\"> <span class=\"Currency\" id=\"87220f9d62c3482e92e7de72a26869cd\">50 $ </span><span class=\"Measurement\" id=\"0095b9efb90a4cca991e73547c7165f1\">(1.32 %) </span></td></tr></tbody></table>"
+            "text_as_html": "<table class=\"Table\" id=\"dc3792d4422e444f90876b56d0cfb20d\"> <thead> <tr> <th>Description</th><th>Row header</th></tr></thead><tbody> <tr> <td>Value description</td><td>50 $ (1.32 %)</td></tr></tbody></table>"
         },
-        "text": "Description Row header   Value description  50 $ (1.32 %)",
+        "text": "Description Row header Value description 50 $ (1.32 %)",
         "type": "Table"
     },
     {

--- a/test_unstructured/documents/unstructured_json_output/example.json
+++ b/test_unstructured/documents/unstructured_json_output/example.json
@@ -56,7 +56,7 @@
             "parent_id": "3a6b156a81764e17be128264241f8136",
             "text_as_html": "<form class=\"Form\" id=\"637c2f6935fb4353a5f73025ce04619d\"> <label class=\"FormField\" for=\"company-name\" id=\"50027cccbe1948c9853ce0de37b635c2\">From field name </label><input class=\"FormFieldValue\" id=\"0032242af75c4b37984ea7fea9aac74c\" value=\"Example value\" /></form>"
         },
-        "text": "From field name",
+        "text": "From field name Example value",
         "type": "UncategorizedText"
     },
     {

--- a/test_unstructured/partition/html/test_html_to_ontology_parsing.py
+++ b/test_unstructured/partition/html/test_html_to_ontology_parsing.py
@@ -594,3 +594,18 @@ def test_text_is_wrapped_inside_layout_element():
     parsed_ontology = indent_html(remove_all_ids(ontology.to_html()))
 
     assert parsed_ontology == expected_html
+
+
+def test_text_in_form_field_value():
+    # language=HTML
+    input_html = """
+    <div class="Page">
+    <input class="FormFieldValue" value="Random Input Value"/>
+    </div>
+    """
+    page = parse_html_to_ontology(input_html)
+
+    assert len(page.children) == 1
+    form_field_value = page.children[0]
+    print(page)
+    assert form_field_value.text == "Random Input Value"

--- a/test_unstructured/partition/html/test_html_to_ontology_parsing.py
+++ b/test_unstructured/partition/html/test_html_to_ontology_parsing.py
@@ -477,14 +477,10 @@ def test_table_and_time():
             <tbody>
                 <tr>
                     <td colspan="5">
-                        <time>
                             June 30, 2023
-                        </time>
                     </td>
                 <td>
-                    <span>
                         $—
-                    </span>
                 </td>
                 </tr>
             </tbody>

--- a/test_unstructured/partition/html/test_html_to_ontology_parsing.py
+++ b/test_unstructured/partition/html/test_html_to_ontology_parsing.py
@@ -607,5 +607,4 @@ def test_text_in_form_field_value():
 
     assert len(page.children) == 1
     form_field_value = page.children[0]
-    print(page)
     assert form_field_value.text == "Random Input Value"

--- a/test_unstructured/partition/html/test_html_to_ontology_parsing.py
+++ b/test_unstructured/partition/html/test_html_to_ontology_parsing.py
@@ -355,13 +355,13 @@ def test_broken_cell_is_not_raising_error():
     expected_html = _wrap_with_body(
         """
     <div class="Page">
-        <table class="Table">
-            <tbody class="TableBody">
-                <tr class="TableRow">
-                   <td class="TableCell" tablecell&quot;="">
+        <table>
+            <tbody>
+                <tr>
+                   <td tablecell&quot;="">
                     83.64 GiB
                    </td>
-                  <th class="TableCellHeader" rowspan="2">
+                  <th rowspan="2">
                     Fair Value
                  </th>
                </tr>
@@ -405,13 +405,13 @@ def test_table():
     expected_html = _wrap_with_body(
         """
     <div class="Page">
-        <table class="Table">
-            <tbody class="TableBody">
-                <tr class="TableRow">
-                  <td class="TableCell">
+        <table>
+            <tbody>
+                <tr>
+                  <td>
                     Fair Value1
                   </td>
-                  <th class="TableCellHeader" rowspan="2">
+                  <th rowspan="2">
                     Fair Value2
                  </th>
                </tr>
@@ -466,23 +466,23 @@ def test_table_and_time():
     expected_html = _wrap_with_body(
         """
     <div class="Page">
-        <table class="Table">
-            <thead class='TableHeader'>
-                <tr class="TableRow">
-                    <th class="TableCellHeader"  colspan="6">
+        <table>
+            <thead>
+                <tr>
+                    <th colspan="6">
                         Carrying Value
                     </th>
                 </tr>
             </thead>
-            <tbody class='TableBody'>
-                <tr class="TableRow">
-                    <td class="TableCell" colspan="5">
-                        <time class="CalendarDate">
+            <tbody>
+                <tr>
+                    <td colspan="5">
+                        <time>
                             June 30, 2023
                         </time>
                     </td>
-                <td class="TableCell">
-                    <span class="Currency">
+                <td>
+                    <span>
                         $—
                     </span>
                 </td>

--- a/test_unstructured/partition/html/test_html_to_ontology_parsing.py
+++ b/test_unstructured/partition/html/test_html_to_ontology_parsing.py
@@ -607,4 +607,5 @@ def test_text_in_form_field_value():
 
     assert len(page.children) == 1
     form_field_value = page.children[0]
-    assert form_field_value.text == "Random Input Value"
+    assert form_field_value.text == ""
+    assert form_field_value.to_text() == "Random Input Value"

--- a/test_unstructured/partition/html/test_html_to_ontology_parsing.py
+++ b/test_unstructured/partition/html/test_html_to_ontology_parsing.py
@@ -355,7 +355,7 @@ def test_broken_cell_is_not_raising_error():
     expected_html = _wrap_with_body(
         """
     <div class="Page">
-        <table>
+        <table class="Table">
             <tbody>
                 <tr>
                    <td tablecell&quot;="">
@@ -405,7 +405,7 @@ def test_table():
     expected_html = _wrap_with_body(
         """
     <div class="Page">
-        <table>
+        <table class="Table">
             <tbody>
                 <tr>
                   <td>
@@ -466,7 +466,7 @@ def test_table_and_time():
     expected_html = _wrap_with_body(
         """
     <div class="Page">
-        <table>
+        <table class="Table">
             <thead>
                 <tr>
                     <th colspan="6">

--- a/test_unstructured/partition/html/test_html_to_unstructured_and_back_parsing.py
+++ b/test_unstructured/partition/html/test_html_to_unstructured_and_back_parsing.py
@@ -321,14 +321,14 @@ def test_table():
             detection_origin="vlm_partitioner",
             element_id="2",
             metadata=ElementMetadata(
-                text_as_html='<table class="Table"> '
+                text_as_html='<table class="Table" id="2"> '
                 "<tbody> "
                 "<tr> "
                 "<td>"
-                "Fair Value1 "
+                "Fair Value1"
                 "</td>"
                 '<th rowspan="2">'
-                "Fair Value2 "
+                "Fair Value2"
                 "</th></tr></tbody></table>",
                 parent_id="1",
             ),

--- a/test_unstructured/partition/html/test_html_to_unstructured_and_back_parsing.py
+++ b/test_unstructured/partition/html/test_html_to_unstructured_and_back_parsing.py
@@ -324,13 +324,13 @@ def test_table():
             detection_origin="vlm_partitioner",
             element_id="2",
             metadata=ElementMetadata(
-                text_as_html='<table class="Table" id="2"> '
-                '<tbody class="TableBody" id="3"> '
-                '<tr class="TableRow" id="4"> '
-                '<td class="TableCell" id="5">'
+                text_as_html="<table> "
+                "<tbody> "
+                "<tr> "
+                "<td>"
                 "Fair Value1 "
                 "</td>"
-                '<th class="TableCellHeader" rowspan="2" id="6">'
+                '<th rowspan="2">'
                 "Fair Value2 "
                 "</th></tr></tbody></table>",
                 parent_id="1",

--- a/test_unstructured/partition/html/test_html_to_unstructured_and_back_parsing.py
+++ b/test_unstructured/partition/html/test_html_to_unstructured_and_back_parsing.py
@@ -314,17 +314,14 @@ def test_table():
     unstructured_elements, parsed_ontology = _parse_to_unstructured_elements_and_back_to_html(
         html_as_str
     )
-    expected_html = indent_html(html_as_str, html_parser="html.parser")
-    parsed_html = indent_html(parsed_ontology.to_html(), html_parser="html.parser")
 
-    assert expected_html == parsed_html
     expected_elements = _page_elements + [
         Table(
             text="Fair Value1 Fair Value2",
             detection_origin="vlm_partitioner",
             element_id="2",
             metadata=ElementMetadata(
-                text_as_html="<table> "
+                text_as_html='<table class="Table"> '
                 "<tbody> "
                 "<tr> "
                 "<td>"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.4-dev0"  # pragma: no cover
+__version__ = "0.16.4-dev1"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.3"  # pragma: no cover
+__version__ = "0.16.3-dev1"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.3-dev1"  # pragma: no cover
+__version__ = "0.16.4-dev1"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.4-dev1"  # pragma: no cover
+__version__ = "0.16.4-dev0"  # pragma: no cover

--- a/unstructured/documents/ontology.py
+++ b/unstructured/documents/ontology.py
@@ -456,6 +456,18 @@ class Form(OntologyElement):
     elementType: ElementTypeEnum = Field(ElementTypeEnum.form, frozen=True)
     allowed_tags: List[str] = Field(["form"], frozen=True)
 
+    def to_text(self, add_children=True) -> str:
+        # Start with the text of the current element
+        texts = [self.text] if self.text else []
+
+        # If add_children is True, recursively get text from children
+        if add_children:
+            for child in self.children:
+                texts.append(child.to_text(add_children=True))
+
+        # Join all text parts and return as a single string
+        return " ".join(filter(None, texts)).strip()
+
 
 class FormField(OntologyElement):
     description: str = Field("A property value of a form", frozen=True)

--- a/unstructured/documents/ontology.py
+++ b/unstructured/documents/ontology.py
@@ -442,6 +442,10 @@ class FormFieldValue(OntologyElement):
     elementType: ElementTypeEnum = Field(ElementTypeEnum.form, frozen=True)
     allowed_tags: List[str] = Field(["input"], frozen=True)
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.text = self.additional_attributes.get("value", "")
+
 
 class Checkbox(OntologyElement):
     description: str = Field("A small box that can be checked or unchecked", frozen=True)

--- a/unstructured/documents/ontology.py
+++ b/unstructured/documents/ontology.py
@@ -90,7 +90,7 @@ class OntologyElement(BaseModel):
         return result_html
 
     def to_text(self, add_children=True) -> str:
-        return BeautifulSoup(self.to_html(), "html.parser").get_text().strip()
+        return " ".join(BeautifulSoup(self.to_html(add_children), "html.parser").stripped_strings)
 
     def _construct_attribute_string(self, attributes: dict) -> str:
         return " ".join(
@@ -263,20 +263,14 @@ class Table(OntologyElement):
     allowed_tags: List[str] = Field(["table"], frozen=True)
 
     def to_html(self, add_children=True) -> str:
-        raw_html = super().to_html(add_children=add_children)
-
-        cleaned_html = self._remove_ids_and_classes(raw_html)
-
-        return cleaned_html
-
-    def _remove_ids_and_classes(self, html: str) -> str:
-        soup = BeautifulSoup(html, "html.parser")
+        soup = BeautifulSoup(super().to_html(add_children), "html.parser")
 
         for tag in soup.find_all(True):
-            if "id" in tag.attrs:
-                del tag.attrs["id"]
-            if "class" in tag.attrs and tag.name != "table":
-                del tag.attrs["class"]
+            if tag.name != "table":
+                tag.attrs.pop("class", None)
+                tag.attrs.pop("id", None)
+            if tag.name in ["td", "th"]:
+                tag.string = " ".join(tag.stripped_strings)
 
         return str(soup)
 

--- a/unstructured/documents/ontology.py
+++ b/unstructured/documents/ontology.py
@@ -89,6 +89,9 @@ class OntologyElement(BaseModel):
 
         return result_html
 
+    def to_text(self, add_children=True) -> str:
+        return BeautifulSoup(self.to_html(), "html.parser").get_text().strip()
+
     def _construct_attribute_string(self, attributes: dict) -> str:
         return " ".join(
             f'{key}="{value}"' if value else f"{key}" for key, value in attributes.items()
@@ -480,6 +483,9 @@ class FormFieldValue(OntologyElement):
         combined_attr_str = f"{class_attr} {attr_str}".strip()
 
         return f"<{self.html_tag_name} {combined_attr_str} />"
+
+    def to_text(self, add_children=True) -> str:
+        return super().to_text() + self.text
 
 
 class Checkbox(OntologyElement):

--- a/unstructured/documents/ontology.py
+++ b/unstructured/documents/ontology.py
@@ -477,24 +477,8 @@ class FormFieldValue(OntologyElement):
     elementType: ElementTypeEnum = Field(ElementTypeEnum.form, frozen=True)
     allowed_tags: List[str] = Field(["input"], frozen=True)
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.text = self.additional_attributes.get("value", "")
-
-    def to_html(self, add_children=True) -> str:
-        additional_attrs = copy(self.additional_attributes)
-        additional_attrs.pop("class", None)
-
-        attr_str = self._construct_attribute_string(additional_attrs)
-
-        class_attr = f'class="{self.css_class_name}"' if self.css_class_name else ""
-
-        combined_attr_str = f"{class_attr} {attr_str}".strip()
-
-        return f"<{self.html_tag_name} {combined_attr_str} />"
-
     def to_text(self, add_children=True) -> str:
-        return super().to_text() + self.text
+        return super().to_text() + self.additional_attributes.get("value", "")
 
 
 class Checkbox(OntologyElement):

--- a/unstructured/documents/ontology.py
+++ b/unstructured/documents/ontology.py
@@ -275,7 +275,7 @@ class Table(OntologyElement):
         for tag in soup.find_all(True):
             if "id" in tag.attrs:
                 del tag.attrs["id"]
-            if "class" in tag.attrs:
+            if "class" in tag.attrs and tag.name != "table":
                 del tag.attrs["class"]
 
         return str(soup)

--- a/unstructured/documents/ontology.py
+++ b/unstructured/documents/ontology.py
@@ -457,15 +457,12 @@ class Form(OntologyElement):
     allowed_tags: List[str] = Field(["form"], frozen=True)
 
     def to_text(self, add_children=True) -> str:
-        # Start with the text of the current element
         texts = [self.text] if self.text else []
 
-        # If add_children is True, recursively get text from children
         if add_children:
             for child in self.children:
                 texts.append(child.to_text(add_children=True))
 
-        # Join all text parts and return as a single string
         return " ".join(filter(None, texts)).strip()
 
 

--- a/unstructured/partition/html/transformations.py
+++ b/unstructured/partition/html/transformations.py
@@ -96,10 +96,8 @@ def ontology_to_unstructured_elements(
         ]
         element_class = TYPE_TO_TEXT_ELEMENT_MAP[unstructured_element_class_name]
         html_code_of_ontology_element = ontology_element.to_html()
-        element_text = (
-            BeautifulSoup(html_code_of_ontology_element, "html.parser").get_text().strip()
-        )
-        # TODO value attribute from form input should be added to the text
+        element_text = ontology_element.to_text()
+
         unstructured_element = element_class(
             text=element_text,
             element_id=ontology_element.id,


### PR DESCRIPTION
- the "value" attribute from <input/> tag will be taken into account and processed as "text" in ontology
- the tables will now be parsed without any ids and classes - we have different reasons behind that, for example, embeddings with ids and classes can lose some semantic value. Also, more tokens = more expensive LLM call
-  cleaned to_html, created to_text for OntologyElement