### PR TITLE
fix: None text attribute when normalizing Picture to Image element

### DIFF
--- a/unstructured/partition/common/common.py
+++ b/unstructured/partition/common/common.py
@@ -50,7 +50,7 @@ def normalize_layout_element(
     else:
         layout_dict = layout_element
 
-    text = layout_dict.get("text", "")
+    text = layout_dict.get("text") or ""
     # Both `coordinates` and `coordinate_system` must be present
     # in order to add coordinates metadata to the element.
     coordinates = layout_dict.get("coordinates") if coordinate_system else None


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/Unstructured-IO/unstructured/issues/4084). Issue description is below: 

When using yolox as the Hi-res model for loading outputs / annotations, it annotates with bbox dimensions but missing text for complex images, resulting in text being set to None. But later on printing or accessing the Image element (__str__ method), it should be returning string instead of None.