### PR TITLE
fix: enable huge_tree for HTMLParser to handle large documents

### DIFF
--- a/unstructured/partition/html/parser.py
+++ b/unstructured/partition/html/parser.py
@@ -926,7 +926,7 @@ def derive_element_type_from_text(text: str) -> type[Text] | None:
 # ------------------------------------------------------------------------------------------------
 
 
-html_parser = etree.HTMLParser(remove_comments=True)
+html_parser = etree.HTMLParser(remove_comments=True, huge_tree=True)
 # -- elements that don't have a registered class get DefaultElement --
 fallback = etree.ElementDefaultClassLookup(element=DefaultElement)
 # -- elements that do have a registered class are assigned that class via lookup --


### PR DESCRIPTION
Pass `huge_tree=True` to `lxml.html.HTMLParser` so that deeply nested or very large HTML documents can be parsed without hitting the default tree depth limit.

Closes #4289