### PR TITLE
Fix: make pdf image dpi consistent <- Ingest test fixtures update

### DIFF
--- a/test_unstructured_ingest/expected-structured-output-html/azure/IRS-form-1987.pdf.html
+++ b/test_unstructured_ingest/expected-structured-output-html/azure/IRS-form-1987.pdf.html
@@ -7,8 +7,8 @@
   </title>
  </head>
  <body>
-  <h1 class="Title" id="f78db4158d91e24ff80f4c4ffd75f936">
-   FM) Department of the Treasury Internal Revenue Service Instructions for Form 3115 (Rev. November 1987) Application for Change in Accounting Method
+  <h1 class="Title" id="a278e93c883ff4444a18689f657a2a38">
+   Ay Department of the Treasury Internal Revenue Service Instructions for Form 3115 (Rev. November 1987) Application for Change in Accounting Method
   </h1>
   <p class="NarrativeText" id="5801c515b515aadfb7717e4c36a4cea4">
    (Section references are to the Internal Revenue Code unless otherwise noted.)
@@ -25,23 +25,23 @@
   <h1 class="Title" id="85af235e687b4a6537e5542a42456d25">
    Purpose of Form
   </h1>
-  <p class="NarrativeText" id="8753b1907d0b40b882489a68baf3fe2c">
-   File this form to request a change in your accounting method, including the accounting treatment of any item. If you are requesting a change in accounting period, use Form 1128, Application for Change in Accounting Period. For more information, see Publication 538, Accounting Periods and Methods.
+  <p class="NarrativeText" id="21dd0367f76fe2f5f1c553ea7b901857">
+   File this form to request a change in your accounting method, including the accounting treatment of any item. If you are requesting a change In accounting period, use Form 1128, Application for Change in Accounting Period. For more information, see Publication 538, Accounting Periods and Methods.
   </p>
-  <p class="NarrativeText" id="741b30ff5f4f03b9c65c419649d8a97d">
-   When filing Form 3115, taxpayers are reminded to determine if IRS has published a ruling or procedure dealing with the specific type of change since November 1987 (the current revision date of Form 3115)
+  <p class="NarrativeText" id="0cf9161971e9ea8feec111ff7d24f403">
+   When filing Form 3115, taxpayers are reminded to determine if IRS has published a ruling or procedure dealing with the specific type of change since November 1987 (the current revision date of Form 3115),
   </p>
   <p class="NarrativeText" id="0fb8eb24db1b27f6f8b69213e3dd9b41">
    Long-term contracts. —If you are required to change your method of accounting for long-term contracts under section 460, see Notice 87-61 (9/21/87), 1987-38 IRB 40, for the notification procedures that must be followed.
   </p>
-  <p class="NarrativeText" id="f225ebefe4a8aa2af646f50d4422c3a3">
-   Other methods. —Unless the Service has published a regulation or procedure to the contrary, all other changes tn accounting methods required by the Act are automatically considered to be approved by the Commissioner. Examples of method changes automatically approved by the Commissioner are those changes required to effect: (1) the repeal of the reserve method for bad debts of taxpayers other than financial institutions (Act section 805); (2) the repeal of the installment method for sales under a revolving credit plan (Act section 812); (3) the inclusion of income attributable to the sale or furnishing of utility services no later than the year in which the services were provided to customers (Act section 821); and (4) the repeal of the deduction for qualified discount coupons (Act section 823). Do not file Form 3115 for these changes.
+  <p class="NarrativeText" id="fd78f4e1d471af7ddb468878e4401dab">
+   Other methods.—Unless the Service has published a regulation or procedure to the contrary, all other changes tn accounting methods required by the Act are automatically considered to be approved by the Commissioner. Examples of method changes automatically approved by the Commissioner are those changes required to effect: (1) the repeal of the reserve method for bad debts of taxpayers other than financial institutions (Act section 805); (2) the repeal of the installment method for sales under a revolving credit plan (Act section 812); (3) the inclusion of income attributable to the sale or furnishing of utility services no later than the year in which the services were provided to customers (Act section 821); and (4) the repeal of the deduction for qualified discount coupons (Act section 823). Do not file Form 3115 for these changes.
   </p>
   <p class="NarrativeText" id="2826b3c8ca76c4125969a1f820d84dbd">
    Generally, applicants must complete Section A. In addition, complete the appropriate sections (B-1 through H) for which a change |s desired.
   </p>
-  <p class="NarrativeText" id="c91bf5618a9b5a45f1bc3ed4c58a9094">
-   You must give all relevant facts, including a detailed description of your present and proposed methods. You must also state the reason(s) you believe approval to make the requested change should be granted. Attach additional pages if more space is needed for explanations. Each page should show your name, address, and identifying number
+  <p class="NarrativeText" id="b8f9f1fdeffadd34472959092459fba9">
+   You must give all relevant facts, including a detailed description of your present and proposed methods. You must also state the reason(s) you believe approval to make the requested change should be granted. Attach additional pages if more space is needed for explanations. Each page should show your name, address, and identifying number.
   </p>
   <p class="NarrativeText" id="b7ac9f40a0b010ca0f9a6dedba12a95c">
    State whether you desire a conference In the National Office if the Service proposes to disapprove your application.
@@ -49,11 +49,11 @@
   <h1 class="Title" id="45da2e5561453f7cdfcf31c1ace13cf0">
    Changes to Accounting Methods Required Under the Tax Reform Act of 1986
   </h1>
-  <p class="NarrativeText" id="dd15989799b65cd7f3aa7f292e3acda0">
-   Uniform capitalization rules and limitation on cash method.—f you are required to change your method of accounting under section,263A (relating to the capitalization and inclusion in inventory costs of certain expenses) or 448 (limiting the use of the cash method of accounting by certain taxpayers) as added by the Tax Reform Act of 1986 (“Act”), the change Is treated as initiated by the taxpayer, approved by the Commissioner, and the period for taking the adjustments under section 481(a) into account will not exceed 4 years. (Hospitals required to change from the cash method under section 448 have 10 years to take the adjustrnents into account.) Complete Section A and the appropriate sections (B-1 or C and D) for which the change is required.
+  <p class="NarrativeText" id="158783669b4b944ae0057b632797dcfe">
+   Uniform capitalization rules and Jimitation on cash method.—f you are required to change your method of accounting under section,263A (relating to the capitalization and inclusion in inventory costs of certain expenses) or 448 (limiting the use of the cash method of accounting by certain taxpayers) as added by the Tax Reform Act of 1986 (“Act”), the change !s treated as Initiated by the taxpayer, approved by the Commissioner, and the period for taking the adjustments under section 481(a) into account will not exceed 4 years. (Hospitals required to change from the cash method under section 448 have 10 years to take the adjustrnents into account.) Complete Section A and the appropriate sections (B-1 or C and D) for which the change is required.
   </p>
