### PR TITLE
chore: minor CHANGELOG.md update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 ### Enhancement
 - Improve the VoyageAI integration
 - Add voyage-context-3 support
-
-## 0.18.19-dev0
-
-### Enhancement
 - Flag extracted elements as such in the metadata for downstream use
 
 ### Features


### PR DESCRIPTION
last release actually should have been 0.18.19. let's skip it and just fix the CHANGELOG