### PR TITLE
fix: skip complexity check when strategy is explicitly fast

### DIFF
--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -1616,6 +1616,17 @@ def test_is_pdf_too_complex_returns_false_for_normal_pdf():
     assert not pdf.is_pdf_too_complex(filename=example_doc_path("pdf/layout-parser-paper.pdf"))
 
 
+def test_partition_pdf_fast_strategy_bypasses_complexity_check():
+    """When strategy="fast" is explicit, the complexity check should not skip extraction."""
+    filename = example_doc_path("pdf/layout-parser-paper-fast.pdf")
+    with mock.patch.object(pdf, "is_pdf_too_complex", return_value=True) as mock_complex:
+        elements = pdf.partition_pdf(filename=filename, strategy=PartitionStrategy.FAST)
+    # is_pdf_too_complex should not have been called when strategy is "fast"
+    mock_complex.assert_not_called()
+    # elements should not be empty — text extraction should proceed regardless
+    assert len(elements) > 0
+
+
 def test_document_to_element_list_omits_coord_system_when_coord_points_absent():
     # TODO (yao): investigate why we need this test. The LayoutElement definition suggests bbox
     # can't be None and it has to be a Rectangle object that has x1, y1, x2, y2 attributes.

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -300,7 +300,9 @@ def partition_pdf_or_image(
 
     if not is_image:
         try:
-            if is_pdf_too_complex(filename=filename, file=file):
+            if strategy != PartitionStrategy.FAST and is_pdf_too_complex(
+                filename=filename, file=file
+            ):
                 logger.info(
                     "PDF is too complex for text extraction based on heuristic checks. "
                     "Falling back to hi_res strategy without text extraction."


### PR DESCRIPTION
## Summary
- Fixes #4260 — `partition_pdf(strategy="fast")` returns an empty list for PDFs flagged as "too complex"
- Root cause: the `is_pdf_too_complex()` check added in #4268 skips text extraction when a PDF is complex, but when `strategy="fast"` is explicitly set, the strategy isn't changed — so `_partition_pdf_with_pdfparser()` receives empty `extracted_elements` and returns `[]`
- Fix: bypass the `is_pdf_too_complex()` check entirely when `strategy="fast"`, since the user explicitly requested text-based extraction. The complexity check is only relevant for `strategy="auto"` where it decides between fast and hi_res.

## Files changed
- `unstructured/partition/pdf.py` — added `strategy != PartitionStrategy.FAST` guard before calling `is_pdf_too_complex()`
- `test_unstructured/partition/pdf_image/test_pdf.py` — added test verifying fast strategy bypasses complexity check and returns non-empty results

## Test plan
- [x] New test: `test_partition_pdf_fast_strategy_bypasses_complexity_check` — mocks `is_pdf_too_complex` to return True, verifies it's never called when strategy is fast, verifies elements are extracted
- [x] Existing fast strategy tests pass (`test_partition_pdf_with_fast_strategy`, `test_partition_pdf_with_fast_strategy_from_file`, `test_partition_pdf_with_fast_groups_text`)
- [x] Existing complexity check tests pass
- [x] Linter and formatter clean