### PR TITLE
feat: convenience unstructured-get-json.sh update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ metricsdiff.txt
 
 # analysis
 annotated/
+.aider*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.17.6-dev0
+
+### Enhancements
+
+### Features
+
+### Fixes
+
 ## 0.17.5
 
 ### Enhancements

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -29,7 +29,7 @@ Options:
   --s3            Write the resulting output to s3 (like a pastebin)
   --write-html    Convert JSON output to HTML. Set the env var $UNST_WRITE_HTML to skip providing this option.
   --open-html     Automatically open HTML output in browser (macOS only). 
-                  Set the env var $UNST_AUTO_OPEN_HTML to skip providing this option.
+                  Set the env var $UNST_AUTO_OPEN_HTML=true to skip providing this option.
   --help          Display this help and exit.
 
 

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -88,14 +88,11 @@ VLM_MODEL=""
 
 # Function to check if more than one strategy is enabled
 check_strategy_conflict() {
-  echo "foo e"
   local count=0
   $HI_RES && ((count++))
   $FAST && ((count++))
   $OCR_ONLY && ((count++))
   $VLM && ((count++))
-
-  echo count is "$count"
   
   if [ "$count" -gt 1 ]; then
     echo "Error: Only one strategy option (--hi-res, --fast, --ocr-only, --vlm) can be specified at a time."
@@ -200,7 +197,6 @@ if [ -z "$INPUT" ]; then
   exit 1
 fi
 
-echo hello
 # Check for strategy conflicts after all arguments are processed
 check_strategy_conflict
 

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -86,7 +86,6 @@ OPEN_HTML=${UNST_AUTO_OPEN_HTML:-false}
 VLM_PROVIDER=""
 VLM_MODEL=""
 
-
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
   --hi-res)
@@ -186,10 +185,10 @@ fi
 
 # Check for strategy conflicts after all arguments are processed
 STRATEGY_COUNT=0
-$HI_RES && STRATEGY_COUNT=$((STRATEGY_COUNT+1))
-$FAST && STRATEGY_COUNT=$((STRATEGY_COUNT+1))
-$OCR_ONLY && STRATEGY_COUNT=$((STRATEGY_COUNT+1))
-$VLM && STRATEGY_COUNT=$((STRATEGY_COUNT+1))
+$HI_RES && STRATEGY_COUNT=$((STRATEGY_COUNT + 1))
+$FAST && STRATEGY_COUNT=$((STRATEGY_COUNT + 1))
+$OCR_ONLY && STRATEGY_COUNT=$((STRATEGY_COUNT + 1))
+$VLM && STRATEGY_COUNT=$((STRATEGY_COUNT + 1))
 
 if [ "$STRATEGY_COUNT" -gt 1 ]; then
   echo "Error: Only one strategy option (--hi-res, --fast, --ocr-only, --vlm) can be specified at a time."
@@ -297,10 +296,10 @@ echo "JSON Output file: ${JSON_OUTPUT_FILEPATH}"
 # Convert JSON to HTML if requested
 if [ "$WRITE_HTML" = true ]; then
   HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
-  
+
   # Check if all elements have metadata.text_as_html field that is not empty or null
   ALL_HAVE_HTML=$(jq 'map(has("metadata") and ((.metadata | has("text_as_html")) or false) and ((.metadata.text_as_html != null) or false) and ((.metadata.text_as_html != "") or false)) | all' "${JSON_OUTPUT_FILEPATH}")
-  
+
   if [ "$ALL_HAVE_HTML" = "true" ]; then
     # Create HTML directly from metadata.text_as_html fields
     {
@@ -318,7 +317,7 @@ if [ "$WRITE_HTML" = true ]; then
       jq -r 'map(.metadata.text_as_html) | join("\n")' "${JSON_OUTPUT_FILEPATH}"
       echo "</body>"
       echo "</html>"
-    } > "${HTML_OUTPUT_FILEPATH}"
+    } >"${HTML_OUTPUT_FILEPATH}"
     echo "HTML written directly from metadata.text_as_html fields to: ${HTML_OUTPUT_FILEPATH}"
   else
     # Fall back to using the Python script
@@ -326,7 +325,7 @@ if [ "$WRITE_HTML" = true ]; then
     PYTHONPATH="${SCRIPT_DIR}/../.." python3 "${SCRIPT_DIR}/../html/elements_json_to_html.py" "${JSON_OUTPUT_FILEPATH}" --outdir "${TMP_OUTPUTS_DIR}"
     echo "HTML written using Python script to: ${HTML_OUTPUT_FILEPATH}"
   fi
