### PR TITLE
bugfix/fix missing extensions in file detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.16.22-dev0
+
+### Fixes
+
+* **Handle filenames without extensions in file type detection**
+
 ## 0.16.21
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.21"  # pragma: no cover
+__version__ = "0.16.22-dev0"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -346,11 +346,15 @@ class _FileTypeDetectionContext:
         # -- get from file_path, or file when it has a name (path) --
         with self.open() as file:
             if hasattr(file, "name") and file.name:
-                return os.path.splitext(file.name)[1].lower()
+                splitext = os.path.splitext(file.name)
+                if len(splitext) > 1:
+                    return splitext[1].lower()
 
         # -- otherwise use metadata file-path when provided --
         if file_path := self._metadata_file_path:
-            return os.path.splitext(file_path)[1].lower()
+            splitext = os.path.splitext(file_path)
+            if len(splitext) > 1:
+                return splitext[1].lower()
 
         # -- otherwise empty str means no extension, same as a path like "a/b/name-no-ext" --
         return ""


### PR DESCRIPTION
### Description
Currently the logic breaks if the filename of the file does not include the extension and we explicitly index expecting it to exist, causing an error. This checks for that to exist first. 