### PR TITLE
fix chucking text None type has no attribute stripe

### DIFF
--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -416,6 +416,20 @@ class DescribePreChunk:
         )
         assert pre_chunk._text == "hello"
 
+    def it_can_chunk_elements_with_none_text_without_error(self):
+        """Regression test for AttributeError when Image elements have None text."""
+        pre_chunk = PreChunk(
+            [Image(None), Text("hello world"), Image(None)], 
+            overlap_prefix="", 
+            opts=ChunkingOptions()
+        )
+        
+        # Should not raise AttributeError when generating chunks
+        chunks = list(pre_chunk.iter_chunks())
+        
+        assert len(chunks) == 1
+        assert chunks[0].text == "hello world"
+
     @pytest.mark.parametrize(
         ("max_characters", "combine_text_under_n_chars", "expected_value"),
         [
@@ -1025,6 +1039,15 @@ class Describe_TableChunker:
         assert orig_element.metadata.orig_elements is None
         # -- computation is only on first call, all chunks get exactly the same orig-elements --
         assert table_chunker._orig_elements is orig_elements
+
+    def it_handles_table_with_none_text_without_error(self):
+        """Regression test for AttributeError when Table elements have None text."""
+        table = Table(None)  # Table with None text
+        
+        # Should not raise AttributeError and should produce no chunks
+        chunks = list(_TableChunker.iter_chunks(table, "", ChunkingOptions()))
+        
+        assert len(chunks) == 0
 
 
 # ================================================================================================

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -503,12 +503,10 @@ class PreChunk:
         if self._overlap_prefix:
             yield self._overlap_prefix
         for e in self._elements:
-            if e.text is None:
-                continue
-            text = " ".join(e.text.strip().split())
-            if not text:
-                continue
-            yield text
+            if e.text:
+                text = " ".join(e.text.strip().split())
+                if text:
+                    yield text
 
     @lazyproperty
     def _text(self) -> str:
@@ -848,13 +846,18 @@ class _TableChunker:
     @lazyproperty
     def _table_text(self) -> str:
         """The text in this table, not including any overlap-prefix or extra whitespace."""
+        if not self._table.text:
+            return ""
         return " ".join(self._table.text.split())
 
     @lazyproperty
     def _text_with_overlap(self) -> str:
         """The text for this chunk, including the overlap-prefix when present."""
         overlap_prefix = self._overlap_prefix
-        table_text = self._table.text.strip()
+        if not self._table.text:
+            table_text = ""
+        else:
+            table_text = self._table.text.strip()
         # -- use row-separator between overlap and table-text --
         return overlap_prefix + "\n" + table_text if overlap_prefix else table_text
 


### PR DESCRIPTION
### Summary
To fix error `Error in chunk: 512: {"detail":"'NoneType' object has no attribute 'strip'"}` I found the logs under same org (could assume this is the same job)
screenshot:
stacktrace:



### Notes
longer term we should make partitioner (vlm + utic-api) not return text with Null
adding check in chunking for saftey as well