### PR TITLE
Add OCR_AGENT_CACHE_SIZE environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.18.10
+
+### Enhancements
+
+### Features
+- **Add OCR_AGENT_CACHE_SIZE environment variable** Added configurable cache size for OCR agents to control memory usage.
+
+### Fixes
+
 ## 0.18.10-dev0
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.10-dev0"  # pragma: no cover
+__version__ = "0.18.10"  # pragma: no cover

--- a/unstructured/partition/utils/config.py
+++ b/unstructured/partition/utils/config.py
@@ -112,6 +112,11 @@ class ENVConfig:
         return self._get_string("OCR_AGENT", OCR_AGENT_TESSERACT)
 
     @property
+    def OCR_AGENT_CACHE_SIZE(self) -> int:
+        """Maximum number of OCR agents to cache per process"""
+        return self._get_int("OCR_AGENT_CACHE_SIZE", 1)
+
+    @property
     def EXTRACT_IMAGE_BLOCK_CROP_HORIZONTAL_PAD(self) -> int:
         """extra image block content to add around an identified element(`Image`, `Table`) region
         horizontally; measured in pixels

--- a/unstructured/partition/utils/ocr_models/ocr_interface.py
+++ b/unstructured/partition/utils/ocr_models/ocr_interface.py
@@ -34,7 +34,7 @@ class OCRAgent(ABC):
         return cls.get_instance(ocr_agent_cls_qname, language)
 
     @staticmethod
-    @functools.lru_cache(maxsize=None)
+    @functools.lru_cache(maxsize=env_config.OCR_AGENT_CACHE_SIZE)
     def get_instance(ocr_agent_module: str, language: str) -> "OCRAgent":
         module_name, class_name = ocr_agent_module.rsplit(".", 1)
         if module_name not in OCR_AGENT_MODULES_WHITELIST:


### PR DESCRIPTION
## Problem
OCR agents used unlimited caching, causing excessive memory usage. Each cached OCR agent consumes different amounts of memory, but can easily consume ~800MB.

## Solution
Add `OCR_AGENT_CACHE_SIZE` environment variable to limit cached OCR agents per process.

- **Default**: 1 cached agent
- **Configurable**: Set to 0 to disable caching, or higher for more languages