### PR TITLE
chore: bump dependencies for 0.18.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.18.34
+
+### Enhancements
+- Bump `unstructured-inference` to 1.2.0
+
+### Fixes
+- **Security update**: Bumped `cryptography` to 46.0.4 to address security vulnerabilities
+- Bumped dependencies: `psutil`, `pypdf`, `python-iso639`, `tqdm`, `wrapt`, `protobuf`, `google-auth`, `pikepdf`, `pathspec`, `pytokens`
+
 ## 0.18.33
 
 ### Enhancements

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ click==8.3.1
     # via
     #   nltk
     #   python-oxmsg
-cryptography==46.0.3
+cryptography==46.0.4
     # via unstructured-client
 dataclasses-json==0.6.7
     # via
@@ -87,15 +87,15 @@ packaging==26.0
     # via
     #   marshmallow
     #   unstructured-client
-psutil==7.2.1
+psutil==7.2.2
     # via -r ./base.in
 pycparser==3.0
     # via cffi
-pypdf==6.6.1
+pypdf==6.6.2
     # via unstructured-client
 python-dateutil==2.9.0.post0
     # via unstructured-client
-python-iso639==2025.11.16
+python-iso639==2026.1.31
     # via -r ./base.in
 python-magic==0.4.27
     # via -r ./base.in
@@ -120,7 +120,7 @@ six==1.17.0
     #   unstructured-client
 soupsieve==2.8.3
     # via beautifulsoup4
-tqdm==4.67.1
+tqdm==4.67.2
     # via
     #   -r ./base.in
     #   nltk
@@ -150,5 +150,5 @@ urllib3==2.6.3
     #   unstructured-client
 webencodings==0.5.1
     # via html5lib
-wrapt==2.0.1
+wrapt==2.1.0
     # via -r ./base.in

--- a/requirements/extra-paddleocr.txt
+++ b/requirements/extra-paddleocr.txt
@@ -107,7 +107,7 @@ pillow==12.1.0
     #   paddlepaddle
     #   scikit-image
     #   unstructured-paddleocr
-protobuf==6.33.4
+protobuf==6.33.5
     # via
     #   -c ././deps/constraints.txt
     #   paddlepaddle
@@ -153,7 +153,7 @@ termcolor==3.3.0
     # via fire
 tifffile==2025.5.10
     # via scikit-image
-tqdm==4.67.1
+tqdm==4.67.2
     # via
     #   -c ./base.txt
     #   unstructured-paddleocr

--- a/requirements/extra-pdf-image.txt
+++ b/requirements/extra-pdf-image.txt
@@ -21,9 +21,10 @@ coloredlogs==15.0.1
     # via onnxruntime
 contourpy==1.3.2
     # via matplotlib
-cryptography==46.0.3
+cryptography==46.0.4
     # via
     #   -c ./base.txt
+    #   google-auth
     #   pdfminer-six
 cycler==0.12.1
     # via matplotlib
@@ -48,7 +49,7 @@ fsspec==2026.1.0
     #   torch
 google-api-core[grpc]==2.29.0
     # via google-cloud-vision
-google-auth==2.47.0
+google-auth==2.48.0
     # via
     #   google-api-core
     #   google-cloud-vision
@@ -146,7 +147,7 @@ pdfminer-six==20260107
     #   unstructured-inference
 pi-heif==1.2.0
     # via -r ./extra-pdf-image.in
-pikepdf==10.2.0
+pikepdf==10.3.0
     # via -r ./extra-pdf-image.in
 pillow==12.1.0
     # via
@@ -160,7 +161,7 @@ proto-plus==1.27.0
     # via
     #   google-api-core
     #   google-cloud-vision
-protobuf==6.33.4
+protobuf==6.33.5
     # via
     #   -c ././deps/constraints.txt
     #   google-api-core
@@ -170,7 +171,7 @@ protobuf==6.33.4
     #   onnx
     #   onnxruntime
     #   proto-plus
-psutil==7.2.1
+psutil==7.2.2
     # via
     #   -c ./base.txt
     #   accelerate
@@ -188,7 +189,7 @@ pycparser==3.0
     #   cffi
 pyparsing==3.3.2
     # via matplotlib
-pypdf==6.6.1
+pypdf==6.6.2
     # via
     #   -c ./base.txt
     #   -r ./extra-pdf-image.in
@@ -260,7 +261,7 @@ torchvision==0.25.0
     # via
     #   effdet
     #   timm
-tqdm==4.67.1
+tqdm==4.67.2
     # via
     #   -c ./base.txt
     #   huggingface-hub
@@ -278,7 +279,7 @@ typing-extensions==4.15.0
     #   torch
 tzdata==2025.3
     # via pandas
-unstructured-inference==1.1.7
+unstructured-inference==1.2.0
     # via -r ./extra-pdf-image.in
 unstructured-pytesseract==0.3.15
     # via -r ./extra-pdf-image.in
@@ -287,7 +288,7 @@ urllib3==2.6.3
     #   -c ./base.txt
     #   -c ././deps/constraints.txt
     #   requests
-wrapt==2.0.1
+wrapt==2.1.0
     # via
     #   -c ./base.txt
     #   deprecated

--- a/requirements/extra-xlsx.txt
+++ b/requirements/extra-xlsx.txt
@@ -4,7 +4,7 @@ cffi==2.0.0
     # via
     #   -c ./base.txt
     #   cryptography
-cryptography==46.0.3
+cryptography==46.0.4
     # via
     #   -c ./base.txt
     #   msoffcrypto-tool

--- a/requirements/huggingface.txt
+++ b/requirements/huggingface.txt
@@ -88,7 +88,7 @@ tokenizers==0.21.4
     #   transformers
 torch==2.10.0
     # via -r ./huggingface.in
-tqdm==4.67.1
+tqdm==4.67.2
     # via
     #   -c ./base.txt
     #   huggingface-hub

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -50,7 +50,7 @@ packaging==26.0
     #   -c ./base.txt
     #   black
     #   pytest
-pathspec==1.0.3
+pathspec==1.0.4
     # via
     #   black
     #   mypy
@@ -89,7 +89,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ./base.txt
     #   freezegun
-pytokens==0.4.0
+pytokens==0.4.1
     # via black
 ruff==0.14.14
     # via -r ./test.in

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.33"  # pragma: no cover
+__version__ = "0.18.34"  # pragma: no cover


### PR DESCRIPTION
- Bump unstructured-inference to 1.2.0
- Bump cryptography to 46.0.4 (security)
- Bump psutil, pypdf, python-iso639, tqdm, wrapt, protobuf, google-auth, pikepdf, pathspec, pytokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)