### PR TITLE
Feat/unpin urllib3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.16.19-dev1
 
 ### Enhancements
+- **Unpin some dependencies**. A few dependencies has updated and no longer needs to be pinned to avoid compatibility issues
 
 ### Features
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,6 +12,7 @@ python-iso639
 langdetect
 # NOTE(robinson) - numpy pin is because ONNX model weights are only compatible
 # with numpy 1.x.x
+# NOTE: onnx >= 1.17 supports numpy > 2; but paddlepaddle still requires numpy<2
 numpy<2
 rapidfuzz
 backoff

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -100,7 +100,7 @@ python-magic==0.4.27
     # via -r ./base.in
 python-oxmsg==0.0.1
     # via -r ./base.in
-rapidfuzz==3.11.0
+rapidfuzz==3.12.1
     # via -r ./base.in
 regex==2024.11.6
     # via nltk
@@ -141,9 +141,8 @@ unstructured-client==0.25.9
     # via
     #   -c ././deps/constraints.txt
     #   -r ./base.in
-urllib3==1.26.20
+urllib3==2.3.0
     # via
-    #   -c ././deps/constraints.txt
     #   requests
     #   unstructured-client
 webencodings==0.5.1

--- a/requirements/deps/constraints.txt
+++ b/requirements/deps/constraints.txt
@@ -8,12 +8,7 @@ weaviate-client>=3.26.7,<4.0.0
 # TODO: Constriant due to multiple versions being installed during pip-compile
 grpcio>=1.65.5
 # TODO: Pinned in transformers package, remove when that gets updated (https://github.com/huggingface/transformers/blob/main/setup.py)
-tokenizers>=0.19,<0.20
-# TODO: Constaint due to boto, with python before 3.10 not requiring openssl 1.1.1, remove when that gets
-# updated or we drop support for 3.9
-urllib3<1.27
-# TODO: Constriant due to aiobotocore, remove when that gets updates:
-botocore<1.34.132
+tokenizers>=0.21,<0.22
 # TODO: Constriant due to both 8.5.0 and 8.4.0 being installed during pip-compile
 importlib-metadata>=8.5.0
 # (austin): Versions below this have a different interface for passing parameters

--- a/requirements/extra-paddleocr.in
+++ b/requirements/extra-paddleocr.in
@@ -1,5 +1,5 @@
 -c ./deps/constraints.txt
 -c base.txt
 
-paddlepaddle==3.0.0b1
-unstructured.paddleocr==2.8.1.0
+paddlepaddle>=3.0.0b1
+unstructured.paddleocr>=2.8.1.0

--- a/requirements/extra-paddleocr.txt
+++ b/requirements/extra-paddleocr.txt
@@ -100,7 +100,7 @@ packaging==24.2
     #   lazy-loader
     #   matplotlib
     #   scikit-image
-paddlepaddle==3.0.0b1
+paddlepaddle==3.0.0rc1
     # via -r ./extra-paddleocr.in
 pdf2image==1.17.0
     # via unstructured-paddleocr
@@ -125,7 +125,7 @@ python-dateutil==2.9.0.post0
     #   matplotlib
 pyyaml==6.0.2
     # via unstructured-paddleocr
-rapidfuzz==3.11.0
+rapidfuzz==3.12.1
     # via
     #   -c ./base.txt
     #   unstructured-paddleocr
@@ -167,9 +167,8 @@ typing-extensions==4.12.2
     #   paddlepaddle
 unstructured-paddleocr==2.8.1.0
     # via -r ./extra-paddleocr.in
-urllib3==1.26.20
+urllib3==2.3.0
     # via
-    #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   requests
 zipp==3.21.0

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -67,7 +67,7 @@ grpcio==1.70.0
     #   grpcio-status
 grpcio-status==1.70.0
     # via google-api-core
-huggingface-hub==0.28.0
+huggingface-hub==0.28.1
     # via
     #   timm
     #   tokenizers
