### PR TITLE
Feature/remove unnessary re for table ele in pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 Two executions of the same code, on the same file, produce different results. The order of the elements is random.
 This makes it impossible to write stable unit tests, for example, or to obtain reproducible results.
 - **Do not use NLP to determine element types for extracted elements with hi_res.** This avoids extraneous Title elements in hi_res outputs. This only applies to *extracted* elements, meaning text objects that are found outside of Object Detection objects which get mapped to *inferred* elements. (*extracted* and *inferred* elements get merged together to form the list of `Element`s returned by `pdf_partition()`)
+- **RE_MULTISPACE_INCLUDING_NEWLINES was incorrectly used for Table or TableChunk** Newlines should not be removed from Table or TableChunk elements. The re.sub is not needed for Table or TableChunk elements now.
 
 ## 0.17.5
 

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -36,7 +36,7 @@ from unstructured.documents.elements import (
     PageBreak,
     Text,
     Title,
-    process_metadata,
+    process_metadata, TableChunk, Table,
 )
 from unstructured.errors import PageCountExceededError
 from unstructured.file_utils.filetype import add_metadata_with_filetype
@@ -823,8 +823,9 @@ def _partition_pdf_or_image_local(
 
         if isinstance(el, Image):
             out_elements.append(cast(Element, el))
-        # NOTE(crag): this is probably always a Text object, but check for the sake of typing
-        elif isinstance(el, Text):
+        # NOTE(crag): this is probably always a Text object, but check for the sake of typing.
+        # NOTE(JQQ): Escape RE for Table and TableChunk
+        elif isinstance(el, Text) and not isinstance(el, (Table, TableChunk)):
             el.text = re.sub(
                 RE_MULTISPACE_INCLUDING_NEWLINES,
                 " ",


### PR DESCRIPTION
RE_MULTISPACE_INCLUDING_NEWLINES is applied to all elements of the Text category after partitioning PDF files. The relevant code is shown below:

```python
out_elements = []
for el in elements:
    if isinstance(el, PageBreak) and not include_page_breaks:
        continue

    if isinstance(el, Image):
        out_elements.append(cast(Element, el))
    # NOTE(crag): this is probably always a Text object, but check for the sake of typing
    elif isinstance(el, Text):
        el.text = re.sub(
            RE_MULTISPACE_INCLUDING_NEWLINES,
            " ",
            el.text or "",
        ).strip()
        if el.text or isinstance(el, PageBreak):
            out_elements.append(cast(Element, el))
```

Newlines will not be removed from Table or TableChunk elements now.