### PR TITLE
feat: keep input tag's class attr in table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.18.9-dev0
+## 0.18.9
 
 ### Enhancements
 
@@ -19,6 +19,8 @@
 ## 0.18.7
 
 ### Enhancements
+
+- **`text_as_html` for Table element now keeps both `input` and `img` tag's `class` attribute** Previously in partition HTML any tag inside a table is stripped of its `class` attribute. Now this attribute is preserved for both `input` and `img` tag in the table element's `metadata.text_as_html`.
 
 ### Features
 - **Add language detection for PDFs** Add document and element level language detection to PDFs.

--- a/test_unstructured/documents/test_ontology_to_unstructured_parsing.py
+++ b/test_unstructured/documents/test_ontology_to_unstructured_parsing.py
@@ -37,6 +37,10 @@ def test_remove_ids_and_class_from_table():
             <td><IMG class="Signature" alt="cell 3"/></td>
             <td>cell 4</td>
         </tr>
+        <tr>
+            <td><input class="Checkbox" type="checkbox"/></td>
+            <td>Option 1</td>
+        </tr>
     </table>
     """
     soup = BeautifulSoup(html_text, "html.parser")
@@ -51,6 +55,10 @@ def test_remove_ids_and_class_from_table():
 <tr>
 <td><img alt="cell 3" class="Signature"/></td>
 <td>cell 4</td>
+</tr>
+<tr>
+<td><input class="Checkbox" type="checkbox"/></td>
+<td>Option 1</td>
 </tr>
 </table>
 """

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.9-dev0"  # pragma: no cover
+__version__ = "0.18.9"  # pragma: no cover

--- a/unstructured/documents/ontology.py
+++ b/unstructured/documents/ontology.py
@@ -147,13 +147,16 @@ class OntologyElement(BaseModel):
         return None
 
 
-def remove_ids_and_class_from_table(soup: BeautifulSoup) -> BeautifulSoup:
+def remove_ids_and_class_from_table(
+    soup: BeautifulSoup, class_attr_to_keep: list[str] = ["img", "input"]
+) -> BeautifulSoup:
     """
     Remove id and class attributes from tags inside tables,
-    except preserve class attributes for img tags.
+    except preserve class attributes for selected tags.
 
     Args:
         soup: BeautifulSoup object containing the HTML
+        class_attr_to_keep: a list of tag names whose class attr will be kept
 
     Returns:
         BeautifulSoup: Modified soup with attributes removed
@@ -162,7 +165,7 @@ def remove_ids_and_class_from_table(soup: BeautifulSoup) -> BeautifulSoup:
         if tag.name.lower() == "table":  # type: ignore
             continue  # We keep table tag
         tag.attrs.pop("id", None)  # type: ignore
-        if tag.name.lower() != "img":  # type: ignore
+        if tag.name.lower() not in class_attr_to_keep:  # type: ignore
             tag.attrs.pop("class", None)  # type: ignore
     return soup
 


### PR DESCRIPTION
This change affects partition html.

Previously when there is a table in the html, we clean any tags inside the table of their class and id attributes except for the class attribute for `img` tags. This change also preserves the class attribute for `input` tags inside a table. This change is reflected in a table element's metadata.text_as_html attribute.