### PR TITLE
fix: pin deltalake<1.3.0 for ARM64 Docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.26
+
+### Fixes
+- Pin `deltalake<1.3.0` to fix ARM64 Docker builds (1.3.0 missing Linux ARM64 wheels)
+
 ## 0.18.25
 
 ### Fixes

--- a/requirements/ingest/ingest.txt
+++ b/requirements/ingest/ingest.txt
@@ -1,4 +1,7 @@
 unstructured-ingest[airtable, astradb, azure, azure-cognitive-search, bedrock, biomed, box, chroma, confluence, couchbase, databricks-volumes, delta-table, discord, dropbox, elasticsearch, embed-huggingface, embed-octoai, embed-vertexai, embed-voyageai, gcs, github, gitlab, google-drive, hubspot, jira, kafka, kdbai, milvus, mongodb, notion, onedrive, openai, opensearch, outlook, pinecone, postgres, qdrant, reddit, remote, s3, salesforce, sftp, sharepoint, singlestore, slack, vectara, weaviate, wikipedia]>=0.2.1
+# deltalake 1.3.0 is missing Linux ARM64 wheels (builder OOM'd), causing Docker ARM64 builds to fail.
+# Remove this constraint once deltalake publishes ARM64 wheels or unstructured-ingest adds the pin.
+deltalake<1.3.0
 s3fs>=2024.9.0
 urllib3>=2.4.0
 backoff>=2.2.1

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.25"  # pragma: no cover
+__version__ = "0.18.26"  # pragma: no cover


### PR DESCRIPTION
## Summary
- Pin `deltalake<1.3.0` to fix ARM64 Docker build failures

## Problem
`deltalake` 1.3.0 is missing Linux ARM64 wheels due to a builder OOM issue on their CI. When pip can't find a wheel, it tries to build from source, which fails because the Wolfi base image doesn't have a C compiler (`cc`).

This causes the `unstructured-ingest[delta-table]` install to fail, breaking the ARM64 Docker image.

https://github.com/delta-io/delta-rs/issues/4041

## Solution
Temporarily pin `deltalake<1.3.0` until:
- deltalake publishes ARM64 wheels for 1.3.0+, OR
- unstructured-ingest adds the pin to its `delta-table` extra

## Test plan
- [ ] ARM64 Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins a dependency to unblock ARM64 builds and publishes a patch release.
> 
> - Add `deltalake<1.3.0` to `requirements/ingest/ingest.txt` to avoid missing Linux ARM64 wheels breaking Docker builds
> - Bump version to `0.18.26` and add corresponding CHANGELOG entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4f15b4e060a039a8ec6d7e21abfb6b51139695e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->