-  
+
   # Open HTML file in browser if requested and on macOS
   if [ "$OPEN_HTML" = true ] && [ "$(uname)" == "Darwin" ]; then
     open "${HTML_OUTPUT_FILEPATH}"

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -28,7 +28,7 @@ Options:
   --verbose       Enable verbose logging including printing first 8 elements to stdout
   --s3            Write the resulting output to s3 (like a pastebin)
   --write-html    Convert JSON output to HTML. Set the env var $UNST_WRITE_HTML to skip providing this option.
-  --open-html     Automatically open HTML output in browser (macOS only). 
+  --open-html     Automatically open HTML output in browser (macOS only) if --write-html. 
                   Set the env var UNST_AUTO_OPEN_HTML=true to skip providing this option.
   --help          Display this help and exit.
 

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -105,22 +105,18 @@ while [[ "$#" -gt 0 ]]; do
   --hi-res)
     HI_RES=true
     shift
-    check_strategy_conflict
     ;;
   --fast)
     FAST=true
     shift
-    check_strategy_conflict
     ;;
   --ocr-only)
     OCR_ONLY=true
     shift
-    check_strategy_conflict
     ;;
   --vlm)
     VLM=true
     shift
-    check_strategy_conflict
     ;;
   --vlm-provider)
     if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
@@ -200,6 +196,9 @@ if [ -z "$INPUT" ]; then
   echo "Error: File or URL argument is missing."
   exit 1
 fi
+
+# Check for strategy conflicts after all arguments are processed
+check_strategy_conflict
 
 if $TRACE; then
   set -x

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -246,7 +246,6 @@ if [ "$WRITE_HTML" = true ]; then
   # Open HTML file in browser if requested and on macOS
   if [ "$OPEN_HTML" = true ] && [ "$(uname)" == "Darwin" ]; then
     open "${HTML_OUTPUT_FILEPATH}"
-    echo "Opened HTML file in browser"
   fi
 fi
 

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -29,7 +29,7 @@ Options:
   --s3            Write the resulting output to s3 (like a pastebin)
   --write-html    Convert JSON output to HTML. Set the env var $UNST_WRITE_HTML to skip providing this option.
   --open-html     Automatically open HTML output in browser (macOS only). 
-                  Set the env var $UNST_AUTO_OPEN_HTML=true to skip providing this option.
+                  Set the env var UNST_AUTO_OPEN_HTML=true to skip providing this option.
   --help          Display this help and exit.
 
 

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -17,8 +17,10 @@ Options:
   --fast          fast strategy: No OCR, just extract embedded text
   --ocr-only      ocr_only strategy: Perform OCR (Optical Character Recognition) only. No layout segmentation.
   --vlm           vlm strategy: Use Vision Language Model for processing
