### PR TITLE
perf: upgrade pdfminer-six to 20260107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.27-dev5
+
+### Enhancement
+- Upgrade pdfminer-six to 20260107 to fix ~15-18% performance regression from eager f-string evaluation
+
 ## 0.18.27-dev4
 
 ### Fixes

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -146,7 +146,7 @@ pandas==2.3.3
     # via unstructured-inference
 pdf2image==1.17.0
     # via -r extra-pdf-image.in
-pdfminer-six==20251230
+pdfminer-six==20260107
     # via
     #   -r extra-pdf-image.in
     #   unstructured-inference

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.27-dev4"  # pragma: no cover
+__version__ = "0.18.27-dev5"  # pragma: no cover


### PR DESCRIPTION
Fixes ~15-18% performance regression introduced in 20251230 where f-strings were evaluated eagerly even when logging was disabled.

See: https://github.com/pdfminer/pdfminer.six/issues/1233
Fix: https://github.com/pdfminer/pdfminer.six/pull/1234

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores PDF parsing performance by updating dependency and releasing a new dev version.
> 
> - **Deps:** Upgrade `pdfminer-six` from `20251230` to `20260107` in `requirements/extra-pdf-image.txt` to fix ~15–18% slowdown from eager f-string evaluation in logging
> - **Release:** Bump `__version__` to `0.18.27-dev5` and add CHANGELOG entry under *Enhancement*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dfed88a2a2ef90471e4e658c7c2ba82a99e4447. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->