-  <p class="NarrativeText" id="7adee4d7e6f11ddd9cca7bd3506117dc">
-   Disregard the instructions under Time and Place for Filing and Late Applications. Instead, attach Form 3115 to your income tax return for the year of change; do not file it separately. Also include on a separate statement accompanying the Form 3115 the period over which the section 481(a) adjustment will be taken into account and the basis for that conclusion. Identify the automatic change being made at the top of page 1 of Form 3115 (e.g., “Automatic Change to Accrual Method—Section 448"). See Temporary Regulations sections 1.263A-1T and 1.448-1T for additional information
+  <p class="NarrativeText" id="486102e7c1f95b669f23516c52b4b22a">
+   Disregard the instructions under Time and Place for Filing and Late Applications. Instead, attach Form 3115 to your income tax return for the year of change; do not file it separately. Also include on a separate statement accompanying the Form 3115 the period over which the section 481(a) adjustment will be taken into account and the basis for that conclusion. Identify the automatic change being made at the top of page 1 of Form 3115 (e.g., “Automatic Change to Accrual Method—Section 448”). See Temporary Regulations sections 1.263A-1T and 1.448-1T for additional information.
   </p>
   <h1 class="Title" id="daacd181c8b4c9cdeaa9762e5efd3586">
    Time and Place for Filing
@@ -85,8 +85,8 @@
   <p class="NarrativeText" id="8702d8676330458b169220b33924e3e2">
    Individuals. —An individual should enter his or her social security number in this block. If the application is made on behalf of a husband and wife who file their income tax return jointly, enter the social security numbers of both.
   </p>
-  <p class="NarrativeText" id="4a9b9ec8ba60e739f49cfd240aa4439f">
-   Others.-—The employer identification number of an applicant other than an individual should be entered in this block.
+  <p class="NarrativeText" id="5ab614de4ef721a684e4e8e0c8fb5788">
+   Others.-—The employer identification number of an applicant other than an individual should be entered tn this block.
   </p>
   <h1 class="Title" id="4751d71840e9b5cab30cc47704dae731">
    Signature
@@ -94,8 +94,8 @@
   <p class="NarrativeText" id="3c683355b205b83c4c0d3437e6cfa7e1">
    Individuals. —An individual desiring the change should sign the application. If the application pertains to a husband and wife filing a joint income tax return, the names of both should appear in the heading and both should sign.
   </p>
-  <p class="NarrativeText" id="e8cfd8f6db0442ba89ebad7a26a61fe9">
-   Partnerships.—The form should be signed with the partnership name followed by the signature of one of the general partners and the words “General Partner.”
+  <p class="NarrativeText" id="1a487e582980fedf46613e0848befc44">
+   Partnerships.—The form shouid be signed with the partnership name followed by the signature of one of the general partners and the words “General Partner.”
   </p>
   <p class="NarrativeText" id="28ac207401b182955c7f456e4ed569e7">
    Corporations, cooperatives, and insurance companies.—The form should show the name of the corporation, cooperative, or insurance company and the signature of the president, vice president, treasurer, assistant treasurer, or chief accounting officer (such as tax officer) authorized to sign, and his or her official title. Receivers, trustees, or assignees must sign any application they are required to file. For a subsidiary corporation filing a consolidated return with its parent, the form should be signed by an officer of the parent corporation.
@@ -118,20 +118,20 @@
   <h1 class="Title" id="5a646ca8e56ece623a47079b32e62fc6">
    Specific Instructions
   </h1>
-  <h1 class="Title" id="1505240fbe441adc4acdbc867689af29">
-   SectionA
+  <h1 class="Title" id="e0e692b1f478333e3950f8cb2483a484">
+   Section A
   </h1>
-  <p class="NarrativeText" id="1010f24ec42ba67381ab00d6bab4f64e">
-   Item 5a, page 1.—“Taxable income or (loss) from operations” is to be entered before application of any net operating !oss deduction under section 172(a).
+  <p class="NarrativeText" id="e6ef62be27627e0886c49f013b3eb389">
+   Item 5a, page 1.— “Taxable income or (loss) from operations” is to be entered before application of any net operating loss deduction under section 172(a).
   </p>
   <p class="NarrativeText" id="5a797a3ffef4100ca3d0100c1812979f">
    Item 6, page 2.—The term “gross receipts” includes total sales (net of returns and allowances) and all amounts received for services. In addition, gross receipts include any income from investments and from incidental or outside sources (e.g., interest, dividends, rents, royalties, and annuities). However, if you area resaler of personal property, exclude from gross receipts any amounts not derived in the ordinary course of a trade or business. Gross receipts do not include amounts received for sales taxes if, under the applicable state or local law, the tax is legally imposed on the purchaser of the good or service, and the taxpayer merely collects and remits the tax to the taxing authority.
   </p>
-  <p class="NarrativeText" id="803aea48f7a67d05a1f325166686e26a">
-   Item 7b, page 2.—If item 7b Is “Yes,” indicate ona separate sheet the following for each separate trade or business: Nature of business
+  <p class="NarrativeText" id="31b52f9f7ca8d75190858bf0d55805db">
+   Item 7b, page 2.—If item 7b 1s “Yes,” indicate on a separate sheet the following for each separate trade or business: Nature of business
   </p>
-  <p class="NarrativeText" id="3ff02da9894f328f5ac2810bbe7ba61a">
-   (manufacturing, retailer, wholesaler, etc.), employer identification number, overall method of accounting, and whether, in the last 6 years, that business has changed its accounting method, or Is also changing its accounting method as part of this request or as a separate request.
+  <p class="NarrativeText" id="a34b5c633b40ae532a293aa5ece41ff6">
+   (manufacturing, retailer, wholesaler, etc.), employer identification number, overall method of accounting, and whether, in the last 6 years, that business has changed its accounting method, or is also changing its accounting method as part of this request or as a separate request.
   </p>
   <p class="NarrativeText" id="28d8006c1f48ce2aec42391c8318fc8a">
    Item 11, page 2.—If you cannot provide the requested information, you may sign a statement under penalties of perjury that:
@@ -142,35 +142,35 @@
   <p class="NarrativeText" id="1dbbb077a11837f518df88bb5103f8c6">
    (2) Explains in detail why you cannot provide the requested information.
   </p>
-  <p class="NarrativeText" id="f5150d77d7e1cc7d6dc4d5928c6a0ad0">
-   See section 5.06(2) of Rev. Proc. 84-74 for the required perjury statement that must be attached.
+  <p class="NarrativeText" id="69c4ed1728897f266bed4a53365bcafa">
+   See section 5,06(2) of Rev. Proc. 84-74 for the required perjury statement that must be attached.
   </p>
   <p class="NarrativeText" id="7dfd48d6268b5b5a7ee2815aeee3ed4c">
    If IRS later examines your return for the year of the change or for later years, it has the right to verify your statement at that time.
   </p>
-  <p class="NarrativeText" id="3e968ed0cd6eeceea5ac7473b6ea957b">
-   Item 13, page 2.—Insert the actual number of tax years. Use of the term “since inception” is not acceptable. However, “more than 6 years” !s acceptable.
+  <p class="NarrativeText" id="fb1b9c839bbca33510a6374d1e860e6e">
+   Item 13, page 2.— Insert the actual number of tax years. Use of the term “since inception” Is not acceptable. However, “more than 6 years” Is acceptable.
   </p>
   <h1 class="Title" id="3e880cc1372ef2191411caec8044548d">
    Section B-1
   </h1>
-  <p class="NarrativeText" id="fd7024d7ebbfd93449699e3569bc504c">
-   Item 1b, page 2.—Include any amounts reported as income ina prior year although the income had not been accrued (earned) or received in the prior year; for example, discount on installment loans reported as income for the year in which the loans were made instead of for the year or years in which the income was received or earned. Advance payments under Rev. Proc. 71-21 or Regulations section 1.451-5 must be fully explained and all pertinent information must be submitted with this application
+  <p class="NarrativeText" id="f239c78f0866a8a41d36370f128676b6">
+   Item 1b, page 2.—Include any amounts reported as income in a prior year although the income had not been accrued (earned) or received In the prior year; for example, discount on installment loans reported as income for the year In which the loans were made instead of for the year or years in which the income was received or earned. Advance payments under Rev. Proc. 71-21 or Regulations section 1.451-5 must be fully explained and all pertinent information must be submitted with this application.
   </p>
   <h1 class="Title" id="1f5704b56b007d890b634121c86d81ac">
    Sections B-2 and B-3
   </h1>
-  <p class="NarrativeText" id="9307e539e4f3ec48cec57ac058cb5d7a">
-   Limitation on the Use of the Cash Method of Accounting. —Except as provided below, C corporations, partnerships with a C corporation as a partner, and tax shelters may not use the cash method of accounting. For purposes of this limitation, a trust subject to the tax on unrelated business income under section 511 is treated as aC corporation with respect to its unrelated trade or business activities.
+  <p class="NarrativeText" id="6720eba15ed08f5d66f8dc84b6a94fa8">
+   Limitation on the Use of the Cash Method of Accounting.—Except as provided below, C corporations, partnerships with a C corporation as a partner, and tax shelters may not use the cash method of accounting. For purposes of this limitation, a trust subject to the tax on unrelated business Income under section 511 1s treated as aC corporation with respect to its unrelated trade or business activities.
   </p>
   <p class="NarrativeText" id="454de5bfbdcba4385a21dd6261c57d53">
    The limitation on the use of the cash method (except for tax shelters) does not apply to—
   </p>
-  <p class="NarrativeText" id="fc1f0d4d56acd27a18ba80ab0acfb9e9">
-   (1) Farming businesses.—F or this purpose, the term “farming business” 1s defined in section 263A(e)(4), but it also includes the raising, harvesting, or growing of trees to which section 263A(c)(5) applies. Notwithstanding this exception, section 447 requires certain C corporations and partnerships with a C corporation as a partner to use the accrual method.
+  <p class="NarrativeText" id="22e4f1d701efc16645e77991781051f5">
+   (1) Farming businesses. —For this purpose, the term “farming business” is defined in section 263A(e)(4), but it also includes the raising, harvesting, or growing of trees to which section 263A(c)(5) applies. Notwithstanding this exception, section 447 requires certain C corporations and partnerships with a C corporation as a partner to use the accrual method.
   </p>
-  <p class="NarrativeText" id="4b957afb9ee0144c57063ae3f8813c49">
-   (2) Qualified personal service corporations. — A “qualified personal service corporation” is any corporation: (a) substantially all of the activities of which involve the performance of services In the fields of health, law, engineering, architecture, accounting, actuarial science, performing arts, or consulting, and (b)
+  <p class="NarrativeText" id="7d5701b44f1ad554006cf31e8efeb719">
+   (2) Qualified personal service corporations. — A “qualified personal service corporation” 1s any corporation: (a) substantially all of the activities of which involve the performance of services In the fields of health, law, engineering, architecture, accounting, actuarial science, performing arts, or consulting, and (b)
   </p>
   <h1 class="Title" id="80474543fe96478feeda72a22f019cd1">
    Page 2
@@ -178,17 +178,17 @@
   <p class="NarrativeText" id="e4776aaec9edf7383c95941623c47ff6">
    substantially all of the stock of which is owned by employees performing the services, retired employees who had performed the services, any estate of any individual who had performed the services listed above, or any person who acquired stock of the corporation as a result of the death of an employee or retiree described above if the acquisition occurred within 2 years of death.
   </p>
-  <p class="NarrativeText" id="7bd3982f648c6d35765fee5a195619c0">
-   (3) Entities with gross receipts of $5,000,000 or less. —To qualify for this exception, the C corporation’s or partnership’s annual average gross receipts for the three years ending with the prior tax year may not exceed $5,000,000. !f the corporation or partnership was not in existence for the entire 3-year period, the period of existence Is used to determine whether the corporation or partnership qualifies. If any tax year in the 3-year period is a short tax year, the corporation or partnership must annualize the gross receipts by multiplying the gross receipts by 12 and dividing the result by the number of months tn the short period.
+  <p class="NarrativeText" id="6ee9a057174e1c9cf99d653ad1c09371">
+   (3) Entities with gross receipts of $5,000,000 or less. —To qualify for this exception, the C corporation’s or partnership’s annual average gross receipts for the three years ending with the prior tax year may not exceed $5,000,000. If the corporation or partnership was not in existence for the entire 3-year period, the period of existence Is used to determine whether the corporation or partnership qualifies. If any tax year in the 3-year period is a short tax year, the corporation or partnership must annualize the gross receipts by multiplying the gross receipts by 12 and dividing the result by the number of months tn the short period.
   </p>
-  <p class="NarrativeText" id="138fd3015529f8bd386da37b0de434d7">
-   For more information, see section 448 and Temporary Regulations section 1.448-1T
+  <p class="NarrativeText" id="427e5fe33c8c181ccb93c7de11946c13">
+   For more information, see section 448 and Temporary Regulations section 1.448-1T.
   </p>
   <h1 class="Title" id="53f108c0145a6e0ff0c71192756817f3">
    Section C
   </h1>
-  <p class="NarrativeText" id="c67e8f108a1f0f6f6820d1f6a599ab02">
-   Applicants must give complete details about the present method of valuing inventory and the proposed method. State whether all or part of your inventory ts involved in the change.
+  <p class="NarrativeText" id="e2f18bc74e6cafcd9692b5daf1849492">
+   Applicants must give complete details about the present method of valuing inventory and the proposed method. State whether all or part of your inventory ts involved tn the change.
   </p>
   <p class="NarrativeText" id="215447c644517536b7bda561f7e92994">
    Inventories of retail merchants.—The retail method of pricing inventories does not contemplate valuation of goods at the retail selling price. The retail selling price of goods on hand must be reduced to approximate cost or cost or market, whichever is lower, by the adjustments required in Regulations section 1.471-8.
@@ -199,8 +199,8 @@
   <p class="NarrativeText" id="4d46c2d1fc2022eca60307767c40de5e">
    (1) The specific types and classes of goods in the LIFO inventories involved in the proposed changes and the comparative value of such inventories as of the end of the tax year preceding the year of change determined by: (a) the LIFO method, and (b) the proposed method and basis (such as FIFO cost or lower of cost or market).
   </p>
-  <p class="NarrativeText" id="dca354b76d6465ac0b8e2f4875bb532f">
-   (2) State whether the proposed identification and valuation methods conform to the inventory method currently used with respect to non-LIFO inventories, if any, or how such method is otherwise consistent with Regulations section 1.472-6.
+  <p class="NarrativeText" id="294b1260ca3b5c9f0ba0d989ea96ac31">
+   (2) State whether the proposed identification and valuation methods conform to the inventory method currently used with respect to non-LIFO Inventories, if any, or how such method is otherwise consistent with Regulations section 1.472-6.
   </p>
   <p class="NarrativeText" id="38bdbab3ffbac579f7574b14e684ba33">
    (3) The termination event statement required by section 5.10 of Rev. Proc. 84-74 and an explanation if there has been a termination event.
@@ -211,14 +211,14 @@
   <p class="NarrativeText" id="7ee33bcf10d7639196914b65fd469696">
    Applicants requesting to change their method of valuing property produced, property acquired for resale, or long-term contracts under section 263A or 460 MUST complete section D showing the treatment under both the present and proposed methods.
   </p>
-  <p class="NarrativeText" id="75f4fb193debfbf1f8dd60aca82837df">
-   ® U.S. Government Printing Office: 1987—201-993/60166
+  <p class="NarrativeText" id="ac03b00e18c3ba3be848b73947358f1b">
+   &amp; U.S. Government Printing Office: 1987—201-993/60166
   </p>
   <h1 class="Title" id="049500f268fce8fc31b6ff3fbd31d0ff">
    Section E
   </h1>
-  <p class="NarrativeText" id="a684d77321935da5475b080bc2ab7e28">
-   Section 460(f) provides that the term “long-term contract” means any contract for the manufacturing, building, installation, or construction of property that is not completed within the tax year in which it is entered into. However, a manufacturing contract will not qualify as a long-term contract unless the contract involves the manufacture of: (1) a unique item not normally included in your finished goods inventory, or (2) any item that normally requires more than 12 calendar months to complete.
+  <p class="NarrativeText" id="8f23a32fb527d5d2c99e6ce9d43a0506">
+   Section 460(f) provides that the term “long-term contract” means any contract for the manufacturing, building, installation, or construction of property that is not completed within the tax year in which it is entered into. However, a manufacturing contract will not qualify as a long-term contract unless the contract involves the manufacture of: (1)a unique item not normally included in your finished goods inventory, or (2) any item that normally requires more than 12 calendar months to complete.
   </p>
   <p class="NarrativeText" id="87c912787c7a57a6a9762222b6fad6d0">
    All long-term contracts entered into after February 28, 1986, except for real property construction contracts expected to be completed within 2 years by contractors whose average annual gross receipts for the 3 prior tax years do not exceed $10,000,000, must be accounted for using either the percentage of completion- capitalized cost method or the percentage of completion method. See section 460.
@@ -229,20 +229,20 @@
   <h1 class="Title" id="4791a3266557b2140bd00383e0175156">
    Section G
   </h1>
-  <p class="NarrativeText" id="daecf7c8c48c378964d6932150a8ea06">
-   This section 1s to be used only to request a change in a method of accounting for depreciation under section 167.
+  <p class="NarrativeText" id="f4d23d878433825c90ab6e6090d9ece6">
+   This section ts to be used only to request a change in a method of accounting for depreciation under section 167.
   </p>
-  <p class="NarrativeText" id="498cf287a4930d9bd8d6ce89ee3018e9">
-   Rev. Proc. 74-11 provides a procedure whereby applicants are considered to have obtained the consent of the Commissioner to change their method of accounting for depreciation. You must file Form 3115 with the Service Center where your return will be filed within the first 180 days of the tax year in which it is desired to make the change. Attach.a copy of the form to the income tax return for the tax year of the change.
+  <p class="NarrativeText" id="2854aca9e6a37d275a60a126e431ef6e">
+   Rev. Proc. 74-11 provides a procedure whereby applicants are considered to have obtained the consent of the Commissioner to change their method of accounting for depreciation. You must file Form 3115 with the Service Center where your return will be filed within the first 180 days of the tax year in which it is desired to make the change. Attach a copy of the form to the income tax return for the tax year of the change.
   </p>
-  <p class="NarrativeText" id="bc3d896ded808d99ce1a66ccdc30a5a6">
-   Note: Do not use Form 3115 to make an election under section 168. Such an election may be made only on the tax return for the year in which the property is placed in service. In addition, Form 3115 is not to be used to request approval to revoke an election made under section 168. Such a request must be made in accordance with Rev. Proc. 87-1 (updated annually).
+  <p class="NarrativeText" id="4fb331478f9a833e74ffd537b02e26d2">
+   Note: Do not use Form 3115 to make an election under section 168. Such an election may be made only on the tax return for the year in which the property is placed tn service. In addition, Form 3115 is not to be used to request approval to revoke an election made under section 168. Such a request must be made in accordance with Rev. Proc. 87-1 (updated annually).
   </p>
   <h1 class="Title" id="bffd98608b117004651716ad50fd2aa3">
    Section H
   </h1>
-  <p class="NarrativeText" id="2c3490b47d0f31f3fd0ccdb75286b1df">
-   Generally, this section should be used for requesting changes in a method of accounting for which provision has not been made elsewhere on this form. Attach additional pages if more space ts needed for a full explanation of the present method used and the proposed change requested.
+  <p class="NarrativeText" id="8b524af5086ce3b0afc2c395be45ba33">
+   Generally, this section should be used for requesting changes !n a method of accounting for which provision has not been made elsewhere on this form. Attach additional pages if more space ts needed for a full explanation of the present method used and the proposed change requested.
   </p>
   <p class="NarrativeText" id="ce1245e8b15f12dac06016bec84193aa">
    If you are making an election under section 458, show the applicable information under Regulations section 1.458-10.

--- a/test_unstructured_ingest/expected-structured-output-html/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.html
+++ b/test_unstructured_ingest/expected-structured-output-html/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.html
@@ -25,8 +25,8 @@
   <p class="UncategorizedText" id="4608f9aa33a0cab158565817b0d15743">
    v
   </p>
-  <p class="UncategorizedText" id="6f69e5f921907e689f1a52bd84282b31">
-   arXiv
+  <p class="UncategorizedText" id="32c128c3cfeca2ab12b98d336ccfddfc">
+   arX1V
   </p>
   <p class="UncategorizedText" id="ed4e590932b333f40d0e1367b6b0e32e">
    i
@@ -43,8 +43,8 @@
   <h1 class="Title" id="d3be9e3d661e2a79f37257caa5b54d8c">
    LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis
   </h1>
-  <p class="NarrativeText" id="97c951d2dd3a1b5452d0c55e62e8ea78">
-   Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson’, and Weining Li®
+  <p class="NarrativeText" id="4dfee7e352ae892814e46bb220094b0f">
+   Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson®, and Weining Li&gt;
   </p>
   <p class="NarrativeText" id="23b8def20ce16f929d4f558b2a19f200">
    1 Allen Institute for AI shannons@allenai.org 2 Brown University ruochen zhang@brown.edu 3 Harvard University {melissadell,jacob carlson}@fas.harvard.edu 4 University of Washington bcgl@cs.washington.edu 5 University of Waterloo w422li@uwaterloo.ca
@@ -55,10 +55,13 @@
   <p class="NarrativeText" id="caffc7480fdd82a089ae387e01aabdb9">
    Keywords: Document Image Analysis · Deep Learning · Layout Analysis · Character Recognition · Open Source library · Toolkit.
   </p>
-  <h1 class="Title" id="3a170066f972d25cc303a05ddc16d52c">
-   1 Introduction
+  <p class="UncategorizedText" id="fac7bfe169d228f12a722b04ec288ac3">
+   1
+  </p>
+  <h1 class="Title" id="b80c5d03ae12c07fd94fe7ce85ff75e5">
+   Introduction
   </h1>
-  <p class="NarrativeText" id="8de96d1e80af35f9b6954252e14c2caf">
+  <p class="NarrativeText" id="c676c7c3cc942056073be2efe4a7fbfc">
    Deep Learning(DL)-based approaches are the state-of-the-art for a wide range of document image analysis (DIA) tasks including document image classiﬁcation [11,
   </p>
   <h1 class="Title" id="e7e0acf197e89d650d39fa3ce929509e">
@@ -91,9 +94,9 @@
   <p class="NarrativeText" id="583775f22c8080098beebbef960e2fbf">
    LayoutParser is well aligned with recent eﬀorts for improving DL model reusability in other disciplines like natural language processing [8, 34] and com- puter vision [35], but with a focus on unique challenges in DIA. We show LayoutParser can be applied in sophisticated and large-scale digitization projects
   </p>
-  <h1 class="Title" id="f5a6697190c20bf6030d8e4ae8f6861a">
+  <li class="ListItem" id="f5a6697190c20bf6030d8e4ae8f6861a">
    LayoutParser: A Uniﬁed Toolkit for DL-Based DIA
-  </h1>
+  </li>
   <p class="NarrativeText" id="50846086f4d9ece02052735686278699">
    that require precision, eﬃciency, and robustness, as well as simple and light- weight document processing tasks focusing on eﬃcacy and ﬂexibility (Section 5). LayoutParser is being actively maintained, and support for more deep learning models and novel methods in text-based layout analysis methods [37, 34] is planned.
   </p>
@@ -112,15 +115,15 @@
   <p class="NarrativeText" id="73feaff827cbc7089d3f95d1e5aac6aa">
    Recent years have also seen numerous eﬀorts to create libraries for promoting reproducibility and reusability in the ﬁeld of DL. Libraries like Dectectron2 [35],
   </p>
-  <div class="Footer" id="b1fa4bbd1bdda08489faab5bf3adf5cc">
+  <li class="ListItem" id="b1fa4bbd1bdda08489faab5bf3adf5cc">
    6 The number shown is obtained by specifying the search type as ‘code’.
-  </div>
+  </li>
   <p class="UncategorizedText" id="db639db124b6064248de0c0dc71510a4">
    7 https://ocr-d.de/en/about
   </p>
-  <div class="Footer" id="d881ce84f017d89f6e35e2bc4b133bfc">
+  <p class="UncategorizedText" id="d881ce84f017d89f6e35e2bc4b133bfc">
    8 https://github.com/BobLd/DocumentLayoutAnalysis
-  </div>
+  </p>
   <p class="UncategorizedText" id="9b96c128deddda1a32c739a2df157496">
    9 https://github.com/leonlulu/DeepLayout
   </p>
@@ -133,26 +136,23 @@
   <p class="UncategorizedText" id="460b163c13ad7cad4fce325820a76481">
    12 https://github.com/PaddlePaddle/PaddleOCR
   </p>
-  <p class="UncategorizedText" id="fe238f610fe610b8ce1abaa08a0e3e63">
-   4
-  </p>
-  <p class="UncategorizedText" id="92c4289ad4af7c0793e40d5662707e0a">
-   Z. Shen et al.
-  </p>
-  <img alt="Model Customization Efficient Data Annotation Customized Model Training} === | Layout Detection Models | === DIA Pipeline Sharing OCR Module | = | Layout Data Structure ) = { storage &amp; Visualization Community Platform DIA Model Hub" class="Image" id="c4f9a0b797137c8c8f492f1af753f9a0"/>
-  <p class="NarrativeText" id="466f0bc21599ccf0fa27c021cb023f90">
+  <li class="ListItem" id="4ee4b32d55cf115add5734b1958b078d">
+   4 Z. Shen et al.
+  </li>
+  <img alt="Model Customization Document Images Community Platform DIA Model Hub “| Efficient Data Annotation Customized Model Training} === | Layout Detection Models | === DIA Pipeline Sharing OCR Module =— | Layout Data Structure | == | Storage &amp; Visualization iF" class="Image" id="e264392de87494789d1192a5dbc5af77"/>
+  <p class="NarrativeText" id="cefd08a6e022c1288d551ca4d088e7a0">
    Fig.1: The overall architecture of LayoutParser. For an input document image, the core LayoutParser library provides a set of oﬀ-the-shelf tools for layout detection, OCR, visualization, and storage, backed by a carefully designed layout data structure. LayoutParser also supports high level customization via eﬃcient layout annotation and model training functions. These improve model accuracy on the target samples. The community platform enables the easy sharing of DIA models and whole digitization pipelines to promote reusability and reproducibility. A collection of detailed documentation, tutorials and exemplar projects make LayoutParser easy to learn and use.
   </p>
-  <p class="NarrativeText" id="b4948db85ca791e99aa92589fc41734f">
+  <p class="NarrativeText" id="bc4e71c1982fa113c76dea6b5821d3e4">
    AllenNLP [8] and transformers [34] have provided the community with complete DL-based support for developing and deploying models for general computer vision and natural language processing problems. LayoutParser, on the other hand, specializes speciﬁcally in DIA tasks. LayoutParser is also equipped with a community platform inspired by established model hubs such as Torch Hub [23] and TensorFlow Hub [1]. It enables the sharing of pretrained models as well as full document processing pipelines that are unique to DIA tasks.
   </p>
-  <p class="NarrativeText" id="7651db80014a85ab253367d3bd3e4f88">
+  <p class="NarrativeText" id="d2119cdfef98e3e3c177c44175be69a4">
    There have been a variety of document data collections to facilitate the development of DL models. Some examples include PRImA [3](magazine layouts), PubLayNet [38](academic paper layouts), Table Bank [18](tables in academic papers), Newspaper Navigator Dataset [16, 17](newspaper ﬁgure layouts) and HJDataset [31](historical Japanese document layouts). A spectrum of models trained on these datasets are currently available in the LayoutParser model zoo to support diﬀerent use cases.
   </p>
-  <h1 class="Title" id="5a1838a8f40b4523094652cf14ab974c">
+  <h1 class="Title" id="695dba85a54c05b38377a5960b7dca52">
    3 The Core LayoutParser Library
   </h1>
-  <p class="NarrativeText" id="47e45d28d96fc14ddc709835de35ece5">
+  <p class="NarrativeText" id="cf23ea5ede08492b2715a8a3b5b23daf">
    At the core of LayoutParser is an oﬀ-the-shelf toolkit that streamlines DL- based document image analysis. Five components support a simple interface with comprehensive functionalities: 1) The layout detection models enable using pre-trained or self-trained DL models for layout detection with just four lines of code. 2) The detected layout information is stored in carefully engineered
   </p>
   <li class="ListItem" id="cd1112d2b15a0d27a29b1c83b2afd0dd">
