### PR TITLE
rfctr: prep for pluggable partitioners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 0.16.11
+## 0.16.12-dev0
+
+### Enhancements
+
+- **Prepare auto-partitioning for pluggable partitioners**. Move toward a uniform partitioner call signature so a custom or override partitioner can be registered without code changes.
+
+### Features
 
 ### Fixes
 
-- Fix ipv4 regex to correctly include up to three digit octets.
+## 0.16.11
 
 ### Enhancements
 
@@ -13,6 +19,8 @@
 ### Features
 
 ### Fixes
+
+- Fix ipv4 regex to correctly include up to three digit octets.
 
 ## 0.16.10
 

--- a/test_unstructured/metrics/test_element_type.py
+++ b/test_unstructured/metrics/test_element_type.py
@@ -29,6 +29,7 @@ from unstructured.staging.base import elements_to_json
                 ("Title", 0): 4,
                 ("Title", 1): 1,
                 ("NarrativeText", 0): 3,
+                ("PageBreak", None): 3,
                 ("ListItem", 0): 6,
                 ("ListItem", 1): 6,
                 ("ListItem", 2): 3,

--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -1232,17 +1232,6 @@ class DescribeHtmlPartitionerOptions:
 
         assert opts.detection_origin == detection_origin
 
-    # -- .encoding -------------------------------
-
-    @pytest.mark.parametrize("encoding", ["utf-8", None])
-    def it_knows_the_caller_provided_encoding(
-        self, encoding: str | None, opts_args: dict[str, Any]
-    ):
-        opts_args["encoding"] = encoding
-        opts = HtmlPartitionerOptions(**opts_args)
-
-        assert opts.encoding == encoding
-
     # -- .html_text ------------------------------
 
     def it_gets_the_HTML_from_the_file_path_when_one_is_provided(self, opts_args: dict[str, Any]):

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -895,7 +895,7 @@ def test_auto_partition_raises_with_bad_type(request: FixtureRequest):
 
     with pytest.raises(
         UnsupportedFileFormatError,
-        match="Invalid file made-up.fake. The FileType.UNK file type is not supported in partiti",
+        match="Partitioning is not supported for the FileType.UNK file type.",
     ):
         partition(filename="made-up.fake", strategy=PartitionStrategy.HI_RES)
 

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -560,7 +560,6 @@ def test_auto_partition_pdf_with_fast_strategy(request: FixtureRequest):
         strategy=PartitionStrategy.FAST,
         languages=None,
         metadata_filename=None,
-        include_page_breaks=False,
         infer_table_structure=False,
         extract_images_in_pdf=False,
         extract_image_block_types=None,

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 import json
 import os
 import pathlib
@@ -1035,26 +1034,6 @@ def test_auto_partition_forwards_metadata_filename_via_kwargs():
         elements = partition(file=f, metadata_filename="much-more-interesting-name.txt")
 
     assert all(e.metadata.filename == "much-more-interesting-name.txt" for e in elements)
