### PR TITLE
update scarf_analytics() GET request with timeouts

### DIFF
--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -291,7 +291,8 @@ def scarf_analytics():
                     + platform.machine()
                     + "&gpu="
                     + str(gpu_present)
-                    + "&dev=true",
+                    + "&dev=true", 
+                    timeout=2
                 )
             else:
                 requests.get(
@@ -306,6 +307,7 @@ def scarf_analytics():
                     + "&gpu="
                     + str(gpu_present)
                     + "&dev=false",
+                    timeout=2
                 )
     except Exception:
         pass


### PR DESCRIPTION
Occasionally in offline environments, scarf_analytics() can block the main process since `unstructured.io` is not accessible yet the GET request did not implement timeout, It will freeze with the following log 
```
2024-11-13 08:45:05.615 | DEBUG    | urllib3.connectionpool:_new_conn:1055 - Starting new HTTPS connection (1): packages.unstructured.io:443
```