@@ -168,10 +168,10 @@
       Dataset
      </th>
      <th style="border: 1px solid black;">
-      | Base Model'|
+      Base Model’
      </th>
      <th style="border: 1px solid black;">
-      Large Model |
+      Large Model
      </th>
      <th style="border: 1px solid black;">
       Notes
@@ -227,10 +227,9 @@
       F
      </td>
      <td style="border: 1px solid black;">
-      F
      </td>
      <td style="border: 1px solid black;">
-      Table region on modern scientific and business document.
+      Table region on modern scientific and business document
      </td>
     </tr>
     <tr style="border: 1px solid black;">
@@ -248,53 +247,53 @@
     </tr>
    </tbody>
   </table>
-  <p class="UncategorizedText" id="2ec98f0a0b35309e06494a35af88d51c">
-   1 For each dataset, we train several models of diﬀerent sizes for diﬀerent needs (the trade-oﬀ between accuracy
+  <p class="FigureCaption" id="f978160527177fa39c13774ec8dfa9cb">
+   1 For each dataset, we train several models of diﬀerent sizes for diﬀerent needs (the trade-oﬀ between accuracy vs. computational cost). For “base model” and “large model”, we refer to using the ResNet 50 or ResNet 101 backbones [13], respectively. One can train models of diﬀerent architectures, like Faster R-CNN [28] (F) and Mask R-CNN [12] (M). For example, an F in the Large Model column indicates it has a Faster R-CNN model trained using the ResNet 101 backbone. The platform is maintained and a number of additions will be made to the model zoo in coming months.
   </p>
-  <p class="FigureCaption" id="59e8b34937e08c490512e38b5803dce3">
-   vs. computational cost). For “base model” and “large model”, we refer to using the ResNet 50 or ResNet 101 backbones [13], respectively. One can train models of diﬀerent architectures, like Faster R-CNN [28] (F) and Mask R-CNN [12] (M). For example, an F in the Large Model column indicates it has a Faster R-CNN model trained using the ResNet 101 backbone. The platform is maintained and a number of additions will be made to the model zoo in coming months.
-  </p>
-  <p class="NarrativeText" id="0b9e7697400602ac472eda5564c0f44d">
+  <p class="NarrativeText" id="55b33df7609960c3552a0b7bc1a5a9c6">
    layout data structures, which are optimized for eﬃciency and versatility. 3) When necessary, users can employ existing or customized OCR models via the uniﬁed API provided in the OCR module. 4) LayoutParser comes with a set of utility functions for the visualization and storage of the layout data. 5) LayoutParser is also highly customizable, via its integration with functions for layout data annotation and model training. We now provide detailed descriptions for each component.
   </p>
-  <h1 class="Title" id="9e349da0d3169a69ebef29f87c80aa84">
+  <h1 class="Title" id="6e9df774416cc71548308e324b4bdbb7">
    3.1 Layout Detection Models
   </h1>
-  <p class="NarrativeText" id="f446727c56457e21e13708bf3821774d">
+  <p class="NarrativeText" id="bbcc10c2b92de0cbdce8629f18b0d7ad">
    In LayoutParser, a layout model takes a document image as an input and generates a list of rectangular boxes for the target content regions. Diﬀerent from traditional methods, it relies on deep convolutional neural networks rather than manually curated rules to identify content regions. It is formulated as an object detection problem and state-of-the-art models like Faster R-CNN [28] and Mask R-CNN [12] are used. This yields prediction results of high accuracy and makes it possible to build a concise, generalized interface for layout detection. LayoutParser, built upon Detectron2 [35], provides a minimal API that can perform layout detection with only four lines of code in Python:
   </p>
-  <li class="ListItem" id="53b448c75f1556b1f60b4e3324bd0724">
+  <li class="ListItem" id="508a6705bb0bfb693616cc14fec5e1b9">
    1 import layoutparser as lp
   </li>
-  <p class="NarrativeText" id="eaf41ed9e5bb3da52339a954727209eb">
-   2 image = cv2.imread("image_file") # load images 3 model = lp.Detectron2LayoutModel( 4 "lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config")
-  </p>
-  <li class="ListItem" id="dd05ea3368e0313a428d5e2b45401718">
+  <li class="ListItem" id="d7eccf8affb9442c47b466236f1dc3d4">
+   2 image = cv2.imread("image_file") # load images
+  </li>
+  <li class="ListItem" id="f30541418a7dca51e3e4cd880486ab9c">
    3 model = lp.Detectron2LayoutModel(
   </li>
-  <li class="ListItem" id="9fd6cd6d821c887bffbf2d5059354e02">
+  <p class="UncategorizedText" id="29e642de3b82879282412bc518a0b561">
+   "lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config")
+  </p>
+  <li class="ListItem" id="4d9fec76fbadfe7f4577be24fa1b646f">
+   4
+  </li>
+  <li class="ListItem" id="2b6917b3494980ac75bb52f0f07baf43">
    5 layout = model.detect(image)
   </li>
-  <p class="NarrativeText" id="a396a606cfc323c02a0de45d91b69d6d">
+  <p class="NarrativeText" id="7548183e8c62fd95c88ba09f48403e0e">
    LayoutParser provides a wealth of pre-trained model weights using various datasets covering diﬀerent languages, time periods, and document types. Due to domain shift [7], the prediction performance can notably drop when models are ap- plied to target samples that are signiﬁcantly diﬀerent from the training dataset. As document structures and layouts vary greatly in diﬀerent domains, it is important to select models trained on a dataset similar to the test samples. A semantic syntax is used for initializing the model weights in LayoutParser, using both the dataset name and model name lp://&lt;dataset-name&gt;/&lt;model-architecture-name&gt;.
   </p>
-  <p class="UncategorizedText" id="676118b62c2261113a23a610c2ac50cb">
-   6
+  <p class="NarrativeText" id="9822d87165468afaadb6f46d821030af">
+   6 Z. Shen et al.
   </p>
-  <p class="UncategorizedText" id="710ac103981c6363195774b02ee582d4">
-   Z. Shen et al.
-  </p>
-  <img alt='o 3 4 9 s a 8 4 8 3 8 8 . g . £ o 3 ¥ Coordinate § F g 3 + § 3 Block Block Reading| 4 $ Extra features Tea | [ye | | ower é 2 a o ¢ 8 [ coordinatel textblock1 | 3 a , see 3 i A .., textblock2 , layouti ] § " @ A list of the layout elements é' class="Image" id="403965f98f47c92554207f7628ffeefe"/>
-  <p class="FigureCaption" id="9f11aa6b22dea1bba7eb0d122c0c5562">
+  <img alt="o ) # ay Ss cH 3 Rectangle Quadrilateral g 4 M&lt; -d fe) 3 v Es 4 4 o for) ° q a Coordinate 8S 4 P 9 + () ‘ 3 ri) Block Block Reading] g Extra features Text Tye | | onder E ° 4 a ¢ a [ coordinatel textblock1 4 » 1 pees ‘ 3 ES .., textblock2 layout1 ] F 1 Uf lf a q o A list of the layout elements E" class="Image" id="b03c134c31ac99a48d297deeb16360c4"/>
+  <p class="FigureCaption" id="0a9486298b412d0a5afd62b652c6ccda">
    Fig.2: The relationship between the three types of layout data structures. Coordinate supports three kinds of variation; TextBlock consists of the co- ordinate information and extra features like block text, types, and reading orders; a Layout object is a list of all possible layout elements, including other Layout objects. They all support the same set of transformation and operation APIs for maximum ﬂexibility.
   </p>
