### PR TITLE
refactor: chunk PDF rendering for OCR and extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.22.17
+
+### Enhancements
+- **Prepare PDF rendering for process-isolated PDFium execution**: Resolve the PDF renderer at call time instead of binding it once at import time, so downstream integrations can safely monkey-patch `convert_pdf_to_image()` to a process-isolated implementation without stale aliases bypassing the patch.
+- **Chunk PDF rendering during OCR and image extraction**: `process_file_with_ocr()` now renders multi-page PDFs in configurable page ranges (`PDFIUM_CHUNK_SIZE`, default `8`) instead of one full-document render, and `save_elements()` renders only the page ranges actually needed for extracted images/tables instead of rasterizing the entire document.
+- **Harden `PDFIUM_CHUNK_SIZE` configuration**: Invalid `PDFIUM_CHUNK_SIZE` values now fall back safely to the default with a warning instead of raising a request-path `ValueError`.
+
 ## 0.22.16
 
 ### Enhancements

--- a/test_unstructured/partition/pdf_image/test_ocr.py
+++ b/test_unstructured/partition/pdf_image/test_ocr.py
@@ -710,15 +710,11 @@ def test_process_file_with_ocr_chunks_pdf_pages(monkeypatch, mocker):
 
     def _fake_render(*args, **kwargs):
         render_calls.append((kwargs["first_page"], kwargs["last_page"]))
-        return image_paths[(kwargs["first_page"], kwargs["last_page"])]
+        return image_paths.get((kwargs["first_page"], kwargs["last_page"]), [])
 
     mocker.patch(
         "unstructured.partition.pdf_image.ocr.convert_pdf_to_image",
         side_effect=_fake_render,
-    )
-    mocker.patch(
-        "unstructured.partition.pdf_image.ocr.pdf2image.pdfinfo_from_path",
-        return_value={"Pages": 10},
     )
     mocker.patch(
         "unstructured.partition.pdf_image.ocr.PILImage.open",
@@ -729,6 +725,7 @@ def test_process_file_with_ocr_chunks_pdf_pages(monkeypatch, mocker):
         side_effect=lambda page_layout, image, **kwargs: page_layout,
     )
     monkeypatch.setenv("PDFIUM_CHUNK_SIZE", "4")
+    mocker.patch("unstructured.partition.pdf_image.ocr.os.path.isfile", return_value=True)
 
     result = ocr.process_file_with_ocr(
         filename="dummy.pdf",
@@ -738,7 +735,7 @@ def test_process_file_with_ocr_chunks_pdf_pages(monkeypatch, mocker):
     )
 
     assert result.pages == doc.pages
-    assert render_calls == [(1, 4), (5, 8), (9, 10)]
+    assert render_calls == [(1, 4), (5, 8), (9, 10), (11, 11)]
     assert supplement.call_count == 10
 
 
@@ -750,15 +747,13 @@ def test_process_file_with_ocr_invalid_chunk_size_falls_back(monkeypatch, mocker
 
     def _fake_render(*args, **kwargs):
         render_calls.append((kwargs["first_page"], kwargs["last_page"]))
+        if kwargs["first_page"] > 10:
+            return []
         return [f"/tmp/page_{i}.png" for i in range(kwargs["first_page"], kwargs["last_page"] + 1)]
 
     mocker.patch(
         "unstructured.partition.pdf_image.ocr.convert_pdf_to_image",
         side_effect=_fake_render,
-    )
-    mocker.patch(
-        "unstructured.partition.pdf_image.ocr.pdf2image.pdfinfo_from_path",
-        return_value={"Pages": 10},
     )
     mocker.patch(
         "unstructured.partition.pdf_image.ocr.PILImage.open",
@@ -770,6 +765,7 @@ def test_process_file_with_ocr_invalid_chunk_size_falls_back(monkeypatch, mocker
     )
     warn = mocker.patch("unstructured.partition.pdf_image.pdf_image_utils.logger.warning")
     monkeypatch.setenv("PDFIUM_CHUNK_SIZE", "auto")
+    mocker.patch("unstructured.partition.pdf_image.ocr.os.path.isfile", return_value=True)
 
     ocr.process_file_with_ocr(
         filename="dummy.pdf",
@@ -778,7 +774,7 @@ def test_process_file_with_ocr_invalid_chunk_size_falls_back(monkeypatch, mocker
         is_image=False,
     )
 
-    assert render_calls == [(1, 8), (9, 10)]
+    assert render_calls == [(1, 8), (9, 10), (11, 11)]
     warn.assert_called_once()
 
 
@@ -801,19 +797,55 @@ def test_process_file_with_ocr_raises_when_layout_is_empty_but_pdf_renders(mocke
         )
 
     render.assert_called_once()
+    assert render.call_args.kwargs["first_page"] == 1
+    assert render.call_args.kwargs["last_page"] == 1
 
 
-@pytest.mark.parametrize("rendered_page_count", [1, 3])
-def test_process_file_with_ocr_raises_on_pdf_layout_page_count_mismatch(
-    rendered_page_count, mocker
-):
+def test_process_file_with_ocr_raises_when_chunk_render_count_mismatch(mocker):
     doc = MagicMock(DocumentLayout)
     doc.pages = [MagicMock(PageLayout) for _ in range(2)]
 
-    render = mocker.patch("unstructured.partition.pdf_image.ocr.convert_pdf_to_image")
+    render = mocker.patch(
+        "unstructured.partition.pdf_image.ocr.convert_pdf_to_image",
+        return_value=["/tmp/page_1.png"],
+    )
+    mocker.patch("unstructured.partition.pdf_image.ocr.os.path.isfile", return_value=True)
+
+    with pytest.raises(ValueError, match="Expected 2 rendered page\\(s\\) for range 1-2, got 1\\."):
+        ocr.process_file_with_ocr(
+            filename="dummy.pdf",
+            out_layout=doc,
+            extracted_layout=[],
+            is_image=False,
+        )
+
+    render.assert_called_once()
+
+
+def test_process_file_with_ocr_raises_on_pdf_layout_page_count_mismatch(mocker):
+    doc = MagicMock(DocumentLayout)
+    doc.pages = [MagicMock(PageLayout) for _ in range(2)]
+    render_calls = []
+
+    def _fake_render(*args, **kwargs):
+        render_calls.append((kwargs["first_page"], kwargs["last_page"]))
+        if (kwargs["first_page"], kwargs["last_page"]) == (1, 2):
+            return ["/tmp/page_1.png", "/tmp/page_2.png"]
+        if (kwargs["first_page"], kwargs["last_page"]) == (3, 3):
+            return ["/tmp/page_3.png"]
+        return []
+
     mocker.patch(
-        "unstructured.partition.pdf_image.ocr.pdf2image.pdfinfo_from_path",
-        return_value={"Pages": rendered_page_count},
+        "unstructured.partition.pdf_image.ocr.convert_pdf_to_image",
+        side_effect=_fake_render,
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.PILImage.open",
+        return_value=Image.new("RGB", (16, 16)),
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.supplement_page_layout_with_ocr",
+        side_effect=lambda page_layout, image, **kwargs: page_layout,
     )
     mocker.patch("unstructured.partition.pdf_image.ocr.os.path.isfile", return_value=True)
 
@@ -825,4 +857,4 @@ def test_process_file_with_ocr_raises_on_pdf_layout_page_count_mismatch(
             is_image=False,
         )
 
-    render.assert_not_called()
+    assert render_calls == [(1, 2), (3, 3)]

--- a/test_unstructured/partition/pdf_image/test_ocr.py
+++ b/test_unstructured/partition/pdf_image/test_ocr.py
@@ -1,3 +1,4 @@
+import io
 from collections import namedtuple
 from typing import Optional
 from unittest.mock import MagicMock, patch
@@ -66,6 +67,27 @@ def test_process_file_with_ocr_invalid_filename(is_image):
             out_layout=DocumentLayout(),
             extracted_layout=[],
         )
+
+
+def test_process_data_with_ocr_restores_file_position(mocker):
+    source_file = io.BytesIO(b"pdf-bytes")
+    source_file.seek(4)
+    result_layout = MagicMock(DocumentLayout)
+
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.process_file_with_ocr",
+        return_value=result_layout,
+    )
+
+    result = ocr.process_data_with_ocr(
+        data=source_file,
+        is_image=False,
+        out_layout=DocumentLayout(),
+        extracted_layout=[],
+    )
+
+    assert result is result_layout
+    assert source_file.tell() == 4
 
 
 def test_supplement_page_layout_with_ocr_invalid_ocr():
@@ -673,3 +695,134 @@ def test_pass_down_agents(mock_ocr_get_instance, mocker, mock_page):
         "language": "eng",
         "ocr_agent_module": OCR_AGENT_TESSERACT,
     }
