### PR TITLE
feat: refactor environment variable checks for scarf analytics

### DIFF
--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -278,7 +278,9 @@ def scarf_analytics():
     python_version = ".".join(platform.python_version().split(".")[:2])
 
     try:
-        if os.getenv("SCARF_NO_ANALYTICS") != "true" and os.getenv("DO_NOT_TRACK") != "true":
+        scarf_no_analytics = os.getenv("SCARF_NO_ANALYTICS", "").lower()
+        do_not_track = os.getenv("DO_NOT_TRACK", "").lower()
+        if scarf_no_analytics != "true" and do_not_track != "true":
             if "dev" in __version__:
                 requests.get(
                     "https://packages.unstructured.io/python-telemetry?version="


### PR DESCRIPTION
This PR enhances the handling of the `SCARF_NO_ANALYTICS` and `DO_NOT_TRACK` environment variables by converting their values to lowercase before checking them. This improvement ensures that the checks are consistent, allowing developers to set `SCARF_NO_ANALYTICS` by `os.environ["SCARF_NO_ANALYTICS"]=str(True)` (In fact, the result of `str(True)` is `"True"`, with a capital `'T'`) without causing unexpected behavior. This change promotes more robust code and mitigates case-sensitivity issues.