### PR TITLE
feat: add DocumentData type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 0.18.1-dev0
+## 0.18.1
 
 ### Enhancements
 
 ### Features
+- **Add DocumentData element type** This is helpful in scenarios where there is large data that does not make sense to represent across each element in the document.
 
 ### Fixes
 - The `encoding` property of the `_CsvPartitioningContext` is now properly used.

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.1-dev0"  # pragma: no cover
+__version__ = "0.18.1"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -975,6 +975,7 @@ class FormKeysValues(Text):
 
     category = "FormKeysValues"
 
+
 class DocumentData(Text):
     """An element for capturing document-level data,
     particularly for large data that does not make sense to

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -640,6 +640,7 @@ class ElementType:
     PAGE_NUMBER = "PageNumber"
     CODE_SNIPPET = "CodeSnippet"
     FORM_KEYS_VALUES = "FormKeysValues"
+    DOCUMENT_DATA = "DocumentData"
 
     @classmethod
     def to_dict(cls):
@@ -974,6 +975,13 @@ class FormKeysValues(Text):
 
     category = "FormKeysValues"
 
+class DocumentData(Text):
+    """An element for capturing document-level data,
+    particularly for large data that does not make sense to
+    represent across each element in the document."""
+
+    category = "DocumentData"
+
 
 TYPE_TO_TEXT_ELEMENT_MAP: dict[str, type[Text]] = {
     ElementType.TITLE: Title,
@@ -1013,6 +1021,7 @@ TYPE_TO_TEXT_ELEMENT_MAP: dict[str, type[Text]] = {
     ElementType.CODE_SNIPPET: CodeSnippet,
     ElementType.PAGE_NUMBER: PageNumber,
     ElementType.FORM_KEYS_VALUES: FormKeysValues,
+    ElementType.DOCUMENT_DATA: DocumentData,
 }
 
 

--- a/unstructured/partition/html/convert.py
+++ b/unstructured/partition/html/convert.py
@@ -216,6 +216,7 @@ TYPE_TO_HTML_MAP = {
     ElementType.PAGE_NUMBER: ElementHtml,
     ElementType.CODE_SNIPPET: ElementHtml,
     ElementType.FORM_KEYS_VALUES: ElementHtml,
+    ElementType.DOCUMENT_DATA: ElementHtml,
 }
 
 


### PR DESCRIPTION
In scenarios where there is a large amount of data that represents the document rather than individual elements in the document, it may be preferable to specify this in a single location rather than duplicating the data across all elements (as we do for smaller metadata like filename or filetype)

This PR adds DocumentData element type which can be used to uniquely capture this data.