### PR TITLE
fix: throw validation error when json is passed with invalid unstructured json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 - **Fix image extraction for PNG files.** When `extract_image_block_to_payload` is True, and the image is a PNG, we get a Pillow error. We need to remove the PNG transparency layer before saving the image.
+- **Throw validation error when json is passed with invalid unstructured json
 
 ## 0.17.6
 

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -189,7 +189,7 @@ def test_partition_json_works_with_empty_string():
 
 def test_partition_json_works_with_empty_item():
     with pytest.raises(ValueError):
-        assert partition_json(text="{}") == []
+        partition_json(text="{}")
 
 
 def test_partition_json_works_with_empty_list():

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -186,10 +186,12 @@ def test_partition_json_raises_with_none_specified():
 def test_partition_json_works_with_empty_string():
     assert partition_json(text="") == []
 
+def test_partition_json_works_with_empty_item():
+    with pytest.raises(ValueError):
+        assert partition_json(text="{}") == []
 
 def test_partition_json_works_with_empty_list():
     assert partition_json(text="[]") == []
-
 
 def test_partition_json_raises_with_too_many_specified():
     path = example_doc_path("fake-text.txt")
@@ -287,6 +289,10 @@ def test_partition_json_from_text_prefers_metadata_last_modified():
 
 # ------------------------------------------------------------------------------------------------
 
+def test_partition_json_raises_with_unprocessable_json_array():
+    text = '[{"invalid": "schema"}]'
+    with pytest.raises(ValueError):
+        partition_json(text=text)
 
 def test_partition_json_raises_with_unprocessable_json():
     # NOTE(robinson) - This is unprocessable because it is not a list of dicts,

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -187,7 +187,7 @@ def test_partition_json_works_with_empty_string():
     assert partition_json(text="") == []
 
 
-def test_partition_json_works_with_empty_item():
+def test_partition_json_fails_with_empty_item():
     with pytest.raises(ValueError):
         partition_json(text="{}")
 

--- a/test_unstructured/partition/test_json.py
+++ b/test_unstructured/partition/test_json.py
@@ -186,12 +186,15 @@ def test_partition_json_raises_with_none_specified():
 def test_partition_json_works_with_empty_string():
     assert partition_json(text="") == []
 
+
 def test_partition_json_works_with_empty_item():
     with pytest.raises(ValueError):
         assert partition_json(text="{}") == []
 
+
 def test_partition_json_works_with_empty_list():
     assert partition_json(text="[]") == []
+
 
 def test_partition_json_raises_with_too_many_specified():
     path = example_doc_path("fake-text.txt")
@@ -289,10 +292,12 @@ def test_partition_json_from_text_prefers_metadata_last_modified():
 
 # ------------------------------------------------------------------------------------------------
 
+
 def test_partition_json_raises_with_unprocessable_json_array():
     text = '[{"invalid": "schema"}]'
     with pytest.raises(ValueError):
         partition_json(text=text)
+
 
 def test_partition_json_raises_with_unprocessable_json():
     # NOTE(robinson) - This is unprocessable because it is not a list of dicts,

--- a/test_unstructured/partition/test_ndjson.py
+++ b/test_unstructured/partition/test_ndjson.py
@@ -191,7 +191,7 @@ def test_partition_ndjson_works_with_empty_string():
 
 def test_partition_ndjson_works_with_empty_item():
     with pytest.raises(ValueError):
-        assert partition_ndjson(text="{}") == []
+        partition_ndjson(text="{}")
 
 
 def test_partition_ndjson_works_with_empty_list():

--- a/test_unstructured/partition/test_ndjson.py
+++ b/test_unstructured/partition/test_ndjson.py
@@ -189,14 +189,14 @@ def test_partition_ndjson_works_with_empty_string():
     assert partition_ndjson(text="") == []
 
 
-def test_partition_ndjson_works_with_empty_item():
+def test_partition_ndjson_fails_with_empty_item():
     with pytest.raises(ValueError):
         partition_ndjson(text="{}")
 
 
-def test_partition_ndjson_works_with_empty_list():
+def test_partition_ndjson_fails_with_empty_list():
     with pytest.raises(ValueError):
