### PR TITLE
fix/Prepare for breaking change in upcoming unstructured-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.16.21-dev2
+## 0.16.21-dev3
 
 ### Enhancements
 
@@ -7,6 +7,8 @@
 ### Features
 
 ### Fixes
+
+- **Address forward compatibility issue in partition_via_api** - As of unstructured-client==0.30.0, the `server_url` is passed to the method rather than the client instance.
 
 ## 0.16.20
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.21-dev2"  # pragma: no cover
+__version__ = "0.16.21-dev3"  # pragma: no cover

--- a/unstructured/partition/api.py
+++ b/unstructured/partition/api.py
@@ -94,7 +94,7 @@ def partition_via_api(
     # Note(austin) - the sdk takes the base url, but we have the full api_url
     # For consistency, just strip off the path when it's given
     base_url = api_url[:-19] if "/general/v0/general" in api_url else api_url
-    sdk = UnstructuredClient(api_key_auth=api_key, server_url=base_url)
+    sdk = UnstructuredClient(api_key_auth=api_key)
 
     if filename is not None:
         with open(filename, "rb") as f:
@@ -126,6 +126,7 @@ def partition_via_api(
 
     response = sdk.general.partition(
         request=req,
+        server_url=base_url,
         retries=retries_config,
     )
 


### PR DESCRIPTION
In the unreleased 0.30.0 of unstructured-client, handling of the server_url is changing. Instead of passing a url to the instance of the client, it's preferred that we set the server_url per endpoint. We can make this change against existing versions of the client in order to be compatible when 0.30.0 is released.