-  --vlm-provider  Specify the VLM model provider when using --vlm strategy (see: https://docs.unstructured.io/api-reference/workflow/workflows#vlm-strategy)
-  --vlm-model     Specify the VLM model when using --vlm strategy (see: https://docs.unstructured.io/api-reference/workflow/workflows#vlm-strategy)
+  --vlm-provider  Specify the VLM model provider when using --vlm strategy
+                  (see: https://docs.unstructured.io/api-reference/workflow/workflows#vlm-strategy)
+  --vlm-model     Specify the VLM model when using --vlm strategy
+                  (see: https://docs.unstructured.io/api-reference/workflow/workflows#vlm-strategy)
   --tables        Enable table extraction: tables are represented as html in metadata
   --images        Include base64images in json
   --coordinates   Include coordinates in the output

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -299,7 +299,7 @@ if [ "$WRITE_HTML" = true ]; then
   HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
   
   # Check if all elements have metadata.text_as_html field that is not empty or null
-  ALL_HAVE_HTML=$(jq 'map(has("metadata") and (.metadata | has("text_as_html")) and (.metadata.text_as_html != null) and (.metadata.text_as_html != "")) | all' "${JSON_OUTPUT_FILEPATH}")
+  ALL_HAVE_HTML=$(jq 'map(has("metadata") and ((.metadata | has("text_as_html")) or false) and ((.metadata.text_as_html != null) or false) and ((.metadata.text_as_html != "") or false)) | all' "${JSON_OUTPUT_FILEPATH}")
   
   if [ "$ALL_HAVE_HTML" = "true" ]; then
     # Create HTML directly from metadata.text_as_html fields

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -299,7 +299,7 @@ if [ "$WRITE_HTML" = true ]; then
   HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
   
   # Check if all elements have metadata.text_as_html field that is not empty or null
-  ALL_HAVE_HTML=$(jq 'map(has("metadata") and (.metadata | has("text_as_html")) and .metadata.text_as_html != null and .metadata.text_as_html != "") | all' "${JSON_OUTPUT_FILEPATH}")
+  ALL_HAVE_HTML=$(jq 'map(has("metadata") and (.metadata | has("text_as_html")) and (.metadata.text_as_html != null) and (.metadata.text_as_html != "")) | all' "${JSON_OUTPUT_FILEPATH}")
   
   if [ "$ALL_HAVE_HTML" = "true" ]; then
     # Create HTML directly from metadata.text_as_html fields

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -298,11 +298,11 @@ echo "JSON Output file: ${JSON_OUTPUT_FILEPATH}"
 if [ "$WRITE_HTML" = true ]; then
   HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
   
-  # Check if all elements have text_as_html field that is not empty or null
-  ALL_HAVE_HTML=$(jq 'map(has("text_as_html") and .text_as_html != null and .text_as_html != "") | all' "${JSON_OUTPUT_FILEPATH}")
+  # Check if all elements have metadata.text_as_html field that is not empty or null
+  ALL_HAVE_HTML=$(jq 'map(has("metadata") and .metadata | has("text_as_html") and .metadata.text_as_html != null and .metadata.text_as_html != "") | all' "${JSON_OUTPUT_FILEPATH}")
   
   if [ "$ALL_HAVE_HTML" = "true" ]; then
-    # Create HTML directly from text_as_html fields
+    # Create HTML directly from metadata.text_as_html fields
     {
       echo "<!DOCTYPE html>"
       echo "<html>"
@@ -315,11 +315,11 @@ if [ "$WRITE_HTML" = true ]; then
       echo "  </style>"
       echo "</head>"
       echo "<body>"
-      jq -r 'map(.text_as_html) | join("\n")' "${JSON_OUTPUT_FILEPATH}"
+      jq -r 'map(.metadata.text_as_html) | join("\n")' "${JSON_OUTPUT_FILEPATH}"
       echo "</body>"
       echo "</html>"
     } > "${HTML_OUTPUT_FILEPATH}"
-    echo "HTML written directly from text_as_html fields to: ${HTML_OUTPUT_FILEPATH}"
+    echo "HTML written directly from metadata.text_as_html fields to: ${HTML_OUTPUT_FILEPATH}"
   else
     # Fall back to using the Python script
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -17,8 +17,8 @@ Options:
   --fast          fast strategy: No OCR, just extract embedded text
   --ocr-only      ocr_only strategy: Perform OCR (Optical Character Recognition) only. No layout segmentation.
   --vlm           vlm strategy: Use Vision Language Model for processing
-  --vlm-provider  Specify the VLM model provider when using --vlm strategy
-  --vlm-model     Specify the VLM model when using --vlm strategy
+  --vlm-provider  Specify the VLM model provider when using --vlm strategy (see: https://docs.unstructured.io/api-reference/workflow/workflows#vlm-strategy)
+  --vlm-model     Specify the VLM model when using --vlm strategy (see: https://docs.unstructured.io/api-reference/workflow/workflows#vlm-strategy)
   --tables        Enable table extraction: tables are represented as html in metadata
   --images        Include base64images in json
   --coordinates   Include coordinates in the output

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -221,6 +221,14 @@ elif $OCR_ONLY; then
 elif $VLM; then
   if $VERBOSE; then echo "Sending API request with vlm strategy"; fi
   STRATEGY="-vlm"
+  # Add provider and model to filename if specified
+  if [ -n "$VLM_PROVIDER" ] && [ -n "$VLM_MODEL" ]; then
+    STRATEGY="-vlm-${VLM_PROVIDER}-${VLM_MODEL}"
+  elif [ -n "$VLM_PROVIDER" ]; then
+    STRATEGY="-vlm-${VLM_PROVIDER}"
+  elif [ -n "$VLM_MODEL" ]; then
+    STRATEGY="-vlm-model-${VLM_MODEL}"
+  fi
   JSON_OUTPUT_FILEPATH=${TMP_OUTPUTS_DIR}/${FILENAME}${STRATEGY}.json
   CURL_STRATEGY=(-F "strategy=vlm")
   if [ -n "$VLM_PROVIDER" ]; then

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -234,7 +234,7 @@ echo "JSON Output file: ${JSON_OUTPUT_FILEPATH}"
 if [ "$WRITE_HTML" = true ]; then
   HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  PYTHONPATH="${SCRIPT_DIR}/../.." python3 -c "import os, sys; sys.path.insert(0, os.path.join('${SCRIPT_DIR}', '..')); from html.elements_json_to_html import json_to_html; from pathlib import Path; json_to_html(Path('${JSON_OUTPUT_FILEPATH}'), Path('${TMP_OUTPUTS_DIR}'), False, False)"
+  PYTHONPATH="${SCRIPT_DIR}/../.." python3 "${SCRIPT_DIR}/../html/elements_json_to_html.py" "${JSON_OUTPUT_FILEPATH}" --outdir "${TMP_OUTPUTS_DIR}"
   echo "HTML written to: ${HTML_OUTPUT_FILEPATH}"
 fi
 

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -88,11 +88,14 @@ VLM_MODEL=""
 
 # Function to check if more than one strategy is enabled
 check_strategy_conflict() {
+  echo "foo e"
   local count=0
   $HI_RES && ((count++))
   $FAST && ((count++))
   $OCR_ONLY && ((count++))
   $VLM && ((count++))
+
+  echo count is "$count"
   
   if [ "$count" -gt 1 ]; then
     echo "Error: Only one strategy option (--hi-res, --fast, --ocr-only, --vlm) can be specified at a time."
@@ -197,6 +200,7 @@ if [ -z "$INPUT" ]; then
   exit 1
 fi
 
+echo hello
 # Check for strategy conflicts after all arguments are processed
 check_strategy_conflict
 

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -196,6 +196,12 @@ if [ "$STRATEGY_COUNT" -gt 1 ]; then
   exit 1
 fi
 
+# Check if vlm-provider or vlm-model are provided without --vlm
+if { [ -n "$VLM_PROVIDER" ] || [ -n "$VLM_MODEL" ]; } && ! $VLM; then
+  echo "Error: --vlm-provider or --vlm-model can only be used with --vlm strategy."
+  exit 1
+fi
+
 if $TRACE; then
   set -x
 fi

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -23,6 +23,7 @@ Options:
   --trace         Enable trace logging for debugging, useful to cut and paste the executed curl call
   --verbose       Enable verbose logging including printing first 8 elements to stdout
   --s3            Write the resulting output to s3 (like a pastebin)
+  --write-html    Convert JSON output to HTML. Set the env var $UNST_WRITE_HTML to skip providing this option.
   --help          Display this help and exit.
 
 
@@ -74,6 +75,7 @@ FREEMIUM=false
 TABLES=true
 IMAGES=false
 S3=""
+WRITE_HTML=${UNST_WRITE_HTML:-false}
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -103,6 +105,10 @@ while [[ "$#" -gt 0 ]]; do
     ;;
   --s3)
     S3=true
+    shift
+    ;;
+  --write-html)
+    WRITE_HTML=true
     shift
     ;;
   --tables)
@@ -223,6 +229,12 @@ else
   echo "total number of elements: " $(jq 'length' "${JSON_OUTPUT_FILEPATH}")
 fi
 echo "JSON Output file: ${JSON_OUTPUT_FILEPATH}"
+
+# Convert JSON to HTML if requested
+if [ "$WRITE_HTML" = true ]; then
+  HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
+  echo "Would write HTML to: ${HTML_OUTPUT_FILEPATH}"
+fi
 
 # write .json output to s3 location
 if [ -n "$S3" ]; then

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -234,7 +234,7 @@ echo "JSON Output file: ${JSON_OUTPUT_FILEPATH}"
 if [ "$WRITE_HTML" = true ]; then
   HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  PYTHONPATH="${SCRIPT_DIR}/../.." python -c "import os, sys; sys.path.insert(0, os.path.join('${SCRIPT_DIR}', '..')); from html.elements_json_to_html import json_to_html; from pathlib import Path; json_to_html(Path('${JSON_OUTPUT_FILEPATH}'), Path('${TMP_OUTPUTS_DIR}'), False, False)"
+  PYTHONPATH="${SCRIPT_DIR}/../.." python3 -c "import os, sys; sys.path.insert(0, os.path.join('${SCRIPT_DIR}', '..')); from html.elements_json_to_html import json_to_html; from pathlib import Path; json_to_html(Path('${JSON_OUTPUT_FILEPATH}'), Path('${TMP_OUTPUTS_DIR}'), False, False)"
   echo "HTML written to: ${HTML_OUTPUT_FILEPATH}"
 fi
 

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -89,11 +89,8 @@ VLM_MODEL=""
 # Function to check if more than one strategy is enabled
 check_strategy_conflict() {
   local count=0
-  echo "$count"
   $HI_RES && ((count++))
-  echo "hi_res $count"
   $FAST && ((count++))
-  echo "fast $count"
   $OCR_ONLY && ((count++))
   $VLM && ((count++))
   

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -17,6 +17,7 @@ Options:
   --fast          fast strategy: No OCR, just extract embedded text
   --ocr-only      ocr_only strategy: Perform OCR (Optical Character Recognition) only. No layout segmentation.
   --vlm           vlm strategy: Use Vision Language Model for processing
+  --vlm-provider  Specify the VLM model provider when using --vlm strategy
   --tables        Enable table extraction: tables are represented as html in metadata
   --images        Include base64images in json
   --coordinates   Include coordinates in the output
@@ -78,6 +79,7 @@ IMAGES=false
 S3=""
 WRITE_HTML=${UNST_WRITE_HTML:-false}
 OPEN_HTML=${UNST_AUTO_OPEN_HTML:-false}
+VLM_PROVIDER=""
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -96,6 +98,15 @@ while [[ "$#" -gt 0 ]]; do
   --vlm)
     VLM=true
     shift
+    ;;
+  --vlm-provider)
+    if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+      VLM_PROVIDER=$2
+      shift 2
+    else
+      echo "Error: Argument for $1 is missing" >&2
+      exit 1
+    fi
     ;;
   --trace)
     TRACE=true
@@ -198,6 +209,9 @@ elif $VLM; then
   STRATEGY="-vlm"
   JSON_OUTPUT_FILEPATH=${TMP_OUTPUTS_DIR}/${FILENAME}${STRATEGY}.json
   CURL_STRATEGY=(-F "strategy=vlm")
+  if [ -n "$VLM_PROVIDER" ]; then
+    CURL_STRATEGY+=(-F "vlm_model_provider=$VLM_PROVIDER")
+  fi
 else
   if $VERBOSE; then echo "Sending API request WITHOUT a strategy"; fi
   JSON_OUTPUT_FILEPATH=${TMP_OUTPUTS_DIR}/${FILENAME}${STRATEGY}.json

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -233,7 +233,9 @@ echo "JSON Output file: ${JSON_OUTPUT_FILEPATH}"
 # Convert JSON to HTML if requested
 if [ "$WRITE_HTML" = true ]; then
   HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
-  echo "Would write HTML to: ${HTML_OUTPUT_FILEPATH}"
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  PYTHONPATH="${SCRIPT_DIR}/../.." python -c "import os, sys; sys.path.insert(0, os.path.join('${SCRIPT_DIR}', '..')); from html.elements_json_to_html import json_to_html; from pathlib import Path; json_to_html(Path('${JSON_OUTPUT_FILEPATH}'), Path('${TMP_OUTPUTS_DIR}'), False, False)"
+  echo "HTML written to: ${HTML_OUTPUT_FILEPATH}"
 fi
 
 # write .json output to s3 location

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -86,19 +86,6 @@ OPEN_HTML=${UNST_AUTO_OPEN_HTML:-false}
 VLM_PROVIDER=""
 VLM_MODEL=""
 
-# Function to check if more than one strategy is enabled
-check_strategy_conflict() {
-  local count=0
-  $HI_RES && ((count++))
-  $FAST && ((count++))
-  $OCR_ONLY && ((count++))
-  $VLM && ((count++))
-  
-  if [ "$count" -gt 1 ]; then
-    echo "Error: Only one strategy option (--hi-res, --fast, --ocr-only, --vlm) can be specified at a time."
-    exit 1
-  fi
-}
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -198,7 +185,16 @@ if [ -z "$INPUT" ]; then
 fi
 
 # Check for strategy conflicts after all arguments are processed
-check_strategy_conflict
+STRATEGY_COUNT=0
+$HI_RES && STRATEGY_COUNT=$((STRATEGY_COUNT+1))
+$FAST && STRATEGY_COUNT=$((STRATEGY_COUNT+1))
+$OCR_ONLY && STRATEGY_COUNT=$((STRATEGY_COUNT+1))
+$VLM && STRATEGY_COUNT=$((STRATEGY_COUNT+1))
+
+if [ "$STRATEGY_COUNT" -gt 1 ]; then
+  echo "Error: Only one strategy option (--hi-res, --fast, --ocr-only, --vlm) can be specified at a time."
+  exit 1
+fi
 
 if $TRACE; then
   set -x

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -18,6 +18,7 @@ Options:
   --ocr-only      ocr_only strategy: Perform OCR (Optical Character Recognition) only. No layout segmentation.
   --vlm           vlm strategy: Use Vision Language Model for processing
   --vlm-provider  Specify the VLM model provider when using --vlm strategy
+  --vlm-model     Specify the VLM model when using --vlm strategy
   --tables        Enable table extraction: tables are represented as html in metadata
   --images        Include base64images in json
   --coordinates   Include coordinates in the output
@@ -80,6 +81,7 @@ S3=""
 WRITE_HTML=${UNST_WRITE_HTML:-false}
 OPEN_HTML=${UNST_AUTO_OPEN_HTML:-false}
 VLM_PROVIDER=""
+VLM_MODEL=""
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -102,6 +104,15 @@ while [[ "$#" -gt 0 ]]; do
   --vlm-provider)
     if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
       VLM_PROVIDER=$2
+      shift 2
+    else
+      echo "Error: Argument for $1 is missing" >&2
+      exit 1
+    fi
+    ;;
+  --vlm-model)
+    if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+      VLM_MODEL=$2
       shift 2
     else
       echo "Error: Argument for $1 is missing" >&2
