### PR TITLE
fix: handle multipart MIME attachments in partition_email

### DIFF
--- a/example-docs/eml/mime-signed-multipart.eml
+++ b/example-docs/eml/mime-signed-multipart.eml
@@ -1,0 +1,26 @@
+MIME-Version: 1.0
+From: sender@example.com
+To: recipient@example.com
+Subject: PGP Signed Email
+Date: Mon, 10 Feb 2025 12:00:00 +0000
+Message-ID: <signed-test@example.com>
+Content-Type: multipart/signed; micalg=pgp-sha256;
+ protocol="application/pgp-signature";
+ boundary="signed-boundary"
+
+--signed-boundary
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This is a PGP signed email body.
+
+--signed-boundary
+Content-Type: application/pgp-signature; name="signature.asc"
+Content-Disposition: attachment; filename="signature.asc"
+Content-Transfer-Encoding: 7bit
+
+-----BEGIN PGP SIGNATURE-----
+iQEzBAABCAAdFiEEfakeSignatureDataHere
+-----END PGP SIGNATURE-----
+
+--signed-boundary--

--- a/example-docs/eml/mime-signed-with-attachment.eml
+++ b/example-docs/eml/mime-signed-with-attachment.eml
@@ -1,0 +1,38 @@
+MIME-Version: 1.0
+From: sender@example.com
+To: recipient@example.com
+Subject: PGP Signed Email With Attachment
+Date: Mon, 10 Feb 2025 12:00:00 +0000
+Message-ID: <signed-attach-test@example.com>
+Content-Type: multipart/mixed; boundary="outer-boundary"
+
+--outer-boundary
+Content-Type: multipart/signed; micalg=pgp-sha256;
+ protocol="application/pgp-signature";
+ boundary="signed-boundary"
+
+--signed-boundary
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+This is a PGP signed email with an attachment.
+
+--signed-boundary
+Content-Type: application/pgp-signature; name="signature.asc"
+Content-Disposition: attachment; filename="signature.asc"
+Content-Transfer-Encoding: 7bit
+
+-----BEGIN PGP SIGNATURE-----
+iQEzBAABCAAdFiEEfakeSignatureDataHere
+-----END PGP SIGNATURE-----
+
+--signed-boundary--
+
+--outer-boundary
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: attachment; filename="note.txt"
+Content-Transfer-Encoding: 7bit
+
+This is a text attachment.
+
+--outer-boundary--

--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -389,6 +389,66 @@ def test_partition_email_silently_skips_attachments_it_cannot_partition():
     ]
 
 
+def test_partition_email_handles_multipart_signed_attachment():
+    """A PGP-signed email wrapped in multipart/mixed does not crash (issue #3922).
+
+    When a multipart/signed part appears as an "attachment" inside a multipart/mixed
+    envelope, ``get_content()`` raises ``KeyError`` because Python's content-manager
+    has no handler for multipart types. The partitioner should handle this gracefully
+    by falling back to ``as_bytes()`` in ``_file_bytes``.
+    """
+    import email
+    import email.policy
+
+    from unstructured.partition.email import _AttachmentPartitioner
+
+    with open(example_doc_path("eml/mime-signed-with-attachment.eml"), "rb") as f:
+        msg = email.message_from_binary_file(f, policy=email.policy.default)
+
+    ctx = EmailPartitioningContext(
+        example_doc_path("eml/mime-signed-with-attachment.eml"),
+        process_attachments=True,
+    )
+
+    for att in msg.iter_attachments():
+        if att.is_multipart():
+            partitioner = _AttachmentPartitioner(att, ctx)
+            # -- this used to raise KeyError: 'multipart/signed' --
+            file_bytes = partitioner._file_bytes
+            assert isinstance(file_bytes, bytes)
+            assert len(file_bytes) > 0
+            assert b"PGP signed email" in file_bytes
+            break
+    else:
+        pytest.fail("No multipart attachment found in test email")
+
+
+def test_partition_email_file_bytes_works_for_non_multipart():
+    """_file_bytes still works normally for regular (non-multipart) attachments."""
+    import email
+    import email.policy
+
+    from unstructured.partition.email import _AttachmentPartitioner
+
+    with open(example_doc_path("eml/mime-signed-with-attachment.eml"), "rb") as f:
+        msg = email.message_from_binary_file(f, policy=email.policy.default)
+
+    ctx = EmailPartitioningContext(
+        example_doc_path("eml/mime-signed-with-attachment.eml"),
+        process_attachments=True,
+    )
+
+    for att in msg.iter_attachments():
+        if not att.is_multipart():
+            partitioner = _AttachmentPartitioner(att, ctx)
+            file_bytes = partitioner._file_bytes
+            assert isinstance(file_bytes, bytes)
+            assert b"text attachment" in file_bytes
+            break
+    else:
+        pytest.fail("No non-multipart attachment found in test email")
+
+
 # ================================================================================================
 # ISOLATED UNIT TESTS
 # ================================================================================================