-  <p class="NarrativeText" id="d997f63fd79c7e03050ca01b58dfdf0a">
+  <p class="NarrativeText" id="43f1ee92756d0ae08882e548ff4c83d8">
    Shown in Table 1, LayoutParser currently hosts 9 pre-trained models trained on 5 diﬀerent datasets. Description of the training dataset is provided alongside with the trained models such that users can quickly identify the most suitable models for their tasks. Additionally, when such a model is not readily available, LayoutParser also supports training customized layout models and community sharing of the models (detailed in Section 3.5).
   </p>
-  <h1 class="Title" id="836e9227ef393d8b00369e6300fbba4c">
+  <h1 class="Title" id="74d4520c77d6971b927aa01c65f7129e">
    3.2 Layout Data Structures
   </h1>
-  <p class="NarrativeText" id="601f7d95172984c75de081023ca64c15">
+  <p class="NarrativeText" id="bf2dab9cd733e9dab6ef649810667a00">
    A critical feature of LayoutParser is the implementation of a series of data structures and operations that can be used to eﬃciently process and manipulate the layout elements. In document image analysis pipelines, various post-processing on the layout analysis model outputs is usually required to obtain the ﬁnal outputs. Traditionally, this requires exporting DL model outputs and then loading the results into other pipelines. All model outputs from LayoutParser will be stored in carefully engineered data types optimized for further processing, which makes it possible to build an end-to-end document digitization pipeline within LayoutParser. There are three key components in the data structure, namely the Coordinate system, the TextBlock, and the Layout. They provide diﬀerent levels of abstraction for the layout data, and a set of APIs are supported for transformations or operations on these classes.
   </p>
   <li class="ListItem" id="48d58ed9a3d95637df68c8b810147ba1">
@@ -315,12 +314,12 @@
   <li class="ListItem" id="e9e376b644bc78af6977b31e86e1d36f">
    1 ocr_agent = lp.TesseractAgent()
   </li>
-  <li class="ListItem" id="7f736fc72998c81eaff74b157ed4b005">
+  <p class="NarrativeText" id="7f736fc72998c81eaff74b157ed4b005">
    2 # Can be easily switched to other OCR software
-  </li>
-  <p class="NarrativeText" id="ffb8f709daf70f8dad507c4d212cd8b2">
-   3 tokens = ocr_agent.detect(image)
   </p>
+  <li class="ListItem" id="ffb8f709daf70f8dad507c4d212cd8b2">
+   3 tokens = ocr_agent.detect(image)
+  </li>
   <p class="NarrativeText" id="6ff992f959960183ac0634ba464f4ea6">
    The OCR outputs will also be stored in the aforementioned layout data structures and can be seamlessly incorporated into the digitization pipeline. Currently LayoutParser supports the Tesseract and Google Cloud Vision OCR engines.
   </p>
@@ -343,10 +342,7 @@
       block.pad(top,
      </th>
      <th style="border: 1px solid black;">
-      bottom,
-     </th>
-     <th style="border: 1px solid black;">
-      right,
+      bottom, right,
      </th>
      <th style="border: 1px solid black;">
       left)
@@ -359,11 +355,10 @@
    <tbody>
     <tr style="border: 1px solid black;">
      <td style="border: 1px solid black;">
-      block.scale(fx, fy)
+      block.scale(fx,
      </td>
      <td style="border: 1px solid black;">
-     </td>
-     <td style="border: 1px solid black;">
+      fy)
      </td>
      <td style="border: 1px solid black;">
      </td>
@@ -373,11 +368,10 @@
     </tr>
     <tr style="border: 1px solid black;">
      <td style="border: 1px solid black;">
-      block.shift (dx, dy)
+      block.shift(dx,
      </td>
      <td style="border: 1px solid black;">
-     </td>
-     <td style="border: 1px solid black;">
+      dy)
      </td>
      <td style="border: 1px solid black;">
      </td>
@@ -394,14 +388,12 @@
      <td style="border: 1px solid black;">
      </td>
      <td style="border: 1px solid black;">
-     </td>
-     <td style="border: 1px solid black;">
       Whether block] is inside of block2
      </td>
     </tr>
     <tr style="border: 1px solid black;">
      <td style="border: 1px solid black;">
-      block1. intersect
+      block1.intersect
      </td>
      <td style="border: 1px solid black;">
       (block2)
@@ -409,9 +401,17 @@
      <td style="border: 1px solid black;">
      </td>
      <td style="border: 1px solid black;">
+      Return the intersection region of block1 and block2. Coordinate type to be determined based on the inputs.
+     </td>
+    </tr>
+    <tr style="border: 1px solid black;">
+     <td style="border: 1px solid black;">
      </td>
      <td style="border: 1px solid black;">
-      Return the intersection region of block1 and block2. Coordinate type to be determined based on the inputs.
+     </td>
+     <td style="border: 1px solid black;">
+     </td>
+     <td style="border: 1px solid black;">
      </td>
     </tr>
     <tr style="border: 1px solid black;">
@@ -423,9 +423,7 @@
      <td style="border: 1px solid black;">
      </td>
      <td style="border: 1px solid black;">
-     </td>
-     <td style="border: 1px solid black;">
-      Return the union region of block1 and block2. Coordinate type to be determined based the inputs.
+      Return the union region of blockl and block2. Coordinate type to be determined based on the inputs. Convert the absolute coordinates of block1 to
      </td>
     </tr>
     <tr style="border: 1px solid black;">
@@ -437,28 +435,12 @@
      <td style="border: 1px solid black;">
      </td>
      <td style="border: 1px solid black;">
-     </td>
-     <td style="border: 1px solid black;">
-      Convert the absolute coordinates of block1 to relative coordinates to block2
+      relative coordinates to block2 Calculate the absolute coordinates of block1 given
      </td>
     </tr>
     <tr style="border: 1px solid black;">
      <td style="border: 1px solid black;">
-      block1.condition_on(block2)
-     </td>
-     <td style="border: 1px solid black;">
-     </td>
-     <td style="border: 1px solid black;">
-     </td>
-     <td style="border: 1px solid black;">
-     </td>
-     <td style="border: 1px solid black;">
-      Calculate the absolute coordinates of block1 given the canvas block2’s absolute coordinates
-     </td>
-    </tr>
-    <tr style="border: 1px solid black;">
-     <td style="border: 1px solid black;">
-      block. crop_image
+      block1.condition_on(block2) block. crop_image
      </td>
      <td style="border: 1px solid black;">
       (image)
@@ -466,9 +448,7 @@
      <td style="border: 1px solid black;">
      </td>
      <td style="border: 1px solid black;">
-     </td>
-     <td style="border: 1px solid black;">
-      Obtain the image segments in the block region
+      the canvas block2’s absolute coordinates Obtain the image segments in the block region
      </td>
     </tr>
    </tbody>
@@ -491,26 +471,29 @@
   <p class="NarrativeText" id="894921dce9d1291116c38d561c2fff59">
    14 https://altoxml.github.io
   </p>
-  <li class="ListItem" id="c069937e6c2bfc0f856835f3af4d6181">
-   LayoutParser: A Uniﬁed Toolkit for DL-Based DIA
+  <li class="ListItem" id="8c43dbfa734bf2d766c260f253381da8">
+   9
   </li>
-  <img alt="10g Buypunog uayoy Aeydsiq 1 vondo 10g 6ulpunog usyoy api :z uondo, Mode I: Showing Layout on the Original Image Mode Il: Drawing OCR’ Text at the Correspoding Position" class="Image" id="0f24d2d9d336ceae460a3852785eee67"/>
-  <p class="NarrativeText" id="4d1b9566e792683b9559b778be4f4046">
+  <p class="UncategorizedText" id="dfa95a5d6dec88cb5c802366b8841672">
+   LayoutParser: A Uniﬁed Toolkit for DL-Based DIA
+  </p>
+  <img alt="4 Anonymous ICDAR 2021 Submission 3 ynonymous_)FCDAR_] 2021) Submission &lt;= + + xog Buipunog uayo, Aejdsig :1 uondo ated | vith fimetions for! layout | ‘etailed descriptions for’ each! xog Bulpunog uayo) apiy :z uondo Mode |: Showing Layout on the Original Image Mode II: Drawing OCR’d Text at the Correspoding Position" class="Image" id="8c7735c2c17a96741a9d5d6b3740f8d6"/>
+  <p class="NarrativeText" id="fb0f4f71d292bd9f2f935ca0c76cf6a3">
    Fig.3: Layout detection and OCR results visualization generated by the LayoutParser APIs. Mode I directly overlays the layout region bounding boxes and categories over the original image. Mode II recreates the original document via drawing the OCR’d texts at their corresponding positions on the image canvas. In this ﬁgure, tokens in textual regions are ﬁltered using the API and then displayed.
   </p>
-  <p class="NarrativeText" id="625c9e1d41a9740f094041595f79953d">
+  <p class="NarrativeText" id="7d5983166b8a43afc2202b6200f5afa9">
    can also be highly sensitive and not sharable publicly. To overcome these chal- lenges, LayoutParser is built with rich features for eﬃcient data annotation and customized model training.
   </p>
-  <p class="NarrativeText" id="a3498730b5cd3fe9405fad69bcf37882">
+  <p class="NarrativeText" id="9561eae776a8a4c9b8e7a92d2e2b54ae">
    LayoutParser incorporates a toolkit optimized for annotating document lay- outs using object-level active learning [32]. With the help from a layout detection model trained along with labeling, only the most important layout objects within each image, rather than the whole image, are required for labeling. The rest of the regions are automatically annotated with high conﬁdence predictions from the layout detection model. This allows a layout dataset to be created more eﬃciently with only around 60% of the labeling budget.
   </p>
-  <p class="NarrativeText" id="c4ccf2cf2e7495668221cbe51534f90b">
+  <p class="NarrativeText" id="cd9ff032b8a80f56188ad2b5b7156573">
    After the training dataset is curated, LayoutParser supports diﬀerent modes for training the layout models. Fine-tuning can be used for training models on a small newly-labeled dataset by initializing the model with existing pre-trained weights. Training from scratch can be helpful when the source dataset and target are signiﬁcantly diﬀerent and a large training set is available. However, as suggested in Studer et al.’s work[33], loading pre-trained weights on large-scale datasets like ImageNet [5], even from totally diﬀerent domains, can still boost model performance. Through the integrated API provided by LayoutParser, users can easily compare model performances on the benchmark datasets.
   </p>
   <li class="ListItem" id="59c95b02b488f297417af4125e4ac316">
    10 Z. Shen et al.
   </li>
-  <img alt="Intra-column reading order ‘Token Categories Variabte (EE company type Column Categories J tie Adatress () tet [J Section Header Column reading order Maximum Allowed Height (b) Illustration of the recreated document with dense text structure for better OCR performance" class="Image" id="1dd15be7cc0092ea5c221a34bf854869"/>
+  <img alt="Intra-column reading order Token Categories 2 (Address £ = / Number 3 Variable {7 company type Column Categories Title = ier, Ba KS ie A ATL ge HR a OH a A a S| Rolls Soper ee eres be] Address B Rm a Sanne i es g ee a RUC AH unl een cen RENE Section Header S| ganm Bin MR TR RM AM L_ ES Baap hn} 4 Hb es GH A AR 25% B ei FE : ie § Aa at FL eta BE &amp; ih 3 as GJ rr S me (b) Illustration of the recreated document with dense text structure for better OCR performance" class="Image" id="a6aa8357c70f57fb94d3168f2f32c24a"/>
   <p class="NarrativeText" id="9667b0e42f9d28607c7c13bffb760906">
    Fig.4: Illustration of (a) the original historical Japanese document with layout detection results and (b) a recreated version of the document image that achieves much better character recognition recall. The reorganization algorithm rearranges the tokens based on the their detected bounding boxes given a maximum allowed height.
   </p>
@@ -547,16 +530,16 @@
   <p class="NarrativeText" id="42551c9b40827dcdc52055b4d25c6fc3">
    As shown in Figure 4 (a), the document contains columns of text written vertically 15, a common style in Japanese. Due to scanning noise and archaic printing technology, the columns can be skewed or have vari- able widths, and hence cannot be eas- ily identiﬁed via rule-based methods. Within each column, words are sepa- rated by white spaces of variable size, and the vertical positions of objects can be an indicator of their layout type.
   </p>
-  <img alt='“Active Learning Layout Annotate Layout Dataset | Annotation Toolkit ¥ Tayo betetion Deep Learning Layout " Model Training &amp; Inference, ¥ Post processing Handy Data Structures &amp; APIs for Layout Data ¥ Text Recognition | &lt;—— Default and bustomized ¥ pon Wa i — ayout Structure Visualization &amp; Export | &lt;—— | vic alization &amp; Storage The Japanese Document Helpful LayoutParser Digitization Pipeline Modules' class="Image" id="0ae05b73a88b238b80c4d18c6f9274ec"/>
+  <img alt="Active Learning Layout Annotate Layout Dataset | + Model Training &amp; Inference Post processing Handy Dat Structures &amp; —e—e€v Text Recognition | &lt;—— ations Layout Structure Visualization &amp; Export | «| V3. alization &amp; Storage Default and Customized OCR Models The Japanese Document Helpful LayoutParser Digitization Pipeline Modules" class="Image" id="22458898f1f58cfb0b54a438a4737567"/>
   <p class="NarrativeText" id="80291b42f1785935496188bb52788288">
    Fig.5: Illustration of how LayoutParser helps with the historical document digi- tization pipeline.
   </p>
   <li class="ListItem" id="c5b22d5a9f8b657ad4acdf6ad1f0bdd0">
    15 A document page consists of eight rows like this. For simplicity we skip the row segmentation discussion and refer readers to the source code when available.
   </li>
