### PR TITLE
fix(filetype): handle missing libmagic library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 ### Features
 
 ### Fixes
+
 - **ElementMetadata consolidation** Now `text_as_html` metadata is combined across all elements in CompositeElement when chunking HTML output
+- **Fixed ImportError when `libmagic` library is not installed** File type detection now correctly falls back to using `filetype` if the `magic` module cannot be imported.
 
 ## 0.16.5
 

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -25,6 +25,7 @@ from unstructured.file_utils.filetype import (
     _ZipFileDifferentiator,
     detect_filetype,
     is_json_processable,
+    LIBMAGIC_AVAILABLE
 )
 from unstructured.file_utils.model import FileType
 
@@ -298,6 +299,7 @@ def test_it_detects_correct_file_type_using_strategy_2_when_libmagic_guesses_rec
     assert file_type is expected_value
 
 
+@pytest.mark.skipif(not LIBMAGIC_AVAILABLE, reason="Skipping this test since libmagic is not available")
 @pytest.mark.parametrize(
     ("expected_value", "file_name"),
     [
@@ -466,7 +468,7 @@ def test_detect_filetype_from_file_warns_when_libmagic_is_not_installed(
         detect_filetype(file=f)
 
     assert "WARNING" in caplog.text
-    assert "libmagic is unavailable but assists in filetype detection. Please cons" in caplog.text
+    assert "magic module is installed but libmagic is unavailable. Please cons" in caplog.text
 
 
 # ================================================================================================
@@ -632,10 +634,12 @@ def test_detect_filetype_raises_with_neither_path_or_file_like_object_specified(
         detect_filetype()
 
 
+@pytest.mark.skipif(not LIBMAGIC_AVAILABLE, reason="Skipping this test since libmagic is not available")
 def test_it_detects_EMPTY_from_file_path_to_empty_file():
     assert detect_filetype(example_doc_path("empty.txt")) == FileType.EMPTY
 
 
+@pytest.mark.skipif(not LIBMAGIC_AVAILABLE, reason="Skipping this test since libmagic is not available")
 def test_it_detects_EMPTY_from_empty_file_like_object():
     with open(example_doc_path("empty.txt"), "rb") as f:
         assert detect_filetype(file=f) == FileType.EMPTY
@@ -859,6 +863,7 @@ class Describe_FileTypeDetectionContext:
 
     # -- .mime_type ---------------------------------------------
 
+    @pytest.mark.skipif(not LIBMAGIC_AVAILABLE, reason="Skipping this test since libmagic is not available")
     def it_provides_the_MIME_type_detected_by_libmagic_from_a_file_path(self):
         ctx = _FileTypeDetectionContext(file_path=example_doc_path("norwich-city.txt"))
         assert ctx.mime_type == "text/plain"
@@ -878,6 +883,7 @@ class Describe_FileTypeDetectionContext:
             assert "libmagic is unavailable" in caplog.text
             assert "consider installing libmagic" in caplog.text
 
+    @pytest.mark.skipif(not LIBMAGIC_AVAILABLE, reason="Skipping this test since libmagic is not available")
     def it_provides_the_MIME_type_detected_by_libmagic_from_a_file_like_object(self):
         with open(example_doc_path("norwich-city.txt"), "rb") as f:
             ctx = _FileTypeDetectionContext(file=f)
@@ -1094,6 +1100,7 @@ class Describe_TextFileDifferentiator:
 
     # -- .applies() ---------------------------------------------
 
+    @pytest.mark.skipif(not LIBMAGIC_AVAILABLE, reason="Skipping this test since libmagic is not available")
     def it_provides_a_qualifying_alternate_constructor_which_constructs_when_applicable(self):
         """The constructor determines whether this differentiator is applicable.
 


### PR DESCRIPTION
As reported in #3781, the check for availability of the `libmagic` library is not correct. The existing code checks whether the `magic` module is available, but the attempt to `import magic` fails if the`libmagic` library is not also available. On the Mac, `libmagic` is not installed by default; the user must install it manually, typically via `brew install libmagic`.

This PR detects whether `libmagic` is installed by importing the `magic` module in a `try` block, setting `LIBMAGIC_AVAILABLE` accordingly. `MAGIC_AVAILABLE` is set to true if the `magic` module is installed so that an appropriate warning can be displayed if the fallback `filetype` module returns `None` for a mime type. Tests that rely on `libmagic` being installed are skipped if it is not.

`pytest -v test_unstructured/file_utils` succeeds:

```console
(.venv) ppatterson@MBP-W7FQ7Y97F0 unstructured % pytest -v test_unstructured/file_utils
============================================== test session starts ==============================================
platform darwin -- Python 3.10.15, pytest-8.3.3, pluggy-1.5.0 -- /Users/ppatterson/src/unstructured/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/ppatterson/src/unstructured
configfile: setup.cfg
plugins: cov-5.0.0, mock-3.14.0, anyio-4.6.2.post1, requests-mock-1.12.1
collected 440 items      
...
================================== 411 passed, 28 skipped, 1 xfailed in 3.68s ===================================
```