@@ -211,6 +222,9 @@ elif $VLM; then
   CURL_STRATEGY=(-F "strategy=vlm")
   if [ -n "$VLM_PROVIDER" ]; then
     CURL_STRATEGY+=(-F "vlm_model_provider=$VLM_PROVIDER")
+  fi
+  if [ -n "$VLM_MODEL" ]; then
+    CURL_STRATEGY+=(-F "vlm_model=$VLM_MODEL")
   fi
 else
   if $VERBOSE; then echo "Sending API request WITHOUT a strategy"; fi

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -86,23 +86,41 @@ OPEN_HTML=${UNST_AUTO_OPEN_HTML:-false}
 VLM_PROVIDER=""
 VLM_MODEL=""
 
+# Function to check if more than one strategy is enabled
+check_strategy_conflict() {
+  local count=0
+  $HI_RES && ((count++))
+  $FAST && ((count++))
+  $OCR_ONLY && ((count++))
+  $VLM && ((count++))
+  
+  if [ "$count" -gt 1 ]; then
+    echo "Error: Only one strategy option (--hi-res, --fast, --ocr-only, --vlm) can be specified at a time."
+    exit 1
+  fi
+}
+
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
   --hi-res)
     HI_RES=true
     shift
+    check_strategy_conflict
     ;;
   --fast)
     FAST=true
     shift