+
+
+def test_process_file_with_ocr_chunks_pdf_pages(monkeypatch, mocker):
+    image_paths = {
+        (1, 4): [f"/tmp/page_{i}.png" for i in range(1, 5)],
+        (5, 8): [f"/tmp/page_{i}.png" for i in range(5, 9)],
+        (9, 10): [f"/tmp/page_{i}.png" for i in range(9, 11)],
+    }
+    render_calls = []
+
+    doc = MagicMock(DocumentLayout)
+    doc.pages = [MagicMock(PageLayout) for _ in range(10)]
+
+    def _fake_render(*args, **kwargs):
+        render_calls.append((kwargs["first_page"], kwargs["last_page"]))
+        return image_paths[(kwargs["first_page"], kwargs["last_page"])]
+
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.convert_pdf_to_image",
+        side_effect=_fake_render,
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.pdf2image.pdfinfo_from_path",
+        return_value={"Pages": 10},
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.PILImage.open",
+        return_value=Image.new("RGB", (16, 16)),
+    )
+    supplement = mocker.patch(
+        "unstructured.partition.pdf_image.ocr.supplement_page_layout_with_ocr",
+        side_effect=lambda page_layout, image, **kwargs: page_layout,
+    )
+    monkeypatch.setenv("PDFIUM_CHUNK_SIZE", "4")
+
+    result = ocr.process_file_with_ocr(
+        filename="dummy.pdf",
+        out_layout=doc,
+        extracted_layout=[],
+        is_image=False,
+    )
+
+    assert result.pages == doc.pages
+    assert render_calls == [(1, 4), (5, 8), (9, 10)]
+    assert supplement.call_count == 10
+
+
+def test_process_file_with_ocr_invalid_chunk_size_falls_back(monkeypatch, mocker):
+    doc = MagicMock(DocumentLayout)
+    doc.pages = [MagicMock(PageLayout) for _ in range(10)]
+
+    render_calls = []
+
+    def _fake_render(*args, **kwargs):
+        render_calls.append((kwargs["first_page"], kwargs["last_page"]))
+        return [f"/tmp/page_{i}.png" for i in range(kwargs["first_page"], kwargs["last_page"] + 1)]
+
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.convert_pdf_to_image",
+        side_effect=_fake_render,
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.pdf2image.pdfinfo_from_path",
+        return_value={"Pages": 10},
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.PILImage.open",
+        return_value=Image.new("RGB", (16, 16)),
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.supplement_page_layout_with_ocr",
+        side_effect=lambda page_layout, image, **kwargs: page_layout,
+    )
+    warn = mocker.patch("unstructured.partition.pdf_image.pdf_image_utils.logger.warning")
+    monkeypatch.setenv("PDFIUM_CHUNK_SIZE", "auto")
+
+    ocr.process_file_with_ocr(
+        filename="dummy.pdf",
+        out_layout=doc,
+        extracted_layout=[],
+        is_image=False,
+    )
+
+    assert render_calls == [(1, 8), (9, 10)]
+    warn.assert_called_once()
+
+
+def test_process_file_with_ocr_raises_when_layout_is_empty_but_pdf_renders(mocker):
+    doc = MagicMock(DocumentLayout)
+    doc.pages = []
+
+    render = mocker.patch(
+        "unstructured.partition.pdf_image.ocr.convert_pdf_to_image",
+        return_value=["/tmp/page_1.png"],
+    )
+    mocker.patch("unstructured.partition.pdf_image.ocr.os.path.isfile", return_value=True)
+
+    with pytest.raises(ValueError, match="empty layout"):
+        ocr.process_file_with_ocr(
+            filename="dummy.pdf",
+            out_layout=doc,
+            extracted_layout=[],
+            is_image=False,
+        )
+
+    render.assert_called_once()
+
+
+@pytest.mark.parametrize("rendered_page_count", [1, 3])
+def test_process_file_with_ocr_raises_on_pdf_layout_page_count_mismatch(
+    rendered_page_count, mocker
+):
+    doc = MagicMock(DocumentLayout)
+    doc.pages = [MagicMock(PageLayout) for _ in range(2)]
+
+    render = mocker.patch("unstructured.partition.pdf_image.ocr.convert_pdf_to_image")
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.pdf2image.pdfinfo_from_path",
+        return_value={"Pages": rendered_page_count},
+    )
+    mocker.patch("unstructured.partition.pdf_image.ocr.os.path.isfile", return_value=True)
+
+    with pytest.raises(ValueError, match="page-count mismatch"):
+        ocr.process_file_with_ocr(
+            filename="dummy.pdf",
+            out_layout=doc,
+            extracted_layout=[],
+            is_image=False,
+        )
+
+    render.assert_not_called()

--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -36,6 +36,9 @@ from unstructured.documents.elements import (
     Text,
     Title,
 )
+from unstructured.documents.elements import (
+    Image as ImageElement,
+)
 from unstructured.errors import PageCountExceededError
 from unstructured.partition import pdf, strategies
 from unstructured.partition.pdf_image import ocr, pdfminer_processing
