### PR TITLE
refactor: replace deprecated decorators in partition_image with apply_metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.21.9
+
+### Enhancements
+- **Replace deprecated `process_metadata` + `add_metadata` decorators in `partition_image` with unified `apply_metadata`**: Aligns image partitioner with the modern decorator pattern already used by `partition_pdf` and `partition_docx`, consolidating metadata post-processing into a single decorator.
+
 ## 0.21.8
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.21.8"  # pragma: no cover
+__version__ = "0.21.9"  # pragma: no cover

--- a/unstructured/partition/image.py
+++ b/unstructured/partition/image.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 from typing import IO, Any, Optional
 
 from unstructured.chunking import add_chunking_strategy
-from unstructured.documents.elements import Element, process_metadata
-from unstructured.file_utils.filetype import add_metadata
+from unstructured.documents.elements import Element
+from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import exactly_one
 from unstructured.partition.common.lang import check_language_args
+from unstructured.partition.common.metadata import apply_metadata
 from unstructured.partition.pdf import partition_pdf_or_image
 from unstructured.partition.utils.constants import PartitionStrategy
 
 
-@process_metadata()  # TODO(shreya): update to use `apply_metadata` decorator
-@add_metadata
+@apply_metadata(FileType.IMAGE)
 @add_chunking_strategy
 def partition_image(
     filename: Optional[str] = None,


### PR DESCRIPTION
## Summary

Resolves the TODO left in `unstructured/partition/image.py` (line 14) by replacing the legacy `@process_metadata()` + `@add_metadata` decorator stack with the modern, unified `@apply_metadata(FileType.IMAGE)` decorator.

## Details

The `partition_image` function was still using the older, two-step metadata decorator pattern:

@process_metadata()  # TODO(shreya): update to use @apply_metadata decorator
@add_metadata
@add_chunking_strategy

This PR removes those deprecated decorators and replaces them with:

@apply_metadata(FileType.IMAGE)
@add_chunking_strategy

---

## Why this matters

### Alignment

This brings `partition_image` into alignment with the established patterns already used by `partition_pdf` and `partition_docx`, which both correctly utilize `@apply_metadata(FileType.XXX)`.

### Safety

`@apply_metadata` correctly handles the superset of responsibilities from the old decorators (hash IDs, hierarchy, filetype MIME derivation, filename/url processing, and language detection). Because `partition_image` delegates parsing to `partition_pdf_or_image` (which is a plain function without metadata decorators), there is no risk of double-application.

---

## Changes Made

* Updated `unstructured/partition/image.py` to use `@apply_metadata(FileType.IMAGE)`.
* Replaced `process_metadata` and `add_metadata` imports with `apply_metadata` and `FileType`.
* Added an entry to `CHANGELOG.md` documenting the enhancement for `v0.21.9`.
* Bumped `version.py` to `0.21.9`.

---

## Testing

* Verified existing image partitioning unit tests pass locally.
* Verified no import cycle or side-effect regressions in `partition_pdf` or `partition_docx`.
* Followed all guidelines in `CONTRIBUTING.md`.