-  <h1 class="Title" id="9d917f215b0115c679105482b80d2d2d">
+  <li class="ListItem" id="9d917f215b0115c679105482b80d2d2d">
    12 Z. Shen et al.
-  </h1>
+  </li>
   <p class="NarrativeText" id="4bba0fe5b17811e76afbf7650f2f6792">
    To decipher the complicated layout
   </p>
@@ -581,13 +564,13 @@
   <li class="ListItem" id="2b7101f39954d5301166b82906202ea9">
    LayoutParser: A Uniﬁed Toolkit for DL-Based DIA
   </li>
-  <img alt="(6) Partial table atthe bottom (b) Ful page table (©) Partial table atthe top (4) Mis detected text line" class="Image" id="e45bde8fddca133387e91d96fa2d136a"/>
+  <img alt="ra (a) Partial table at the bottom (b) Full page table (c) Partial table at the top (d) Mis-detected text line" class="Image" id="d7ab3da5ec0adb1b2b4fb5f800a545a0"/>
   <p class="FigureCaption" id="d35d253341e8b8d837f384ecd6ac410a">
    Fig.6: This lightweight table detector can identify tables (outlined in red) and cells (shaded in blue) in diﬀerent locations on a page. In very few cases (d), it might generate minor error predictions, e.g, failing to capture the top text line of a table.
   </p>
-  <h1 class="Title" id="60e4fa05c78628ec1c6fa6003b86b52e">
+  <li class="ListItem" id="60e4fa05c78628ec1c6fa6003b86b52e">
    5.2 A light-weight Visual Table Extractor
-  </h1>
+  </li>
   <p class="NarrativeText" id="445ad333fa3f7f85d2be634fbdeeb72a">
    Detecting tables and parsing their structures (table extraction) are of central im- portance for many document digitization tasks. Many previous works [26, 30, 27] and tools 18 have been developed to identify and parse table structures. Yet they might require training complicated models from scratch, or are only applicable for born-digital PDF documents. In this section, we show how LayoutParser can help build a light-weight accurate visual table extractor for legal docket tables using the existing resources with minimal eﬀort.
   </p>
@@ -639,8 +622,8 @@
   <li class="ListItem" id="a742cc226eba47ed37993cde0d2718d9">
    [8] Gardner, M., Grus, J., Neumann, M., Tafjord, O., Dasigi, P., Liu, N., Peters, M., Schmitz, M., Zettlemoyer, L.: Allennlp: A deep semantic natural language processing platform. arXiv preprint arXiv:1803.07640 (2018)
   </li>
-  <li class="ListItem" id="0176491ee2584bffdfb943caa8aefab4">
-   Lukasz Garncarek, Powalski, R., Stanistawek, T., Topolski, B., Halama, P., Graliriski, F.: Lambert: Layout-aware (language) modeling using bert for in- formation extraction (2020)
+  <li class="ListItem" id="b28cae31cc0ad503c9658c6b3e3bd4d7">
+   Lukasz Garncarek, Powalski, R., Stanistawek, T., Topolski, B., Halama, P., Gralinski, F.: Lambert: Layout-aware (language) modeling using bert for in- formation extraction (2020)
   </li>
   <li class="ListItem" id="95bc71fb3542f420dfa50e22eb8c734f">
    [10] Graves, A., Fern´andez, S., Gomez, F., Schmidhuber, J.: Connectionist temporal classiﬁcation: labelling unsegmented sequence data with recurrent neural networks. In: Proceedings of the 23rd international conference on Machine learning. pp. 369–376 (2006)

