### PR TITLE
fix: resolve warnings of logger library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 - **Fix image extraction for PNG files.** When `extract_image_block_to_payload` is True, and the image is a PNG, we get a Pillow error. We need to remove the PNG transparency layer before saving the image.
+- **Fix logger deprecation warning**: Replaced usage of `logger.warn` with `logger.warning` to comply with the Python logging standards.
 
 ## 0.17.6
 

--- a/unstructured/partition/api.py
+++ b/unstructured/partition/api.py
@@ -86,7 +86,7 @@ def partition_via_api(
 
     if file_filename is not None:
         metadata_filename = file_filename
-        logger.warn(
+        logger.warning(
             "The file_filename kwarg will be deprecated in a future version of unstructured. "
             "Please use metadata_filename instead.",
         )
@@ -277,7 +277,7 @@ def partition_multiple_via_api(
 
     if file_filenames is not None:
         metadata_filenames = file_filenames
-        logger.warn(
+        logger.warning(
             "The file_filenames kwarg will be deprecated in a future version of unstructured. "
             "Please use metadata_filenames instead.",
         )


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```