### PR TITLE
Add a note to README.md about CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+- **Remind contributors to update the changelog**.  CI fails if you don't add an entry to `CHANGELOG.md` but this is not mentioned in the development documentation.
+
 ## 0.16.11
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ If using the optional `pre-commit`, you'll just need to install the hooks with `
 `pre-commit` package is installed as part of `make install` mentioned above. Finally, if you decided to use `pre-commit`
 you can also uninstall the hooks with `pre-commit uninstall`.
 
+When submitting a pull request, make sure to add an entry to
+[`CHANGELOG.md`](./CHANGELOG.md) (under the development version at the
+top of the file) describing the changes.
+
 In addition to develop in your local OS we also provide a helper to use docker providing a development environment:
 
 ```bash


### PR DESCRIPTION
There is a (good!) check in CI that makes sure that a PR adds a note to `CHANGELOG.md`.

Unfortunately this isn't mentioned anywhere that I can find in the documentation.  So here's a note in `README.md`.

Yes, I added an entry to `CHANGELOG.md` ;-)