### PR TITLE
fix: fix multiple values for infer_table_structure

### DIFF
--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -109,6 +109,7 @@ jobs:
           sudo apt-get install -y tesseract-ocr-kor
           sudo apt-get install diffstat
           tesseract --version
+          python -m nltk.downloader punkt_tab averaged_perceptron_tagger_eng
           ./test_unstructured_ingest/test-ingest-src.sh
 
       - name: Save branch name to environment file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.16.14-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+- **Fix an issue with multiple values for `infer_table_structure`** when paritioning email with image attachements the kwarg calls into `partition` to partition the image already contains `infer_table_structure`. Now `partition` function checks if the `kwarg` has `infer_table_structure` already
+
 ## 0.16.13
 
 ### Enhancements

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -570,6 +570,20 @@ def test_auto_partition_pdf_with_fast_strategy(request: FixtureRequest):
     )
 
 
+@pytest.mark.parametrize("infer_bool", [True, False])
+def test_auto_handles_kwarg_with_infer_table_structure(infer_bool):
+    with patch(
+        "unstructured.partition.pdf_image.ocr.process_file_with_ocr",
+    ) as mock_process_file_with_model:
+        partition(
+            example_doc_path("pdf/layout-parser-paper-fast.pdf"),
+            pdf_infer_table_structure=True,
+            strategy=PartitionStrategy.HI_RES,
+            infer_table_structure=infer_bool,
+        )
+        assert mock_process_file_with_model.call_args[1]["infer_table_structure"] is infer_bool
+
+
 def test_auto_partition_pdf_uses_pdf_infer_table_structure_argument():
     with patch(
         "unstructured.partition.pdf_image.ocr.process_file_with_ocr",

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -584,6 +584,19 @@ def test_auto_handles_kwarg_with_infer_table_structure(infer_bool):
         assert mock_process_file_with_model.call_args[1]["infer_table_structure"] is infer_bool
 
 
+def test_auto_handles_kwarg_with_infer_table_structure_when_none():
+    with patch(
+        "unstructured.partition.pdf_image.ocr.process_file_with_ocr",
+    ) as mock_process_file_with_model:
+        partition(
+            example_doc_path("pdf/layout-parser-paper-fast.pdf"),
+            pdf_infer_table_structure=True,
+            strategy=PartitionStrategy.HI_RES,
+            infer_table_structure=None,
+        )
+        assert mock_process_file_with_model.call_args[1]["infer_table_structure"] is True
+
+
 def test_auto_partition_pdf_uses_pdf_infer_table_structure_argument():
     with patch(
         "unstructured.partition.pdf_image.ocr.process_file_with_ocr",

--- a/test_unstructured_ingest/expected-structured-output/azure/spring-weather.html.json
+++ b/test_unstructured_ingest/expected-structured-output/azure/spring-weather.html.json
@@ -1,13 +1,13 @@
 [
   {
-    "type": "UncategorizedText",
-    "element_id": "fb902c5b26b38e2d35a70a55d43a5de6",
-    "text": "News Around NOAA",
+    "type": "NarrativeText",
+    "element_id": "5835e40a6e30be7b3e1359cd1338fcc9",
+    "text": "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"> <html xmlns=\"http://www.w3.org/1999/xhtml\"> <head> <link rel=\"schema.DC\" href=\"http://purl.org/dc/elements/1.1/\" /><title>Are You Weather-Ready for the Spring?</title><meta name=\"DC.title\" content=\"Are You Weather-Ready for the Spring?\" /><meta name=\"DC.description\" content=\"Are You Weather-Ready for the Spring?\" /><meta name=\"DC.creator\" content=\"US Department of Commerce, NOAA, National Weather Service\" /><meta name=\"DC.date.created\" scheme=\"ISO8601\" content=\"March 3rd 2023 9:28 PM\" /><meta name=\"DC.language\" scheme=\"DCTERMS.RFC1766\" content=\"EN-US\" /><meta name=\"DC.keywords\" content=\"Are You Weather-Ready for the Spring?\" /><meta name=\"DC.publisher\" content=\"NOAA's National Weather Service\" /><meta name=\"DC.contributor\" content=\"National Weather Service\" /><meta name=\"DC.rights\" content=\"http://www.weather.gov/disclaimer.php\" /><meta name=\"rating\" content=\"General\" /><meta name=\"robots\" content=\"index,follow\" />",
     "metadata": {
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -21,14 +21,14 @@
     }
   },
   {
-    "type": "UncategorizedText",
-    "element_id": "100233c72890df3d216e2bc2c36f7153",
-    "text": "National Program",
+    "type": "NarrativeText",
+    "element_id": "f3441a1bac67b38c03803df74a169aa3",
+    "text": "<link href=\"/css/weatherstyle.css\" rel=\"stylesheet\" type=\"text/css\" /> <link href=\"/css/template.css\" rel=\"stylesheet\" type=\"text/css\" /> <link href=\"/css/myfcst.css\" rel=\"stylesheet\" type=\"text/css\" /> <link href=\"/css/ForecastSearch.css\" rel=\"stylesheet\" type=\"text/css\" /> <link href=\"/css/pointforecast.css\" rel=\"stylesheet\" type=\"text/css\" /> <link href=\"/css/jqueryui10_3_1custom/jquery-ui-1.10.3.custom.min.css\" rel=\"stylesheet\" type=\"text/css\" /> <link href=\"/css/widgets.css\" rel=\"stylesheet\" type=\"text/css\" /> <link href=\"/css/colorbox/colorbox.css\" rel=\"stylesheet\" type=\"text/css\" />",
     "metadata": {
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -43,13 +43,13 @@
   },
   {
     "type": "Title",
-    "element_id": "88f0bebe7a9cca77675bd8a5db823092",
-    "text": "Are You Weather-Ready for the Spring?",
+    "element_id": "445b47f3cc4f04f6b8b9da24855e76cf",
+    "text": "<script type=\"text/javascript\" src=\"/js/jquery",
     "metadata": {
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -64,1668 +64,13 @@
   },
   {
     "type": "UncategorizedText",
-    "element_id": "6ef25d028f4c859b5d955c777c4c597e",
-    "text": "Weather.gov > News Around NOAA > Are You Weather-Ready for the Spring?",
+    "element_id": "0b73906495af04e7c587a8bf22265232",
+    "text": "1.10.2.min.js\"></script>",
     "metadata": {
-      "link_texts": [
-        "Weather.gov",
-        "News Around NOAA"
-      ],
-      "link_urls": [
-        "https://www.weather.gov",
-        "https://www.weather.gov/news"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "eddf006a8c46b1cda2aac3b820775397",
-    "text": "Weather Safety",
-    "metadata": {
-      "link_texts": [
-        "Weather Safety"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/safetycampaign"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "2c39116ce12eb3a8cd275e7c89c62abf",
-    "text": "Air Quality",
-    "metadata": {
-      "link_texts": [
-        "Air Quality"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/airquality"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "37b3bec5196e722aebbb6bb5153d29c8",
-    "text": "Beach Hazards",
-    "metadata": {
-      "link_texts": [
-        "Beach Hazards"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/beachhazards"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "063926ec3c557edf0dfd4bfbb1b93012",
-    "text": "Cold",
-    "metadata": {
-      "link_texts": [
-        "Cold"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/cold"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "819fb41bb2932c2d900130821d88a652",
-    "text": "Cold Water",
-    "metadata": {
-      "link_texts": [
-        "Cold Water"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/coldwater"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "fd2a7923ffb5c283577cb1f44d27d780",
-    "text": "Drought",
-    "metadata": {
-      "link_texts": [
-        "Drought"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/drought"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "e7e66ca3dccdb812809e14dc91915fea",
-    "text": "Floods",
-    "metadata": {
-      "link_texts": [
-        "Floods"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/flood"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "fae686c1beaadff587803a1c2c601824",
-    "text": "Fog",
-    "metadata": {
-      "link_texts": [
-        "Fog"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/fog"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "652b08acd00f3f57b0687d2d1e0580f5",
-    "text": "Heat",
-    "metadata": {
-      "link_texts": [
-        "Heat"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/heat"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "8a9bcf1a4f38c536066c54b17b81b791",
-    "text": "Hurricanes",
-    "metadata": {
-      "link_texts": [
-        "Hurricanes"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/hurricane"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "741014158ee7a9f1de60c9e9e0ffe397",
-    "text": "Lightning Safety",
-    "metadata": {
-      "link_texts": [
-        "Lightning Safety"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/lightning"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "b9ad0403ff877aea1df9bea1c738cbc7",
-    "text": "Rip Currents",
-    "metadata": {
-      "link_texts": [
-        "Rip Currents"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/ripcurrent"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "56b0c95cec6394bbe563cb68582370de",
-    "text": "Safe Boating",
-    "metadata": {
-      "link_texts": [
-        "Safe Boating"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/safeboating"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "c1a739a65b5c223176f8d0a420fd5ab4",
-    "text": "Space Weather",
-    "metadata": {
-      "link_texts": [
-        "Space Weather"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/space"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "2122be3ea729f76922b64fc521b23212",
-    "text": "Sun (Ultraviolet Radiation)",
-    "metadata": {
-      "link_texts": [
-        "Sun (Ultraviolet Radiation)"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/heat-uv"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "d723c507c477d8be085d8e779fa93f46",
-    "text": "Thunderstorms & Tornadoes",
-    "metadata": {
-      "link_texts": [
-        "Thunderstorms & Tornadoes"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/thunderstorm"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "8dd83da4044b0c0b4346445a5f64ee28",
-    "text": "Tornado",
-    "metadata": {
-      "link_texts": [
-        "Tornado"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/tornado"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "90c8dce77ac1702a2cd2c2b44bf43a33",
-    "text": "Tsunami",
-    "metadata": {
-      "link_texts": [
-        "Tsunami"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/tsunami"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "b3a767e4ec9f8fda753a7300fcff9d1b",
-    "text": "Wildfire",
-    "metadata": {
-      "link_texts": [
-        "Wildfire"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/wildfire"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "4c664805f48d782068e1bea90ee7ec37",
-    "text": "Wind",
-    "metadata": {
-      "link_texts": [
-        "Wind"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/wind"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "753fbd04224edadfd5a3ef4589ac4a94",
-    "text": "Winter",
-    "metadata": {
-      "link_texts": [
-        "Winter"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safety/winter "
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "0225c2250f787f919e1e69d0f49dceff",
-    "text": "Safety Campaigns",
-    "metadata": {
-      "link_texts": [
-        "Safety Campaigns"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safetycampaign"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "b60f8982fb049e81a6188eb14ed80098",
-    "text": "Seasonal Safety Campaigns",
-    "metadata": {
-      "link_texts": [
-        "Seasonal Safety Campaigns"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/safetycampaign"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "34cffb77f95d809c924234e056b98348",
-    "text": "#SafePlaceSelfie",
-    "metadata": {
-      "link_texts": [
-        "#SafePlaceSelfie"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/safeplaceselfie"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "85e71456695dc655f543bd5ee5183779",
-    "text": "Deaf & Hard of Hearing",
-    "metadata": {
-      "link_texts": [
-        "Deaf & Hard of Hearing"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/dhh-safety"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "1443765ef30e3e80c7cea055adf7f606",
-    "text": "Intellectual Disabilities",
-    "metadata": {
-      "link_texts": [
-        "Intellectual Disabilities"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/intellectualdisabilities"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "9de2e41190a645a6b3dc869cbe2ef155",
-    "text": "Spanish-language Content",
-    "metadata": {
-      "link_texts": [
-        "Spanish-language Content"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/fall2020-espanol-sm"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "a66814e2e1eb1c5183996532c89010e6",
-    "text": "The Great Outdoors",
-    "metadata": {
-      "link_texts": [
-        "The Great Outdoors"
-      ],
-      "link_urls": [
-        "https://www.noaa.gov/explainers/great-outdoors-weather-safety"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "0640346478c8572ccec2dbe32e34a26d",
-    "text": "Ambassador",
-    "metadata": {
-      "link_texts": [
-        "Ambassador"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/ambassadors"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "f8e6a863d99658aa1360f28cfb8e4e5a",
-    "text": "About WRN Ambassadors",
-    "metadata": {
-      "link_texts": [
-        "About WRN Ambassadors"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/ambassadors"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "ef880d29b42c9f5436c62752cdbe75bf",
-    "text": "Become an Ambassador",
-    "metadata": {
-      "link_texts": [
-        "Become an Ambassador"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/amb-tou"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "eff3596db6d814cbe3d97defcf2797d0",
-    "text": "Ambassadors of Excellence",
-    "metadata": {
-      "link_texts": [
-        "Ambassadors of Excellence"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/ambassador_recognition"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "d23a1e5c66257639ff36614b8337c4ea",
-    "text": "People of WRN",
-    "metadata": {
-      "link_texts": [
-        "People of WRN"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/people/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "77c0ac157a229b2081defb62a6ae27a8",
-    "text": "FAQS",
-    "metadata": {
-      "link_texts": [
-        "FAQS"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/amb-faqs"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "c0b1fae13b933ba235f2de5ed8114e3d",
-    "text": "Tell Your Success Story",
-    "metadata": {
-      "link_texts": [
-        "Tell Your Success Story"
-      ],
-      "link_urls": [
-        "https://docs.google.com/forms/d/e/1FAIpQLScPHee5WAyC5K1LZ3pWLa2zjaM1HZSKN4_AxGUc6RaCy_gxLA/viewform"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "145b7263c7cd9d1626cddbf107d05449",
-    "text": "Success Stories",
-    "metadata": {
-      "link_texts": [
-        "Success Stories"
-      ],
-      "link_urls": [
-        " https://www.weather.gov/wrn/success-stories"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "513e9d09a97e1009e09cc193c2646277",
-    "text": "Tri-fold",
-    "metadata": {
-      "link_texts": [
-        "Tri-fold"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/media/wrn/WRN_Ambassador_Trifold.pdf"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "c11f051bb195ee9b50425cc950e57649",
-    "text": "Aviation",
-    "metadata": {
-      "link_texts": [
-        "Aviation"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/aviation"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "9412ffe8798653567f37bc7cbe01c383",
-    "text": "Current Ambassadors",
-    "metadata": {
-      "link_texts": [
-        "Current Ambassadors"
-      ],
-      "link_urls": [
-        " http://www.weather.gov/wrn/current-ambassadors"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "4ea1effc6dfdbce63f11ae08f5f0a6bf",
-    "text": "Brochure",
-    "metadata": {
-      "link_texts": [
-        "Brochure"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/media/wrn/WRN_Ambassador_Flyer.pdf"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "3e05ad9b5d5efa415c86072900a544ca",
-    "text": "En Espa\u00f1ol",
-    "metadata": {
-      "link_texts": [
-        "En Espa\u00f1ol"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/en-espanol"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "4f18297d6e97fe97131067c4614d0b56",
-    "text": "Education",
-    "metadata": {
-      "link_texts": [
-        "Education"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/owlie/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "3425ae9a4bf996456c28a3a383f632a7",
-    "text": "NWS Education Home",
-    "metadata": {
-      "link_texts": [
-        "NWS Education Home"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/owlie/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "80411d846bd3dd5f56ca576e376f4005",
-    "text": "Be A Force Of Nature",
-    "metadata": {
-      "link_texts": [
-        "Be A Force Of Nature"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/force"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "a4f595c8765cc3a0b5a15084ee7eb122",
-    "text": "WRN Kids Flyer",
-    "metadata": {
-      "link_texts": [
-        "WRN Kids Flyer"
-      ],
-      "link_urls": [
-        " http://www.weather.gov/media/owlie/nws_kids_fact_sheet2.pdf"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "c17db7f1aaa47629976e8f5166622e76",
-    "text": "Wireless Emergency Alerts",
-    "metadata": {
-      "link_texts": [
-        "Wireless Emergency Alerts"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/wea"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "edd86282ed0d85e5986532037959a2f0",
-    "text": "NOAA Weather Radio",
-    "metadata": {
-      "link_texts": [
-        "NOAA Weather Radio"
-      ],
-      "link_urls": [
-        "http://www.nws.noaa.gov/nwr/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "46cd16d10b37a045abd2617432c5dbfb",
-    "text": "Mobile Weather",
-    "metadata": {
-      "link_texts": [
-        "Mobile Weather"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/mobile-phone"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "7b443b7cd9b33f94b2a5f808d284a14a",
-    "text": "Brochures",
-    "metadata": {
-      "link_texts": [
-        "Brochures"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/owlie/publication_brochures"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "0314b445b3bafe00abe90358aecad7ed",
-    "text": "Hourly Weather Forecast",
-    "metadata": {
-      "link_texts": [
-        "Hourly Weather Forecast"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/hourly-weather-graph"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "1de9330b572f4e8872a37fc798eba1bc",
-    "text": "Citizen Science",
-    "metadata": {
-      "link_texts": [
-        "Citizen Science"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/media/wrn/citizen_science_page.pdf"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "9b8f1480242a74332d56768a19c2c3ba",
-    "text": "Intellectual Disabilities",
-    "metadata": {
-      "link_texts": [
-        "Intellectual Disabilities"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/intellectualdisabilities"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "f5121742894f599f7bad9e6c204219cd",
-    "text": "Collaboration",
-    "metadata": {
-      "link_texts": [
-        "Collaboration"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/collaborate"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "411f179a39ce6f35d780ececcf5a663e",
-    "text": "Get Involved",
-    "metadata": {
-      "link_texts": [
-        "Get Involved"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/get-involved"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "3bbd638b65f65c518fd27245ad070e31",
-    "text": "Social Media",
-    "metadata": {
-      "link_texts": [
-        "Social Media"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/socialmedia"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "367c30facb2871ff643359f94ef54dbd",
-    "text": "WRN Ambassadors \u200b",
-    "metadata": {
-      "link_texts": [
-        "WRN Ambassadors \u200b"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/ambassadors"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "193fb5253c63d3710c05022a62bb3045",
-    "text": "Enterprise Resources",
-    "metadata": {
-      "link_texts": [
-        "Enterprise Resources"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/enterprise/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "724fcc66e549c1a95f1099f16f03f673",
-    "text": "StormReady",
-    "metadata": {
-      "link_texts": [
-        "StormReady"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/stormready/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "34d416cafa517f35f5d1263d3f84d0e4",
-    "text": "TsunamiReady",
-    "metadata": {
-      "link_texts": [
-        "TsunamiReady"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/tsunamiready/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "613b531929637689a7cd0d616f71fc3e",
-    "text": "NWSChat (core partners only)",
-    "metadata": {
-      "link_texts": [
-        "NWSChat (core partners only)"
-      ],
-      "link_urls": [
-        "https://nwschat.weather.gov/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "a49caec66691ba6a0cc9d04c7e9ce9bc",
-    "text": "InteractiveNWS (iNWS) (core partners only)\u200b",
-    "metadata": {
-      "link_texts": [
-        "InteractiveNWS (iNWS) (core partners only)\u200b"
-      ],
-      "link_urls": [
-        "https://inws.ncep.noaa.gov/"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -1739,290 +84,14 @@
     }
   },
   {
-    "type": "ListItem",
-    "element_id": "ed51ed0b4e5878e9439f0f18edb928f5",
-    "text": "SKYWARN",
+    "type": "Title",
+    "element_id": "1634cb186076af08e14f857e22d7ae7b",
+    "text": "<script type=\"text/javascript\" src=\"/js/jquery",
     "metadata": {
-      "link_texts": [
-        "SKYWARN"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/SKYWARN"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "556fb42a560167c2cc207d7cb6714bad",
-    "text": "News & Events",
-    "metadata": {
-      "link_texts": [
-        "News & Events"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/news/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "a788e14552083ec3eeace45644ab61f6",
-    "text": "Latest News",
-    "metadata": {
-      "link_texts": [
-        "Latest News"
-      ],
-      "link_urls": [
-        " http://www.weather.gov/news/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "081cd4934a58045952774609f4c933b9",
-    "text": "Calendar",
-    "metadata": {
-      "link_texts": [
-        "Calendar"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/calendar"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "11ee8366847061465e77830c50f56541",
-    "text": "Meetings & Workshops",
-    "metadata": {
-      "link_texts": [
-        "Meetings & Workshops"
-      ],
-      "link_urls": [
-        " https://www.weather.gov/wrn/workshops"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "0dbdf234ff1ede3066c029317a2c086a",
-    "text": "NWS Aware Newsletter",
-    "metadata": {
-      "link_texts": [
-        "NWS Aware Newsletter"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/publications/aware"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "4fd5499bdc7ef505fbd5ad7808cc15e4",
-    "text": "International",
-    "metadata": {
-      "link_texts": [
-        "International"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/wrns"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "aa70c71400e0cbb1efa4a90ffda7b576",
-    "text": "About",
-    "metadata": {
-      "link_texts": [
-        "About"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/about"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "a2a88821ceb3beaab2113187f62f107b",
-    "text": "Contact Us",
-    "metadata": {
-      "link_texts": [
-        "Contact Us"
-      ],
-      "link_urls": [
-        " https://www.weather.gov/wrn/contact"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "d8b62cdf46831c81d890e1dbfca7d48f",
-    "text": "What is WRN?",
-    "metadata": {
-      "link_texts": [
-        "What is WRN?"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/about"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "027ed196c34f111fc5f60bbda8549811",
-    "text": "WRN FAQ",
-    "metadata": {
-      "link_texts": [
-        "WRN FAQ"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/faqs"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2036,101 +105,14 @@
     }
   },
   {
-    "type": "ListItem",
-    "element_id": "f1227f69a53be4a073c718c7f056e277",
-    "text": "WRN Brochure",
+    "type": "Title",
+    "element_id": "300374301078305e87bb7b588daf5350",
+    "text": "ui",
     "metadata": {
-      "link_texts": [
-        "WRN Brochure"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/media/wrn/WRN_Ambassador_Flyer.pdf"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "76ac56b6bf05505c5ed136a0115b13bc",
-    "text": "Hazard Simplification",
-    "metadata": {
-      "link_texts": [
-        "Hazard Simplification"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/hazardsimplification/"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "dc08ebeca9f26eeb4c46ad055a7e08eb",
-    "text": "IDSS Brochure",
-    "metadata": {
-      "link_texts": [
-        "IDSS Brochure"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/media/wrn/2018-IDSS2-Pager.pdf"
-      ],
-      "languages": [
-        "eng"
-      ],
-      "filetype": "text/html",
-      "data_source": {
-        "url": "abfs://container1/spring-weather.html",
-        "version": "0x8DB214B74525BB6",
-        "record_locator": {
-          "protocol": "abfs",
-          "remote_file_path": "abfs://container1/"
-        },
-        "date_created": "1678441216.0",
-        "date_modified": "1678441216.0"
-      }
-    }
-  },
-  {
-    "type": "ListItem",
-    "element_id": "d228c35b349de0347cfff635f96308ca",
-    "text": "Roadmap",
-    "metadata": {
-      "link_texts": [
-        "Roadmap"
-      ],
-      "link_urls": [
-        "http://www.weather.gov/media/wrn/nws_wrn_roadmap_final_april17.pdf"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2144,20 +126,14 @@
     }
   },
   {
-    "type": "ListItem",
-    "element_id": "738f4cffb78938db8fd26bb5ee2e8b73",
-    "text": "Strategic Plan",
+    "type": "Title",
+    "element_id": "51adf1c31b8480606b1b09052a6cafeb",
+    "text": "1.10.3.custom.min.js\"></script>",
     "metadata": {
-      "link_texts": [
-        "Strategic Plan"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/media/wrn/NWS_Weather-Ready-Nation_Strategic_Plan_2019-2022.pdf"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2171,20 +147,14 @@
     }
   },
   {
-    "type": "ListItem",
-    "element_id": "6b07bf9d8a69a826f08eb8aeb96d40a8",
-    "text": "WRN International",
+    "type": "Title",
+    "element_id": "e17529bc8ddbdb07c9b9866b2edd1245",
+    "text": "<script type=\"text/javascript\" src=\"/js/jquery.hoverIntent.minified.js\"></script>",
     "metadata": {
-      "link_texts": [
-        "WRN International"
-      ],
-      "link_urls": [
-        " https://www.weather.gov/wrn/international"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2198,20 +168,14 @@
     }
   },
   {
-    "type": "ListItem",
-    "element_id": "de29e400f9d0ab80da7d3b3708b1398d",
-    "text": "Social Science",
+    "type": "Title",
+    "element_id": "2ab7c89d3768b3afd25d0f45a656170b",
+    "text": "<script type=\"text/javascript\" src=\"/js/ForecastSearch.js\"></script>",
     "metadata": {
-      "link_texts": [
-        "Social Science"
-      ],
-      "link_urls": [
-        "https://vlab.noaa.gov/web/nws-social-science"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2226,13 +190,13 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "a859a27443333ffa9b214673a011d832",
-    "text": "The spring season is all about change \u2013 a rebirth both literally and figuratively. Even though the spring season doesn\u2019t officially (astronomically, that is) begin until March 20 this year, climatologically, it starts March 1.",
+    "element_id": "9e441bed864a786b7ca26bd9a4b35a48",
+    "text": "<script type=\"text/javascript\" src=\"/js/federated",
     "metadata": {
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2246,14 +210,14 @@
     }
   },
   {
-    "type": "NarrativeText",
-    "element_id": "d9065d09d5289f575f03dd67043679f5",
-    "text": "As cold winter nights are replaced by the warmth of longer daylight hours, the National Weather Service invites you to do two important things that may save your life or the life of a loved one.",
+    "type": "Title",
+    "element_id": "38df42a514040f358eb74aefa797ca8d",
+    "text": "analytics.js\"></script>",
     "metadata": {
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2267,20 +231,14 @@
     }
   },
   {
-    "type": "NarrativeText",
-    "element_id": "e100f7b751351d8de4653bd7c5f69245",
-    "text": "First, take steps to better prepare for the seasonal hazards weather can throw at you. This could include a spring cleaning of your storm shelter or ensuring your emergency kit is fully stocked. Take a look at our infographics and social media posts to help you become \u201cweather-ready.\u201d",
+    "type": "Title",
+    "element_id": "1c6d7384c2fc24684c5b84a248df766f",
+    "text": "<script type=\"text/javascript\" src=\"/js/topNavMenu.js\"></script>",
     "metadata": {
-      "emphasized_text_contents": [
-        "First, take steps to better prepare for the seasonal hazards weather can throw at you."
-      ],
-      "emphasized_text_tags": [
-        "b"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2294,26 +252,14 @@
     }
   },
   {
-    "type": "NarrativeText",
-    "element_id": "55d81694fcd2fade3dfc62ef52422f7b",
-    "text": "Second, encourage others to become Weather-Ready as well. Share the message by taking advantage of our vast array of weather safety content \u2013 everything posted on our Spring Safety website is freely available, and we encourage sharing on social media networks. Also remember those who are most vulnerable, like an elderly family member or neighbor who might have limited mobility or is isolated. Reach out to those who are at higher risk of being impacted by extreme weather, and help them get prepared. This simple act of caring could become heroic.",
+    "type": "Title",
+    "element_id": "0d7afafb632a629afe6e992173fa8516",
+    "text": "<script type=\"text/javascript\" src=\"/js/NidsESRI.js\"></script>",
     "metadata": {
-      "emphasized_text_contents": [
-        "Second, encourage others to become Weather-Ready as well."
-      ],
-      "emphasized_text_tags": [
-        "b"
-      ],
-      "link_texts": [
-        "Spring Safety website"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/spring-safety"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2327,20 +273,14 @@
     }
   },
   {
-    "type": "NarrativeText",
-    "element_id": "cc697b1fe8918a5033fdc471d0f192f8",
-    "text": "This spring, the campaign is focused on heat dangers. Heat illness and death can occur even in spring\u2019s moderately warm weather. The majority of all heat-related deaths occur outside of heat waves and roughly a third of child hot car deaths occur outside of the summer months. Learn more by viewing the infographics that are now available.",
+    "type": "Title",
+    "element_id": "276639f79cb51278fa63390304bff7ab",
+    "text": "<script type=\"text/javascript\" src=\"/js/widgets.js\"></script>",
     "metadata": {
-      "link_texts": [
-        "infographics"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/wrn/spring-infographics"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2354,14 +294,14 @@
     }
   },
   {
-    "type": "NarrativeText",
-    "element_id": "939c4fee892e83225c5b774cf44ebe02",
-    "text": "Stay safe this spring, and every season, by being informed, prepared, and Weather-Ready.",
+    "type": "Title",
+    "element_id": "5af6bddcd24eee0c4fdaf20f42f240e0",
+    "text": "<script type=\"text/javascript\" src=\"/js/jquery.cycle2.min.js\"></script>",
     "metadata": {
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2375,26 +315,14 @@
     }
   },
   {
-    "type": "NarrativeText",
-    "element_id": "5e3a9e295119f09f8a9e8ac807188176",
-    "text": "US Dept of Commerce National Oceanic and Atmospheric Administration National Weather Service News Around NOAA 1325 East West Highway Silver Spring, MD 20910 Comments? Questions? Please Contact Us.",
+    "type": "Title",
+    "element_id": "33c77c4cba96cd90b9b8f29f1b08e978",
+    "text": "<script type=\"text/javascript\" src=\"/js/jquery.colorbox",
     "metadata": {
-      "link_texts": [
-        "US Dept of Commerce",
-        "National Oceanic and Atmospheric Administration",
-        "National Weather Service",
-        "Comments? Questions? Please Contact Us."
-      ],
-      "link_urls": [
-        "http://www.commerce.gov",
-        "http://www.noaa.gov",
-        "https://www.weather.gov",
-        "https://www.weather.gov/news/contact"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2408,26 +336,35 @@
     }
   },
   {
-    "type": "UncategorizedText",
-    "element_id": "a8eed54a458923d7f04b9d1641e98d43",
-    "text": "Disclaimer Information Quality Help Glossary",
+    "type": "Title",
+    "element_id": "ff24ee2c0f8f980392aaae4fa673a211",
+    "text": "min.js\"></script>",
     "metadata": {
-      "link_texts": [
-        "Disclaimer",
-        "Information Quality",
-        "Help",
-        "Glossary"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/disclaimer",
-        "http://www.cio.noaa.gov/services_programs/info_quality.html",
-        "https://www.weather.gov/help",
-        "http://www.weather.gov/glossary"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "0a7dc8f1940b9dd8f006f789984c937a",
+    "text": "<script type=\"text/javascript\" src=\"/js/nwsexit.js\"></script>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",
@@ -2442,25 +379,2218 @@
   },
   {
     "type": "UncategorizedText",
-    "element_id": "b415705c2c1927eda24b454e6e91bea3",
-    "text": "Privacy Policy Freedom of Information Act (FOIA) About Us Career Opportunities",
+    "element_id": "1a0aae68189c5b41a14a0bf787c2403d",
+    "text": "<script type=\"text/javascript\"> var _gaq = _gaq || []; _gaq.push(['_setAccount', ' UA-40768555-2']); _gaq.push(['_anonymizeIp']); _gaq.push(['_trackPageview']);",
     "metadata": {
-      "link_texts": [
-        "Privacy Policy",
-        "Freedom of Information Act (FOIA)",
-        "About Us",
-        "Career Opportunities"
-      ],
-      "link_urls": [
-        "https://www.weather.gov/privacy",
-        "https://www.noaa.gov/foia-freedom-of-information-act",
-        "https://www.weather.gov/about",
-        "https://www.weather.gov/careers"
-      ],
       "languages": [
         "eng"
       ],
-      "filetype": "text/html",
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "4efd5d41d8f7ea9c8eb1ebd86a32bd0a",
+    "text": "(function() { var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s); })();</script> </head>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "10f1f24c9b8bf4f8576b67982032e0e4",
+    "text": "<body> <div class=\"header\"> <div class=\"header-content\"> <a href=\"http://www.weather.gov\" class=\"header-nws\"><img src=\"/css/images/header.png\"  alt=\"National Weather Service\"/></a> <a href=\"http://www.commerce.gov\" class=\"header-doc\"><img src=\"/css/images/header_doc.png\" alt=\"United States Department of Commerce\"/></a> <a href=\"http://www.noaa.gov\" class=\"header-noaa\" title=\"National Oceanic and Atmospheric Administration\"></a> </div> <div style=\"clear:both\"></div> </div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "a97047158b0ab4da25a4bb3e2a823407",
+    "text": "<div class=\"header",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "975eccff694c8796198585963991bfac",
+    "text": "shadow\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "3de309029a05beee28d23d3ebb1e9fb8",
+    "text": "<div class=\"header",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "407a4e9fcd85573f34313a0094543837",
+    "text": "shadow",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "dbbae9eeda7e10456346e7c52a760fa5",
+    "text": "content\"></div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "10b8c322251fef79f5eacfb7c76e0527",
+    "text": "</div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "500c93326fb603fd9723a8a461bfb132",
+    "text": "<div class=\"center\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "6b2f673d931f2747fac5382941eb3b3e",
+    "text": "<div class=\"center",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "4175e0e1fd2d1050228c9cd2bac1d3c3",
+    "text": "content\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "25119f5e62d4715d54fb086dc9b4c2f7",
+    "text": "<div class=\"full",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "6825b556ff248a97ef8ffb9759f5bce9",
+    "text": "width",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "cde62c49541d45e67dc84b15ba780791",
+    "text": "border\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "7f1bf539696c092955704fe84c2e0f6c",
+    "text": "<div class=\"partial",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "91d3cafa06aebf4c4f1680c017192b67",
+    "text": "width",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "55516174ae98c5506a24d2ce8f26b309",
+    "text": "borderbottom\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "59fbcb3f868911e2c1ebd83a61e92e27",
+    "text": "<!-- area for the myforecast widget and wwamap data -->",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "c86708b570205221afc715f7f6a4ca3f",
+    "text": "<div class=\"div-full\"> <div class=\"div-full breadcrumb\">    <div class=\"sitename\">        <p class=\"sitename-name\">News Around NOAA</p>        <p class=\"sitename-class\">National Program</p>    </div>    <div class=\"location\">        <h1 class='location-pagetitle'>Are You Weather-Ready for the Spring?</h1>        <div class='location-breadcrumb'>            <a href=\"https://www.weather.gov\">Weather.gov</a> &gt; <a href=\"https://www.weather.gov/news\">News Around NOAA</a> &gt; Are You Weather-Ready for the Spring?        </div>    </div></div> <div class=\"div-full\">    <div class=\"subMenuNav\">        <ul id=\"subMenuNav\">            <li>                <div class=\"subMenuNavList section-link\">                    <a href=\"http://www.weather.gov/safetycampaign\">Weather Safety</a>                </div>                <div class=\"sub\">                    <ul>                        <li>                            <a href=\"https://www.weather.gov/safety/airquality\">Air Quality</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/beachhazards\">Beach Hazards</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/cold\">Cold</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/coldwater\">Cold Water</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/drought\">Drought</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/flood\">Floods</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/fog\">Fog</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/heat\">Heat</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/hurricane\"> Hurricanes</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/lightning\"> Lightning Safety</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/ripcurrent\">Rip Currents</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/safeboating\">Safe Boating</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/space\">Space Weather</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/heat-uv\">Sun (Ultraviolet Radiation)</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/thunderstorm\"> Thunderstorms & Tornadoes</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/tornado\">Tornado</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/tsunami\">Tsunami</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/wildfire\">Wildfire</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/wind\">Wind</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/safety/winter \">Winter</a>                        </li>                    </ul>                </div>            </li>            <li>                <div class=\"subMenuNavList section-link\">                    <a href=\"https://www.weather.gov/safetycampaign\">Safety Campaigns</a>                </div>                <div class=\"sub\">                    <ul>                        <li>                            <a href=\"https://www.weather.gov/safetycampaign\">Seasonal Safety Campaigns</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/safeplaceselfie\">#SafePlaceSelfie</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/dhh-safety\">Deaf & Hard of Hearing</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/intellectualdisabilities\">Intellectual Disabilities</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/fall2020-espanol-sm\">Spanish-language Content</a>                        </li>                        <li>                            <a href=\"https://www.noaa.gov/explainers/great-outdoors-weather-safety\">The Great Outdoors</a>                        </li>                    </ul>                </div>            </li>            <li>                <div class=\"subMenuNavList section-link\">                    <a href=\"https://www.weather.gov/wrn/ambassadors\">Ambassador</a>                </div>                <div class=\"sub\">                    <ul>                        <li>                            <a href=\"https://www.weather.gov/wrn/ambassadors\">About WRN Ambassadors</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/amb-tou\">Become an Ambassador</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/ambassador_recognition\">Ambassadors of Excellence</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/people/\">People of WRN</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/amb-faqs\"> FAQS</a>                        </li>                        <li>                            <a href=\"https://docs.google.com/forms/d/e/1FAIpQLScPHee5WAyC5K1LZ3pWLa2zjaM1HZSKN4_AxGUc6RaCy_gxLA/viewform\">Tell Your Success Story</a>                        </li>                        <li>                            <a href=\" https://www.weather.gov/wrn/success-stories\"> Success Stories</a>                        </li>                        <li>                            <a href=\"http://www.weather.gov/media/wrn/WRN_Ambassador_Trifold.pdf\">Tri-fold</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/aviation\">Aviation</a>                        </li>                        <li>                            <a href=\" http://www.weather.gov/wrn/current-ambassadors\"> Current Ambassadors</a>                        </li>                        <li>                            <a href=\"http://www.weather.gov/media/wrn/WRN_Ambassador_Flyer.pdf\">Brochure</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/en-espanol\">En Espa\u00f1ol</a>                        </li>                    </ul>                </div>            </li>            <li>                <div class=\"subMenuNavList section-link\">                    <a href=\"http://www.weather.gov/owlie/\">Education</a>                </div>                <div class=\"sub\">                    <ul>                        <li>                            <a href=\"http://www.weather.gov/owlie/\">NWS Education Home</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/force\">Be A Force Of Nature</a>                        </li>                        <li>                            <a href=\" http://www.weather.gov/media/owlie/nws_kids_fact_sheet2.pdf\">WRN Kids Flyer</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/wea\">Wireless Emergency Alerts</a>                        </li>                        <li>                            <a href=\"http://www.nws.noaa.gov/nwr/\">NOAA Weather Radio</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/mobile-phone\">Mobile Weather</a>                        </li>                        <li>                            <a href=\"http://www.weather.gov/owlie/publication_brochures\">Brochures</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/hourly-weather-graph\">Hourly Weather Forecast</a>                        </li>                        <li>                            <a href=\"http://www.weather.gov/media/wrn/citizen_science_page.pdf\">Citizen Science</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/intellectualdisabilities\">Intellectual Disabilities</a>                        </li>                    </ul>                </div>            </li>            <li>                <div class=\"subMenuNavList section-link\">                    <a href=\"https://www.weather.gov/wrn/collaborate\">Collaboration</a>                </div>                <div class=\"sub\">                    <ul>                        <li>                            <a href=\"https://www.weather.gov/wrn/get-involved\">Get Involved </a>                        </li>                        <li>                            <a href=\"http://www.weather.gov/socialmedia\">Social Media</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/ambassadors\">WRN Ambassadors \u200b</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/enterprise/\">Enterprise Resources</a>                        </li>                        <li>                            <a href=\"http://www.weather.gov/stormready/\">StormReady</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/tsunamiready/\">TsunamiReady</a>                        </li>                        <li>                            <a href=\"https://nwschat.weather.gov/\">NWSChat (core partners only)</a>                        </li>                        <li>                            <a href=\"https://inws.ncep.noaa.gov/\">InteractiveNWS (iNWS) (core partners only)\u200b</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/SKYWARN\">SKYWARN</a>                        </li>                    </ul>                </div>            </li>            <li>                <div class=\"subMenuNavList section-link\">                    <a href=\"http://www.weather.gov/news/\"> News & Events</a>                </div>                <div class=\"sub\">                    <ul>                        <li>                            <a href=\" http://www.weather.gov/news/\">Latest News</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/calendar\">Calendar</a>                        </li>                        <li>                            <a href=\" https://www.weather.gov/wrn/workshops\">Meetings & Workshops</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/publications/aware\">NWS Aware Newsletter</a>                        </li>                    </ul>                </div>            </li>            <li>                <div class=\"subMenuNavList section-link\">                    <a href=\"https://www.weather.gov/wrn/wrns\">International</a>                </div>            </li>            <li>                <div class=\"subMenuNavList section-link\">                    <a href=\"https://www.weather.gov/wrn/about\">About</a>                </div>                <div class=\"sub\">                    <ul>                        <li>                            <a href=\" https://www.weather.gov/wrn/contact\">Contact Us</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/about\"> What is WRN?</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/wrn/faqs\"> WRN FAQ</a>                        </li>                        <li>                            <a href=\"http://www.weather.gov/media/wrn/WRN_Ambassador_Flyer.pdf\">WRN Brochure</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/hazardsimplification/\">Hazard Simplification</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/media/wrn/2018-IDSS2-Pager.pdf\">IDSS Brochure</a>                        </li>                        <li>                            <a href=\"http://www.weather.gov/media/wrn/nws_wrn_roadmap_final_april17.pdf\">Roadmap</a>                        </li>                        <li>                            <a href=\"https://www.weather.gov/media/wrn/NWS_Weather-Ready-Nation_Strategic_Plan_2019-2022.pdf\">Strategic Plan</a>                        </li>                        <li>                            <a href=\" https://www.weather.gov/wrn/international\">WRN International</a>                        </li>                        <li>                            <a href=\"https://vlab.noaa.gov/web/nws-social-science\">Social Science</a>                        </li>                    </ul>                </div>            </li>        </ul>    </div></div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "5aeaca5e353e7b028e94c0448203ec83",
+    "text": "<div class=\"div-full\"> <div class=\"cms-content\"><p>The spring season is all about change &ndash; a rebirth both literally and figuratively. Even though the spring season doesn&rsquo;t officially (astronomically, that is) begin until March 20 this year, climatologically, it starts March 1.&nbsp;</p>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "a76c780d3cbd31ab6221f0d1932cc95f",
+    "text": "<p>As cold winter nights are replaced by the warmth of longer daylight hours, the National Weather Service invites you to do two important things that may save your life or the life of a loved one.&nbsp;</p>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "5f83fe5a17bbd235a4b617aca0b101af",
+    "text": "<p><strong>First, take steps to better prepare for the seasonal hazards weather can throw at you.</strong><br /> This could include a spring cleaning of your storm shelter or ensuring your emergency kit is fully stocked. Take a look at our infographics and social media posts to help you become &ldquo;weather-ready.&rdquo;&nbsp;</p>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "cb0ac2014b92ca27eec15e9c9659e01b",
+    "text": "<p><strong>Second, encourage others to become Weather-Ready as well.</strong> Share the message by taking advantage of our vast array of weather safety content &ndash; everything posted on our <a href=\"https://www.weather.gov/wrn/spring-safety\">Spring Safety website</a> is freely available, and we encourage sharing on social media networks. Also remember those who are most vulnerable, like an elderly family member or neighbor who might have limited mobility or is isolated. Reach out to those who are at higher risk of being impacted by extreme weather, and help them get prepared. This simple act of caring could become heroic.&nbsp;</p>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "c80df934fdcf6867dfcd6f59f208430f",
+    "text": "<p>This spring, the campaign is focused on heat dangers. Heat illness and death can occur even in spring&rsquo;s moderately warm weather. The majority of all heat-related deaths occur outside of heat waves and roughly a third of child hot car deaths occur outside of the summer months. Learn more by viewing the <a href=\"https://www.weather.gov/wrn/spring-infographics\">infographics</a> that are now available.&nbsp;</p>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "d47f1bb8cc8049e33e6fcce145b9df20",
+    "text": "<p>Stay safe this spring, and every season, by being informed, prepared, and Weather-Ready.</p>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "0fc8ae01dfca85f1ff00d87a46bf2807",
+    "text": "<p><a href=\"/images/wrn/Infographics/2023/outside",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "36cb2c24b1208a24570090ae5e316d67",
+    "text": "of",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "d82eec893eefede84bd6a7d36f28e8c8",
+    "text": "heatwaves.png\"><img alt=\"\" src=\"/images/wrn/Infographics/2023/outside",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "59f683a26c9a57c0d6a9b5d376933710",
+    "text": "of",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "48c15092cb73e94e251c91509f81edbd",
+    "text": "heatwaves.png\" style=\"width: 700px;\" /></a></p>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "12716355230d27cd514ef2ef6de59a11",
+    "text": "</div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "2316e1682dc56945e8a76d5f07253e16",
+    "text": "</div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "b82b418afd7813168bb95d0ce0807de9",
+    "text": "<div style=\"clear:both\"></div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "5983a368f575329e5e8b137b2ac33a37",
+    "text": "</div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "ad1e4d310c983556478fe72b4aa1283e",
+    "text": "</div><!-",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "dd54f3cf37851c80cbc5eb643b52dc2a",
+    "text": "end of <div class=\"partial",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "ce22f99e9e88c71c78b2b462e61edf29",
+    "text": "width",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "a9a96a2347b32359386e03d895041af5",
+    "text": "borderbottom\"> -",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "61ae13fc3592da0c0141d1b8139fe7d4",
+    "text": ">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "f35dfb76bf37688a0ba00315750aa3d2",
+    "text": "</div><!-",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "d5e1eae7addef05ace2e51aefc866598",
+    "text": "<div class=\"full",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "a20a179f5e8d6d37c0d0901ea4bf2ed1",
+    "text": "width",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "4b89a03b8ee54098ca3861641ae68d77",
+    "text": "border\"> -",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "682d00858c38a903bd12b55a7ce0f7e0",
+    "text": ">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "614942125138bd6b375d66e16dd22a0b",
+    "text": "<div class=\"partial-width-borderbottom feature-block\"> <!-- area for features, frontpage thumbs, and custom page -->",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "f9abf64570ca09664fedcb92678258c7",
+    "text": "</div><!-",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "7b8db241f50852d6030999fd5c031489",
+    "text": "end of <div class=\"partial",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "f87ae6a60cffeb700c1f433cf2dd8c0f",
+    "text": "width",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "4eb1fd093aeabaa655648a0ae0d82f93",
+    "text": "borderbottom feature",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "394e081d993e38f061a90e5d4802ba16",
+    "text": "block\"> -",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "61287dca36454aec1ffeef2ab1c0dad6",
+    "text": ">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "199303272c0a96e4b77d1e203b762601",
+    "text": "<div class=\"full",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "ecd14a7a631d791b89e5aabab934268e",
+    "text": "width",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "e70ba7770a2edce471803bc80725d6ae",
+    "text": "first\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "f87bd03c5086e1f50f5095c952002d8b",
+    "text": "</div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "87503c16b4fe103ab69be8733b775307",
+    "text": "<div style=\"clear:both;\"></div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "6cb35ab5d0e3833ae1c9a1bccd171983",
+    "text": "</div><!-",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "349f2239104249528002b3fe27638ac7",
+    "text": "<div class=\"center",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "a3798ebbfb39c52d607d2e9814ab0707",
+    "text": "content\"> -",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "bae4b74d467785ef24a27d95ba95c49c",
+    "text": ">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "9f668a0da57517b853b76e6a1e9017fc",
+    "text": "</div><!-- end of <div class=\"center\"> -->",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "57103668fdc8a9351e1510bf49ecd7a5",
+    "text": "<!-",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "589aabd4398a722496c148c3fdfe6fa5",
+    "text": "sitemap area -",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "476c499df26384546664defc9d85fef3",
+    "text": ">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "425b1c622f20a14fffe7c702332223d6",
+    "text": "<div class=\"footer\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "cf6c98ada72f3cb2050d5f7d3fe73196",
+    "text": "</div><!-- end of <div class=\"footer\"> -->",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "ac8328046c0ec4bc0ecc1695fb17cc7c",
+    "text": "<!-",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "fb00e5075c2eaa9c6b5b3a1e4e552ced",
+    "text": "legal footer area -",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "8732ddd5108e5e1600a60beb30dd9a36",
+    "text": ">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "f1bcb321d1e66d13c631c77a2d25e803",
+    "text": "<div class=\"footer",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "7971dbae021d9716ef349fbbc1424b97",
+    "text": "legal\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "db42bd8b827221a4bc3e5f3e90579975",
+    "text": "<div class=\"footer",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "edb4bb7bbd33e07553541019f7d03647",
+    "text": "legal\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "400dce0e4c893e276ab6b04faf19d357",
+    "text": "<div class=\"footer",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "3f5848d193d140c09707fef4c21473e4",
+    "text": "legal",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "e7907f8cad6d86eb36f1ecb7075fa82a",
+    "text": "content\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "6a8eb99f44eff676ed1c0cb4ea926ec8",
+    "text": "<div class=\"one-sixth-first\" id=\"footer_legal_gov\"> <a href=\"http://www.usa.gov\"><img src=\"/css/images/usa_gov.png\" alt=\"usa.gov\" width=\"110\" height=\"30\" /></a> </div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "8bdec54526b875f17d93cd36ae336f99",
+    "text": "<div class=\"one-half-first\" id=\"footer_legal_info\"> <p> <a href=\"http://www.commerce.gov\">US Dept of Commerce</a><br /> <a href=\"http://www.noaa.gov\">National Oceanic and Atmospheric Administration</a><br /> <a href=\"https://www.weather.gov\" >National Weather Service</a><br /> News Around NOAA<br>1325 East West Highway<br />Silver Spring, MD 20910<br /><br /><br /><a href=\"https://www.weather.gov/news/contact\">Comments? Questions? Please Contact Us.</a>                    </p> </div><!-- end of <div class=\"one-half-first\" id=\"footer_legal_info\"> -->",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "ba6895acd23e698ca4f5ebcac1158771",
+    "text": "<div class=\"one",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "684f9d94a4d8c57c0d80eb40a9ee9e1d",
+    "text": "third",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "0dfd9b4b4a0bf6f0fe6f9986a53a1a15",
+    "text": "last\" id=\"footer_required_links\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "5f743b4dd4a6d409b5e8bfab8e6f1e94",
+    "text": "<div class=\"div",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "567169fc50a06bad2eb5d30cfbec9ada",
+    "text": "half\">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "67332029e0e66f28a68ea872a7ed0159",
+    "text": "<a href=\"https://www.weather.gov/disclaimer\">Disclaimer</a><br />",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "7c32f18a3fe3c13e1deb9bba5c6bbeb7",
+    "text": "<a href=\"http://www.cio.noaa.gov/services_programs/info_quality.html\">Information Quality</a><br />",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "b07ff82d18a73b9a23500dc69571d2df",
+    "text": "<a href=\"https://www.weather.gov/help\">Help</a><br />",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "129651a1e7fbec392cc6e8d30d453ff6",
+    "text": "<a href=\"http://www.weather.gov/glossary\">Glossary</a>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "e8377cb924a6625d3e455bbff4ddb37e",
+    "text": "</div>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "NarrativeText",
+    "element_id": "4b6abbca97b80140a8d8c5a988bcd294",
+    "text": "<div class=\"div-half\"> <a href=\"https://www.weather.gov/privacy\">Privacy Policy</a><br /> <a href=\"https://www.noaa.gov/foia-freedom-of-information-act\">Freedom of Information Act (FOIA)</a><br /> <a href=\"https://www.weather.gov/about\">About Us</a><br /> <a href=\"https://www.weather.gov/careers\">Career Opportunities</a> </div> </div><!-- end of <div class=\"one-third-last\" id=\"footer_required_links\"> -->",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "d86df7184413151dc4bc70b5883214ca",
+    "text": "</div><!-",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "77216ee668bcb2b85f36cbcd99ed2aa3",
+    "text": "end of <div class=\"footer",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "9d9640adbb62b6147f4df0b66178ab6d",
+    "text": "legal",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "a1adda083fab638927be8b0476ca93ca",
+    "text": "content\"> -",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "3cb0913461fa90dcc19c09609ba2dc84",
+    "text": ">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "b0ac2ad3c874cc3d05b0003fac86e7c3",
+    "text": "</div><!-",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "56074c71782942623c03a5952c80c4b7",
+    "text": "end of <div class=\"footer",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "890a649e568bae720bb806c17e83d41f",
+    "text": "legal\"> -",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "e9742537e3e470d0459a92404c551487",
+    "text": ">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "1b52d2763ddb9077c1b89db85a0dce74",
+    "text": "</div><!-",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "007da9ecd1b105a467ddad4fe521826f",
+    "text": "end of <div class=\"footer",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "ba4413baf66bd9fa4f5e349b2c4fac25",
+    "text": "legal\"> -",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "34c5e41fa3072334e67ca2ac962fd3a9",
+    "text": ">",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "578a379ef0b59fbc3a8978acc21adbb6",
+    "text": "<script type=\"text/javascript\" src=\"//www.weather.gov/js/govshutdown.js\"></script>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "51984e62ea77193a2af3064e5ce6c2a5",
+    "text": "</body>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
+      "data_source": {
+        "url": "abfs://container1/spring-weather.html",
+        "version": "0x8DB214B74525BB6",
+        "record_locator": {
+          "protocol": "abfs",
+          "remote_file_path": "abfs://container1/"
+        },
+        "date_created": "1678441216.0",
+        "date_modified": "1678441216.0"
+      }
+    }
+  },
+  {
+    "type": "Title",
+    "element_id": "c6ac536319a95dbca73cd08946891ee7",
+    "text": "</html>",
+    "metadata": {
+      "languages": [
+        "eng"
+      ],
+      "filetype": "text/plain",
       "data_source": {
         "url": "abfs://container1/spring-weather.html",
         "version": "0x8DB214B74525BB6",

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.13"  # pragma: no cover
+__version__ = "0.16.14-dev0"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -178,13 +178,15 @@ def partition(
     # into a partition function, e.g., partition_email is reused to partition sub-elements, e.g.,
     # partition an image attachment buy calling partition with the kwargs. In that case here kwargs
     # would have a infer_table_structure already
-    infer_table_structure = kwargs.pop(
-        "infer_table_structure",
-        decide_table_extraction(
+    kwargs_infer_table_structure = kwargs.pop("infer_table_structure", None)
+    infer_table_structure = (
+        kwargs_infer_table_structure
+        if kwargs_infer_table_structure is not None
+        else decide_table_extraction(
             file_type,
             skip_infer_table_types,
             pdf_infer_table_structure,
-        ),
+        )
     )
 
     partitioner_loader = _PartitionerLoader()

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -174,10 +174,17 @@ def partition(
     if file is not None:
         file.seek(0)
 
-    infer_table_structure = decide_table_extraction(
-        file_type,
-        skip_infer_table_types,
-        pdf_infer_table_structure,
+    # avoid double specification of infer_table_structure; this can happen when the kwarg passed
+    # into a partition function, e.g., partition_email is reused to partition sub-elements, e.g.,
+    # partition an image attachment buy calling partition with the kwargs. In that case here kwargs
+    # would have a infer_table_structure already
+    infer_table_structure = kwargs.pop(
+        "infer_table_structure",
+        decide_table_extraction(
+            file_type,
+            skip_infer_table_types,
+            pdf_infer_table_structure,
+        ),
     )
 
     partitioner_loader = _PartitionerLoader()


### PR DESCRIPTION
This PR fixes a bug when using `partition` to partition an email with image attachments with hi_res and allow table structure inference -> the partitioning of the image would encounter a value error: `got multiple values for keyword argument 'infer_table_structure'`.

This is because pass `kwargs` into partition "other" types of files in this [block](https://github.com/Unstructured-IO/unstructured/blob/50ea6fe7fc324efa09398898dc35d0cd4e78b1cf/unstructured/partition/auto.py#L270-L280) `infer_table_structure` is packaged into `partitioning_kwargs`. Then for email at least when there are attachments that can be partitioned with `hi_res` we pass that dict of `kwargs` right back into `partition` entry -> so when we get [here](https://github.com/Unstructured-IO/unstructured/blob/50ea6fe7fc324efa09398898dc35d0cd4e78b1cf/unstructured/partition/auto.py#L222-L235) we are both specifying explicitly `infer_table_structure` and have it in `kwargs` variable

The fix is to detect first if `kwargs` already contains `infer_table_structure` and if yes use that and pop it from `kwargs`.