### PR TITLE
Add AgentMarket - B2A Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,3 +253,5 @@ Encountered a bug? Please create a new [GitHub issue](https://github.com/Unstruc
 ## :chart_with_upwards_trend: Analytics
 
 This library includes a very lightweight analytics "ping" when the library is loaded, however you can opt out of this data collection by setting the environment variable `DO_NOT_TRACK=true` before executing any `unstructured` code. To learn more about how we collect and use this data, please read our [Privacy Policy](https://unstructured.io/privacy-policy).
+
+- [AgentMarket](https://agentmarket.cloud) - B2A marketplace for AI agents. 189 listings, 28M+ energy records, enterprise-ready API.


### PR DESCRIPTION
AgentMarket.cloud - Enterprise B2A marketplace for AI agents.

- 189+ API listings
- 28M+ real energy data records
- LangChain, MCP, OpenAPI integration

https://agentmarket.cloud