+    check_strategy_conflict
     ;;
   --ocr-only)
     OCR_ONLY=true
     shift
+    check_strategy_conflict
     ;;
   --vlm)
     VLM=true
     shift
+    check_strategy_conflict
     ;;
   --vlm-provider)
     if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -297,11 +297,9 @@ echo "JSON Output file: ${JSON_OUTPUT_FILEPATH}"
 if [ "$WRITE_HTML" = true ]; then
   HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
 
-  # Check if all elements have metadata.text_as_html field that is not empty or null
-  ALL_HAVE_HTML=$(jq 'map(has("metadata") and ((.metadata | has("text_as_html")) or false) and ((.metadata.text_as_html != null) or false) and ((.metadata.text_as_html != "") or false)) | all' "${JSON_OUTPUT_FILEPATH}")
-
-  if [ "$ALL_HAVE_HTML" = "true" ]; then
-    # Create HTML directly from metadata.text_as_html fields
+  if $VLM; then
+    # VLM output has all metadata.text_as_html fields defined, so
+    # create HTML directly from the metadata.text_as_html fields
     {
       echo "<!DOCTYPE html>"
       echo "<html>"
@@ -320,7 +318,8 @@ if [ "$WRITE_HTML" = true ]; then
     } >"${HTML_OUTPUT_FILEPATH}"
     echo "HTML written directly from metadata.text_as_html fields to: ${HTML_OUTPUT_FILEPATH}"
   else