--- a/test_unstructured_ingest/expected-structured-output/azure/IRS-form-1987.pdf.json
+++ b/test_unstructured_ingest/expected-structured-output/azure/IRS-form-1987.pdf.json
@@ -1,8 +1,8 @@
 [
   {
     "type": "Title",
-    "element_id": "f78db4158d91e24ff80f4c4ffd75f936",
-    "text": "FM) Department of the Treasury Internal Revenue Service Instructions for Form 3115 (Rev. November 1987) Application for Change in Accounting Method",
+    "element_id": "a278e93c883ff4444a18689f657a2a38",
+    "text": "Ay Department of the Treasury Internal Revenue Service Instructions for Form 3115 (Rev. November 1987) Application for Change in Accounting Method",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -133,8 +133,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "8753b1907d0b40b882489a68baf3fe2c",
-    "text": "File this form to request a change in your accounting method, including the accounting treatment of any item. If you are requesting a change in accounting period, use Form 1128, Application for Change in Accounting Period. For more information, see Publication 538, Accounting Periods and Methods.",
+    "element_id": "21dd0367f76fe2f5f1c553ea7b901857",
+    "text": "File this form to request a change in your accounting method, including the accounting treatment of any item. If you are requesting a change In accounting period, use Form 1128, Application for Change in Accounting Period. For more information, see Publication 538, Accounting Periods and Methods.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -155,8 +155,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "741b30ff5f4f03b9c65c419649d8a97d",
-    "text": "When filing Form 3115, taxpayers are reminded to determine if IRS has published a ruling or procedure dealing with the specific type of change since November 1987 (the current revision date of Form 3115)",
+    "element_id": "0cf9161971e9ea8feec111ff7d24f403",
+    "text": "When filing Form 3115, taxpayers are reminded to determine if IRS has published a ruling or procedure dealing with the specific type of change since November 1987 (the current revision date of Form 3115),",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -199,8 +199,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "f225ebefe4a8aa2af646f50d4422c3a3",
-    "text": "Other methods. —Unless the Service has published a regulation or procedure to the contrary, all other changes tn accounting methods required by the Act are automatically considered to be approved by the Commissioner. Examples of method changes automatically approved by the Commissioner are those changes required to effect: (1) the repeal of the reserve method for bad debts of taxpayers other than financial institutions (Act section 805); (2) the repeal of the installment method for sales under a revolving credit plan (Act section 812); (3) the inclusion of income attributable to the sale or furnishing of utility services no later than the year in which the services were provided to customers (Act section 821); and (4) the repeal of the deduction for qualified discount coupons (Act section 823). Do not file Form 3115 for these changes.",
+    "element_id": "fd78f4e1d471af7ddb468878e4401dab",
+    "text": "Other methods.—Unless the Service has published a regulation or procedure to the contrary, all other changes tn accounting methods required by the Act are automatically considered to be approved by the Commissioner. Examples of method changes automatically approved by the Commissioner are those changes required to effect: (1) the repeal of the reserve method for bad debts of taxpayers other than financial institutions (Act section 805); (2) the repeal of the installment method for sales under a revolving credit plan (Act section 812); (3) the inclusion of income attributable to the sale or furnishing of utility services no later than the year in which the services were provided to customers (Act section 821); and (4) the repeal of the deduction for qualified discount coupons (Act section 823). Do not file Form 3115 for these changes.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -243,8 +243,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "c91bf5618a9b5a45f1bc3ed4c58a9094",
-    "text": "You must give all relevant facts, including a detailed description of your present and proposed methods. You must also state the reason(s) you believe approval to make the requested change should be granted. Attach additional pages if more space is needed for explanations. Each page should show your name, address, and identifying number",
+    "element_id": "b8f9f1fdeffadd34472959092459fba9",
+    "text": "You must give all relevant facts, including a detailed description of your present and proposed methods. You must also state the reason(s) you believe approval to make the requested change should be granted. Attach additional pages if more space is needed for explanations. Each page should show your name, address, and identifying number.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -309,8 +309,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "dd15989799b65cd7f3aa7f292e3acda0",
-    "text": "Uniform capitalization rules and limitation on cash method.—f you are required to change your method of accounting under section,263A (relating to the capitalization and inclusion in inventory costs of certain expenses) or 448 (limiting the use of the cash method of accounting by certain taxpayers) as added by the Tax Reform Act of 1986 (“Act”), the change Is treated as initiated by the taxpayer, approved by the Commissioner, and the period for taking the adjustments under section 481(a) into account will not exceed 4 years. (Hospitals required to change from the cash method under section 448 have 10 years to take the adjustrnents into account.) Complete Section A and the appropriate sections (B-1 or C and D) for which the change is required.",
+    "element_id": "158783669b4b944ae0057b632797dcfe",
+    "text": "Uniform capitalization rules and Jimitation on cash method.—f you are required to change your method of accounting under section,263A (relating to the capitalization and inclusion in inventory costs of certain expenses) or 448 (limiting the use of the cash method of accounting by certain taxpayers) as added by the Tax Reform Act of 1986 (“Act”), the change !s treated as Initiated by the taxpayer, approved by the Commissioner, and the period for taking the adjustments under section 481(a) into account will not exceed 4 years. (Hospitals required to change from the cash method under section 448 have 10 years to take the adjustrnents into account.) Complete Section A and the appropriate sections (B-1 or C and D) for which the change is required.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -331,8 +331,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "7adee4d7e6f11ddd9cca7bd3506117dc",
-    "text": "Disregard the instructions under Time and Place for Filing and Late Applications. Instead, attach Form 3115 to your income tax return for the year of change; do not file it separately. Also include on a separate statement accompanying the Form 3115 the period over which the section 481(a) adjustment will be taken into account and the basis for that conclusion. Identify the automatic change being made at the top of page 1 of Form 3115 (e.g., “Automatic Change to Accrual Method—Section 448\"). See Temporary Regulations sections 1.263A-1T and 1.448-1T for additional information",
+    "element_id": "486102e7c1f95b669f23516c52b4b22a",
+    "text": "Disregard the instructions under Time and Place for Filing and Late Applications. Instead, attach Form 3115 to your income tax return for the year of change; do not file it separately. Also include on a separate statement accompanying the Form 3115 the period over which the section 481(a) adjustment will be taken into account and the basis for that conclusion. Identify the automatic change being made at the top of page 1 of Form 3115 (e.g., “Automatic Change to Accrual Method—Section 448”). See Temporary Regulations sections 1.263A-1T and 1.448-1T for additional information.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -573,8 +573,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "4a9b9ec8ba60e739f49cfd240aa4439f",
-    "text": "Others.-—The employer identification number of an applicant other than an individual should be entered in this block.",
+    "element_id": "5ab614de4ef721a684e4e8e0c8fb5788",
+    "text": "Others.-—The employer identification number of an applicant other than an individual should be entered tn this block.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -639,8 +639,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "e8cfd8f6db0442ba89ebad7a26a61fe9",
-    "text": "Partnerships.—The form should be signed with the partnership name followed by the signature of one of the general partners and the words “General Partner.”",
+    "element_id": "1a487e582980fedf46613e0848befc44",
+    "text": "Partnerships.—The form shouid be signed with the partnership name followed by the signature of one of the general partners and the words “General Partner.”",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -815,8 +815,8 @@
   },
   {
     "type": "Title",
-    "element_id": "1505240fbe441adc4acdbc867689af29",
-    "text": "SectionA",
+    "element_id": "e0e692b1f478333e3950f8cb2483a484",
+    "text": "Section A",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -837,8 +837,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "1010f24ec42ba67381ab00d6bab4f64e",
-    "text": "Item 5a, page 1.—“Taxable income or (loss) from operations” is to be entered before application of any net operating !oss deduction under section 172(a).",
+    "element_id": "e6ef62be27627e0886c49f013b3eb389",
+    "text": "Item 5a, page 1.— “Taxable income or (loss) from operations” is to be entered before application of any net operating loss deduction under section 172(a).",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -881,8 +881,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "803aea48f7a67d05a1f325166686e26a",
-    "text": "Item 7b, page 2.—If item 7b Is “Yes,” indicate ona separate sheet the following for each separate trade or business: Nature of business",
+    "element_id": "31b52f9f7ca8d75190858bf0d55805db",
+    "text": "Item 7b, page 2.—If item 7b 1s “Yes,” indicate on a separate sheet the following for each separate trade or business: Nature of business",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -903,8 +903,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "3ff02da9894f328f5ac2810bbe7ba61a",
-    "text": "(manufacturing, retailer, wholesaler, etc.), employer identification number, overall method of accounting, and whether, in the last 6 years, that business has changed its accounting method, or Is also changing its accounting method as part of this request or as a separate request.",
+    "element_id": "a34b5c633b40ae532a293aa5ece41ff6",
+    "text": "(manufacturing, retailer, wholesaler, etc.), employer identification number, overall method of accounting, and whether, in the last 6 years, that business has changed its accounting method, or is also changing its accounting method as part of this request or as a separate request.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -991,8 +991,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "f5150d77d7e1cc7d6dc4d5928c6a0ad0",
-    "text": "See section 5.06(2) of Rev. Proc. 84-74 for the required perjury statement that must be attached.",
+    "element_id": "69c4ed1728897f266bed4a53365bcafa",
+    "text": "See section 5,06(2) of Rev. Proc. 84-74 for the required perjury statement that must be attached.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1035,8 +1035,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "3e968ed0cd6eeceea5ac7473b6ea957b",
-    "text": "Item 13, page 2.—Insert the actual number of tax years. Use of the term “since inception” is not acceptable. However, “more than 6 years” !s acceptable.",
+    "element_id": "fb1b9c839bbca33510a6374d1e860e6e",
+    "text": "Item 13, page 2.— Insert the actual number of tax years. Use of the term “since inception” Is not acceptable. However, “more than 6 years” Is acceptable.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1079,8 +1079,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "fd7024d7ebbfd93449699e3569bc504c",
-    "text": "Item 1b, page 2.—Include any amounts reported as income ina prior year although the income had not been accrued (earned) or received in the prior year; for example, discount on installment loans reported as income for the year in which the loans were made instead of for the year or years in which the income was received or earned. Advance payments under Rev. Proc. 71-21 or Regulations section 1.451-5 must be fully explained and all pertinent information must be submitted with this application",
+    "element_id": "f239c78f0866a8a41d36370f128676b6",
+    "text": "Item 1b, page 2.—Include any amounts reported as income in a prior year although the income had not been accrued (earned) or received In the prior year; for example, discount on installment loans reported as income for the year In which the loans were made instead of for the year or years in which the income was received or earned. Advance payments under Rev. Proc. 71-21 or Regulations section 1.451-5 must be fully explained and all pertinent information must be submitted with this application.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1123,8 +1123,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "9307e539e4f3ec48cec57ac058cb5d7a",
-    "text": "Limitation on the Use of the Cash Method of Accounting. —Except as provided below, C corporations, partnerships with a C corporation as a partner, and tax shelters may not use the cash method of accounting. For purposes of this limitation, a trust subject to the tax on unrelated business income under section 511 is treated as aC corporation with respect to its unrelated trade or business activities.",
+    "element_id": "6720eba15ed08f5d66f8dc84b6a94fa8",
+    "text": "Limitation on the Use of the Cash Method of Accounting.—Except as provided below, C corporations, partnerships with a C corporation as a partner, and tax shelters may not use the cash method of accounting. For purposes of this limitation, a trust subject to the tax on unrelated business Income under section 511 1s treated as aC corporation with respect to its unrelated trade or business activities.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1167,8 +1167,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "fc1f0d4d56acd27a18ba80ab0acfb9e9",
-    "text": "(1) Farming businesses.—F or this purpose, the term “farming business” 1s defined in section 263A(e)(4), but it also includes the raising, harvesting, or growing of trees to which section 263A(c)(5) applies. Notwithstanding this exception, section 447 requires certain C corporations and partnerships with a C corporation as a partner to use the accrual method.",
+    "element_id": "22e4f1d701efc16645e77991781051f5",
+    "text": "(1) Farming businesses. —For this purpose, the term “farming business” is defined in section 263A(e)(4), but it also includes the raising, harvesting, or growing of trees to which section 263A(c)(5) applies. Notwithstanding this exception, section 447 requires certain C corporations and partnerships with a C corporation as a partner to use the accrual method.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1189,8 +1189,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "4b957afb9ee0144c57063ae3f8813c49",
-    "text": "(2) Qualified personal service corporations. — A “qualified personal service corporation” is any corporation: (a) substantially all of the activities of which involve the performance of services In the fields of health, law, engineering, architecture, accounting, actuarial science, performing arts, or consulting, and (b)",
+    "element_id": "7d5701b44f1ad554006cf31e8efeb719",
+    "text": "(2) Qualified personal service corporations. — A “qualified personal service corporation” 1s any corporation: (a) substantially all of the activities of which involve the performance of services In the fields of health, law, engineering, architecture, accounting, actuarial science, performing arts, or consulting, and (b)",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1255,8 +1255,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "7bd3982f648c6d35765fee5a195619c0",
-    "text": "(3) Entities with gross receipts of $5,000,000 or less. —To qualify for this exception, the C corporation’s or partnership’s annual average gross receipts for the three years ending with the prior tax year may not exceed $5,000,000. !f the corporation or partnership was not in existence for the entire 3-year period, the period of existence Is used to determine whether the corporation or partnership qualifies. If any tax year in the 3-year period is a short tax year, the corporation or partnership must annualize the gross receipts by multiplying the gross receipts by 12 and dividing the result by the number of months tn the short period.",
+    "element_id": "6ee9a057174e1c9cf99d653ad1c09371",
+    "text": "(3) Entities with gross receipts of $5,000,000 or less. —To qualify for this exception, the C corporation’s or partnership’s annual average gross receipts for the three years ending with the prior tax year may not exceed $5,000,000. If the corporation or partnership was not in existence for the entire 3-year period, the period of existence Is used to determine whether the corporation or partnership qualifies. If any tax year in the 3-year period is a short tax year, the corporation or partnership must annualize the gross receipts by multiplying the gross receipts by 12 and dividing the result by the number of months tn the short period.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1277,8 +1277,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "138fd3015529f8bd386da37b0de434d7",
-    "text": "For more information, see section 448 and Temporary Regulations section 1.448-1T",
+    "element_id": "427e5fe33c8c181ccb93c7de11946c13",
+    "text": "For more information, see section 448 and Temporary Regulations section 1.448-1T.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1321,8 +1321,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "c67e8f108a1f0f6f6820d1f6a599ab02",
-    "text": "Applicants must give complete details about the present method of valuing inventory and the proposed method. State whether all or part of your inventory ts involved in the change.",
+    "element_id": "e2f18bc74e6cafcd9692b5daf1849492",
+    "text": "Applicants must give complete details about the present method of valuing inventory and the proposed method. State whether all or part of your inventory ts involved tn the change.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1409,8 +1409,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "dca354b76d6465ac0b8e2f4875bb532f",
-    "text": "(2) State whether the proposed identification and valuation methods conform to the inventory method currently used with respect to non-LIFO inventories, if any, or how such method is otherwise consistent with Regulations section 1.472-6.",
+    "element_id": "294b1260ca3b5c9f0ba0d989ea96ac31",
+    "text": "(2) State whether the proposed identification and valuation methods conform to the inventory method currently used with respect to non-LIFO Inventories, if any, or how such method is otherwise consistent with Regulations section 1.472-6.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1497,8 +1497,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "75f4fb193debfbf1f8dd60aca82837df",
-    "text": "® U.S. Government Printing Office: 1987—201-993/60166",
+    "element_id": "ac03b00e18c3ba3be848b73947358f1b",
+    "text": "& U.S. Government Printing Office: 1987—201-993/60166",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1541,8 +1541,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "a684d77321935da5475b080bc2ab7e28",
-    "text": "Section 460(f) provides that the term “long-term contract” means any contract for the manufacturing, building, installation, or construction of property that is not completed within the tax year in which it is entered into. However, a manufacturing contract will not qualify as a long-term contract unless the contract involves the manufacture of: (1) a unique item not normally included in your finished goods inventory, or (2) any item that normally requires more than 12 calendar months to complete.",
+    "element_id": "8f23a32fb527d5d2c99e6ce9d43a0506",
+    "text": "Section 460(f) provides that the term “long-term contract” means any contract for the manufacturing, building, installation, or construction of property that is not completed within the tax year in which it is entered into. However, a manufacturing contract will not qualify as a long-term contract unless the contract involves the manufacture of: (1)a unique item not normally included in your finished goods inventory, or (2) any item that normally requires more than 12 calendar months to complete.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1629,8 +1629,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "daecf7c8c48c378964d6932150a8ea06",
-    "text": "This section 1s to be used only to request a change in a method of accounting for depreciation under section 167.",
+    "element_id": "f4d23d878433825c90ab6e6090d9ece6",
+    "text": "This section ts to be used only to request a change in a method of accounting for depreciation under section 167.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1651,8 +1651,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "498cf287a4930d9bd8d6ce89ee3018e9",
-    "text": "Rev. Proc. 74-11 provides a procedure whereby applicants are considered to have obtained the consent of the Commissioner to change their method of accounting for depreciation. You must file Form 3115 with the Service Center where your return will be filed within the first 180 days of the tax year in which it is desired to make the change. Attach.a copy of the form to the income tax return for the tax year of the change.",
+    "element_id": "2854aca9e6a37d275a60a126e431ef6e",
+    "text": "Rev. Proc. 74-11 provides a procedure whereby applicants are considered to have obtained the consent of the Commissioner to change their method of accounting for depreciation. You must file Form 3115 with the Service Center where your return will be filed within the first 180 days of the tax year in which it is desired to make the change. Attach a copy of the form to the income tax return for the tax year of the change.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1673,8 +1673,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "bc3d896ded808d99ce1a66ccdc30a5a6",
-    "text": "Note: Do not use Form 3115 to make an election under section 168. Such an election may be made only on the tax return for the year in which the property is placed in service. In addition, Form 3115 is not to be used to request approval to revoke an election made under section 168. Such a request must be made in accordance with Rev. Proc. 87-1 (updated annually).",
+    "element_id": "4fb331478f9a833e74ffd537b02e26d2",
+    "text": "Note: Do not use Form 3115 to make an election under section 168. Such an election may be made only on the tax return for the year in which the property is placed tn service. In addition, Form 3115 is not to be used to request approval to revoke an election made under section 168. Such a request must be made in accordance with Rev. Proc. 87-1 (updated annually).",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1717,8 +1717,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "2c3490b47d0f31f3fd0ccdb75286b1df",
-    "text": "Generally, this section should be used for requesting changes in a method of accounting for which provision has not been made elsewhere on this form. Attach additional pages if more space ts needed for a full explanation of the present method used and the proposed change requested.",
+    "element_id": "8b524af5086ce3b0afc2c395be45ba33",
+    "text": "Generally, this section should be used for requesting changes !n a method of accounting for which provision has not been made elsewhere on this form. Attach additional pages if more space ts needed for a full explanation of the present method used and the proposed change requested.",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [

--- a/test_unstructured_ingest/expected-structured-output/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.json
+++ b/test_unstructured_ingest/expected-structured-output/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.json
@@ -134,8 +134,8 @@
   },
   {
     "type": "UncategorizedText",
-    "element_id": "6f69e5f921907e689f1a52bd84282b31",
-    "text": "arXiv",
+    "element_id": "32c128c3cfeca2ab12b98d336ccfddfc",
+    "text": "arX1V",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -267,8 +267,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "97c951d2dd3a1b5452d0c55e62e8ea78",
-    "text": "Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson’, and Weining Li®",
+    "element_id": "4dfee7e352ae892814e46bb220094b0f",
+    "text": "Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson®, and Weining Li>",
     "metadata": {
       "is_extracted": "true",
       "filetype": "application/pdf",
@@ -365,9 +365,32 @@
     }
   },
   {
+    "type": "UncategorizedText",
+    "element_id": "fac7bfe169d228f12a722b04ec288ac3",
+    "text": "1",
+    "metadata": {
+      "is_extracted": "true",
+      "filetype": "application/pdf",
+      "languages": [
+        "eng"
+      ],
+      "page_number": 1,
+      "data_source": {
+        "record_locator": {
+          "path": "/home/runner/work/unstructured/unstructured/test_unstructured_ingest/example-docs/layout-parser-paper.pdf"
+        },
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "Title",
-    "element_id": "3a170066f972d25cc303a05ddc16d52c",
-    "text": "1 Introduction",
+    "element_id": "b80c5d03ae12c07fd94fe7ce85ff75e5",
+    "text": "Introduction",
     "metadata": {
       "is_extracted": "true",
       "filetype": "application/pdf",
@@ -389,7 +412,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "8de96d1e80af35f9b6954252e14c2caf",
+    "element_id": "c676c7c3cc942056073be2efe4a7fbfc",
     "text": "Deep Learning(DL)-based approaches are the state-of-the-art for a wide range of document image analysis (DIA) tasks including document image classiﬁcation [11,",
     "metadata": {
       "is_extracted": "true",
@@ -709,7 +732,7 @@
     }
   },
   {
-    "type": "Title",
+    "type": "ListItem",
     "element_id": "f5a6697190c20bf6030d8e4ae8f6861a",
     "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA",
     "metadata": {
@@ -1025,7 +1048,7 @@
     }
   },
   {
-    "type": "Footer",
+    "type": "ListItem",
     "element_id": "b1fa4bbd1bdda08489faab5bf3adf5cc",
     "text": "6 The number shown is obtained by specifying the search type as ‘code’.",
     "metadata": {
@@ -1071,7 +1094,7 @@
     }
   },
   {
-    "type": "Footer",
+    "type": "UncategorizedText",
     "element_id": "d881ce84f017d89f6e35e2bc4b133bfc",
     "text": "8 https://github.com/BobLd/DocumentLayoutAnalysis",
     "metadata": {
@@ -1186,32 +1209,9 @@
     }
   },
   {
-    "type": "UncategorizedText",
-    "element_id": "fe238f610fe610b8ce1abaa08a0e3e63",
-    "text": "4",
-    "metadata": {
-      "is_extracted": "true",
-      "filetype": "application/pdf",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 4,
-      "data_source": {
-        "record_locator": {
-          "path": "/home/runner/work/unstructured/unstructured/test_unstructured_ingest/example-docs/layout-parser-paper.pdf"
-        },
-        "permissions_data": [
-          {
-            "mode": 33188
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "92c4289ad4af7c0793e40d5662707e0a",
-    "text": "Z. Shen et al.",
+    "type": "ListItem",
+    "element_id": "4ee4b32d55cf115add5734b1958b078d",
+    "text": "4 Z. Shen et al.",
     "metadata": {
       "is_extracted": "true",
       "filetype": "application/pdf",
@@ -1233,8 +1233,8 @@
   },
   {
     "type": "Image",
-    "element_id": "c4f9a0b797137c8c8f492f1af753f9a0",
-    "text": "Model Customization Efficient Data Annotation Customized Model Training} === | Layout Detection Models | === DIA Pipeline Sharing OCR Module | = | Layout Data Structure ) = { storage & Visualization Community Platform DIA Model Hub",
+    "element_id": "e264392de87494789d1192a5dbc5af77",
+    "text": "Model Customization Document Images Community Platform DIA Model Hub “| Efficient Data Annotation Customized Model Training} === | Layout Detection Models | === DIA Pipeline Sharing OCR Module =— | Layout Data Structure | == | Storage & Visualization iF",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1255,7 +1255,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "466f0bc21599ccf0fa27c021cb023f90",
+    "element_id": "cefd08a6e022c1288d551ca4d088e7a0",
     "text": "Fig.1: The overall architecture of LayoutParser. For an input document image, the core LayoutParser library provides a set of oﬀ-the-shelf tools for layout detection, OCR, visualization, and storage, backed by a carefully designed layout data structure. LayoutParser also supports high level customization via eﬃcient layout annotation and model training functions. These improve model accuracy on the target samples. The community platform enables the easy sharing of DIA models and whole digitization pipelines to promote reusability and reproducibility. A collection of detailed documentation, tutorials and exemplar projects make LayoutParser easy to learn and use.",
     "metadata": {
       "is_extracted": "true",
@@ -1278,7 +1278,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "b4948db85ca791e99aa92589fc41734f",
+    "element_id": "bc4e71c1982fa113c76dea6b5821d3e4",
     "text": "AllenNLP [8] and transformers [34] have provided the community with complete DL-based support for developing and deploying models for general computer vision and natural language processing problems. LayoutParser, on the other hand, specializes speciﬁcally in DIA tasks. LayoutParser is also equipped with a community platform inspired by established model hubs such as Torch Hub [23] and TensorFlow Hub [1]. It enables the sharing of pretrained models as well as full document processing pipelines that are unique to DIA tasks.",
     "metadata": {
       "is_extracted": "true",
@@ -1323,7 +1323,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "7651db80014a85ab253367d3bd3e4f88",
+    "element_id": "d2119cdfef98e3e3c177c44175be69a4",
     "text": "There have been a variety of document data collections to facilitate the development of DL models. Some examples include PRImA [3](magazine layouts), PubLayNet [38](academic paper layouts), Table Bank [18](tables in academic papers), Newspaper Navigator Dataset [16, 17](newspaper ﬁgure layouts) and HJDataset [31](historical Japanese document layouts). A spectrum of models trained on these datasets are currently available in the LayoutParser model zoo to support diﬀerent use cases.",
     "metadata": {
       "is_extracted": "true",
@@ -1378,7 +1378,7 @@
   },
   {
     "type": "Title",
-    "element_id": "5a1838a8f40b4523094652cf14ab974c",
+    "element_id": "695dba85a54c05b38377a5960b7dca52",
     "text": "3 The Core LayoutParser Library",
     "metadata": {
       "is_extracted": "true",
@@ -1401,7 +1401,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "47e45d28d96fc14ddc709835de35ece5",
+    "element_id": "cf23ea5ede08492b2715a8a3b5b23daf",
     "text": "At the core of LayoutParser is an oﬀ-the-shelf toolkit that streamlines DL- based document image analysis. Five components support a simple interface with comprehensive functionalities: 1) The layout detection models enable using pre-trained or self-trained DL models for layout detection with just four lines of code. 2) The detected layout information is stored in carefully engineered",
     "metadata": {
       "is_extracted": "true",
@@ -1501,30 +1501,7 @@
           "start_index": 65
         }
       ],
-      "text_as_html": "<table><thead><tr><th>Dataset</th><th>| Base Model'|</th><th>Large Model |</th><th>Notes</th></tr></thead><tbody><tr><td>PubLayNet [38]</td><td>F/M</td><td>M</td><td>Layouts of modern scientific documents</td></tr><tr><td>PRImA [3]</td><td>M</td><td></td><td>Layouts of scanned modern magazines and scientific reports</td></tr><tr><td>Newspaper [17]</td><td>F</td><td></td><td>Layouts of scanned US newspapers from the 20th century</td></tr><tr><td>TableBank [18]</td><td>F</td><td>F</td><td>Table region on modern scientific and business document.</td></tr><tr><td>HJDataset [31]</td><td>F/M</td><td></td><td>Layouts of history Japanese documents</td></tr></tbody></table>",
-      "filetype": "application/pdf",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 5,
-      "data_source": {
-        "record_locator": {
-          "path": "/home/runner/work/unstructured/unstructured/test_unstructured_ingest/example-docs/layout-parser-paper.pdf"
-        },
-        "permissions_data": [
-          {
-            "mode": 33188
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "2ec98f0a0b35309e06494a35af88d51c",
-    "text": "1 For each dataset, we train several models of diﬀerent sizes for diﬀerent needs (the trade-oﬀ between accuracy",
-    "metadata": {
-      "is_extracted": "true",
+      "text_as_html": "<table><thead><tr><th>Dataset</th><th>Base Model’</th><th>Large Model</th><th>Notes</th></tr></thead><tbody><tr><td>PubLayNet [38]</td><td>F/M</td><td>M</td><td>Layouts of modern scientific documents</td></tr><tr><td>PRImA [3]</td><td>M</td><td></td><td>Layouts of scanned modern magazines and scientific reports</td></tr><tr><td>Newspaper [17]</td><td>F</td><td></td><td>Layouts of scanned US newspapers from the 20th century</td></tr><tr><td>TableBank [18]</td><td>F</td><td></td><td>Table region on modern scientific and business document</td></tr><tr><td>HJDataset [31]</td><td>F/M</td><td></td><td>Layouts of history Japanese documents</td></tr></tbody></table>",
       "filetype": "application/pdf",
       "languages": [
         "eng"
@@ -1544,8 +1521,8 @@
   },
   {
     "type": "FigureCaption",
-    "element_id": "59e8b34937e08c490512e38b5803dce3",
-    "text": "vs. computational cost). For “base model” and “large model”, we refer to using the ResNet 50 or ResNet 101 backbones [13], respectively. One can train models of diﬀerent architectures, like Faster R-CNN [28] (F) and Mask R-CNN [12] (M). For example, an F in the Large Model column indicates it has a Faster R-CNN model trained using the ResNet 101 backbone. The platform is maintained and a number of additions will be made to the model zoo in coming months.",
+    "element_id": "f978160527177fa39c13774ec8dfa9cb",
+    "text": "1 For each dataset, we train several models of diﬀerent sizes for diﬀerent needs (the trade-oﬀ between accuracy vs. computational cost). For “base model” and “large model”, we refer to using the ResNet 50 or ResNet 101 backbones [13], respectively. One can train models of diﬀerent architectures, like Faster R-CNN [28] (F) and Mask R-CNN [12] (M). For example, an F in the Large Model column indicates it has a Faster R-CNN model trained using the ResNet 101 backbone. The platform is maintained and a number of additions will be made to the model zoo in coming months.",
     "metadata": {
       "is_extracted": "true",
       "links": [
@@ -1584,7 +1561,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "0b9e7697400602ac472eda5564c0f44d",
+    "element_id": "55b33df7609960c3552a0b7bc1a5a9c6",
     "text": "layout data structures, which are optimized for eﬃciency and versatility. 3) When necessary, users can employ existing or customized OCR models via the uniﬁed API provided in the OCR module. 4) LayoutParser comes with a set of utility functions for the visualization and storage of the layout data. 5) LayoutParser is also highly customizable, via its integration with functions for layout data annotation and model training. We now provide detailed descriptions for each component.",
     "metadata": {
       "is_extracted": "true",
@@ -1607,7 +1584,7 @@
   },
   {
     "type": "Title",
-    "element_id": "9e349da0d3169a69ebef29f87c80aa84",
+    "element_id": "6e9df774416cc71548308e324b4bdbb7",
     "text": "3.1 Layout Detection Models",
     "metadata": {
       "is_extracted": "true",
@@ -1630,7 +1607,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "f446727c56457e21e13708bf3821774d",
+    "element_id": "bbcc10c2b92de0cbdce8629f18b0d7ad",
     "text": "In LayoutParser, a layout model takes a document image as an input and generates a list of rectangular boxes for the target content regions. Diﬀerent from traditional methods, it relies on deep convolutional neural networks rather than manually curated rules to identify content regions. It is formulated as an object detection problem and state-of-the-art models like Faster R-CNN [28] and Mask R-CNN [12] are used. This yields prediction results of high accuracy and makes it possible to build a concise, generalized interface for layout detection. LayoutParser, built upon Detectron2 [35], provides a minimal API that can perform layout detection with only four lines of code in Python:",
     "metadata": {
       "is_extracted": "true",
@@ -1670,7 +1647,7 @@
   },
   {
     "type": "ListItem",
-    "element_id": "53b448c75f1556b1f60b4e3324bd0724",
+    "element_id": "508a6705bb0bfb693616cc14fec5e1b9",
     "text": "1 import layoutparser as lp",
     "metadata": {
       "is_extracted": "true",
@@ -1692,9 +1669,9 @@
     }
   },
   {
-    "type": "NarrativeText",
-    "element_id": "eaf41ed9e5bb3da52339a954727209eb",
-    "text": "2 image = cv2.imread(\"image_file\") # load images 3 model = lp.Detectron2LayoutModel( 4 \"lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config\")",
+    "type": "ListItem",
+    "element_id": "d7eccf8affb9442c47b466236f1dc3d4",
+    "text": "2 image = cv2.imread(\"image_file\") # load images",
     "metadata": {
       "is_extracted": "true",
       "filetype": "application/pdf",
@@ -1716,7 +1693,7 @@
   },
   {
     "type": "ListItem",
-    "element_id": "dd05ea3368e0313a428d5e2b45401718",
+    "element_id": "f30541418a7dca51e3e4cd880486ab9c",
     "text": "3 model = lp.Detectron2LayoutModel(",
     "metadata": {
       "is_extracted": "true",
@@ -1738,8 +1715,54 @@
     }
   },
   {
+    "type": "UncategorizedText",
+    "element_id": "29e642de3b82879282412bc518a0b561",
+    "text": "\"lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config\")",
+    "metadata": {
+      "is_extracted": "true",
+      "filetype": "application/pdf",
+      "languages": [
+        "eng"
+      ],
+      "page_number": 5,
+      "data_source": {
+        "record_locator": {
+          "path": "/home/runner/work/unstructured/unstructured/test_unstructured_ingest/example-docs/layout-parser-paper.pdf"
+        },
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "ListItem",
-    "element_id": "9fd6cd6d821c887bffbf2d5059354e02",
+    "element_id": "4d9fec76fbadfe7f4577be24fa1b646f",
+    "text": "4",
+    "metadata": {
+      "is_extracted": "partial",
+      "filetype": "application/pdf",
+      "languages": [
+        "eng"
+      ],
+      "page_number": 5,
+      "data_source": {
+        "record_locator": {
+          "path": "/home/runner/work/unstructured/unstructured/test_unstructured_ingest/example-docs/layout-parser-paper.pdf"
+        },
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "ListItem",
+    "element_id": "2b6917b3494980ac75bb52f0f07baf43",
     "text": "5 layout = model.detect(image)",
     "metadata": {
       "is_extracted": "true",
@@ -1762,7 +1785,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "a396a606cfc323c02a0de45d91b69d6d",
+    "element_id": "7548183e8c62fd95c88ba09f48403e0e",
     "text": "LayoutParser provides a wealth of pre-trained model weights using various datasets covering diﬀerent languages, time periods, and document types. Due to domain shift [7], the prediction performance can notably drop when models are ap- plied to target samples that are signiﬁcantly diﬀerent from the training dataset. As document structures and layouts vary greatly in diﬀerent domains, it is important to select models trained on a dataset similar to the test samples. A semantic syntax is used for initializing the model weights in LayoutParser, using both the dataset name and model name lp://<dataset-name>/<model-architecture-name>.",
     "metadata": {
       "is_extracted": "true",
@@ -1791,32 +1814,9 @@
     }
   },
   {
-    "type": "UncategorizedText",
-    "element_id": "676118b62c2261113a23a610c2ac50cb",
-    "text": "6",
-    "metadata": {
-      "is_extracted": "true",
-      "filetype": "application/pdf",
-      "languages": [
-        "eng"
-      ],
-      "page_number": 6,
-      "data_source": {
-        "record_locator": {
-          "path": "/home/runner/work/unstructured/unstructured/test_unstructured_ingest/example-docs/layout-parser-paper.pdf"
-        },
-        "permissions_data": [
-          {
-            "mode": 33188
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "UncategorizedText",
-    "element_id": "710ac103981c6363195774b02ee582d4",
-    "text": "Z. Shen et al.",
+    "type": "NarrativeText",
+    "element_id": "9822d87165468afaadb6f46d821030af",
+    "text": "6 Z. Shen et al.",
     "metadata": {
       "is_extracted": "true",
       "filetype": "application/pdf",
@@ -1838,8 +1838,8 @@
   },
   {
     "type": "Image",
-    "element_id": "403965f98f47c92554207f7628ffeefe",
-    "text": "o 3 4 9 s a 8 4 8 3 8 8 . g . £ o 3 ¥ Coordinate § F g 3 + § 3 Block Block Reading| 4 $ Extra features Tea | [ye | | ower é 2 a o ¢ 8 [ coordinatel textblock1 | 3 a , see 3 i A .., textblock2 , layouti ] § \" @ A list of the layout elements é",
+    "element_id": "b03c134c31ac99a48d297deeb16360c4",
+    "text": "o ) # ay Ss cH 3 Rectangle Quadrilateral g 4 M< -d fe) 3 v Es 4 4 o for) ° q a Coordinate 8S 4 P 9 + () ‘ 3 ri) Block Block Reading] g Extra features Text Tye | | onder E ° 4 a ¢ a [ coordinatel textblock1 4 » 1 pees ‘ 3 ES .., textblock2 layout1 ] F 1 Uf lf a q o A list of the layout elements E",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -1860,7 +1860,7 @@
   },
   {
     "type": "FigureCaption",
-    "element_id": "9f11aa6b22dea1bba7eb0d122c0c5562",
+    "element_id": "0a9486298b412d0a5afd62b652c6ccda",
     "text": "Fig.2: The relationship between the three types of layout data structures. Coordinate supports three kinds of variation; TextBlock consists of the co- ordinate information and extra features like block text, types, and reading orders; a Layout object is a list of all possible layout elements, including other Layout objects. They all support the same set of transformation and operation APIs for maximum ﬂexibility.",
     "metadata": {
       "is_extracted": "true",
@@ -1883,7 +1883,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "d997f63fd79c7e03050ca01b58dfdf0a",
+    "element_id": "43f1ee92756d0ae08882e548ff4c83d8",
     "text": "Shown in Table 1, LayoutParser currently hosts 9 pre-trained models trained on 5 diﬀerent datasets. Description of the training dataset is provided alongside with the trained models such that users can quickly identify the most suitable models for their tasks. Additionally, when such a model is not readily available, LayoutParser also supports training customized layout models and community sharing of the models (detailed in Section 3.5).",
     "metadata": {
       "is_extracted": "true",
@@ -1913,7 +1913,7 @@
   },
   {
     "type": "Title",
-    "element_id": "836e9227ef393d8b00369e6300fbba4c",
+    "element_id": "74d4520c77d6971b927aa01c65f7129e",
     "text": "3.2 Layout Data Structures",
     "metadata": {
       "is_extracted": "true",
@@ -1936,7 +1936,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "601f7d95172984c75de081023ca64c15",
+    "element_id": "bf2dab9cd733e9dab6ef649810667a00",
     "text": "A critical feature of LayoutParser is the implementation of a series of data structures and operations that can be used to eﬃciently process and manipulate the layout elements. In document image analysis pipelines, various post-processing on the layout analysis model outputs is usually required to obtain the ﬁnal outputs. Traditionally, this requires exporting DL model outputs and then loading the results into other pipelines. All model outputs from LayoutParser will be stored in carefully engineered data types optimized for further processing, which makes it possible to build an end-to-end document digitization pipeline within LayoutParser. There are three key components in the data structure, namely the Coordinate system, the TextBlock, and the Layout. They provide diﬀerent levels of abstraction for the layout data, and a set of APIs are supported for transformations or operations on these classes.",
     "metadata": {
       "is_extracted": "true",
@@ -2113,7 +2113,7 @@
     }
   },
   {
-    "type": "ListItem",
+    "type": "NarrativeText",
     "element_id": "7f736fc72998c81eaff74b157ed4b005",
     "text": "2 # Can be easily switched to other OCR software",
     "metadata": {
@@ -2136,7 +2136,7 @@
     }
   },
   {
-    "type": "NarrativeText",
+    "type": "ListItem",
     "element_id": "ffb8f709daf70f8dad507c4d212cd8b2",
     "text": "3 tokens = ocr_agent.detect(image)",
     "metadata": {
@@ -2291,7 +2291,7 @@
     "text": "Operation Name Description block.pad(top, bottom, right, left) Enlarge the current block according to the input block.scale(fx, fy) Scale the current block given the ratio in x and y direction block.shift(dx, dy) Move the current block with the shift distances in x and y direction block1.is in(block2) Whether block1 is inside of block2 block1.intersect(block2) Return the intersection region of block1 and block2. Coordinate type to be determined based on the inputs. block1.union(block2) Return the union region of block1 and block2. Coordinate type to be determined based on the inputs. block1.relative to(block2) Convert the absolute coordinates of block1 to relative coordinates to block2 block1.condition on(block2) Calculate the absolute coordinates of block1 given the canvas block2’s absolute coordinates block.crop image(image) Obtain the image segments in the block region",
     "metadata": {
       "is_extracted": "true",
-      "text_as_html": "<table><thead><tr><th>block.pad(top,</th><th>bottom,</th><th>right,</th><th>left)</th><th>Enlarge the current block according to the input</th></tr></thead><tbody><tr><td>block.scale(fx, fy)</td><td></td><td></td><td></td><td>Scale the current block given the ratio in x and y direction</td></tr><tr><td>block.shift (dx, dy)</td><td></td><td></td><td></td><td>Move the current block with the shift distances in x and y direction</td></tr><tr><td>block1.is_in(block2)</td><td></td><td></td><td></td><td>Whether block] is inside of block2</td></tr><tr><td>block1. intersect</td><td>(block2)</td><td></td><td></td><td>Return the intersection region of block1 and block2. Coordinate type to be determined based on the inputs.</td></tr><tr><td>block1.union(block2)</td><td></td><td></td><td></td><td>Return the union region of block1 and block2. Coordinate type to be determined based the inputs.</td></tr><tr><td>block1.relative_to(block2)</td><td></td><td></td><td></td><td>Convert the absolute coordinates of block1 to relative coordinates to block2</td></tr><tr><td>block1.condition_on(block2)</td><td></td><td></td><td></td><td>Calculate the absolute coordinates of block1 given the canvas block2’s absolute coordinates</td></tr><tr><td>block. crop_image</td><td>(image)</td><td></td><td></td><td>Obtain the image segments in the block region</td></tr></tbody></table>",
+      "text_as_html": "<table><thead><tr><th>block.pad(top,</th><th>bottom, right,</th><th>left)</th><th>Enlarge the current block according to the input</th></tr></thead><tbody><tr><td>block.scale(fx,</td><td>fy)</td><td></td><td>Scale the current block given the ratio in x and y direction</td></tr><tr><td>block.shift(dx,</td><td>dy)</td><td></td><td>Move the current block with the shift distances in x and y direction</td></tr><tr><td>block1.is_in(block2)</td><td></td><td></td><td>Whether block] is inside of block2</td></tr><tr><td>block1.intersect</td><td>(block2)</td><td></td><td>Return the intersection region of block1 and block2. Coordinate type to be determined based on the inputs.</td></tr><tr><td></td><td></td><td></td><td></td></tr><tr><td>block1.union(block2)</td><td></td><td></td><td>Return the union region of blockl and block2. Coordinate type to be determined based on the inputs. Convert the absolute coordinates of block1 to</td></tr><tr><td>block1.relative_to(block2)</td><td></td><td></td><td>relative coordinates to block2 Calculate the absolute coordinates of block1 given</td></tr><tr><td>block1.condition_on(block2) block. crop_image</td><td>(image)</td><td></td><td>the canvas block2’s absolute coordinates Obtain the image segments in the block region</td></tr></tbody></table>",
       "filetype": "application/pdf",
       "languages": [
         "eng"
@@ -2478,7 +2478,30 @@
   },
   {
     "type": "ListItem",
-    "element_id": "c069937e6c2bfc0f856835f3af4d6181",
+    "element_id": "8c43dbfa734bf2d766c260f253381da8",
+    "text": "9",
+    "metadata": {
+      "is_extracted": "partial",
+      "filetype": "application/pdf",
+      "languages": [
+        "eng"
+      ],
+      "page_number": 9,
+      "data_source": {
+        "record_locator": {
+          "path": "/home/runner/work/unstructured/unstructured/test_unstructured_ingest/example-docs/layout-parser-paper.pdf"
+        },
+        "permissions_data": [
+          {
+            "mode": 33188
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "UncategorizedText",
+    "element_id": "dfa95a5d6dec88cb5c802366b8841672",
     "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA",
     "metadata": {
       "is_extracted": "true",
@@ -2501,8 +2524,8 @@
   },
   {
     "type": "Image",
-    "element_id": "0f24d2d9d336ceae460a3852785eee67",
-    "text": "10g Buypunog uayoy Aeydsiq 1 vondo 10g 6ulpunog usyoy api :z uondo, Mode I: Showing Layout on the Original Image Mode Il: Drawing OCR’ Text at the Correspoding Position",
+    "element_id": "8c7735c2c17a96741a9d5d6b3740f8d6",
+    "text": "4 Anonymous ICDAR 2021 Submission 3 ynonymous_)FCDAR_] 2021) Submission <= + + xog Buipunog uayo, Aejdsig :1 uondo ated | vith fimetions for! layout | ‘etailed descriptions for’ each! xog Bulpunog uayo) apiy :z uondo Mode |: Showing Layout on the Original Image Mode II: Drawing OCR’d Text at the Correspoding Position",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -2523,7 +2546,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "4d1b9566e792683b9559b778be4f4046",
+    "element_id": "fb0f4f71d292bd9f2f935ca0c76cf6a3",
     "text": "Fig.3: Layout detection and OCR results visualization generated by the LayoutParser APIs. Mode I directly overlays the layout region bounding boxes and categories over the original image. Mode II recreates the original document via drawing the OCR’d texts at their corresponding positions on the image canvas. In this ﬁgure, tokens in textual regions are ﬁltered using the API and then displayed.",
     "metadata": {
       "is_extracted": "true",
@@ -2546,7 +2569,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "625c9e1d41a9740f094041595f79953d",
+    "element_id": "7d5983166b8a43afc2202b6200f5afa9",
     "text": "can also be highly sensitive and not sharable publicly. To overcome these chal- lenges, LayoutParser is built with rich features for eﬃcient data annotation and customized model training.",
     "metadata": {
       "is_extracted": "true",
@@ -2569,7 +2592,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "a3498730b5cd3fe9405fad69bcf37882",
+    "element_id": "9561eae776a8a4c9b8e7a92d2e2b54ae",
     "text": "LayoutParser incorporates a toolkit optimized for annotating document lay- outs using object-level active learning [32]. With the help from a layout detection model trained along with labeling, only the most important layout objects within each image, rather than the whole image, are required for labeling. The rest of the regions are automatically annotated with high conﬁdence predictions from the layout detection model. This allows a layout dataset to be created more eﬃciently with only around 60% of the labeling budget.",
     "metadata": {
       "is_extracted": "true",
@@ -2599,7 +2622,7 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "c4ccf2cf2e7495668221cbe51534f90b",
+    "element_id": "cd9ff032b8a80f56188ad2b5b7156573",
     "text": "After the training dataset is curated, LayoutParser supports diﬀerent modes for training the layout models. Fine-tuning can be used for training models on a small newly-labeled dataset by initializing the model with existing pre-trained weights. Training from scratch can be helpful when the source dataset and target are signiﬁcantly diﬀerent and a large training set is available. However, as suggested in Studer et al.’s work[33], loading pre-trained weights on large-scale datasets like ImageNet [5], even from totally diﬀerent domains, can still boost model performance. Through the integrated API provided by LayoutParser, users can easily compare model performances on the benchmark datasets.",
     "metadata": {
       "is_extracted": "true",
@@ -2657,8 +2680,8 @@
   },
   {
     "type": "Image",
-    "element_id": "1dd15be7cc0092ea5c221a34bf854869",
-    "text": "Intra-column reading order ‘Token Categories Variabte (EE company type Column Categories J tie Adatress () tet [J Section Header Column reading order Maximum Allowed Height (b) Illustration of the recreated document with dense text structure for better OCR performance",
+    "element_id": "a6aa8357c70f57fb94d3168f2f32c24a",
+    "text": "Intra-column reading order Token Categories 2 (Address £ = / Number 3 Variable {7 company type Column Categories Title = ier, Ba KS ie A ATL ge HR a OH a A a S| Rolls Soper ee eres be] Address B Rm a Sanne i es g ee a RUC AH unl een cen RENE Section Header S| ganm Bin MR TR RM AM L_ ES Baap hn} 4 Hb es GH A AR 25% B ei FE : ie § Aa at FL eta BE & ih 3 as GJ rr S me (b) Illustration of the recreated document with dense text structure for better OCR performance",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -2981,8 +3004,8 @@
   },
   {
     "type": "Image",
-    "element_id": "0ae05b73a88b238b80c4d18c6f9274ec",
-    "text": "“Active Learning Layout Annotate Layout Dataset | Annotation Toolkit ¥ Tayo betetion Deep Learning Layout \" Model Training & Inference, ¥ Post processing Handy Data Structures & APIs for Layout Data ¥ Text Recognition | <—— Default and bustomized ¥ pon Wa i — ayout Structure Visualization & Export | <—— | vic alization & Storage The Japanese Document Helpful LayoutParser Digitization Pipeline Modules",
+    "element_id": "22458898f1f58cfb0b54a438a4737567",
+    "text": "Active Learning Layout Annotate Layout Dataset | + Model Training & Inference Post processing Handy Dat Structures & —e—e€v Text Recognition | <—— ations Layout Structure Visualization & Export | «| V3. alization & Storage Default and Customized OCR Models The Japanese Document Helpful LayoutParser Digitization Pipeline Modules",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -3048,7 +3071,7 @@
     }
   },
   {
-    "type": "Title",
+    "type": "ListItem",
     "element_id": "9d917f215b0115c679105482b80d2d2d",
     "text": "12 Z. Shen et al.",
     "metadata": {
@@ -3292,8 +3315,8 @@
   },
   {
     "type": "Image",
-    "element_id": "e45bde8fddca133387e91d96fa2d136a",
-    "text": "(6) Partial table atthe bottom (b) Ful page table (©) Partial table atthe top (4) Mis detected text line",
+    "element_id": "d7ab3da5ec0adb1b2b4fb5f800a545a0",
+    "text": "ra (a) Partial table at the bottom (b) Full page table (c) Partial table at the top (d) Mis-detected text line",
     "metadata": {
       "filetype": "application/pdf",
       "languages": [
@@ -3336,7 +3359,7 @@
     }
   },
   {
-    "type": "Title",
+    "type": "ListItem",
     "element_id": "60e4fa05c78628ec1c6fa6003b86b52e",
     "text": "5.2 A light-weight Visual Table Extractor",
     "metadata": {
@@ -3814,8 +3837,8 @@
   },
   {
     "type": "ListItem",
-    "element_id": "0176491ee2584bffdfb943caa8aefab4",
-    "text": "Lukasz Garncarek, Powalski, R., Stanistawek, T., Topolski, B., Halama, P., Graliriski, F.: Lambert: Layout-aware (language) modeling using bert for in- formation extraction (2020)",
+    "element_id": "b28cae31cc0ad503c9658c6b3e3bd4d7",
+    "text": "Lukasz Garncarek, Powalski, R., Stanistawek, T., Topolski, B., Halama, P., Gralinski, F.: Lambert: Layout-aware (language) modeling using bert for in- formation extraction (2020)",
     "metadata": {
       "is_extracted": "true",
       "filetype": "application/pdf",


### PR DESCRIPTION
This pull request includes updated ingest test fixtures.
Please review and merge if appropriate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates golden test outputs; runtime behavior risk is limited to asserting the new PDF parsing results and may require validation that the new fixtures represent intended output.
> 
> **Overview**
> Updates ingest test fixtures for PDF processing (`IRS-form-1987.pdf` and `layout-parser-paper.pdf`) in both HTML and JSON expected outputs.
> 
> The regenerated fixtures reflect changed OCR/text normalization and layout typing/structure (new `element_id`s, small text deltas, and reclassified elements like `Title`/`Footer` to `ListItem`, plus table HTML serialization differences), consistent with making PDF image DPI/processing output deterministic across runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ba6c12a7fc364cb9170a51ab16c34214fe231a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->