### PR TITLE
feat: allow extraction of camel cased element type names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Enhancements
 
+- **`extract_image_block_types` now also works for CamelCase elemenet type names**. Previously `NarrativeText` and similar CamelCase element types can't be extracted using the mentioned parameter in `partition`. Now figures for those elements can be extracted like `Image` and `Table` elements
+
 ### Features
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.16.24-dev1
+## 0.16.24-dev2
 
 ### Enhancements
 

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -231,6 +231,7 @@ def test_pad_bbox():
         (["table", "image"], ["Table", "Image"]),
         (["unknown"], ["Unknown"]),
         (["Table", "image", "UnknOwn"], ["Table", "Image", "Unknown"]),
+        (["NarrativeText", "narrativetext"], ["NarrativeText", "NarrativeText"]),
     ],
 )
 def test_check_element_types_to_extract(input_types, expected):

--- a/test_unstructured_ingest/expected-structured-output/google-drive/fake.docx.json
+++ b/test_unstructured_ingest/expected-structured-output/google-drive/fake.docx.json
@@ -25,6 +25,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",

--- a/test_unstructured_ingest/expected-structured-output/google-drive/nested/fake.docx.json
+++ b/test_unstructured_ingest/expected-structured-output/google-drive/nested/fake.docx.json
@@ -25,6 +25,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",

--- a/test_unstructured_ingest/expected-structured-output/google-drive/recalibrating-risk-report.pdf.json
+++ b/test_unstructured_ingest/expected-structured-output/google-drive/recalibrating-risk-report.pdf.json
@@ -25,6 +25,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -85,6 +116,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -149,6 +211,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -209,6 +302,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -273,6 +397,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -333,6 +488,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -397,6 +583,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -457,6 +674,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -521,6 +769,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -581,6 +860,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -645,6 +955,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -705,6 +1046,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -769,6 +1141,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -829,6 +1232,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -893,6 +1327,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -953,6 +1418,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -1017,6 +1513,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -1077,6 +1604,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -1141,6 +1699,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -1201,6 +1790,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -1265,6 +1885,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -1325,6 +1976,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -1389,6 +2071,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -1449,6 +2162,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -1513,6 +2257,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -1573,6 +2348,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -1637,6 +2443,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -1697,6 +2534,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -1761,6 +2629,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -1821,6 +2720,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -1885,6 +2815,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -1945,6 +2906,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -2009,6 +3001,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -2069,6 +3092,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -2133,6 +3187,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -2193,6 +3278,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -2257,6 +3373,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -2317,6 +3464,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -2381,6 +3559,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -2441,6 +3650,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -2505,6 +3745,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -2565,6 +3836,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -2629,6 +3931,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -2689,6 +4022,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -2753,6 +4117,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -2813,6 +4208,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -2877,6 +4303,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -2937,6 +4394,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -3001,6 +4489,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -3061,6 +4580,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -3125,6 +4675,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -3185,6 +4766,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -3249,6 +4861,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -3309,6 +4952,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -3373,6 +5047,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -3433,6 +5138,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -3497,6 +5233,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -3557,6 +5324,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -3621,6 +5419,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -3681,6 +5510,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -3745,6 +5605,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -3805,6 +5696,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -3869,6 +5791,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -3929,6 +5882,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -3993,6 +5977,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -4053,6 +6068,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -4117,6 +6163,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -4177,6 +6254,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -4241,6 +6349,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -4301,6 +6440,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -4365,6 +6535,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -4425,6 +6626,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -4489,6 +6721,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -4549,6 +6812,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -4613,6 +6907,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -4673,6 +6998,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -4737,6 +7093,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -4797,6 +7184,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -4861,6 +7279,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -4921,6 +7370,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -4985,6 +7465,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -5045,6 +7556,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -5109,6 +7651,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -5169,6 +7742,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -5233,6 +7837,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -5293,6 +7928,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -5357,6 +8023,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -5417,6 +8114,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -5481,6 +8209,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -5541,6 +8300,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -5605,6 +8395,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -5665,6 +8486,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -5729,6 +8581,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -5789,6 +8672,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -5853,6 +8767,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -5913,6 +8858,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -5977,6 +8953,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -6037,6 +9044,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -6101,6 +9139,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -6161,6 +9230,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -6225,6 +9325,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -6285,6 +9416,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -6349,6 +9511,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -6409,6 +9602,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",
@@ -6473,6 +9697,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -6533,6 +9788,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",