-    # Fall back to using the Python script
+    # most elements will not have metadata.text_as_html defined (by design on Table elements do),
+    # so use the unstructured library's python script for the conversion.
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     PYTHONPATH="${SCRIPT_DIR}/../.." python3 "${SCRIPT_DIR}/../html/elements_json_to_html.py" "${JSON_OUTPUT_FILEPATH}" --outdir "${TMP_OUTPUTS_DIR}"
     echo "HTML written using Python script to: ${HTML_OUTPUT_FILEPATH}"

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -299,7 +299,7 @@ if [ "$WRITE_HTML" = true ]; then
   HTML_OUTPUT_FILEPATH=${JSON_OUTPUT_FILEPATH%.json}.html
   
   # Check if all elements have metadata.text_as_html field that is not empty or null
-  ALL_HAVE_HTML=$(jq 'map(has("metadata") and .metadata | has("text_as_html") and .metadata.text_as_html != null and .metadata.text_as_html != "") | all' "${JSON_OUTPUT_FILEPATH}")
+  ALL_HAVE_HTML=$(jq 'map(has("metadata") and (.metadata | has("text_as_html")) and .metadata.text_as_html != null and .metadata.text_as_html != "") | all' "${JSON_OUTPUT_FILEPATH}")
   
   if [ "$ALL_HAVE_HTML" = "true" ]; then
     # Create HTML directly from metadata.text_as_html fields

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -17,9 +17,9 @@ Options:
   --fast          fast strategy: No OCR, just extract embedded text
   --ocr-only      ocr_only strategy: Perform OCR (Optical Character Recognition) only. No layout segmentation.
   --vlm           vlm strategy: Use Vision Language Model for processing
