### PR TITLE
fix: add .grype.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,3 +398,4 @@ jobs:
           image: "unstructured:dev"
           severity-cutoff: critical
           only-fixed: true
+          output-format: table

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,2 @@
+ignore:
+  - vulnerability: CVE-2024-11053

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.16.12-dev0
+## 0.16.12-dev1
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.12-dev0"  # pragma: no cover
+__version__ = "0.16.12-dev1"  # pragma: no cover


### PR DESCRIPTION
**Summary**
CVE-2024-11053 https://curl.se/docs/CVE-2024-11053.html (severity Low) was published on Dec 11, 2024 and began failing CI builds on open-core on Dec 13, 2024 when it appeared in `grype` apparently misclassified as a critical vulnerability.

The severity reported on the CVE is "Low" so it should not fail builds. Add a `.grype.yaml` file to ignore this CVE until grype is updated.