@@ -209,6 +212,67 @@ def test_partition_pdf_local(monkeypatch, filename, file):
 def test_partition_pdf_local_raises_with_no_filename():
     with pytest.raises((FileNotFoundError, PDFPageCountError, TypeError)):
         pdf._partition_pdf_or_image_local(filename="", file=None, is_image=False)
+
+
+def test_partition_pdf_local_rewinds_file_for_follow_on_hi_res_stages(mocker: MockFixture):
+    source_file = io.BytesIO(b"pdf-bytes")
+    mock_document_layout = mocker.Mock(spec=DocumentLayout)
+    mock_document_layout.pages = [mocker.Mock(spec=PageLayout)]
+    extracted_image = ImageElement(
+        text="Image Text 1",
+        coordinates=((10, 10), (10, 20), (20, 20), (20, 10)),
+        coordinate_system=PixelSpace(width=100, height=100),
+        metadata=ElementMetadata(page_number=1),
+    )
+
+    mocker.patch(
+        "unstructured_inference.inference.layout.process_data_with_model",
+        return_value=mock_document_layout,
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.pdfminer_processing.merge_inferred_with_extracted_layout",
+        return_value=mock_document_layout,
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.pdfminer_processing.clean_pdfminer_inner_elements",
+        side_effect=lambda document_layout: document_layout,
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.ocr.process_file_with_ocr",
+        return_value=mock_document_layout,
+    )
+    mocker.patch(
+        "unstructured.partition.pdf.document_to_element_list",
+        return_value=[extracted_image],
+    )
+
+    downstream_positions = []
+
+    def _save_elements(*args, **kwargs):
+        downstream_positions.append(("save_elements", kwargs["file"].tell()))
+
+    def _run_form_extraction(*args, **kwargs):
+        downstream_positions.append(("run_form_extraction", kwargs["file"].tell()))
+        return []
+
+    mocker.patch(
+        "unstructured.partition.pdf_image.pdf_image_utils.save_elements",
+        side_effect=_save_elements,
+    )
+    mocker.patch(
+        "unstructured.partition.pdf_image.form_extraction.run_form_extraction",
+        side_effect=_run_form_extraction,
+    )
+
+    pdf._partition_pdf_or_image_local(
+        filename="",
+        file=source_file,
+        is_image=False,
+        extract_image_block_types=[ElementType.IMAGE],
+        extract_forms=True,
+    )
+
+    assert downstream_positions == [("save_elements", 0), ("run_form_extraction", 0)]
 
 
 @pytest.mark.parametrize("file_mode", ["filename", "rb", "spool"])

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -123,6 +123,54 @@ def test_convert_pdf_to_image_rejects_both_filename_and_file():
     assert "Exactly one of" in str(exc_info.value)
 
 