-  --vlm-provider  Specify the VLM model provider when using --vlm strategy
+  --vlm-provider  Specify the VLM model provider
                   (see: https://docs.unstructured.io/api-reference/workflow/workflows#vlm-strategy)
-  --vlm-model     Specify the VLM model when using --vlm strategy
+  --vlm-model     Specify the VLM model when using
                   (see: https://docs.unstructured.io/api-reference/workflow/workflows#vlm-strategy)
   --tables        Enable table extraction: tables are represented as html in metadata
   --images        Include base64images in json

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -89,8 +89,11 @@ VLM_MODEL=""
 # Function to check if more than one strategy is enabled
 check_strategy_conflict() {
   local count=0
+  echo "$count"
   $HI_RES && ((count++))
+  echo "hi_res $count"
   $FAST && ((count++))
+  echo "fast $count"
   $OCR_ONLY && ((count++))
   $VLM && ((count++))
   

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -28,7 +28,8 @@ Options:
   --verbose       Enable verbose logging including printing first 8 elements to stdout
   --s3            Write the resulting output to s3 (like a pastebin)
   --write-html    Convert JSON output to HTML. Set the env var $UNST_WRITE_HTML to skip providing this option.
-  --open-html     Automatically open HTML output in browser (macOS only). Set the env var $UNST_AUTO_OPEN_HTML to skip providing this option.
+  --open-html     Automatically open HTML output in browser (macOS only). 
+                  Set the env var $UNST_AUTO_OPEN_HTML to skip providing this option.
   --help          Display this help and exit.
 
 

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -24,6 +24,7 @@ Options:
   --verbose       Enable verbose logging including printing first 8 elements to stdout
   --s3            Write the resulting output to s3 (like a pastebin)
   --write-html    Convert JSON output to HTML. Set the env var $UNST_WRITE_HTML to skip providing this option.
+  --open-html     Automatically open HTML output in browser (macOS only). Set the env var $UNST_AUTO_OPEN_HTML to skip providing this option.
   --help          Display this help and exit.
 
 
@@ -76,6 +77,7 @@ TABLES=true
 IMAGES=false
 S3=""
 WRITE_HTML=${UNST_WRITE_HTML:-false}
+OPEN_HTML=${UNST_AUTO_OPEN_HTML:-false}
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -109,6 +111,10 @@ while [[ "$#" -gt 0 ]]; do
     ;;
   --write-html)
     WRITE_HTML=true
+    shift
+    ;;
+  --open-html)
+    OPEN_HTML=true
     shift
     ;;
   --tables)
@@ -236,6 +242,12 @@ if [ "$WRITE_HTML" = true ]; then
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   PYTHONPATH="${SCRIPT_DIR}/../.." python3 "${SCRIPT_DIR}/../html/elements_json_to_html.py" "${JSON_OUTPUT_FILEPATH}" --outdir "${TMP_OUTPUTS_DIR}"
   echo "HTML written to: ${HTML_OUTPUT_FILEPATH}"
+  
+  # Open HTML file in browser if requested and on macOS
+  if [ "$OPEN_HTML" = true ] && [ "$(uname)" == "Darwin" ]; then
+    open "${HTML_OUTPUT_FILEPATH}"
+    echo "Opened HTML file in browser"
+  fi
 fi
 
 # write .json output to s3 location

--- a/scripts/user/unstructured-get-json.sh
+++ b/scripts/user/unstructured-get-json.sh
@@ -16,6 +16,7 @@ Options:
   --hi-res        hi_res strategy: Enable high-resolution processing, with layout segmentation and OCR
   --fast          fast strategy: No OCR, just extract embedded text
   --ocr-only      ocr_only strategy: Perform OCR (Optical Character Recognition) only. No layout segmentation.
+  --vlm           vlm strategy: Use Vision Language Model for processing
   --tables        Enable table extraction: tables are represented as html in metadata
   --images        Include base64images in json
   --coordinates   Include coordinates in the output
@@ -64,6 +65,7 @@ copy_to_clipboard() {
 HI_RES=false
 FAST=false
 OCR_ONLY=false
+VLM=false
 STRATEGY=""
 VERBOSE=false
 TRACE=false
@@ -85,6 +87,10 @@ while [[ "$#" -gt 0 ]]; do
     ;;
   --ocr-only)
     OCR_ONLY=true
+    shift
+    ;;
+  --vlm)
+    VLM=true
     shift
     ;;
   --trace)
@@ -175,6 +181,11 @@ elif $OCR_ONLY; then
   STRATEGY="-ocr-only"
   JSON_OUTPUT_FILEPATH=${TMP_OUTPUTS_DIR}/${FILENAME}${STRATEGY}.json
   CURL_STRATEGY=(-F "strategy=ocr_only")
+elif $VLM; then
+  if $VERBOSE; then echo "Sending API request with vlm strategy"; fi
+  STRATEGY="-vlm"
+  JSON_OUTPUT_FILEPATH=${TMP_OUTPUTS_DIR}/${FILENAME}${STRATEGY}.json
+  CURL_STRATEGY=(-F "strategy=vlm")
 else
   if $VERBOSE; then echo "Sending API request WITHOUT a strategy"; fi
   JSON_OUTPUT_FILEPATH=${TMP_OUTPUTS_DIR}/${FILENAME}${STRATEGY}.json

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.17.5"  # pragma: no cover
+__version__ = "0.17.6-dev0"  # pragma: no cover

