### PR TITLE
fix: preserve text after line breaks in PowerPoint table cells

### DIFF
--- a/unstructured/partition/pptx.py
+++ b/unstructured/partition/pptx.py
@@ -252,7 +252,7 @@ class _PptxPartitioner:
             return
 
         html_text = htmlify_matrix_of_cell_texts(
-            [[cell.text for cell in row.cells] for row in rows]
+            [[cell.text.replace("\n", " ") for cell in row.cells] for row in rows]
         )
         html_table = HtmlTable.from_html_text(html_text)
 


### PR DESCRIPTION
This commit addresses an issue where text after line breaks in PowerPoint table cells was lost during processing. The issue is resolved by handling cell content similarly to how it is processed for Word documents, using space separation: https://github.com/Unstructured-IO/unstructured/blob/main/unstructured/partition/docx.py#L494