### PR TITLE
⚡️ Speed up function `_kvform_pairs_to_dict` by 1,393%

### DIFF
--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -1054,11 +1054,18 @@ def _kvform_pairs_to_dict(orig_kv_pairs: list[FormKeyValuePair]) -> list[dict[st
     e.g. when FormKeysValues.to_dict() is used.
 
     """
-    kv_pairs: list[dict[str, Any]] = copy.deepcopy(orig_kv_pairs)  # type: ignore
-    for kv_pair in kv_pairs:
+    kv_pairs: list[dict[str, Any]] = []
+    for orig_pair in orig_kv_pairs:
+        kv_pair = dict(orig_pair)
+        kv_pair["key"] = dict(orig_pair["key"])
+        if kv_pair["value"] is not None:
+            kv_pair["value"] = dict(orig_pair["value"])
+
         if kv_pair["key"]["custom_element"] is not None:
             kv_pair["key"]["custom_element"] = kv_pair["key"]["custom_element"].to_dict()
         if kv_pair["value"] is not None and kv_pair["value"]["custom_element"] is not None:
             kv_pair["value"]["custom_element"] = kv_pair["value"]["custom_element"].to_dict()
+
+        kv_pairs.append(kv_pair)
 
     return kv_pairs


### PR DESCRIPTION
<!-- CODEFLASH_OPTIMIZATION: {"function":"_kvform_pairs_to_dict","file":"unstructured/documents/elements.py","speedup_pct":"1,393%","speedup_x":"13.93x","original_runtime":"65.6 milliseconds","best_runtime":"4.40 milliseconds","optimization_type":"general","timestamp":"2025-08-22T03:10:03.843Z","version":"1.0"} -->
### 📄 1,393% (13.93x) speedup for ***`_kvform_pairs_to_dict` in `unstructured/documents/elements.py`***

⏱️ Runtime :   **`65.6 milliseconds`**  **→** **`4.40 milliseconds`** (best of `84` runs)
### 📝 Explanation and details


The optimization replaces the expensive `copy.deepcopy()` operation with selective shallow copying, delivering a **1392% speedup**.

**Key Changes:**
- **Eliminated deepcopy bottleneck**: The original code spent 96.6% of runtime on `copy.deepcopy(orig_kv_pairs)`. The optimized version removes this entirely and builds the result list incrementally.
- **Selective copying strategy**: Instead of deep copying everything upfront, the code now:
  - Creates shallow copies of each pair with `dict(orig_pair)`
  - Explicitly copies only the `key` dict and `value` dict (when not None)
  - Leaves all other nested structures untouched unless they're the specific `custom_element` fields being converted

**Why This Works:**
- The function only mutates the `custom_element` fields by calling `to_dict()` on them
- All other data structures remain unchanged, so they don't need deep copying
- Shallow copying the immediate dict levels is sufficient to prevent mutation of the original input
- The `custom_element.to_dict()` calls create new dict objects anyway, so no additional copying is needed there

**Performance Impact by Test Case:**
- **Empty/small inputs**: 600-1200% faster - eliminates deepcopy overhead entirely
- **Large datasets**: Up to 1871% faster on 300+ element lists - the savings compound with input size
- **Mixed custom elements**: 1000-1500% faster - benefits regardless of how many elements need conversion

This optimization is particularly effective for this use case because the vast majority of the data structure remains immutable, making selective copying far more efficient than blanket deep copying.



✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **33 Passed** |
| ⏪ Replay Tests | ✅ **1 Passed** |
| 🔎 Concolic Coverage Tests | ✅ **1 Passed** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
from __future__ import annotations

import copy
from typing import Any

# imports
import pytest  # used for our unit tests
from unstructured.documents.elements import _kvform_pairs_to_dict

# ---- Helper Classes ----

class DummyElement:
    """A simple dummy class to mimic a custom_element with a to_dict method."""
    def __init__(self, data):
        self.data = data
    def to_dict(self):
        return {"dummy": self.data}

# ---- Unit Tests ----

# ------------------- Basic Test Cases -------------------

def test_empty_input_returns_empty_list():
    # Test with an empty input list
    codeflash_output = _kvform_pairs_to_dict([]) # 7.22μs -> 1.00μs (622% faster)

def test_single_pair_with_none_custom_elements():
    # Test a single pair where custom_element is None for both key and value
    kv_pairs = [
        {
            "key": {"custom_element": None, "other": 1},
            "value": {"custom_element": None, "other": 2}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 18.7μs -> 2.21μs (744% faster)
    # Ensure deep copy (modifying result does not touch input)
    result[0]["key"]["other"] = 999

def test_single_pair_with_custom_element_on_key():
    # Test a single pair with a custom_element on the key only
    kv_pairs = [
        {
            "key": {"custom_element": DummyElement("abc"), "other": "x"},
            "value": {"custom_element": None, "other": "y"}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 35.0μs -> 3.19μs (995% faster)

def test_single_pair_with_custom_element_on_value():
    # Test a single pair with a custom_element on the value only
    kv_pairs = [
        {
            "key": {"custom_element": None, "other": "k"},
            "value": {"custom_element": DummyElement(123), "other": "v"}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 33.2μs -> 3.05μs (988% faster)

def test_single_pair_with_custom_element_on_both():
    # Test a single pair with custom_element on both key and value
    kv_pairs = [
        {
            "key": {"custom_element": DummyElement("foo"), "other": "bar"},
            "value": {"custom_element": DummyElement("baz"), "other": "qux"}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 40.1μs -> 3.14μs (1177% faster)

def test_multiple_pairs_mixed_custom_elements():
    # Test multiple pairs with a mix of None and DummyElement
    kv_pairs = [
        {
            "key": {"custom_element": DummyElement(1), "other": "a"},
            "value": {"custom_element": None, "other": "b"}
        },
        {
            "key": {"custom_element": None, "other": "c"},
            "value": {"custom_element": DummyElement(2), "other": "d"}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 49.8μs -> 4.36μs (1041% faster)

# ------------------- Edge Test Cases -------------------

def test_pair_with_value_field_none():
    # Test with a pair where the value field itself is None
    kv_pairs = [
        {
            "key": {"custom_element": DummyElement("x"), "other": 1},
            "value": None
        }
    ]
    # Should not raise an error
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 29.3μs -> 2.54μs (1055% faster)

def test_pair_with_missing_custom_element_fields():
    # Test with missing custom_element field in key or value
    kv_pairs = [
        {
            "key": {"other": 1},
            "value": {"custom_element": DummyElement("v")}
        }
    ]
    # Should raise a KeyError since code expects 'custom_element' key
    with pytest.raises(KeyError):
        _kvform_pairs_to_dict(kv_pairs) # 29.8μs -> 2.75μs (985% faster)

def test_pair_with_extra_fields_untouched():
    # Test that extra fields are preserved and untouched
    kv_pairs = [
        {
            "key": {"custom_element": None, "extra": [1,2,3]},
            "value": {"custom_element": DummyElement("z"), "another": {"foo": "bar"}}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 38.3μs -> 3.09μs (1140% faster)

def test_pair_with_custom_element_to_dict_returning_non_dict():
    # Test when to_dict returns a non-dict type (should still assign as is)
    class WeirdElement:
        def to_dict(self):
            return "not a dict"
    kv_pairs = [
        {
            "key": {"custom_element": WeirdElement()},
            "value": {"custom_element": None}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 32.0μs -> 3.06μs (946% faster)

def test_original_input_is_deepcopied():
    # Modifying the result should not affect the original input
    kv_pairs = [
        {
            "key": {"custom_element": DummyElement("orig"), "other": {"deep": [1]}},
            "value": {"custom_element": None, "other": 2}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 35.5μs -> 2.90μs (1124% faster)
    result[0]["key"]["other"]["deep"].append(999)

def test_pair_with_nested_custom_element_to_dict():
    # Test where custom_element's to_dict returns nested dicts
    class NestedElement:
        def to_dict(self):
            return {"nested": {"foo": 1, "bar": [2,3]}}
    kv_pairs = [
        {
            "key": {"custom_element": NestedElement()},
            "value": {"custom_element": None}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 32.0μs -> 3.51μs (811% faster)

def test_pair_with_key_field_none():
    # Test with a pair where the key field itself is None
    kv_pairs = [
        {
            "key": None,
            "value": {"custom_element": DummyElement("v")}
        }
    ]
    # Should raise TypeError since code expects dict for key
    with pytest.raises(TypeError):
        _kvform_pairs_to_dict(kv_pairs) # 29.5μs -> 2.85μs (936% faster)

def test_pair_with_missing_key_or_value():
    # Test with missing key or value fields
    kv_pairs = [
        {
            "key": {"custom_element": DummyElement("k")},
            # "value" missing
        }
    ]
    with pytest.raises(KeyError):
        _kvform_pairs_to_dict(kv_pairs) # 28.9μs -> 2.29μs (1160% faster)

# ------------------- Large Scale Test Cases -------------------

def test_large_list_all_none_custom_elements():
    # Test with a large list (1000 elements) where all custom_element fields are None
    kv_pairs = [
        {
            "key": {"custom_element": None, "id": i},
            "value": {"custom_element": None, "id": i+1000}
        }
        for i in range(1000)
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 8.11ms -> 626μs (1195% faster)
    for i in range(0, 1000, 100):  # spot check a few
        pass

def test_large_list_with_mixed_custom_elements():
    # Test with a large list (500 elements) where half have DummyElement, half None
    kv_pairs = []
    for i in range(500):
        if i % 2 == 0:
            key_ce = DummyElement(i)
            value_ce = None
        else:
            key_ce = None
            value_ce = DummyElement(i)
        kv_pairs.append({
            "key": {"custom_element": key_ce, "id": i},
            "value": {"custom_element": value_ce, "id": i+500}
        })
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 6.98ms -> 428μs (1530% faster)
    for i in range(0, 500, 50):  # spot check
        if i % 2 == 0:
            pass
        else:
            pass

def test_large_list_preserves_deepcopy():
    # Test that deep copy is preserved for large lists
    kv_pairs = [
        {
            "key": {"custom_element": DummyElement(i), "deep": {"x": [i]}},
            "value": {"custom_element": None}
        }
        for i in range(100)
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 1.61ms -> 83.2μs (1829% faster)
    result[0]["key"]["deep"]["x"].append(999)

def test_large_list_with_all_custom_elements():
    # Test with a large list (1000 elements) where all custom_elements are DummyElement
    kv_pairs = [
        {
            "key": {"custom_element": DummyElement(i)},
            "value": {"custom_element": DummyElement(i+1000)}
        }
        for i in range(1000)
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 18.3ms -> 1.14ms (1508% faster)
    for i in range(0, 1000, 200):  # spot check
        pass
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
#------------------------------------------------
from __future__ import annotations

import copy
from typing import Any

# imports
import pytest
from unstructured.documents.elements import _kvform_pairs_to_dict


# Define a minimal FormKeyValuePair and a mock custom_element for testing
class MockCustomElement:
    """A mock object to simulate custom_element with a to_dict method."""
    def __init__(self, value):
        self.value = value
    def to_dict(self):
        # Return a dict representation
        return {"mocked": self.value}

# Type alias for clarity in tests
FormKeyValuePair = dict[str, Any]
from unstructured.documents.elements import _kvform_pairs_to_dict

# -------------------- UNIT TESTS --------------------

# -------------------- BASIC TEST CASES --------------------

def test_empty_list_returns_empty():
    # Test that an empty list returns an empty list
    codeflash_output = _kvform_pairs_to_dict([]) # 6.10μs -> 881ns (592% faster)

def test_single_pair_with_none_custom_elements():
    # Test a single pair with custom_element fields as None
    kv = {
        "key": {"custom_element": None, "other": 1},
        "value": {"custom_element": None, "other": 2}
    }
    codeflash_output = _kvform_pairs_to_dict([kv]); result = codeflash_output # 17.8μs -> 2.20μs (710% faster)

def test_single_pair_with_custom_elements():
    # Test a single pair with custom_element fields as MockCustomElement
    kv = {
        "key": {"custom_element": MockCustomElement("abc"), "other": 1},
        "value": {"custom_element": MockCustomElement("xyz"), "other": 2}
    }
    codeflash_output = _kvform_pairs_to_dict([kv]); result = codeflash_output # 40.5μs -> 3.59μs (1027% faster)

def test_multiple_pairs_mixed_custom_elements():
    # Test multiple pairs, some with custom_element, some None
    kv_pairs = [
        {
            "key": {"custom_element": MockCustomElement("a")},
            "value": {"custom_element": None}
        },
        {
            "key": {"custom_element": None},
            "value": {"custom_element": MockCustomElement("b")}
        },
        {
            "key": {"custom_element": None},
            "value": {"custom_element": None}
        }
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 50.6μs -> 4.55μs (1012% faster)

def test_original_list_is_deepcopied():
    # Test that the original list and dicts are not mutated
    kv = {
        "key": {"custom_element": MockCustomElement("foo")},
        "value": {"custom_element": None}
    }
    orig = [kv]
    codeflash_output = _kvform_pairs_to_dict(orig); out = codeflash_output # 29.6μs -> 2.81μs (953% faster)

# -------------------- EDGE TEST CASES --------------------

def test_pair_with_value_none():
    # Test when 'value' is None (not just value["custom_element"])
    kv = {
        "key": {"custom_element": MockCustomElement("k")},
        "value": None
    }
    # Should not raise, and not try to access value["custom_element"]
    codeflash_output = _kvform_pairs_to_dict([kv]); result = codeflash_output # 27.9μs -> 2.61μs (968% faster)

def test_pair_with_key_none():
    # Test when 'key' is None (not just key["custom_element"])
    kv = {
        "key": None,
        "value": {"custom_element": MockCustomElement("val")}
    }
    # Should raise KeyError, as code expects key["custom_element"]
    with pytest.raises(TypeError):
        _kvform_pairs_to_dict([kv]) # 28.7μs -> 2.93μs (877% faster)

def test_pair_missing_custom_element_field():
    # Test when 'custom_element' key is missing in key or value
    kv = {
        "key": {"other": 123},
        "value": {"custom_element": MockCustomElement("v")}
    }
    # Should raise KeyError for missing 'custom_element'
    with pytest.raises(KeyError):
        _kvform_pairs_to_dict([kv]) # 29.6μs -> 2.53μs (1067% faster)

def test_custom_element_to_dict_returns_non_dict():
    # Test if to_dict returns a non-dict object
    class OddCustomElement:
        def to_dict(self):
            return "notadict"
    kv = {
        "key": {"custom_element": OddCustomElement()},
        "value": {"custom_element": None}
    }
    codeflash_output = _kvform_pairs_to_dict([kv]); result = codeflash_output # 31.4μs -> 2.94μs (970% faster)

def test_custom_element_to_dict_raises():
    # Test if to_dict raises an Exception
    class BadCustomElement:
        def to_dict(self):
            raise ValueError("fail!")
    kv = {
        "key": {"custom_element": BadCustomElement()},
        "value": {"custom_element": None}
    }
    with pytest.raises(ValueError):
        _kvform_pairs_to_dict([kv]) # 31.3μs -> 3.44μs (810% faster)

def test_pair_with_extra_fields():
    # Test that extra fields in key/value dicts are preserved
    kv = {
        "key": {"custom_element": MockCustomElement("extra"), "foo": "bar"},
        "value": {"custom_element": None, "baz": 42},
        "meta": "data"
    }
    codeflash_output = _kvform_pairs_to_dict([kv]); result = codeflash_output # 33.5μs -> 2.98μs (1022% faster)

def test_pair_with_nested_custom_element_dict():
    # Test custom_element whose to_dict returns a nested dict
    class NestedCustomElement:
        def to_dict(self):
            return {"nested": {"deep": 1}}
    kv = {
        "key": {"custom_element": NestedCustomElement()},
        "value": {"custom_element": None}
    }
    codeflash_output = _kvform_pairs_to_dict([kv]); result = codeflash_output # 31.2μs -> 3.25μs (863% faster)

# -------------------- LARGE SCALE TEST CASES --------------------

def test_large_number_of_pairs():
    # Test function with a large list of pairs
    n = 1000
    kv_pairs = [
        {
            "key": {"custom_element": MockCustomElement(f"k{i}")},
            "value": {"custom_element": MockCustomElement(f"v{i}")}
        }
        for i in range(n)
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 18.2ms -> 1.17ms (1452% faster)
    for i in range(0, n, 100):  # spot check every 100th element
        pass

def test_large_number_of_pairs_with_nones():
    # Test with a large list, alternating None and custom_element
    n = 500
    kv_pairs = [
        {
            "key": {"custom_element": MockCustomElement(f"k{i}") if i % 2 == 0 else None},
            "value": {"custom_element": MockCustomElement(f"v{i}") if i % 2 == 1 else None}
        }
        for i in range(n)
    ]
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 6.16ms -> 416μs (1378% faster)
    for i in range(0, n, 50):  # spot check
        if i % 2 == 0:
            pass
        else:
            pass

def test_deepcopy_large_structure():
    # Ensure deepcopy works and original is not mutated on large input
    n = 300
    kv_pairs = [
        {
            "key": {"custom_element": MockCustomElement(f"k{i}"), "meta": [i]},
            "value": {"custom_element": None, "meta": [i*2]}
        }
        for i in range(n)
    ]
    orig = copy.deepcopy(kv_pairs)
    codeflash_output = _kvform_pairs_to_dict(kv_pairs); result = codeflash_output # 4.96ms -> 251μs (1871% faster)
    # Check original is unchanged
    for i in range(0, n, 50):
        pass
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
#------------------------------------------------
from unstructured.documents.elements import _kvform_pairs_to_dict

def test__kvform_pairs_to_dict():
    _kvform_pairs_to_dict([])
```

</details>

<details>
<summary>⏪ Replay Tests and Runtime</summary>

| Test File::Test Function                                                                                      | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:--------------------------------------------------------------------------------------------------------------|:--------------|:---------------|:----------|
| `test_pytest_test_unstructured__replay_test_0.py::test_unstructured_documents_elements__kvform_pairs_to_dict` | 447μs         | 200μs          | 123%✅    |

</details>

<details>
<summary>🔎 Concolic Coverage Tests and Runtime</summary>

| Test File::Test Function                                                                        | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:------------------------------------------------------------------------------------------------|:--------------|:---------------|:----------|
| `codeflash_concolic_ktxbqhta/tmppt0_ei25/test_concolic_coverage.py::test__kvform_pairs_to_dict` | 5.80μs        | 765ns          | 658%✅    |

</details>


To edit these changes `git checkout codeflash/optimize-_kvform_pairs_to_dict-mem95nq2` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)