@@ -200,7 +200,7 @@ pyyaml==6.0.2
     #   omegaconf
     #   timm
     #   transformers
-rapidfuzz==3.11.0
+rapidfuzz==3.12.1
     # via
     #   -c ./base.txt
     #   unstructured-inference
@@ -234,7 +234,7 @@ timm==1.0.14
     # via
     #   effdet
     #   unstructured-inference
-tokenizers==0.19.1
+tokenizers==0.21.0
     # via
     #   -c ././deps/constraints.txt
     #   transformers
@@ -253,7 +253,7 @@ tqdm==4.67.1
     #   -c ./base.txt
     #   huggingface-hub
     #   transformers
-transformers==4.44.2
+transformers==4.48.2
     # via unstructured-inference
 typing-extensions==4.12.2
     # via
@@ -267,9 +267,8 @@ unstructured-inference==0.8.6
     # via -r ./extra-pdf-image.in
 unstructured-pytesseract==0.3.13
     # via -r ./extra-pdf-image.in
-urllib3==1.26.20
+urllib3==2.3.0
     # via
-    #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   requests
 wrapt==1.17.2

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -25,7 +25,7 @@ fsspec==2024.12.0
     # via
     #   huggingface-hub
     #   torch
-huggingface-hub==0.28.0
+huggingface-hub==0.28.1
     # via
     #   tokenizers
     #   transformers
@@ -84,7 +84,7 @@ six==1.17.0
     #   langdetect
 sympy==1.13.1
     # via torch
-tokenizers==0.19.1
+tokenizers==0.21.0
     # via
     #   -c ././deps/constraints.txt
     #   transformers
@@ -96,15 +96,14 @@ tqdm==4.67.1
     #   huggingface-hub
     #   sacremoses
     #   transformers
-transformers==4.44.2
+transformers==4.48.2
     # via -r ./huggingface.in
 typing-extensions==4.12.2
     # via
     #   -c ./base.txt
     #   huggingface-hub
     #   torch
-urllib3==1.26.20
+urllib3==2.3.0
     # via
-    #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -54,7 +54,7 @@ exceptiongroup==1.2.2
     #   -c ./base.txt
     #   anyio
     #   pytest
-faker==35.0.0
+faker==35.2.0
     # via jsf
 flake8==7.1.1
     # via
@@ -218,7 +218,7 @@ rpds-py==0.22.3
     #   referencing
 rstr==3.2.2
     # via jsf
-ruff==0.9.3
+ruff==0.9.4
     # via -r ./test.in
 semantic-version==2.10.0
     # via liccheck
@@ -226,6 +226,7 @@ six==1.17.0
     # via
     #   -c ./base.txt
     #   python-dateutil
+    #   vcrpy
 smart-open[http]==7.1.0
     # via jsf
 sniffio==1.3.1
@@ -251,12 +252,10 @@ types-click==7.1.8
     # via -r ./test.in
 types-markdown==3.7.0.20241204
     # via -r ./test.in
-types-requests==2.31.0.6
+types-requests==2.32.0.20241016
     # via -r ./test.in
 types-tabulate==0.9.0.20241207
     # via -r ./test.in
-types-urllib3==1.26.25.14
-    # via types-requests
 typing-extensions==4.12.2
     # via
     #   -c ./base.txt
@@ -274,13 +273,12 @@ tzdata==2025.1
     # via pandas
 ujson==5.10.0
     # via label-studio-sdk
-urllib3==1.26.20
+urllib3==2.3.0
     # via
-    #   -c ././deps/constraints.txt
     #   -c ./base.txt
     #   requests
-    #   vcrpy
-vcrpy==7.0.0
+    #   types-requests
+vcrpy==4.3.0
     # via -r ./test.in
 wrapt==1.17.2
     # via


### PR DESCRIPTION
This PR unpins dependencies that no longer needs the pin. Updates to them have resolved previous observed compatibilities issues.