-
-
-def test_auto_partition_warns_about_file_filename_deprecation(caplog: LogCaptureFixture):
-    file_path = example_doc_path("fake-text.txt")
-
-    with open(file_path, "rb") as f:
-        elements = partition(file=f, file_filename=file_path)
-
-    assert all(e.metadata.filename == "fake-text.txt" for e in elements)
-    assert caplog.records[0].levelname == "WARNING"
-    assert "The file_filename kwarg will be deprecated" in caplog.text
-
-
-def test_auto_partition_raises_when_both_file_filename_and_metadata_filename_args_are_used():
-    file_path = example_doc_path("fake-text.txt")
-    with open(file_path, "rb") as f:
-        file = io.BytesIO(f.read())
-
-    with pytest.raises(ValueError, match="Only one of metadata_filename and file_filename is spe"):
-        partition(file=file, file_filename=file_path, metadata_filename=file_path)
 
 
 # -- ocr_languages --------------------------------------------------------

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.11"  # pragma: no cover
+__version__ = "0.16.12-dev0"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -265,6 +265,7 @@ def partition(
 
     partitioning_kwargs = copy.deepcopy(kwargs)
     partitioning_kwargs["detect_language_per_element"] = detect_language_per_element
+    partitioning_kwargs["languages"] = languages
 
     if file_type == FileType.CSV:
         partition_csv = partitioner_loader.get(file_type)
@@ -273,7 +274,6 @@ def partition(
             file=file,
             encoding=encoding,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             **partitioning_kwargs,
         )
     elif file_type == FileType.DOC:
@@ -282,7 +282,6 @@ def partition(
             filename=filename,
             file=file,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
@@ -293,7 +292,6 @@ def partition(
             filename=filename,
             file=file,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
@@ -304,7 +302,6 @@ def partition(
             filename=filename,
             file=file,
             encoding=encoding,
-            languages=languages,
             **partitioning_kwargs,
         )
     elif file_type == FileType.EPUB:
@@ -314,7 +311,6 @@ def partition(
             file=file,
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             **partitioning_kwargs,
         )
     elif file_type == FileType.HTML:
@@ -324,7 +320,6 @@ def partition(
             file=file,
             include_page_breaks=include_page_breaks,
             encoding=encoding,
-            languages=languages,
             **partitioning_kwargs,
         )
     elif file_type == FileType.MD:
@@ -334,24 +329,19 @@ def partition(
             file=file,
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             **partitioning_kwargs,
         )
+
     elif file_type == FileType.MSG:
         partition_msg = partitioner_loader.get(file_type)
-        elements = partition_msg(
-            filename=filename,
-            file=file,
-            languages=languages,
-            **partitioning_kwargs,
-        )
+        elements = partition_msg(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.ODT:
         partition_odt = partitioner_loader.get(file_type)
         elements = partition_odt(
             filename=filename,
             file=file,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
@@ -362,7 +352,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            languages=languages,
             **partitioning_kwargs,
         )
     elif file_type == FileType.PPT:
@@ -372,7 +361,6 @@ def partition(
             file=file,
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             strategy=strategy,
             **partitioning_kwargs,
         )
@@ -383,7 +371,6 @@ def partition(
             file=file,
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
@@ -395,7 +382,6 @@ def partition(
             file=file,
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             **partitioning_kwargs,
         )
     elif file_type == FileType.RTF:
@@ -405,17 +391,13 @@ def partition(
             file=file,
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             **partitioning_kwargs,
         )
+
     elif file_type == FileType.TSV:
         partition_tsv = partitioner_loader.get(file_type)
-        elements = partition_tsv(
-            filename=filename,
-            file=file,
-            languages=languages,
-            **partitioning_kwargs,
-        )
+        elements = partition_tsv(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.TXT:
         partition_text = partitioner_loader.get(file_type)
         elements = partition_text(
@@ -423,7 +405,6 @@ def partition(
             file=file,
             encoding=encoding,
             paragraph_grouper=paragraph_grouper,
-            languages=languages,
             **partitioning_kwargs,
         )
     elif file_type in (FileType.XLS, FileType.XLSX):
@@ -432,7 +413,6 @@ def partition(
             filename=filename,
             file=file,
             infer_table_structure=infer_table_structure,
-            languages=languages,
             starting_page_number=starting_page_number,
             **partitioning_kwargs,
         )
@@ -443,7 +423,6 @@ def partition(
             file=file,
             encoding=encoding,
             xml_keep_tags=xml_keep_tags,
-            languages=languages,
             **partitioning_kwargs,
         )
     else:

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -43,7 +43,6 @@ def partition(
     extract_image_block_types: Optional[list[str]] = None,
     extract_image_block_output_dir: Optional[str] = None,
     extract_image_block_to_payload: bool = False,
-    xml_keep_tags: bool = False,
     data_source_metadata: Optional[DataSourceMetadata] = None,
     metadata_filename: Optional[str] = None,
     hi_res_model_name: Optional[str] = None,
@@ -124,9 +123,6 @@ def partition(
         Only applicable if `strategy=hi_res` and `extract_image_block_to_payload=False`.
         The filesystem path for saving images of the element type(s)
         specified in 'extract_image_block_types'.
-    xml_keep_tags
-        If True, will retain the XML tags in the output. Otherwise it will simply extract
-        the text from within the tags. Only applies to partition_xml.
     hi_res_model_name
         The layout detection model used when partitioning strategy is set to `hi_res`.
     model_name
@@ -335,12 +331,8 @@ def partition(
 
     elif file_type == FileType.XML:
         partition_xml = partitioner_loader.get(file_type)
-        elements = partition_xml(
-            filename=filename,
-            file=file,
-            xml_keep_tags=xml_keep_tags,
-            **partitioning_kwargs,
-        )
+        elements = partition_xml(filename=filename, file=file, **partitioning_kwargs)
+
     else:
         msg = "Invalid file" if not filename else f"Invalid file {filename}"
         raise UnsupportedFileFormatError(

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import importlib
 import io
-from typing import IO, Any, Callable, Literal, Optional
+from typing import IO, Any, Callable, Optional
 
 import requests
 from typing_extensions import TypeAlias
@@ -34,7 +34,6 @@ def partition(
     ssl_verify: bool = True,
     request_timeout: Optional[int] = None,
     strategy: str = PartitionStrategy.AUTO,
-    paragraph_grouper: Optional[Callable[[str], str]] | Literal[False] = None,
     skip_infer_table_types: list[str] = ["pdf", "jpg", "png", "heic"],
     ocr_languages: Optional[str] = None,  # changing to optional for deprecation
     languages: Optional[list[str]] = None,
@@ -328,12 +327,7 @@ def partition(
 
     elif file_type == FileType.TXT:
         partition_text = partitioner_loader.get(file_type)
-        elements = partition_text(
-            filename=filename,
-            file=file,
-            paragraph_grouper=paragraph_grouper,
-            **partitioning_kwargs,
-        )
+        elements = partition_text(filename=filename, file=file, **partitioning_kwargs)
 
     elif file_type in (FileType.XLS, FileType.XLSX):
         partition_xlsx = partitioner_loader.get(file_type)

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -268,6 +268,7 @@ def partition(
     partitioning_kwargs["encoding"] = encoding
     partitioning_kwargs["infer_table_structure"] = infer_table_structure
     partitioning_kwargs["languages"] = languages
+    partitioning_kwargs["starting_page_number"] = starting_page_number
 
     if file_type == FileType.CSV:
         partition_csv = partitioner_loader.get(file_type)
@@ -278,7 +279,6 @@ def partition(
         elements = partition_doc(
             filename=filename,
             file=file,
-            starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
         )
@@ -287,7 +287,6 @@ def partition(
         elements = partition_docx(
             filename=filename,
             file=file,
-            starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
         )
@@ -330,7 +329,6 @@ def partition(
         elements = partition_odt(
             filename=filename,
             file=file,
-            starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
         )
@@ -357,7 +355,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
         )
@@ -390,14 +387,11 @@ def partition(
             paragraph_grouper=paragraph_grouper,
             **partitioning_kwargs,
         )
+
     elif file_type in (FileType.XLS, FileType.XLSX):
         partition_xlsx = partitioner_loader.get(file_type)
-        elements = partition_xlsx(
-            filename=filename,
-            file=file,
-            starting_page_number=starting_page_number,
-            **partitioning_kwargs,
-        )
+        elements = partition_xlsx(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.XML:
         partition_xml = partitioner_loader.get(file_type)
         elements = partition_xml(

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import importlib
 import io
 from typing import IO, Any, Callable, Literal, Optional
@@ -262,6 +263,9 @@ def partition(
     #  ALL OTHER FILE TYPES
     # ============================================================================================
 
+    partitioning_kwargs = copy.deepcopy(kwargs)
+    partitioning_kwargs["detect_language_per_element"] = detect_language_per_element
+
     if file_type == FileType.CSV:
         partition_csv = partitioner_loader.get(file_type)
         elements = partition_csv(
@@ -270,8 +274,7 @@ def partition(
             encoding=encoding,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.DOC:
         partition_doc = partitioner_loader.get(file_type)
@@ -280,10 +283,9 @@ def partition(
             file=file,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
             starting_page_number=starting_page_number,
             strategy=strategy,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.DOCX:
         partition_docx = partitioner_loader.get(file_type)
@@ -292,10 +294,9 @@ def partition(
             file=file,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
             starting_page_number=starting_page_number,
             strategy=strategy,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.EML:
         partition_email = partitioner_loader.get(file_type)
@@ -304,8 +305,7 @@ def partition(
             file=file,
             encoding=encoding,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.EPUB:
         partition_epub = partitioner_loader.get(file_type)
@@ -315,8 +315,7 @@ def partition(
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.HTML:
         partition_html = partitioner_loader.get(file_type)
@@ -326,8 +325,7 @@ def partition(
             include_page_breaks=include_page_breaks,
             encoding=encoding,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.MD:
         partition_md = partitioner_loader.get(file_type)
@@ -337,8 +335,7 @@ def partition(
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.MSG:
         partition_msg = partitioner_loader.get(file_type)
@@ -346,8 +343,7 @@ def partition(
             filename=filename,
             file=file,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.ODT:
         partition_odt = partitioner_loader.get(file_type)
@@ -356,10 +352,9 @@ def partition(
             file=file,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
             starting_page_number=starting_page_number,
             strategy=strategy,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.ORG:
         partition_org = partitioner_loader.get(file_type)
@@ -368,8 +363,7 @@ def partition(
             file=file,
             include_page_breaks=include_page_breaks,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.PPT:
         partition_ppt = partitioner_loader.get(file_type)
@@ -379,9 +373,8 @@ def partition(
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
             strategy=strategy,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.PPTX:
         partition_pptx = partitioner_loader.get(file_type)
@@ -391,10 +384,9 @@ def partition(
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
             starting_page_number=starting_page_number,
             strategy=strategy,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.RST:
         partition_rst = partitioner_loader.get(file_type)
@@ -404,8 +396,7 @@ def partition(
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.RTF:
         partition_rtf = partitioner_loader.get(file_type)
@@ -415,8 +406,7 @@ def partition(
             include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.TSV:
         partition_tsv = partitioner_loader.get(file_type)
@@ -424,8 +414,7 @@ def partition(
             filename=filename,
             file=file,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.TXT:
         partition_text = partitioner_loader.get(file_type)
@@ -435,8 +424,7 @@ def partition(
             encoding=encoding,
             paragraph_grouper=paragraph_grouper,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type in (FileType.XLS, FileType.XLSX):
         partition_xlsx = partitioner_loader.get(file_type)
@@ -445,9 +433,8 @@ def partition(
             file=file,
             infer_table_structure=infer_table_structure,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
             starting_page_number=starting_page_number,
-            **kwargs,
+            **partitioning_kwargs,
         )
     elif file_type == FileType.XML:
         partition_xml = partitioner_loader.get(file_type)
@@ -457,8 +444,7 @@ def partition(
             encoding=encoding,
             xml_keep_tags=xml_keep_tags,
             languages=languages,
-            detect_language_per_element=detect_language_per_element,
-            **kwargs,
+            **partitioning_kwargs,
         )
     else:
         msg = "Invalid file" if not filename else f"Invalid file {filename}"

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -265,17 +265,14 @@ def partition(
 
     partitioning_kwargs = copy.deepcopy(kwargs)
     partitioning_kwargs["detect_language_per_element"] = detect_language_per_element
+    partitioning_kwargs["encoding"] = encoding
     partitioning_kwargs["infer_table_structure"] = infer_table_structure
     partitioning_kwargs["languages"] = languages
 
     if file_type == FileType.CSV:
         partition_csv = partitioner_loader.get(file_type)
-        elements = partition_csv(
-            filename=filename,
-            file=file,
-            encoding=encoding,
-            **partitioning_kwargs,
-        )
+        elements = partition_csv(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.DOC:
         partition_doc = partitioner_loader.get(file_type)
         elements = partition_doc(
@@ -294,14 +291,11 @@ def partition(
             strategy=strategy,
             **partitioning_kwargs,
         )
+
     elif file_type == FileType.EML:
         partition_email = partitioner_loader.get(file_type)
-        elements = partition_email(
-            filename=filename,
-            file=file,
-            encoding=encoding,
-            **partitioning_kwargs,
-        )
+        elements = partition_email(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.EPUB:
         partition_epub = partitioner_loader.get(file_type)
         elements = partition_epub(
@@ -316,7 +310,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            encoding=encoding,
             **partitioning_kwargs,
         )
     elif file_type == FileType.MD:
@@ -394,7 +387,6 @@ def partition(
         elements = partition_text(
             filename=filename,
             file=file,
-            encoding=encoding,
             paragraph_grouper=paragraph_grouper,
             **partitioning_kwargs,
         )
@@ -411,7 +403,6 @@ def partition(
         elements = partition_xml(
             filename=filename,
             file=file,
-            encoding=encoding,
             xml_keep_tags=xml_keep_tags,
             **partitioning_kwargs,
         )

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -269,6 +269,7 @@ def partition(
     partitioning_kwargs["infer_table_structure"] = infer_table_structure
     partitioning_kwargs["languages"] = languages
     partitioning_kwargs["starting_page_number"] = starting_page_number
+    partitioning_kwargs["strategy"] = strategy
 
     if file_type == FileType.CSV:
         partition_csv = partitioner_loader.get(file_type)
@@ -276,20 +277,11 @@ def partition(
 
     elif file_type == FileType.DOC:
         partition_doc = partitioner_loader.get(file_type)
-        elements = partition_doc(
-            filename=filename,
-            file=file,
-            strategy=strategy,
-            **partitioning_kwargs,
-        )
+        elements = partition_doc(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.DOCX:
         partition_docx = partitioner_loader.get(file_type)
-        elements = partition_docx(
-            filename=filename,
-            file=file,
-            strategy=strategy,
-            **partitioning_kwargs,
-        )
+        elements = partition_docx(filename=filename, file=file, **partitioning_kwargs)
 
     elif file_type == FileType.EML:
         partition_email = partitioner_loader.get(file_type)
@@ -326,12 +318,8 @@ def partition(
 
     elif file_type == FileType.ODT:
         partition_odt = partitioner_loader.get(file_type)
-        elements = partition_odt(
-            filename=filename,
-            file=file,
-            strategy=strategy,
-            **partitioning_kwargs,
-        )
+        elements = partition_odt(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.ORG:
         partition_org = partitioner_loader.get(file_type)
         elements = partition_org(
@@ -346,7 +334,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            strategy=strategy,
             **partitioning_kwargs,
         )
     elif file_type == FileType.PPTX:
@@ -355,7 +342,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            strategy=strategy,
             **partitioning_kwargs,
         )
     elif file_type == FileType.RST:

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -25,17 +25,18 @@ Partitioner: TypeAlias = Callable[..., list[Element]]
 def partition(
     filename: Optional[str] = None,
     *,
-    content_type: Optional[str] = None,
     file: Optional[IO[bytes]] = None,
+    encoding: Optional[str] = None,
+    content_type: Optional[str] = None,
     file_filename: Optional[str] = None,
     url: Optional[str] = None,
+    headers: dict[str, str] = {},
+    ssl_verify: bool = True,
+    request_timeout: Optional[int] = None,
     include_page_breaks: bool = False,
     strategy: str = PartitionStrategy.AUTO,
-    encoding: Optional[str] = None,
     paragraph_grouper: Optional[Callable[[str], str]] | Literal[False] = None,
-    headers: dict[str, str] = {},
     skip_infer_table_types: list[str] = ["pdf", "jpg", "png", "heic"],
-    ssl_verify: bool = True,
     ocr_languages: Optional[str] = None,  # changing to optional for deprecation
     languages: Optional[list[str]] = None,
     detect_language_per_element: bool = False,
@@ -47,7 +48,6 @@ def partition(
     xml_keep_tags: bool = False,
     data_source_metadata: Optional[DataSourceMetadata] = None,
     metadata_filename: Optional[str] = None,
-    request_timeout: Optional[int] = None,
     hi_res_model_name: Optional[str] = None,
     model_name: Optional[str] = None,  # to be deprecated
     starting_page_number: int = 1,
@@ -63,30 +63,34 @@ def partition(
     ----------
     filename
         A string defining the target filename path.
-    content_type
-        A string defining the file content in MIME type
     file
         A file-like object using "rb" mode --> open(filename, "rb").
-    metadata_filename
-        When file is not None, the filename (string) to store in element metadata. E.g. "foo.txt"
+    encoding
+        The character-encoding used to decode the input bytes when drawn from `filename` or `file`.
+        Defaults to "utf-8".
     url
         The url for a remote document. Pass in content_type if you want partition to treat
         the document as a specific content_type.
+    headers
+        The headers to be used in conjunction with the HTTP request if URL is set.
+    ssl_verify
+        If the URL parameter is set, determines whether or not partition uses SSL verification
+        in the HTTP request.
+    request_timeout
+        The timeout for the HTTP request if URL is set. Defaults to None meaning no timeout and
+        requests will block indefinitely.
+    content_type
+        A string defining the file content in MIME type
+    metadata_filename
+        When file is not None, the filename (string) to store in element metadata. E.g. "foo.txt"
     include_page_breaks
         If True, the output will include page breaks if the filetype supports it
     strategy
         The strategy to use for partitioning PDF/image. Uses a layout detection model if set
         to 'hi_res', otherwise partition simply extracts the text from the document
         and processes it.
-    encoding
-        The encoding method used to decode the text input. If None, utf-8 will be used.
-    headers
-        The headers to be used in conjunction with the HTTP request if URL is set.
     skip_infer_table_types
         The document types that you want to skip table extraction with.
-    ssl_verify
-        If the URL parameter is set, determines whether or not partition uses SSL verification
-        in the HTTP request.
     languages
         The languages present in the document, for use in partitioning and/or OCR. For partitioning
         image or pdf documents with Tesseract, you'll first need to install the appropriate
@@ -127,9 +131,6 @@ def partition(
     xml_keep_tags
         If True, will retain the XML tags in the output. Otherwise it will simply extract
         the text from within the tags. Only applies to partition_xml.
-    request_timeout
-        The timeout for the HTTP request if URL is set. Defaults to None meaning no timeout and
-        requests will block indefinitely.
     hi_res_model_name
         The layout detection model used when partitioning strategy is set to `hi_res`.
     model_name

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -33,7 +33,6 @@ def partition(
     headers: dict[str, str] = {},
     ssl_verify: bool = True,
     request_timeout: Optional[int] = None,
-    include_page_breaks: bool = False,
     strategy: str = PartitionStrategy.AUTO,
     paragraph_grouper: Optional[Callable[[str], str]] | Literal[False] = None,
     skip_infer_table_types: list[str] = ["pdf", "jpg", "png", "heic"],
@@ -83,8 +82,6 @@ def partition(
         A string defining the file content in MIME type
     metadata_filename
         When file is not None, the filename (string) to store in element metadata. E.g. "foo.txt"
-    include_page_breaks
-        If True, the output will include page breaks if the filetype supports it
     strategy
         The strategy to use for partitioning PDF/image. Uses a layout detection model if set
         to 'hi_res', otherwise partition simply extracts the text from the document
@@ -208,7 +205,6 @@ def partition(
             filename=filename,
             file=file,
             url=None,
-            include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             strategy=strategy,
             languages=languages,
@@ -228,7 +224,6 @@ def partition(
             filename=filename,
             file=file,
             url=None,
-            include_page_breaks=include_page_breaks,
             infer_table_structure=infer_table_structure,
             strategy=strategy,
             languages=languages,
@@ -289,28 +284,15 @@ def partition(
 
     elif file_type == FileType.EPUB:
         partition_epub = partitioner_loader.get(file_type)
-        elements = partition_epub(
-            filename=filename,
-            file=file,
-            include_page_breaks=include_page_breaks,
-            **partitioning_kwargs,
-        )
+        elements = partition_epub(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.HTML:
         partition_html = partitioner_loader.get(file_type)
-        elements = partition_html(
-            filename=filename,
-            file=file,
-            include_page_breaks=include_page_breaks,
-            **partitioning_kwargs,
-        )
+        elements = partition_html(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.MD:
         partition_md = partitioner_loader.get(file_type)
-        elements = partition_md(
-            filename=filename,
-            file=file,
-            include_page_breaks=include_page_breaks,
-            **partitioning_kwargs,
-        )
+        elements = partition_md(filename=filename, file=file, **partitioning_kwargs)
 
     elif file_type == FileType.MSG:
         partition_msg = partitioner_loader.get(file_type)
@@ -322,44 +304,23 @@ def partition(
 
     elif file_type == FileType.ORG:
         partition_org = partitioner_loader.get(file_type)
-        elements = partition_org(
-            filename=filename,
-            file=file,
-            include_page_breaks=include_page_breaks,
-            **partitioning_kwargs,
-        )
+        elements = partition_org(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.PPT:
         partition_ppt = partitioner_loader.get(file_type)
-        elements = partition_ppt(
-            filename=filename,
-            file=file,
-            include_page_breaks=include_page_breaks,
-            **partitioning_kwargs,
-        )
+        elements = partition_ppt(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.PPTX:
         partition_pptx = partitioner_loader.get(file_type)
-        elements = partition_pptx(
-            filename=filename,
-            file=file,
-            include_page_breaks=include_page_breaks,
-            **partitioning_kwargs,
-        )
+        elements = partition_pptx(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.RST:
         partition_rst = partitioner_loader.get(file_type)
-        elements = partition_rst(
-            filename=filename,
-            file=file,
-            include_page_breaks=include_page_breaks,
-            **partitioning_kwargs,
-        )
+        elements = partition_rst(filename=filename, file=file, **partitioning_kwargs)
+
     elif file_type == FileType.RTF:
         partition_rtf = partitioner_loader.get(file_type)
-        elements = partition_rtf(
-            filename=filename,
-            file=file,
-            include_page_breaks=include_page_breaks,
-            **partitioning_kwargs,
-        )
+        elements = partition_rtf(filename=filename, file=file, **partitioning_kwargs)
 
     elif file_type == FileType.TSV:
         partition_tsv = partitioner_loader.get(file_type)

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -185,6 +185,20 @@ def partition(
 
     partitioner_loader = _PartitionerLoader()
 
+    # -- extracting this post-processing to allow multiple exit-points from function --
+    def augment_metadata(elements: list[Element]) -> list[Element]:
+        """Add some metadata fields to each element."""
+        for element in elements:
+            element.metadata.url = url
+            element.metadata.data_source = data_source_metadata
+            if content_type is not None:
+                out_filetype = FileType.from_mime_type(content_type)
+                element.metadata.filetype = out_filetype.mime_type if out_filetype else None
+            else:
+                element.metadata.filetype = file_type.mime_type
+
+        return elements
+
     if file_type == FileType.CSV:
         partition_csv = partitioner_loader.get(file_type)
         elements = partition_csv(
@@ -435,16 +449,7 @@ def partition(
             f"{msg}. The {file_type} file type is not supported in partition."
         )
 
-    for element in elements:
-        element.metadata.url = url
-        element.metadata.data_source = data_source_metadata
-        if content_type is not None:
-            out_filetype = FileType.from_mime_type(content_type)
-            element.metadata.filetype = out_filetype.mime_type if out_filetype is not None else None
-        else:
-            element.metadata.filetype = file_type.mime_type
-
-    return elements
+    return augment_metadata(elements)
 
 
 def file_and_type_from_url(

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -28,7 +28,6 @@ def partition(
     file: Optional[IO[bytes]] = None,
     encoding: Optional[str] = None,
     content_type: Optional[str] = None,
-    file_filename: Optional[str] = None,
     url: Optional[str] = None,
     headers: dict[str, str] = {},
     ssl_verify: bool = True,
@@ -143,18 +142,6 @@ def partition(
     """
     exactly_one(file=file, filename=filename, url=url)
 
-    if metadata_filename and file_filename:
-        raise ValueError(
-            "Only one of metadata_filename and file_filename is specified. "
-            "metadata_filename is preferred. file_filename is marked for deprecation.",
-        )
-
-    if file_filename is not None:
-        metadata_filename = file_filename
-        logger.warning(
-            "The file_filename kwarg will be deprecated in a future version of unstructured. "
-            "Please use metadata_filename instead.",
-        )
     kwargs.setdefault("metadata_filename", metadata_filename)
 
     if pdf_infer_table_structure:

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -265,6 +265,7 @@ def partition(
 
     partitioning_kwargs = copy.deepcopy(kwargs)
     partitioning_kwargs["detect_language_per_element"] = detect_language_per_element
+    partitioning_kwargs["infer_table_structure"] = infer_table_structure
     partitioning_kwargs["languages"] = languages
 
     if file_type == FileType.CSV:
@@ -273,7 +274,6 @@ def partition(
             filename=filename,
             file=file,
             encoding=encoding,
-            infer_table_structure=infer_table_structure,
             **partitioning_kwargs,
         )
     elif file_type == FileType.DOC:
@@ -281,7 +281,6 @@ def partition(
         elements = partition_doc(
             filename=filename,
             file=file,
-            infer_table_structure=infer_table_structure,
             starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
@@ -291,7 +290,6 @@ def partition(
         elements = partition_docx(
             filename=filename,
             file=file,
-            infer_table_structure=infer_table_structure,
             starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
@@ -310,7 +308,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            infer_table_structure=infer_table_structure,
             **partitioning_kwargs,
         )
     elif file_type == FileType.HTML:
@@ -328,7 +325,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            infer_table_structure=infer_table_structure,
             **partitioning_kwargs,
         )
 
@@ -341,7 +337,6 @@ def partition(
         elements = partition_odt(
             filename=filename,
             file=file,
-            infer_table_structure=infer_table_structure,
             starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
@@ -360,7 +355,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            infer_table_structure=infer_table_structure,
             strategy=strategy,
             **partitioning_kwargs,
         )
@@ -370,7 +364,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            infer_table_structure=infer_table_structure,
             starting_page_number=starting_page_number,
             strategy=strategy,
             **partitioning_kwargs,
@@ -381,7 +374,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            infer_table_structure=infer_table_structure,
             **partitioning_kwargs,
         )
     elif file_type == FileType.RTF:
@@ -390,7 +382,6 @@ def partition(
             filename=filename,
             file=file,
             include_page_breaks=include_page_breaks,
-            infer_table_structure=infer_table_structure,
             **partitioning_kwargs,
         )
 
@@ -412,7 +403,6 @@ def partition(
         elements = partition_xlsx(
             filename=filename,
             file=file,
-            infer_table_structure=infer_table_structure,
             starting_page_number=starting_page_number,
             **partitioning_kwargs,
         )

--- a/unstructured/partition/epub.py
+++ b/unstructured/partition/epub.py
@@ -51,7 +51,6 @@ def partition_epub(
 
     return partition_html(
         text=html_text,
-        encoding="unicode",
         metadata_filename=metadata_filename or filename,
         metadata_file_type=FileType.EPUB,
         metadata_last_modified=metadata_last_modified or last_modified,

--- a/unstructured/partition/html/partition.py
+++ b/unstructured/partition/html/partition.py
@@ -127,14 +127,6 @@ class HtmlPartitionerOptions:
         return self._detection_origin
 
     @lazyproperty
-    def encoding(self) -> str | None:
-        """Caller-provided encoding used to store HTML character stream as bytes.
-
-        `None` when no encoding was provided and encoding should be auto-detected.
-        """
-        return self._encoding
-
-    @lazyproperty
     def html_text(self) -> str:
         """The HTML document as a string, loaded from wherever the caller specified."""
         if self._file_path:

--- a/unstructured/partition/org.py
+++ b/unstructured/partition/org.py
@@ -42,7 +42,6 @@ def partition_org(
 
     return partition_html(
         text=html_text,
-        encoding="unicode",
         metadata_filename=metadata_filename or filename,
         metadata_file_type=FileType.ORG,
         metadata_last_modified=metadata_last_modified or last_modified,

--- a/unstructured/partition/rst.py
+++ b/unstructured/partition/rst.py
@@ -42,7 +42,6 @@ def partition_rst(
 
     return partition_html(
         text=html_text,
-        encoding="unicode",
         metadata_filename=metadata_filename or filename,
         metadata_file_type=FileType.RST,
         metadata_last_modified=metadata_last_modified or last_modified,

--- a/unstructured/partition/rtf.py
+++ b/unstructured/partition/rtf.py
@@ -42,7 +42,6 @@ def partition_rtf(
 
     return partition_html(
         text=html_text,
-        encoding="unicode",
         metadata_filename=metadata_filename or filename,
         metadata_file_type=FileType.RTF,
         metadata_last_modified=metadata_last_modified or last_modified,


### PR DESCRIPTION
**Summary**
Prepare auto-partitioning for pluggable partitioners.

Move toward a uniform partitioner call signature in `auto/partition()` such that a custom or override partitioner can be registered without requiring code changes.

**Additional Context**
The central job of `auto/partition()` is to detect the file-type of the given file and use that to dispatch partitioning to the corresponding partitioner function e.g. `partition_pdf()` or `partition_docx()`. 

In the existing code, each partitioner function is called with parameters "hand-picked" from the available parameters passed to the `partition()` function. This is unnecessary and couples those partitioners tightly with the dispatch function. The desired state is that all available arguments are passed as `kwargs` and the partitioner function "self-selects" the arguments it will be sensitive to, applies its own appropriate default values when the argument is omitted, and simply ignore any arguments it doesn't use. Note that achieving this requires no changes to partitioner functions because they already do precisely this.

So the job is to pass all arguments (other than `filename` and `file`) to the partitioner as `kwargs`. This will allow additional or alternate partitioners to be registered at runtime and dispatched to, because as long as they have the signature `partition_x(filename, file, kwargs) -> list[Element]` then they can be dispatched to without customization.