-        assert partition_ndjson(text="[]") == []
+        partition_ndjson(text="[]")
 
 
 def test_partition_ndjson_raises_with_too_many_specified():

--- a/test_unstructured/partition/test_ndjson.py
+++ b/test_unstructured/partition/test_ndjson.py
@@ -188,10 +188,13 @@ def test_partition_json_raises_with_none_specified():
 def test_partition_ndjson_works_with_empty_string():
     assert partition_ndjson(text="") == []
 
+def test_partition_ndjson_works_with_empty_item():
+    with pytest.raises(ValueError):
+        assert partition_ndjson(text="{}") == []
 
 def test_partition_ndjson_works_with_empty_list():
-    assert partition_ndjson(text="{}") == []
-
+    with pytest.raises(ValueError):
+        assert partition_ndjson(text="[]") == []
 
 def test_partition_ndjson_raises_with_too_many_specified():
     path = example_doc_path("fake-text.txt")
@@ -292,6 +295,10 @@ def test_partition_ndjson_from_text_prefers_metadata_last_modified():
 
 # ------------------------------------------------------------------------------------------------
 
+def test_partition_json_raises_with_unprocessable_json():
+    text = '{"invalid": "schema"}'
+    with pytest.raises(ValueError):
+        partition_ndjson(text=text)
 
 def test_partition_json_raises_with_invalid_json():
     text = '[{"hi": "there"}]]'

--- a/test_unstructured/partition/test_ndjson.py
+++ b/test_unstructured/partition/test_ndjson.py
@@ -188,13 +188,16 @@ def test_partition_json_raises_with_none_specified():
 def test_partition_ndjson_works_with_empty_string():
     assert partition_ndjson(text="") == []
 
+
 def test_partition_ndjson_works_with_empty_item():
     with pytest.raises(ValueError):
         assert partition_ndjson(text="{}") == []
 
+
 def test_partition_ndjson_works_with_empty_list():
     with pytest.raises(ValueError):
         assert partition_ndjson(text="[]") == []
+
 
 def test_partition_ndjson_raises_with_too_many_specified():
     path = example_doc_path("fake-text.txt")
@@ -295,10 +298,12 @@ def test_partition_ndjson_from_text_prefers_metadata_last_modified():
 
 # ------------------------------------------------------------------------------------------------
 
+
 def test_partition_json_raises_with_unprocessable_json():
     text = '{"invalid": "schema"}'
     with pytest.raises(ValueError):
         partition_ndjson(text=text)
+
 
 def test_partition_json_raises_with_invalid_json():
     text = '[{"hi": "there"}]]'

--- a/unstructured/partition/json.py
+++ b/unstructured/partition/json.py
@@ -74,6 +74,11 @@ def partition_json(
     try:
         element_dicts = json.loads(file_text)
         elements = elements_from_dicts(element_dicts)
+        # if we found at least one json element, but no unstructured elements were found, throw 422
+        if len(element_dicts) > 0 and len(elements) == 0:
+            raise ValueError(
+                "JSON cannot be partitioned. Schema does not match the Unstructured schema.",
+            )
     except json.JSONDecodeError:
         raise ValueError("Not a valid json")
 

--- a/unstructured/partition/ndjson.py
+++ b/unstructured/partition/ndjson.py
@@ -75,6 +75,11 @@ def partition_ndjson(
     try:
         element_dicts = ndjson_loads(file_text)
         elements = elements_from_dicts(element_dicts)
+        # if we found at least one json element, but no unstructured elements were found, throw 422
+        if len(element_dicts) > 0 and len(elements) == 0:
+            raise ValueError(
+                "JSON cannot be partitioned. Schema does not match the Unstructured schema.",
+            )
     except json.JSONDecodeError:
         raise ValueError("Not a valid ndjson")
 


### PR DESCRIPTION
### Notes
Adds validation if `json` / `ndjson` are not valid unstructured schema.

### Testing
Manually tested serverless API with example json:

```

test_length = [] = 200

test_invalid = [{"invalid": "schema"}] = 422
test_invalid_ndjson ={"hi": "there"} = 422

test_chunk = [{"type":"Header","element_id":"a23fdadef9277f217563e217ebd074d5" ... = 200

```