### PR TITLE
fix: add EN DASH to UNICODE_BULLETS for clean_bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.18.20-dev0
+
+### Fixes
+- **Fix EN DASH not cleaned by `clean_bullets`**: Added EN DASH (`\u2013`) to `UNICODE_BULLETS` pattern so `clean_bullets` properly removes EN DASH bullet points without requiring `clean_dashes` (fixes #4105)
+
 ## 0.18.29
 
 ### Enhancement

--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -30,6 +30,9 @@ def test_clean_non_ascii_chars(text, expected):
         ("● An excellent point! ●●●", "An excellent point! ●●●"),
         ("An excellent point!", "An excellent point!"),
         ("Morse code! ●●●", "Morse code! ●●●"),
+        ("– An EN DASH bullet point!", "An EN DASH bullet point!"),
+        ("\u2013 Another EN DASH bullet!", "Another EN DASH bullet!"),
+        ("Text with – inside", "Text with – inside"),
     ],
 )
 def test_clean_bullets(text, expected):

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.29"  # pragma: no cover
+__version__ = "0.18.20-dev0"  # pragma: no cover

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -52,6 +52,7 @@ UNICODE_BULLETS: Final[List[str]] = [
     "\u29BE",
     "\u29BF",
     "\u002D",
+    "\u2013",
     "",
     r"\*",
     "\x95",


### PR DESCRIPTION
# Fix: Add EN DASH to clean_bullets

Fixes #4105

## What's the problem?

When using [clean_bullets()](cci:1://file:///root/74/silver/unstructured/unstructured/cleaners/core.py:36:0-48:31), the EN DASH character (`–`, `\u2013`) isn't recognized as a bullet point. This is a problem because some PDFs use EN DASH as bullet markers.

Currently, users have to call [clean_dashes()](cci:1://file:///root/74/silver/unstructured/unstructured/cleaners/core.py:336:0-344:50) as a workaround, but that removes *all* EN DASHes in the text—not just the ones at the start of lines.

## The fix

Added `\u2013` (EN DASH) to the `UNICODE_BULLETS` list in [patterns.py](cci:7://file:///root/74/silver/unstructured/unstructured/nlp/patterns.py:0:0-0:0). Now [clean_bullets()](cci:1://file:///root/74/silver/unstructured/unstructured/cleaners/core.py:36:0-48:31) handles EN DASH bullets the same way it handles other bullet characters.

## Testing

Added test cases to verify:
- EN DASH at the start of text is cleaned
- EN DASH in the middle of text is preserved
- Existing bullet types still work

All tests pass.

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=94194147