+def test_convert_pdf_to_image_preserves_positional_password_argument(monkeypatch):
+    calls = []
+
+    def _fake_render(**kwargs):
+        calls.append(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        "unstructured_inference.inference.layout.convert_pdf_to_image",
+        _fake_render,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pdf_image_utils.convert_pdf_to_image("dummy.pdf", None, 300, tmpdir, True, "secret")
+
+    assert len(calls) == 1
+    assert calls[0]["password"] == "secret"
+    assert calls[0]["first_page"] is None
+    assert calls[0]["last_page"] is None
+
+
+def test_convert_pdf_to_images_uses_runtime_renderer(monkeypatch):
+    calls = []
+
+    def _fake_render(**kwargs):
+        calls.append(kwargs)
+        return [PILImg.new("RGB", (4, 4))]
+
+    monkeypatch.setattr(
+        "unstructured_inference.inference.layout.convert_pdf_to_image",
+        _fake_render,
+    )
+    monkeypatch.setattr(
+        pdf_image_utils.pdf2image,
+        "pdfinfo_from_path",
+        lambda filename, userpw=None: {"Pages": 2},
+    )
+
+    images = list(pdf_image_utils.convert_pdf_to_images(filename="dummy.pdf", chunk_size=1))
+
+    assert len(images) == 2
+    assert len(calls) == 2
+    assert calls[0]["first_page"] == 1
+    assert calls[0]["last_page"] == 1
+    assert calls[1]["first_page"] == 2
+    assert calls[1]["last_page"] == 2
+
+
 @pytest.mark.parametrize(
     ("filename", "is_image"),
     [
@@ -226,7 +274,7 @@ def test_save_elements(
 
 @pytest.mark.parametrize("storage_enabled", [False, True])
 def test_save_elements_with_output_dir_path_none(monkeypatch, storage_enabled):
-    monkeypatch.setenv("GLOBAL_WORKING_DIR_ENABLED", storage_enabled)
+    monkeypatch.setenv("GLOBAL_WORKING_DIR_ENABLED", str(storage_enabled))
     with (
         patch("PIL.Image.open"),
         patch("unstructured.partition.pdf_image.pdf_image_utils.write_image"),
@@ -254,6 +302,115 @@ def test_save_elements_with_output_dir_path_none(monkeypatch, storage_enabled):
         assert os.path.exists(expected_output_dir)
         assert os.path.isdir(expected_output_dir)
         os.chdir(original_cwd)
+
+
+def test_save_elements_renders_only_needed_page_ranges(monkeypatch):
+    elements = [
+        Image(
+            text="Image Text 1",
+            coordinates=((10, 10), (10, 20), (20, 20), (20, 10)),
+            coordinate_system=PixelSpace(width=100, height=100),
+            metadata=ElementMetadata(page_number=11),
+        ),
+        Image(
+            text="Image Text 2",
+            coordinates=((10, 10), (10, 20), (20, 20), (20, 10)),
+            coordinate_system=PixelSpace(width=100, height=100),
+            metadata=ElementMetadata(page_number=12),
+        ),
+        Image(
+            text="Image Text 3",
+            coordinates=((10, 10), (10, 20), (20, 20), (20, 10)),
+            coordinate_system=PixelSpace(width=100, height=100),
+            metadata=ElementMetadata(page_number=14),
+        ),
+    ]
+
+    render_calls = []
+
+    def _fake_render(*args, **kwargs):
+        first_page = kwargs["first_page"]
+        last_page = kwargs["last_page"]
+        render_calls.append((first_page, last_page))
+        return [f"/tmp/page_{page_number}.png" for page_number in range(first_page, last_page + 1)]
+
+    monkeypatch.setenv("PDFIUM_CHUNK_SIZE", "2")
+    with (
+        patch(
+            "unstructured.partition.pdf_image.pdf_image_utils.convert_pdf_to_image",
+            side_effect=_fake_render,
+        ),
+        patch("PIL.Image.open", return_value=PILImg.new("RGB", (32, 32))),
+        patch("unstructured.partition.pdf_image.pdf_image_utils.write_image"),
+        tempfile.TemporaryDirectory() as tmpdir,
+    ):
+        pdf_image_utils.save_elements(
+            elements=elements,
+            starting_page_number=11,
+            element_category_to_save=ElementType.IMAGE,
+            pdf_image_dpi=200,
+            filename="dummy.pdf",
+            output_dir_path=str(tmpdir),
+        )
+
+    assert render_calls == [(1, 2), (4, 4)]
+
+
+def test_save_elements_rewinds_binaryio_pdf_for_each_chunk_and_restores_position(monkeypatch):
+    elements = [
+        Image(
+            text="Image Text 1",
+            coordinates=((10, 10), (10, 20), (20, 20), (20, 10)),
+            coordinate_system=PixelSpace(width=100, height=100),
+            metadata=ElementMetadata(page_number=1),
+        ),
+        Image(
+            text="Image Text 2",
+            coordinates=((10, 10), (10, 20), (20, 20), (20, 10)),
+            coordinate_system=PixelSpace(width=100, height=100),
+            metadata=ElementMetadata(page_number=2),
+        ),
+        Image(
+            text="Image Text 3",
+            coordinates=((10, 10), (10, 20), (20, 20), (20, 10)),
+            coordinate_system=PixelSpace(width=100, height=100),
+            metadata=ElementMetadata(page_number=4),
+        ),
+    ]
+    source_file = io.BytesIO(b"pdf-bytes")
+    source_file.seek(3)
+    render_positions = []
+    render_inputs = []
+
+    def _fake_render(filename, file, dpi, **kwargs):
+        render_positions.append(file.tell())
+        render_inputs.append(file.read() if hasattr(file, "read") else file)
+        first_page = kwargs["first_page"]
+        last_page = kwargs["last_page"]
+        return [f"/tmp/page_{page_number}.png" for page_number in range(first_page, last_page + 1)]
+
+    monkeypatch.setenv("PDFIUM_CHUNK_SIZE", "2")
+    with (
+        patch(
+            "unstructured.partition.pdf_image.pdf_image_utils.convert_pdf_to_image",
+            side_effect=_fake_render,
+        ),
+        patch("PIL.Image.open", return_value=PILImg.new("RGB", (32, 32))),
+        patch("unstructured.partition.pdf_image.pdf_image_utils.write_image"),
+        tempfile.TemporaryDirectory() as tmpdir,
+    ):
+        pdf_image_utils.save_elements(
+            elements=elements,
+            starting_page_number=1,
+            element_category_to_save=ElementType.IMAGE,
+            pdf_image_dpi=200,
+            file=source_file,
+            output_dir_path=str(tmpdir),
+        )
+
+    assert render_positions == [0, 0]
+    assert render_inputs == [b"pdf-bytes", b"pdf-bytes"]
+    assert source_file.tell() == 3
 
 
 def test_write_image_raises_error():

--- a/test_unstructured_ingest/expected-structured-output-html/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.html
+++ b/test_unstructured_ingest/expected-structured-output-html/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.html
@@ -43,8 +43,8 @@
   <h1 class="Title" id="d3be9e3d661e2a79f37257caa5b54d8c">
    LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis
   </h1>
-  <p class="NarrativeText" id="4dfee7e352ae892814e46bb220094b0f">
-   Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson®, and Weining Li&gt;
+  <p class="NarrativeText" id="607ee712429ac9cf3540dbdc5e55e143">
+   Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson?, and Weining Li®
   </p>
   <p class="NarrativeText" id="23b8def20ce16f929d4f558b2a19f200">
    1 Allen Institute for AI shannons@allenai.org 2 Brown University ruochen zhang@brown.edu 3 Harvard University {melissadell,jacob carlson}@fas.harvard.edu 4 University of Washington bcgl@cs.washington.edu 5 University of Waterloo w422li@uwaterloo.ca
@@ -561,8 +561,8 @@
   <li class="ListItem" id="184a3abfd34e7aa04632979ee3c2de36">
    17 This measures the number of edits from the ground-truth text to the predicted text, and lower is better.
   </li>
-  <li class="ListItem" id="2b7101f39954d5301166b82906202ea9">
-   LayoutParser: A Uniﬁed Toolkit for DL-Based DIA
+  <li class="ListItem" id="f1b03448874d9c98a0a59a20b134c513">
+   LayoutParser: A Uniﬁed Toolkit for DL-Based DIA 13
   </li>
   <img alt="ra (a) Partial table at the bottom (b) Full page table (c) Partial table at the top (d) Mis-detected text line" class="Image" id="d7ab3da5ec0adb1b2b4fb5f800a545a0"/>
   <p class="FigureCaption" id="d35d253341e8b8d837f384ecd6ac410a">

--- a/test_unstructured_ingest/expected-structured-output-markdown/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.md
+++ b/test_unstructured_ingest/expected-structured-output-markdown/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.md
@@ -10,7 +10,7 @@ X
 r
 a
 # LayoutParser: A Uniﬁed Toolkit for Deep Learning Based Document Image Analysis
-Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson®, and Weining Li>
+Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson?, and Weining Li®
 1 Allen Institute for AI shannons@allenai.org 2 Brown University ruochen zhang@brown.edu 3 Harvard University {melissadell,jacob carlson}@fas.harvard.edu 4 University of Washington bcgl@cs.washington.edu 5 University of Waterloo w422li@uwaterloo.ca
 Abstract. Recent advances in document image analysis (DIA) have been primarily driven by the application of neural networks. Ideally, research outcomes could be easily deployed in production and extended for further investigation. However, various factors like loosely organized codebases and sophisticated model conﬁgurations complicate the easy reuse of im- portant innovations by a wide audience. Though there have been on-going eﬀorts to improve reusability and simplify deep learning (DL) model development in disciplines like natural language processing and computer vision, none of them are optimized for challenges in the domain of DIA. This represents a major gap in the existing toolkit, as DIA is central to academic research across a wide range of disciplines in the social sciences and humanities. This paper introduces LayoutParser, an open-source library for streamlining the usage of DL in DIA research and applica- tions. The core LayoutParser library comes with a set of simple and intuitive interfaces for applying and customizing DL models for layout de- tection, character recognition, and many other document processing tasks. To promote extensibility, LayoutParser also incorporates a community platform for sharing both pre-trained models and full document digiti- zation pipelines. We demonstrate that LayoutParser is helpful for both lightweight and large-scale digitization pipelines in real-word use cases. The library is publicly available at https://layout-parser.github.io.
 Keywords: Document Image Analysis · Deep Learning · Layout Analysis · Character Recognition · Open Source library · Toolkit.
@@ -120,7 +120,7 @@ Additionally, it is common for historical documents to use unique fonts with di�
 Overall, it is possible to create an intricate and highly accurate digitization pipeline for large-scale digitization using LayoutParser. The pipeline avoids specifying the complicated rules used in traditional methods, is straightforward to develop, and is robust to outliers. The DL models also generate ﬁne-grained results that enable creative approaches like page reorganization for OCR.
 16 This measures the overlap between the detected and ground-truth characters, and the maximum is 1.
 17 This measures the number of edits from the ground-truth text to the predicted text, and lower is better.
-LayoutParser: A Uniﬁed Toolkit for DL-Based DIA
+LayoutParser: A Uniﬁed Toolkit for DL-Based DIA 13
 ra (a) Partial table at the bottom (b) Full page table (c) Partial table at the top (d) Mis-detected text line
 Fig.6: This lightweight table detector can identify tables (outlined in red) and cells (shaded in blue) in diﬀerent locations on a page. In very few cases (d), it might generate minor error predictions, e.g, failing to capture the top text line of a table.
 5.2 A light-weight Visual Table Extractor

--- a/test_unstructured_ingest/expected-structured-output/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.json
+++ b/test_unstructured_ingest/expected-structured-output/local-single-file-with-pdf-infer-table-structure/layout-parser-paper.pdf.json
@@ -267,8 +267,8 @@
   },
   {
     "type": "NarrativeText",
-    "element_id": "4dfee7e352ae892814e46bb220094b0f",
-    "text": "Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson®, and Weining Li>",
+    "element_id": "607ee712429ac9cf3540dbdc5e55e143",
+    "text": "Zejiang Shen! (4), Ruochen Zhang”, Melissa Dell?, Benjamin Charles Germain Lee*, Jacob Carlson?, and Weining Li®",
     "metadata": {
       "is_extracted": "true",
       "filetype": "application/pdf",
@@ -3292,8 +3292,8 @@
   },
   {
     "type": "ListItem",
-    "element_id": "2b7101f39954d5301166b82906202ea9",
-    "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA",
+    "element_id": "f1b03448874d9c98a0a59a20b134c513",
+    "text": "LayoutParser: A Uniﬁed Toolkit for DL-Based DIA 13",
     "metadata": {
       "is_extracted": "true",
       "filetype": "application/pdf",

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.16"  # pragma: no cover
+__version__ = "0.22.17"  # pragma: no cover

--- a/unstructured/partition/pdf_image/ocr.py
+++ b/unstructured/partition/pdf_image/ocr.py
@@ -229,9 +229,7 @@ def process_file_with_ocr(
                     )
                     if image_paths:
                         raise ValueError("OCR received an empty layout for a PDF.")
-                    raise ValueError(
-                        "OCR received an empty layout for a PDF."
-                    )
+                    raise ValueError("OCR received an empty layout for a PDF.")
 
                 layout_page_count = len(out_layout.pages)
                 chunk_size = get_pdfium_chunk_size()

--- a/unstructured/partition/pdf_image/ocr.py
+++ b/unstructured/partition/pdf_image/ocr.py
@@ -5,6 +5,7 @@ import tempfile
 from typing import IO, TYPE_CHECKING, Any, List, Optional, cast
 
 import numpy as np
+import pdf2image
 
 # NOTE(yuming): Rename PIL.Image to avoid conflict with
 # unstructured.documents.elements.Image
@@ -15,7 +16,11 @@ from unstructured.documents.elements import ElementType
 from unstructured.metrics.table.table_formats import SimpleTableCell
 from unstructured.partition.common.lang import tesseract_to_paddle_language
 from unstructured.partition.pdf_image.analysis.layout_dump import OCRLayoutDumper
-from unstructured.partition.pdf_image.pdf_image_utils import convert_pdf_to_image, valid_text
+from unstructured.partition.pdf_image.pdf_image_utils import (
+    convert_pdf_to_image,
+    get_pdfium_chunk_size,
+    valid_text,
+)
 from unstructured.partition.pdf_image.pdfminer_processing import (
     aggregate_embedded_text_by_block,
     bboxes1_is_almost_subregion_of_bboxes2,
@@ -76,7 +81,15 @@ def process_data_with_ocr(
     Returns:
         DocumentLayout: The merged layout information obtained after OCR processing.
     """
-    data_bytes = data if isinstance(data, bytes) else data.read()
+    original_position = None
+    if not isinstance(data, bytes) and hasattr(data, "tell"):
+        original_position = data.tell()
+
+    try:
+        data_bytes = data if isinstance(data, bytes) else data.read()
+    finally:
+        if original_position is not None and not isinstance(data, bytes) and hasattr(data, "seek"):
+            data.seek(original_position)
 
     with tempfile.TemporaryDirectory() as tmp_dir_path:
         tmp_file_path = os.path.join(tmp_dir_path, "tmp_file")
@@ -173,29 +186,65 @@ def process_file_with_ocr(
                 return DocumentLayout.from_pages(merged_page_layouts)
         else:
             with tempfile.TemporaryDirectory() as temp_dir:
-                _image_paths = convert_pdf_to_image(
-                    filename,
-                    dpi=pdf_image_dpi,
-                    output_folder=temp_dir,
-                    path_only=True,
-                    password=password,
-                )
-                image_paths = cast(List[str], _image_paths)
-                for i, image_path in enumerate(image_paths):
-                    extracted_regions = extracted_layout[i] if i < len(extracted_layout) else None
-                    with PILImage.open(image_path) as image:
-                        merged_page_layout = supplement_page_layout_with_ocr(
-                            page_layout=out_layout.pages[i],
-                            image=image,
-                            infer_table_structure=infer_table_structure,
-                            ocr_agent=ocr_agent,
-                            ocr_languages=ocr_languages,
-                            ocr_mode=ocr_mode,
-                            extracted_regions=extracted_regions,
-                            ocr_layout_dumper=ocr_layout_dumper,
-                            table_ocr_agent=table_ocr_agent,
+                if not out_layout.pages:
+                    convert_pdf_to_image(
+                        filename,
+                        dpi=pdf_image_dpi,
+                        output_folder=temp_dir,
+                        path_only=True,
+                        password=password,
+                    )
+                    raise ValueError("OCR received an empty layout for a PDF.")
+
+                rendered_page_count = pdf2image.pdfinfo_from_path(filename, userpw=password)["Pages"]
+                layout_page_count = len(out_layout.pages)
+
+                if rendered_page_count != layout_page_count:
+                    raise ValueError(
+                        "OCR page-count mismatch: rendered PDF has "
+                        f"{rendered_page_count} page(s) but layout has {layout_page_count}."
+                    )
+                chunk_size = get_pdfium_chunk_size()
+                for chunk_start in range(0, len(out_layout.pages), chunk_size):
+                    first_page = chunk_start + 1
+                    last_page = min(chunk_start + chunk_size, len(out_layout.pages))
+                    chunk_dir = os.path.join(temp_dir, f"chunk_{first_page}_{last_page}")
+                    os.makedirs(chunk_dir, exist_ok=True)
+                    _image_paths = convert_pdf_to_image(
+                        filename,
+                        dpi=pdf_image_dpi,
+                        output_folder=chunk_dir,
+                        path_only=True,
+                        first_page=first_page,
+                        last_page=last_page,
+                        password=password,
+                    )
+                    image_paths = cast(List[str], _image_paths)
+                    expected_pages = last_page - first_page + 1
+                    if len(image_paths) != expected_pages:
+                        raise ValueError(
+                            f"Expected {expected_pages} rendered page(s) for range "
+                            f"{first_page}-{last_page}, got {len(image_paths)}."
                         )
-                        merged_page_layouts.append(merged_page_layout)
+                    for page_index, image_path in enumerate(image_paths, start=chunk_start):
+                        extracted_regions = (
+                            extracted_layout[page_index]
+                            if page_index < len(extracted_layout)
+                            else None
+                        )
+                        with PILImage.open(image_path) as image:
+                            merged_page_layout = supplement_page_layout_with_ocr(
+                                page_layout=out_layout.pages[page_index],
+                                image=image,
+                                infer_table_structure=infer_table_structure,
+                                ocr_agent=ocr_agent,
+                                ocr_languages=ocr_languages,
+                                ocr_mode=ocr_mode,
+                                extracted_regions=extracted_regions,
+                                ocr_layout_dumper=ocr_layout_dumper,
+                                table_ocr_agent=table_ocr_agent,
+                            )
+                            merged_page_layouts.append(merged_page_layout)
                 return DocumentLayout.from_pages(merged_page_layouts)
     except Exception as e:
         if os.path.isdir(filename) or os.path.isfile(filename):

--- a/unstructured/partition/pdf_image/ocr.py
+++ b/unstructured/partition/pdf_image/ocr.py
@@ -196,7 +196,10 @@ def process_file_with_ocr(
                     )
                     raise ValueError("OCR received an empty layout for a PDF.")
 
-                rendered_page_count = pdf2image.pdfinfo_from_path(filename, userpw=password)["Pages"]
+                rendered_page_count = pdf2image.pdfinfo_from_path(
+                    filename,
+                    userpw=password,
+                )["Pages"]
                 layout_page_count = len(out_layout.pages)
 
                 if rendered_page_count != layout_page_count:

--- a/unstructured/partition/pdf_image/ocr.py
+++ b/unstructured/partition/pdf_image/ocr.py
@@ -5,7 +5,6 @@ import tempfile
 from typing import IO, TYPE_CHECKING, Any, List, Optional, cast
 
 import numpy as np
-import pdf2image
 
 # NOTE(yuming): Rename PIL.Image to avoid conflict with
 # unstructured.documents.elements.Image
@@ -114,6 +113,37 @@ def process_data_with_ocr(
     return merged_layouts
 
 
+def _render_pdf_image_paths(
+    filename: str,
+    output_folder: str,
+    pdf_image_dpi: int,
+    first_page: int,
+    last_page: int,
+    password: Optional[str] = None,
+    allow_empty: bool = False,
+) -> list[str]:
+    os.makedirs(output_folder, exist_ok=True)
+    _image_paths = convert_pdf_to_image(
+        filename,
+        dpi=pdf_image_dpi,
+        output_folder=output_folder,
+        path_only=True,
+        first_page=first_page,
+        last_page=last_page,
+        password=password,
+    )
+    image_paths = cast(List[str], _image_paths)
+    expected_pages = last_page - first_page + 1
+    if len(image_paths) > expected_pages or (
+        not allow_empty and len(image_paths) != expected_pages
+    ):
+        raise ValueError(
+            f"Expected {expected_pages} rendered page(s) for range "
+            f"{first_page}-{last_page}, got {len(image_paths)}."
+        )
+    return image_paths
+
+
 @requires_dependencies("unstructured_inference")
 def process_file_with_ocr(
     filename: str,
@@ -187,48 +217,36 @@ def process_file_with_ocr(
         else:
             with tempfile.TemporaryDirectory() as temp_dir:
                 if not out_layout.pages:
-                    convert_pdf_to_image(
+                    probe_dir = os.path.join(temp_dir, "probe_1_1")
+                    image_paths = _render_pdf_image_paths(
                         filename,
-                        dpi=pdf_image_dpi,
-                        output_folder=temp_dir,
-                        path_only=True,
+                        output_folder=probe_dir,
+                        pdf_image_dpi=pdf_image_dpi,
+                        first_page=1,
+                        last_page=1,
                         password=password,
+                        allow_empty=True,
                     )
-                    raise ValueError("OCR received an empty layout for a PDF.")
-
-                rendered_page_count = pdf2image.pdfinfo_from_path(
-                    filename,
-                    userpw=password,
-                )["Pages"]
-                layout_page_count = len(out_layout.pages)
-
-                if rendered_page_count != layout_page_count:
+                    if image_paths:
+                        raise ValueError("OCR received an empty layout for a PDF.")
                     raise ValueError(
-                        "OCR page-count mismatch: rendered PDF has "
-                        f"{rendered_page_count} page(s) but layout has {layout_page_count}."
+                        "OCR received an empty layout for a PDF."
                     )
+
+                layout_page_count = len(out_layout.pages)
                 chunk_size = get_pdfium_chunk_size()
-                for chunk_start in range(0, len(out_layout.pages), chunk_size):
+                for chunk_start in range(0, layout_page_count, chunk_size):
                     first_page = chunk_start + 1
-                    last_page = min(chunk_start + chunk_size, len(out_layout.pages))
+                    last_page = min(chunk_start + chunk_size, layout_page_count)
                     chunk_dir = os.path.join(temp_dir, f"chunk_{first_page}_{last_page}")
-                    os.makedirs(chunk_dir, exist_ok=True)
-                    _image_paths = convert_pdf_to_image(
+                    image_paths = _render_pdf_image_paths(
                         filename,
-                        dpi=pdf_image_dpi,
                         output_folder=chunk_dir,
-                        path_only=True,
+                        pdf_image_dpi=pdf_image_dpi,
                         first_page=first_page,
                         last_page=last_page,
                         password=password,
                     )
-                    image_paths = cast(List[str], _image_paths)
-                    expected_pages = last_page - first_page + 1
-                    if len(image_paths) != expected_pages:
-                        raise ValueError(
-                            f"Expected {expected_pages} rendered page(s) for range "
-                            f"{first_page}-{last_page}, got {len(image_paths)}."
-                        )
                     for page_index, image_path in enumerate(image_paths, start=chunk_start):
                         extracted_regions = (
                             extracted_layout[page_index]
@@ -248,6 +266,24 @@ def process_file_with_ocr(
                                 table_ocr_agent=table_ocr_agent,
                             )
                             merged_page_layouts.append(merged_page_layout)
+
+                overflow_probe_dir = os.path.join(
+                    temp_dir,
+                    f"probe_{layout_page_count + 1}_{layout_page_count + 1}",
+                )
+                overflow_paths = _render_pdf_image_paths(
+                    filename,
+                    output_folder=overflow_probe_dir,
+                    pdf_image_dpi=pdf_image_dpi,
+                    first_page=layout_page_count + 1,
+                    last_page=layout_page_count + 1,
+                    password=password,
+                    allow_empty=True,
+                )
+                if overflow_paths:
+                    raise ValueError(
+                        "OCR page-count mismatch: rendered PDF has more pages than the layout."
+                    )
                 return DocumentLayout.from_pages(merged_page_layouts)
     except Exception as e:
         if os.path.isdir(filename) or os.path.isfile(filename):

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -8,13 +8,23 @@ import unicodedata
 from copy import deepcopy
 from io import BytesIO
 from pathlib import Path, PurePath
-from typing import IO, TYPE_CHECKING, BinaryIO, Iterator, List, Optional, Tuple, Union, cast
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    BinaryIO,
+    Callable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 import cv2
 import numpy as np
 import pdf2image
 from PIL import Image
-from unstructured_inference.inference.layout import convert_pdf_to_image as render_pdf_to_image
 
 from unstructured.documents.elements import ElementType
 from unstructured.logger import logger
@@ -53,6 +63,80 @@ def write_image(image: Union[Image.Image, np.ndarray], output_image_path: str):
         raise ValueError("Unsupported Image Type")
 
 
+def _get_render_pdf_to_image() -> Callable[..., Union[List[Image.Image], List[str]]]:
+    # Resolve at call time so runtime monkey patches cannot be bypassed.
+    from unstructured_inference.inference import layout as inference_layout
+
+    return inference_layout.convert_pdf_to_image
+
+
+def get_pdfium_chunk_size(default: int = 8) -> int:
+    raw_value = os.environ.get("PDFIUM_CHUNK_SIZE")
+    if raw_value is None:
+        return default
+    try:
+        return max(1, int(raw_value))
+    except ValueError:
+        logger.warning(
+            "Invalid PDFIUM_CHUNK_SIZE=%r; falling back to %d.",
+            raw_value,
+            default,
+        )
+        return default
+
+
+def iter_chunked_page_ranges(page_numbers: List[int], chunk_size: int) -> Iterator[Tuple[int, int]]:
+    if not page_numbers:
+        return
+
+    sorted_pages = sorted(set(page_numbers))
+    chunk_start = sorted_pages[0]
+    chunk_end = chunk_start
+    chunk_len = 1
+
+    for page_number in sorted_pages[1:]:
+        is_consecutive = page_number == chunk_end + 1
+        if is_consecutive and chunk_len < chunk_size:
+            chunk_end = page_number
+            chunk_len += 1
+            continue
+
+        yield (chunk_start, chunk_end)
+        chunk_start = page_number
+        chunk_end = page_number
+        chunk_len = 1
+
+    yield (chunk_start, chunk_end)
+
+
+def _render_pdf_pages(
+    filename: str = "",
+    file: Optional[Union[bytes, BinaryIO]] = None,
+    dpi: Optional[int] = None,
+    output_folder: Optional[Union[str, PurePath]] = None,
+    path_only: bool = False,
+    password: Optional[str] = None,
+    first_page: Optional[int] = None,
+    last_page: Optional[int] = None,
+) -> Union[List[Image.Image], List[str]]:
+    exactly_one(filename=filename, file=file)
+
+    if dpi is None:
+        dpi = env_config.PDF_RENDER_DPI
+
+    render_pdf_to_image = _get_render_pdf_to_image()
+    return render_pdf_to_image(
+        filename=filename or None,
+        file=file,
+        dpi=dpi,
+        output_folder=output_folder,
+        path_only=path_only,
+        first_page=first_page,
+        last_page=last_page,
+        password=password,
+    )
+
+
 def convert_pdf_to_image(
     filename: str,
     file: Optional[Union[bytes, BinaryIO]] = None,
@@ -60,18 +144,17 @@ def convert_pdf_to_image(
     output_folder: Optional[Union[str, PurePath]] = None,
     path_only: bool = False,
     password: Optional[str] = None,
+    first_page: Optional[int] = None,
+    last_page: Optional[int] = None,
 ) -> Union[List[Image.Image], List[str]]:
-    exactly_one(filename=filename, file=file)
-
-    if dpi is None:
-        dpi = env_config.PDF_RENDER_DPI
-
-    return render_pdf_to_image(
+    return _render_pdf_pages(
         filename=filename,
         file=file,
         dpi=dpi,
         output_folder=output_folder,
         path_only=path_only,
+        first_page=first_page,
+        last_page=last_page,
         password=password,
     )
 
@@ -139,86 +222,130 @@ def save_elements(
 
         os.makedirs(output_dir_path, exist_ok=True)
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        if is_image:
-            if file is None:
-                image_paths = [filename]
+    original_position = None
+    if file is not None and not isinstance(file, bytes) and hasattr(file, "tell"):
+        original_position = file.tell()
+
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            if is_image:
+                if file is None:
+                    image_paths = [filename]
+                else:
+                    if isinstance(file, bytes):
+                        file_data = file
+                    else:
+                        file.seek(0)
+                        file_data = file.read()
+
+                    tmp_file_path = os.path.join(temp_dir, "tmp_file")
+                    with open(tmp_file_path, "wb") as tmp_file:
+                        tmp_file.write(file_data)
+                    image_paths = [tmp_file_path]
             else:
-                if isinstance(file, bytes):
-                    file_data = file
-                else:
-                    file.seek(0)
-                    file_data = file.read()
-
-                tmp_file_path = os.path.join(temp_dir, "tmp_file")
-                with open(tmp_file_path, "wb") as tmp_file:
-                    tmp_file.write(file_data)
-                image_paths = [tmp_file_path]
-        else:
-            _image_paths = convert_pdf_to_image(
-                filename,
-                file,
-                pdf_image_dpi,
-                output_folder=temp_dir,
-                path_only=True,
-                password=password,
-            )
-            image_paths = cast(List[str], _image_paths)
-
-        figure_number = 0
-        for el in elements:
-            if el.category != element_category_to_save:
-                continue
-
-            coordinates = el.metadata.coordinates
-            if not coordinates or not coordinates.points:
-                continue
-
-            points = coordinates.points
-            x1, y1 = points[0]
-            x2, y2 = points[2]
-            h_padding = env_config.EXTRACT_IMAGE_BLOCK_CROP_HORIZONTAL_PAD
-            v_padding = env_config.EXTRACT_IMAGE_BLOCK_CROP_VERTICAL_PAD
-            padded_bbox = cast(
-                Tuple[int, int, int, int], pad_bbox((x1, y1, x2, y2), (h_padding, v_padding))
-            )
-
-            # The page number in the metadata may have been offset
-            # by starting_page_number. Make sure we use the right
-            # value for indexing!
-            assert el.metadata.page_number
-            metadata_page_number = el.metadata.page_number
-            page_index = metadata_page_number - starting_page_number
-
-            figure_number += 1
-            try:
-                image_path = image_paths[page_index]
-                image = Image.open(image_path)
-                cropped_image = image.crop(padded_bbox)
-
-                # PNG images with transparency need to be converted before saving
-                if cropped_image.mode == "RGBA":
-                    cropped_image = cropped_image.convert("RGB")
-
-                if extract_image_block_to_payload:
-                    buffered = BytesIO()
-                    cropped_image.save(buffered, format="JPEG")
-                    img_base64 = base64.b64encode(buffered.getvalue())
-                    img_base64_str = img_base64.decode()
-                    el.metadata.image_base64 = img_base64_str
-                    el.metadata.image_mime_type = "image/jpeg"
-                else:
-                    basename = "table" if el.category == ElementType.TABLE else "figure"
-                    assert output_dir_path
-                    output_f_path = os.path.join(
-                        output_dir_path,
-                        f"{basename}-{metadata_page_number}-{figure_number}.jpg",
+                render_file = file
+                relevant_pdf_pages = [
+                    el.metadata.page_number - starting_page_number + 1
+                    for el in elements
+                    if el.category == element_category_to_save
+                    and el.metadata.coordinates
+                    and el.metadata.coordinates.points
+                    and el.metadata.page_number is not None
+                ]
+                image_paths_by_page: dict[int, str] = {}
+                chunk_size = get_pdfium_chunk_size()
+                for first_page, last_page in iter_chunked_page_ranges(
+                    relevant_pdf_pages, chunk_size
+                ):
+                    chunk_dir = os.path.join(temp_dir, f"chunk_{first_page}_{last_page}")
+                    os.makedirs(chunk_dir, exist_ok=True)
+                    if render_file is not None and not isinstance(render_file, bytes):
+                        render_file.seek(0)
+                    _image_paths = convert_pdf_to_image(
+                        filename,
+                        render_file,
+                        pdf_image_dpi,
+                        output_folder=chunk_dir,
+                        path_only=True,
+                        first_page=first_page,
+                        last_page=last_page,
+                        password=password,
                     )
-                    write_image(cropped_image, output_f_path)
-                    # add image path to element metadata
-                    el.metadata.image_path = output_f_path
-            except (ValueError, IOError):
-                logger.warning("Image Extraction Error: Skipping the failed image", exc_info=True)
+                    chunk_image_paths = cast(List[str], _image_paths)
+                    expected_pages = last_page - first_page + 1
+                    if len(chunk_image_paths) != expected_pages:
+                        raise ValueError(
+                            f"Expected {expected_pages} rendered page(s) for range "
+                            f"{first_page}-{last_page}, got {len(chunk_image_paths)}."
+                        )
+                    for page_number, image_path in enumerate(chunk_image_paths, start=first_page):
+                        image_paths_by_page[page_number] = image_path
+
+            figure_number = 0
+            for el in elements:
+                if el.category != element_category_to_save:
+                    continue
+
+                coordinates = el.metadata.coordinates
+                if not coordinates or not coordinates.points:
+                    continue
+
+                points = coordinates.points
+                x1, y1 = points[0]
+                x2, y2 = points[2]
+                h_padding = env_config.EXTRACT_IMAGE_BLOCK_CROP_HORIZONTAL_PAD
+                v_padding = env_config.EXTRACT_IMAGE_BLOCK_CROP_VERTICAL_PAD
+                padded_bbox = cast(
+                    Tuple[int, int, int, int], pad_bbox((x1, y1, x2, y2), (h_padding, v_padding))
+                )
+
+                # The page number in the metadata may have been offset
+                # by starting_page_number. Make sure we use the right
+                # value for indexing!
+                assert el.metadata.page_number
+                metadata_page_number = el.metadata.page_number
+                page_index = metadata_page_number - starting_page_number
+                pdf_page_number = page_index + 1
+
+                figure_number += 1
+                try:
+                    image_path = (
+                        image_paths[page_index]
+                        if is_image
+                        else image_paths_by_page[pdf_page_number]
+                    )
+                    image = Image.open(image_path)
+                    cropped_image = image.crop(padded_bbox)
+
+                    # PNG images with transparency need to be converted before saving
+                    if cropped_image.mode == "RGBA":
+                        cropped_image = cropped_image.convert("RGB")
+
+                    if extract_image_block_to_payload:
+                        buffered = BytesIO()
+                        cropped_image.save(buffered, format="JPEG")
+                        img_base64 = base64.b64encode(buffered.getvalue())
+                        img_base64_str = img_base64.decode()
+                        el.metadata.image_base64 = img_base64_str
+                        el.metadata.image_mime_type = "image/jpeg"
+                    else:
+                        basename = "table" if el.category == ElementType.TABLE else "figure"
+                        assert output_dir_path
+                        output_f_path = os.path.join(
+                            output_dir_path,
+                            f"{basename}-{metadata_page_number}-{figure_number}.jpg",
+                        )
+                        write_image(cropped_image, output_f_path)
+                        # add image path to element metadata
+                        el.metadata.image_path = output_f_path
+                except (ValueError, IOError):
+                    logger.warning(
+                        "Image Extraction Error: Skipping the failed image",
+                        exc_info=True,
+                    )
+    finally:
+        if original_position is not None and file is not None and not isinstance(file, bytes):
+            file.seek(original_position)
 
 
 def check_element_types_to_extract(
@@ -405,8 +532,8 @@ def convert_pdf_to_images(
     total_pages = info["Pages"]
     for start_page in range(1, total_pages + 1, chunk_size):
         end_page = min(start_page + chunk_size - 1, total_pages)
-        chunk_images = render_pdf_to_image(
-            filename=filename if f_bytes is None else None,
+        chunk_images = _render_pdf_pages(
+            filename=filename if f_bytes is None else "",
             file=f_bytes,
             dpi=env_config.PDF_RENDER_DPI,
             first_page=start_page,


### PR DESCRIPTION
Prepare PDF image rendering for chunked and process-isolated execution while preserving public helper compatibility and adding focused OCR/image extraction regressions.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PDF OCR and image-extraction rendering paths, changing pagination/chunking behavior and adding stricter validation, which could surface new edge cases in page counting or file-like inputs.
> 
> **Overview**
> Prepares PDF rendering to be *process-isolation friendly* by resolving the PDFium renderer at call time (avoiding stale import-time aliases) and keeps `convert_pdf_to_image` compatible while adding `first_page`/`last_page` support.
> 
> Updates OCR and image/table extraction to **render PDFs in configurable page chunks** (`PDFIUM_CHUNK_SIZE`, default `8`) and to rasterize only the page ranges actually needed; adds guardrails for invalid chunk-size values (warn + fallback) and for page-count/layout mismatches.
> 
> Improves robustness for file-like inputs by rewinding/restoring stream positions across OCR/extraction stages, with new tests and updated expected ingest outputs reflecting minor OCR text diffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2498e9c27ca5cfb61dfb41738dc1da53e128ddcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->