--- a/unstructured/partition/common/__init__.py
+++ b/unstructured/partition/common/__init__.py
@@ -16,4 +16,5 @@ EXPECTED_ATTACHMENT_ERRORS: Final[tuple[type[BaseException], ...]] = (
     UnsupportedFileFormatError,
     ImportError,
     FileNotFoundError,
+    KeyError,
 )

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -392,10 +392,9 @@ class _AttachmentPartitioner:
         # -- avoid a circular import.
         from unstructured.partition.auto import partition
 
-        file = io.BytesIO(self._file_bytes)
-
         # -- partition the attachment --
         try:
+            file = io.BytesIO(self._file_bytes)
             elements = partition(
                 file=file,
                 metadata_filename=self._attachment_file_name,
@@ -431,7 +430,16 @@ class _AttachmentPartitioner:
 
     @lazyproperty
     def _file_bytes(self) -> bytes:
-        """The bytes of the attached file."""
+        """The bytes of the attached file.
+
+        For multipart MIME parts (e.g. multipart/signed in PGP-signed emails),
+        ``get_content()`` raises ``KeyError`` because Python's content-manager has
+        no handler for multipart types. In that case we fall back to the raw MIME
+        bytes of the part so downstream partitioners can still attempt to process it.
+        """
+        if self._attachment.is_multipart():
+            return self._attachment.as_bytes()
+
         content = self._attachment.get_content()
 
         if isinstance(content, str):


### PR DESCRIPTION
## Summary
- Fixes #3922 — `partition_email` crashes with `KeyError: 'multipart/mixed'` when processing PGP-signed emails with `process_attachments=True`
- Root cause: Python's `email.contentmanager` has no handler for `multipart/*` content types, so `get_content()` raises `KeyError` when called on a multipart MIME part that appears as an "attachment" (e.g. `multipart/signed` inside a `multipart/mixed` envelope)
- Fix applied in three layers:
  - `_file_bytes`: check `is_multipart()` first and use `as_bytes()` for raw MIME bytes
  - `_iter_elements`: move file creation inside the try/except block for uniform error handling
  - `EXPECTED_ATTACHMENT_ERRORS`: add `KeyError` as safety net for unhandled content types

## Files changed
- `unstructured/partition/email.py` — `_file_bytes` multipart handling + `_iter_elements` error boundary fix
- `unstructured/partition/common/__init__.py` — add `KeyError` to `EXPECTED_ATTACHMENT_ERRORS`
- `test_unstructured/partition/test_email.py` — 2 new unit tests
- `example-docs/eml/mime-signed-multipart.eml` — test fixture (simple PGP-signed email)
- `example-docs/eml/mime-signed-with-attachment.eml` — test fixture (reproduces exact bug scenario)

## Test plan
- [x] `_file_bytes` returns raw bytes for multipart attachments via `as_bytes()`
- [x] `_file_bytes` still works normally for regular (non-multipart) attachments
- [x] All 37 existing unit tests pass unchanged
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)