### PR TITLE
feat: add clean_newline helper function for hyphenated line breaks

### DIFF
--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -26,6 +26,37 @@ def test_clean_non_ascii_chars(text, expected):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        # Basic hyphenated line break
+        ("The docu-\nment is ready", "The document is ready"),
+        # Hyphen with multiple whitespace
+        ("impor-\n   tant information", "important information"),
+        # Multiple hyphenated words
+        ("The docu-\nment con-\ntains impor-\ntant info", "The document contains important info"),
+        # Hyphen at end of line with carriage return
+        ("This is a multi-\r\nline text", "This is a multiline text"),
+        # Hyphen with just spaces (no newline)
+        ("hyph-  enated word", "hyphenated word"),
+        # No hyphens should remain unchanged
+        ("This text has no hyphens", "This text has no hyphens"),
+        # Legitimate hyphens should remain (no whitespace after)
+        ("This has a self-contained word", "This has a self-contained word"),
+    ],
+)
+def test_clean_newline(text, expected):
+    assert core.clean_newline(text) == expected
+
+
+def test_clean_newline_custom_pattern():
+    """Test clean_newline with a custom pattern."""
+    text = "word1--word2"
+    custom_pattern = r"(\w+)--(\w+)"
+    result = core.clean_newline(text, pattern=custom_pattern)
+    assert result == "word1word2"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
         ("● An excellent point!", "An excellent point!"),
         ("● An excellent point! ●●●", "An excellent point! ●●●"),
         ("An excellent point!", "An excellent point!"),

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -34,6 +34,34 @@ def clean_non_ascii_chars(text) -> str:
     return en.decode()
 
 
+def clean_newline(text: str, pattern: str = r"(\w+)-\s+(\w+)") -> str:
+    """Cleans hyphenated words that are split across line breaks.
+
+    This function concatenates words that were split at the end of a line with
+    a hyphen, commonly found in text extracted from PDFs and other documents
+    where text wrapping causes words to break across lines.
+
+    Example
+    -------
+    "The docu-\\nment is ready" -> "The document is ready"
+    "impor-\\n   tant information" -> "important information"
+
+    Parameters
+    ----------
+    text
+        The text to clean
+    pattern
+        The regex pattern to match hyphenated line breaks.
+        Default matches word-hyphen-whitespace(including newlines)-word.
+
+    Returns
+    -------
+    str
+        The text with hyphenated line breaks resolved
+    """
+    return re.sub(pattern, r"\1\2", text)
+
+
 def clean_bullets(text: str) -> str:
     """Cleans unicode bullets from a section of text.
 


### PR DESCRIPTION
## Description

This PR addresses Issue #2513 by adding a `clean_newline` helper function to the cleaners module.

## Changes

- Added `clean_newline()` function to `unstructured/cleaners/core.py`
- Added comprehensive tests in `test_unstructured/cleaners/test_core.py`

## Implementation

The function concatenates words that were split at the end of a line with a hyphen, commonly found in text extracted from PDFs and other documents where text wrapping causes words to break across lines.

```python
def clean_newline(text: str, pattern: str = r"(\w+)-\s+(\w+)") -> str:
    """Cleans hyphenated words that are split across line breaks."""
    return re.sub(pattern, r'\1\2', text)
```

## Examples

```python
>>> from unstructured.cleaners.core import clean_newline
>>> clean_newline("The docu-\nment is ready")
'The document is ready'
>>> clean_newline("impor-\n   tant information")
'important information'
```

## Testing

Added the following test cases:
- Basic hyphenated line break
- Hyphen with multiple whitespace
- Multiple hyphenated words in one string
- Hyphen at end of line with carriage return
- Hyphen with just spaces (no newline)
- Text with no hyphens (should remain unchanged)
- Legitimate hyphens should remain (e.g., "self-contained")
- Custom pattern support

Run tests with:
```bash
pytest test_unstructured/cleaners/test_core.py -v -k "clean_newline"
```

Closes #2513