### PR TITLE
chore: fix CHANGELOG formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.16.8-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
 ## 0.16.7
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.16.7
 
 ### Enhancements
-- **Add image_alt_mode to partition_html** Adds an `image_alt_mode` parameter to `partition_html()` to control how alt text is extracted from images in HTML documents. The parameter can be set to `to_text` to extract alt text as text from <img> html tags
+- **Add image_alt_mode to partition_html** Adds an `image_alt_mode` parameter to `partition_html()` to control how alt text is extracted from images in HTML documents for `html_parser_version=v2` . The parameter can be set to `to_text` to extract alt text as text from `<img>` html tags
 
 ### Features
 
@@ -10,8 +10,8 @@
 ## 0.16.6
 
 ### Enhancements
-- **Every <table> tag is considered to be ontology.Table** Added special handling for tables in HTML partitioning. This change is made to improve the accuracy of table extraction from HTML documents.
-- **Every HTML has default ontology class assigned** When parsing HTML to ontology each defined HTML in the Ontology has assigned default ontology class. This way it is possible to assign ontology class instead of UncategorizedText when the HTML tag is predicted correctly without class assigned class
+- **Every `<table>` tag is considered to be ontology.Table** Added special handling for tables in HTML partitioning (`html_parser_version=v2`. This change is made to improve the accuracy of table extraction from HTML documents.
+- **Every HTML has default ontology class assigned** When parsing HTML with `html_parser_version=v2` to ontology each defined HTML in the Ontology has assigned default ontology class. This way it is possible to assign ontology class instead of UncategorizedText when the HTML tag is predicted correctly without class assigned class
 - **Use (number of actual table) weighted average for table metrics** In evaluating table metrics the mean aggregation now uses the actual number of tables in a document to weight the metric scores
 
 ### Features

--- a/scripts/user/u-tables-inspect.sh
+++ b/scripts/user/u-tables-inspect.sh
@@ -45,6 +45,7 @@ jq -c '.[] | select(.type == "Table") | .metadata.text_as_html' "$JSON_FILE" | w
   HTML_CONTENT=${HTML_CONTENT%\"}
   # add a border and padding to clearly see cell definition
   # shellcheck disable=SC2001
+  HTML_CONTENT=$(echo "$HTML_CONTENT" | sed 's/<table /<table border="1" cellpadding="10" /')
   HTML_CONTENT=$(echo "$HTML_CONTENT" | sed 's/<table>/<table border="1" cellpadding="10">/')
   # add newlines for readability in the html
   # shellcheck disable=SC2001

--- a/scripts/user/u-tables-inspect.sh
+++ b/scripts/user/u-tables-inspect.sh
@@ -46,6 +46,7 @@ jq -c '.[] | select(.type == "Table") | .metadata.text_as_html' "$JSON_FILE" | w
   # add a border and padding to clearly see cell definition
   # shellcheck disable=SC2001
   HTML_CONTENT=$(echo "$HTML_CONTENT" | sed 's/<table /<table border="1" cellpadding="10" /')
+  # shellcheck disable=SC2001
   HTML_CONTENT=$(echo "$HTML_CONTENT" | sed 's/<table>/<table border="1" cellpadding="10">/')
   # add newlines for readability in the html
   # shellcheck disable=SC2001

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.7"  # pragma: no cover
+__version__ = "0.16.8-dev0"  # pragma: no cover


### PR DESCRIPTION
Fixes formatting in CHANGELOG.md where most of the page was bold and indented. (verify the branch version here: https://github.com/Unstructured-IO/unstructured/blob/crag/tables-tweak/CHANGELOG.md)

Bonus tweak: u-table-inspect.sh is more robust to adding borders for visualizations