### PR TITLE
Use bigger runner to publish images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,7 +69,7 @@ jobs:
         ARCH=$(cut -d "/" -f2 <<< ${{ matrix.docker-platform }})
         docker push "$DOCKER_BUILD_REPOSITORY:$ARCH-$SHORT_SHA"
   publish-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: [set-short-sha, build-images]
     env:
       SHORT_SHA: ${{ needs.set-short-sha.outputs.short_sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.20.1
+
+### Fixes
+- Switch CD `publish-images` job runner from `ubuntu-latest` to `ubuntu-latest-m` to fix "no space left on device" error when pulling multi-arch Docker images
+
 ## 0.20.0
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.20.0"  # pragma: no cover
+__version__ = "0.20.1"  # pragma: no cover


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/workflow-only change plus a version/changelog bump; low risk beyond potential runner availability/cost differences.
> 
> **Overview**
> Fixes CD Docker publishing failures by switching the `publish-images` GitHub Actions job runner from `ubuntu-latest` to `ubuntu-latest-m`, addressing "no space left on device" issues when pulling multi-arch images.
> 
> Updates release metadata by bumping `unstructured/__version__.py` to `0.20.1` and adding a matching changelog entry describing the CI runner change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6408c916ab0f2ab2cfedfdcc06b804909a0f9ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->