### PR TITLE
chore: disable fail-build on Anchore container scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,5 +316,6 @@ jobs:
         with:
           image: "unstructured:dev"
           severity-cutoff: critical
+          fail-build: false
           only-fixed: true
           output-format: table


### PR DESCRIPTION
## Summary
- Sets `fail-build: false` on the Anchore `scan-action@v3` step in the CI workflow
- Critical vulnerability findings will still be reported in the scan output, but will no longer block the pipeline

## Test plan
- [ ] Verify CI pipeline runs and the Anchore scan step completes without failing the build
- [ ] Confirm scan results are still visible in the workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; CI will no longer block merges on critical vulnerability findings, which reduces enforcement rather than altering runtime behavior.
> 
> **Overview**
> Updates the CI `test_dockerfile` job to set `fail-build: false` for the `anchore/scan-action@v3` container scan.
> 
> Critical (fixed) vulnerabilities will still be reported in the scan output, but they will no longer fail the pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b01f263d16e3bc6fa083b3efed60215b43b9b04b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->