### PR TITLE
fix: use vulnerabilityAlerts config instead of invalid packageRule ma…

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,21 +6,17 @@
     "github>unstructured-io/renovate-config"
   ],
 
-  // Enable automatic version bumping for Python security updates
-  "packageRules": [
-    {
-      "matchDatasources": ["pypi"],
-      "matchIsVulnerabilityAlert": true,
-      "postUpgradeTasks": {
-        "commands": [
-          "bash scripts/renovate-security-bump.sh"
-        ],
-        "fileFilters": [
-          "unstructured/__version__.py",
-          "CHANGELOG.md"
-        ],
-        "executionMode": "branch"
-      }
+  // Run version bump script for all vulnerability alert PRs
+  "vulnerabilityAlerts": {
+    "postUpgradeTasks": {
+      "commands": [
+        "bash scripts/renovate-security-bump.sh"
+      ],
+      "fileFilters": [
+        "unstructured/__version__.py",
+        "CHANGELOG.md"
+      ],
+      "executionMode": "branch"
     }
-  ]
+  }
 }


### PR DESCRIPTION
…tcher

Move postUpgradeTasks from packageRules to vulnerabilityAlerts object. The matchIsVulnerabilityAlert option doesn't exist in Renovate's schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts Renovate config to correctly trigger version bump tasks on security alerts.
> 
> - Removes `packageRules` with non-existent `matchIsVulnerabilityAlert`
> - Adds `vulnerabilityAlerts.postUpgradeTasks` to run `scripts/renovate-security-bump.sh` with specified `fileFilters` and `executionMode: branch`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 676af0a87990b0a7f6639708ff8f150fb0211433. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->