### PR TITLE
fix: restore double-newline row boundaries in Table.text (#4235)

### DIFF
--- a/test_unstructured/common/test_html_table.py
+++ b/test_unstructured/common/test_html_table.py
@@ -144,7 +144,24 @@ class DescribeHtmlTable:
             "  <tr><td/><td> m n op\n</td><td/></tr>"
             "</table>"
         )
-        assert html_table.text == "a b c def gh i jk l m n op"
+        # Rows are separated by double newlines so callers can reconstruct row boundaries.
+        assert html_table.text == "a b c def\n\ngh i jk l\n\nm n op"
+
+    def it_separates_rows_with_double_newlines_for_boundary_reconstruction(self):
+        """Regression test for issue #4235: row boundaries must be preserved in Table.text."""
+        html_table = HtmlTable.from_html_text(
+            "<table>"
+            "<tr><td>Name</td><td>Score</td><td>URL</td></tr>"
+            "<tr><td>Alice</td><td>1</td><td>www.example.com</td></tr>"
+            "<tr><td>Bob</td><td>2</td><td>www.example2.com</td></tr>"
+            "</table>"
+        )
+        rows = html_table.text.split("\n\n")
+        assert rows == [
+            "Name Score URL",
+            "Alice 1 www.example.com",
+            "Bob 2 www.example2.com",
+        ]
 
 
 class DescribeHtmlRow:

--- a/unstructured/common/html_table.py
+++ b/unstructured/common/html_table.py
@@ -107,10 +107,18 @@ class HtmlTable:
 
     @lazyproperty
     def text(self) -> str:
-        """The clean, concatenated, text for this table."""
-        table_text = " ".join(self._table.itertext())
-        # -- blank cells will introduce extra whitespace, so normalize after accumulating --
-        return " ".join(table_text.split())
+        """The text for this table with rows separated by double newlines.
+
+        Each row's cell texts are joined with a single space. Rows are separated by double
+        newlines so callers can reconstruct row boundaries with ``str(table).split("\\n\\n")``.
+        Empty rows (all cells blank) are suppressed.
+        """
+        row_strings = []
+        for row in self.iter_rows():
+            cell_texts = [t for t in row.iter_cell_texts() if t.strip()]
+            if cell_texts:
+                row_strings.append(" ".join(cell_texts))
+        return "\n\n".join(row_strings)
 
 
 class HtmlRow:


### PR DESCRIPTION
## Summary

Fixes #4235 — `str(Table)` no longer preserves row boundaries after 0.16.0, breaking downstream parsing that relied on `str(table).split("\n\n")` to reconstruct header→value mappings from XLSX sheets.

**Root cause**: `HtmlTable.text` in `unstructured/common/html_table.py` was using `" ".join(self._table.itertext())` which walks all text nodes in document order and flattens everything into a single space-separated string. This lost all row structure.

**Fix**: Replace the flat `itertext()` join with `iter_rows()` / `iter_cell_texts()` — cells within a row are joined with `" "`, rows are joined with `"\n\n"`, and all-blank rows are suppressed. The `metadata.text_as_html` field (compact HTML) is unchanged.

```python
# Before (broken — all cells on one line)
"1 1 0 www.example.com 2 2 0 www.example2.com ..."

# After (row boundaries restored)
"Name Score URL\n\nAlice 1 www.example.com\n\nBob 2 www.example2.com"
```

## Changes

- `unstructured/common/html_table.py` — `HtmlTable.text` now iterates rows and joins with `"\n\n"`
- `test_unstructured/common/test_html_table.py` — updated existing text assertion; added regression test `it_separates_rows_with_double_newlines_for_boundary_reconstruction`

## Test plan

- [x] All 25 existing `test_html_table.py` tests pass
- [x] New regression test confirms `str(table).split("\n\n")` returns one entry per row
- [x] Empty rows (all cells blank) are correctly suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)