### PR TITLE
chore: add html path to ingest-test-fixtures-update-pr

### DIFF
--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -139,6 +139,7 @@ jobs:
           token: ${{ secrets.GH_CREATE_PR_TOKEN }}
           add-paths: |
             test_unstructured_ingest/expected-structured-output
+            test_unstructured_ingest/expected-structured-output-html
             test_unstructured_ingest/metrics
           commit-message: "Update ingest test fixtures"
           branch: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
This should allow the `Ingest Test Fixtures Update PR` workflow to also update expected html outputs.

E.g., before the change, the .html files would be left unmodified:
![image](https://github.com/user-attachments/assets/fa14c1a5-39bd-4e32-b4b9-9552eb312de1)

https://github.com/Unstructured-IO/unstructured/actions/runs/14234877547/job/39892334672