--- a/unstructured/partition/html/convert.py
+++ b/unstructured/partition/html/convert.py
@@ -286,15 +286,20 @@ def group_elements_by_page(
     unstructured_elements: list[Element],
 ) -> list[list[Element]]:
     pages_dict: defaultdict[int, list[Element]] = defaultdict(list)
+    none_page_elements: list[Element] = []
 
     for element in unstructured_elements:
         page_number = element.metadata.page_number
         if page_number is None:
-            logger.warning(f"Page number is not set for an element {element.id}. Skipping.")
-            continue
-        pages_dict[page_number].append(element)
+            logger.warning(f"Page number is not set for an element {element.id}. Adding to 'none' page.")
+            none_page_elements.append(element)
+        else:
+            pages_dict[page_number].append(element)
 
     pages_list = list(pages_dict.values())
+    if none_page_elements:
+        pages_list.append(none_page_elements)
+    
     return pages_list
 
 

--- a/unstructured/partition/html/convert.py
+++ b/unstructured/partition/html/convert.py
@@ -248,12 +248,9 @@ def _elements_to_html_tags_by_parent(elements: list[ElementHtml]) -> list[Elemen
         grouped_children = _group_element_children(children)
         parent = next((el for el in elements if el.element.id == parent_id), None)
         if parent is None:
-            logger.warning(f"Parent element with id {parent_id} not found. Keeping elements without parent.")
-            # Add these elements to the root level instead of skipping them
-            for child in children:
-                child.element.metadata.parent_id = None
-        else:
-            parent.set_children(grouped_children)
+            logger.warning(f"Parent element with id {parent_id} not found. Skipping.")
+            continue
+        parent.set_children(grouped_children)
     return [el for el in elements if el.element.metadata.parent_id is None]
 
 
@@ -289,20 +286,15 @@ def group_elements_by_page(
     unstructured_elements: list[Element],
 ) -> list[list[Element]]:
     pages_dict: defaultdict[int, list[Element]] = defaultdict(list)
-    none_page_elements: list[Element] = []
 
     for element in unstructured_elements:
         page_number = element.metadata.page_number
         if page_number is None:
-            logger.warning(f"Page number is not set for an element {element.id}. Adding to 'none' page.")
-            none_page_elements.append(element)
-        else:
-            pages_dict[page_number].append(element)
+            logger.warning(f"Page number is not set for an element {element.id}. Skipping.")
+            continue
+        pages_dict[page_number].append(element)
 
     pages_list = list(pages_dict.values())
-    if none_page_elements:
-        pages_list.append(none_page_elements)
-    
     return pages_list
 
 

--- a/unstructured/partition/html/convert.py
+++ b/unstructured/partition/html/convert.py
@@ -248,9 +248,12 @@ def _elements_to_html_tags_by_parent(elements: list[ElementHtml]) -> list[Elemen
         grouped_children = _group_element_children(children)
         parent = next((el for el in elements if el.element.id == parent_id), None)
         if parent is None:
-            logger.warning(f"Parent element with id {parent_id} not found. Skipping.")
-            continue
-        parent.set_children(grouped_children)
+            logger.warning(f"Parent element with id {parent_id} not found. Keeping elements without parent.")
+            # Add these elements to the root level instead of skipping them
+            for child in children:
+                child.element.metadata.parent_id = None
+        else:
+            parent.set_children(grouped_children)
     return [el for el in elements if el.element.metadata.parent_id is None]
 
 


### PR DESCRIPTION
* script now supports:
   * the --vlm flag, to process the document with the VLM strategy
   * optionally takes --vlm-model, --vlm-provider args
   * optionally also writes .html outputs by converting unstructured .json output
   * optionally opens those .html outputs in a browser
   
Tested with:
   ```
   unstructured-get-json.sh --write-html --open-html --fast                                                                layout-parser-paper-p2.pdf
unstructured-get-json.sh --write-html --open-html --hi-res                                                              layout-parser-paper-p2.pdf
unstructured-get-json.sh --write-html --open-html --ocr-only                                                            layout-parser-paper-p2.pdf
unstructured-get-json.sh --write-html --open-html --vlm                                                                 layout-parser-paper-p2.pdf
unstructured-get-json.sh --write-html --open-html --vlm --vlm-provider openai    --vlm-model gpt-4o                     layout-parser-paper-p2.pdf
unstructured-get-json.sh --write-html --open-html --vlm --vlm-provider vertexai  --vlm-model gemini-2.0-flash-001       layout-parser-paper-p2.pdf
unstructured-get-json.sh --write-html --open-html --vlm --vlm-provider anthropic --vlm-model claude-3-5-sonnet-20241022 layout-parser-paper-p2.pdf

```

[layout-parser-paper-p2.pdf](https://github.com/user-attachments/files/19514007/layout-parser-paper-p2.pdf)