--- a/test_unstructured_ingest/expected-structured-output/google-drive/test-drive-doc.docx.json
+++ b/test_unstructured_ingest/expected-structured-output/google-drive/test-drive-doc.docx.json
@@ -30,6 +30,37 @@
             "allowFileDiscovery": false
           },
           {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
             "id": "18298851591250030956",
             "displayName": "ingest@unstructured-ingest-test.iam.gserviceaccount.com",
             "type": "user",
@@ -95,6 +126,37 @@
             "kind": "drive#permission",
             "role": "reader",
             "allowFileDiscovery": false
+          },
+          {
+            "id": "10619079449796831495",
+            "displayName": "fuse-team",
+            "type": "group",
+            "kind": "drive#permission",
+            "emailAddress": "fuse-team@unstructured.io",
+            "role": "writer",
+            "deleted": false
+          },
+          {
+            "id": "03887347926440898356",
+            "displayName": "michal.martyniak",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjWWmJCSvduWur55hl36IxwKs5FJ1FWMoK6KtFlNUHDBU-McvlI=s64",
+            "emailAddress": "michal.martyniak@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
+          },
+          {
+            "id": "13662041828528429192",
+            "displayName": "rob",
+            "type": "user",
+            "kind": "drive#permission",
+            "photoLink": "https://lh3.googleusercontent.com/a-/ALV-UjV31Wb5kVmEk66cog1KN-N_twpHHoDttcCQ9pRvE1cz1-FLHQ=s64",
+            "emailAddress": "rob@unstructured.io",
+            "role": "writer",
+            "deleted": false,
+            "pendingOwner": false
           },
           {
             "id": "18298851591250030956",

--- a/test_unstructured_ingest/expected-structured-output/jira-diff/1/10000.json
+++ b/test_unstructured_ingest/expected-structured-output/jira-diff/1/10000.json
@@ -4,7 +4,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -14,7 +14,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "IssueID_IssueKey:10000     JCTP1-1",
@@ -25,7 +26,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -35,7 +36,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "ProjectID_Key:JCTP1     Jira Connector Test Project 1",
@@ -46,7 +48,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -56,18 +58,19 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "IssueType:Task",
     "type": "Title"
   },
   {
-    "element_id": "a1a11be1a987330ca2f6c979a0d40eec",
+    "element_id": "d4f56c4a7b3b451828f77bf4be193b91",
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -77,10 +80,11 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
-    "text": "Status:In Progress",
+    "text": "Status:To Do",
     "type": "Title"
   },
   {
@@ -88,7 +92,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -98,7 +102,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "Priority:{'self': 'https://unstructured-jira-connector-test.atlassian.net/rest/api/2/priority/3', 'iconUrl': 'https://unstructured-jira-connector-test.atlassian.net/images/icons/priorities/medium.svg', 'name': 'Medium', 'id': '3'}",
@@ -109,7 +114,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -119,7 +124,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "AssigneeID_Name:712020:7bc7fdcb-67e7-435d-b4a2-128aee12820c     Unstructured Devops",
@@ -130,7 +136,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -140,7 +146,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "ReporterAdr_Name:devops+jira-connector@unstructured.io     Unstructured Devops",
@@ -151,7 +158,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -161,7 +168,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "Labels:Label1     Label2",
@@ -172,7 +180,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -182,7 +190,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "Components:",
@@ -193,7 +202,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -203,7 +212,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "Unstructured Devops     My comment 1 Unstructured Devops     My attachment image lorem ipsum:",
@@ -214,7 +224,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -224,7 +234,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "!image",
@@ -235,7 +246,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -245,7 +256,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "20230823",
@@ -256,7 +268,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -266,7 +278,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "143650.png|width=83.33333333333333%!",
@@ -277,7 +290,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -287,7 +300,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "Test todo 1",
@@ -298,7 +312,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -308,7 +322,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. [Nam quid possumus facere melius?|http://loripsum.net/] Ita relinquet duas, de quibus etiam atque etiam consideret. Quo modo autem philosophus loquitur? Quid est enim aliud esse versutum? His enim rebus detractis negat se reperire in asotorum vita quod reprehendat. Non est ista, inquam, Piso, magna dissensio. Duo Reges: constructio interrete. In eo enim positum est id, quod dicimus esse expetendum. Traditur, inquit, ab Epicuro ratio neglegendi doloris. Negat enim summo bono afferre incrementum diem. Aberat omnis dolor, qui si adesset, nec molliter ferret et tamen medicis plus quam philosophis uteretur.",
@@ -319,7 +334,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -329,7 +344,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "Sedulo, inquam, faciam. Ergo, si semel tristior effectus est, hilara vita amissa est? Quamquam tu hanc copiosiorem etiam soles dicere. An eum locum libenter invisit, ubi Demosthenes et Aeschines inter se decertare soliti sunt? _Quippe: habes enim a rhetoribus;_ Non minor, inquit, voluptas percipitur ex vilissimis rebus quam ex pretiosissimis. Ut in geometria, prima si dederis, danda sunt omnia. Negat enim summo bono afferre incrementum diem.",
@@ -340,7 +356,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -350,7 +366,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "[Et nemo nimium beatus est;|http://loripsum.net/] Nam et complectitur verbis, quod vult, et dicit plane, quod intellegam; Ab his oratores, ab his imperatores ac rerum publicarum principes extiterunt. Ergo adhuc, quantum equidem intellego, causa non videtur fuisse mutandi nominis. Quis enim redargueret? Ita fit cum gravior, tum etiam splendidior oratio. Sed ut iis bonis erigimur, quae expectamus, sic laetamur iis, quae recordamur. _Bork_ Tubulum fuisse, qua illum, cuius is condemnatus est rogatione, P. [Eiuro, inquit adridens, iniquum, hac quidem de re;|http://loripsum.net/] Si quae forte-possumus.",
@@ -361,7 +378,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -371,7 +388,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "https://unstructured",
@@ -382,7 +400,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -392,7 +410,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "jira",
@@ -403,7 +422,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -413,7 +432,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "connector",
@@ -424,7 +444,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:29:37.774000+00:00",
-        "date_modified": "2023-08-24T12:05:04.690000+00:00",
+        "date_modified": "2025-02-21T13:25:46.017000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP1-1"
@@ -434,7 +454,8 @@
       "filetype": "text/plain",
       "languages": [
         "cat",
-        "eng"
+        "eng",
+        "fra"
       ]
     },
     "text": "test.atlassian.net/rest/api/2/attachment/10000",

--- a/test_unstructured_ingest/expected-structured-output/jira-diff/JCTP2/10009.json
+++ b/test_unstructured_ingest/expected-structured-output/jira-diff/JCTP2/10009.json
@@ -4,7 +4,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -24,7 +24,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -44,7 +44,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -64,7 +64,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -84,7 +84,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -104,7 +104,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -124,7 +124,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -144,7 +144,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -164,7 +164,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -184,7 +184,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"
@@ -204,7 +204,7 @@
     "metadata": {
       "data_source": {
         "date_created": "2023-08-22T11:35:25.467000+00:00",
-        "date_modified": "2023-08-22T11:35:30.285000+00:00",
+        "date_modified": "2025-02-24T10:44:56.243000+00:00",
         "record_locator": {
           "base_url": "https://unstructured-jira-connector-test.atlassian.net",
           "issue_key": "JCTP2-7"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.24-dev1"  # pragma: no cover
+__version__ = "0.16.24-dev2"  # pragma: no cover

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -239,10 +239,12 @@ def check_element_types_to_extract(
             "ex. ['Table', 'Image']",
         )
 
-    available_element_types = list(ElementType.to_dict().values())
+    available_element_types = {e_type.lower(): e_type for e_type in ElementType.to_dict().values()}
     normalized_extract_image_block_types = []
     for el_type in extract_image_block_types:
-        normalized_el_type = el_type.lower().capitalize()
+        normalized_el_type = available_element_types.get(
+            el_type.lower(), el_type.lower().capitalize()
+        )
         if normalized_el_type not in available_element_types:
             logger.warning(f"The requested type ({el_type}) doesn't match any available type")
         normalized_extract_image_block_types.append(normalized_el_type)

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -245,7 +245,7 @@ def check_element_types_to_extract(
         normalized_el_type = available_element_types.get(
             el_type.lower(), el_type.lower().capitalize()
         )
-        if normalized_el_type not in available_element_types:
+        if normalized_el_type not in available_element_types.values():
             logger.warning(f"The requested type ({el_type}) doesn't match any available type")
         normalized_extract_image_block_types.append(normalized_el_type)
 


### PR DESCRIPTION
This PR allows element types with CamelCase names to be extractable using `extract_image_block_types` variable.

Before: specify `extract_image_block_types=["NarrativeText"]` (or any casing for `NarrativeText`) would raise a warning that it doesn't match any available types and not image would be extracted for this element type

Now: specify `extract_image_block_types=["NarrativeText"]` would extract images for this element type

## testing

```python
from unstructured.partition.auto import partition
f = "example-docs/pdf/embedded-images-tables.pdf"
elements = partition(f, strategy="hi_res", extract_image_block_types=["narrativetext"])
```

Without this PR no figures would be extracted. With this PR a local folder would be created to contain images of the narrative text elements in path like `./figures/figure-1-1.jpg`