### PR TITLE
fix: pin adlfs for azure public ingest regression

### DIFF
--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -116,6 +116,7 @@ jobs:
           add-paths: |
             test_unstructured_ingest/expected-structured-output
             test_unstructured_ingest/expected-structured-output-html
+            test_unstructured_ingest/expected-structured-output-markdown
             test_unstructured_ingest/metrics
           commit-message: "Update ingest test fixtures"
           branch: ${{ env.BRANCH_NAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.22.18-dev0
+
+### Fixes
+- Make `ingest-test-fixtures-update-pr` CI job also update the markdown versions of the fixtures.
+
 ## 0.22.18
 
 ### Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,8 @@ required-environments = [
     "sys_platform == 'win32'",
 ]
 constraint-dependencies = [
+    # Temporary pin for Azure public-container ingest regression in adlfs 2026.4.0 stack
+    "adlfs==2026.2.0",
     # deltalake 1.3.0 is missing Linux ARM64 wheels, causing Docker ARM64 builds to fail
     "deltalake<1.3.0",
     "fonttools>=4.60.2",

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.18"  # pragma: no cover
+__version__ = "0.22.18-dev0"  # pragma: no cover

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ required-markers = [
 
 [manifest]
 constraints = [
+    { name = "adlfs", specifier = "==2026.2.0" },
     { name = "deltalake", specifier = "<1.3.0" },
     { name = "fonttools", specifier = ">=4.60.2" },
     { name = "protobuf", specifier = ">=6.30.0" },
@@ -52,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "adlfs"
-version = "2026.4.0"
+version = "2026.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
@@ -61,9 +62,9 @@ dependencies = [
     { name = "azure-storage-blob", extra = ["aio"], marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
     { name = "fsspec", marker = "python_full_version < '3.13' or sys_platform != 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/51/c766cea8a00f84f224aa672ea0f20e4f24091eb90ce56104accd003c7405/adlfs-2026.4.0.tar.gz", hash = "sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d", size = 54730, upload-time = "2026-04-09T17:35:54.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/39/5d7bde68327d9f6b9d73353664f4b247e194130b0ebcd4ca2d0e101fbd57/adlfs-2026.2.0.tar.gz", hash = "sha256:7661330ef67d99e55d15750cadef5a604a82e1513787039be830efc5b53ba533", size = 54018, upload-time = "2026-02-09T18:46:49.876Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/45/6e6061498d2cd7fecfcaa6e17c2057bfcac3578c656b9646c343c7021c6e/adlfs-2026.4.0-py3-none-any.whl", hash = "sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f", size = 46249, upload-time = "2026-04-09T17:35:53.891Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/95/123783625038056187f5bc9036d5249e52751e5dcc685e3f201a0a5d40ba/adlfs-2026.2.0-py3-none-any.whl", hash = "sha256:995fc9acc2ff8d794af15b36c604ab8dc02fe2301a973ce2df0f5b246d13e439", size = 45681, upload-time = "2026-02-09T18:46:48.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
adlfs changed in 2026.4.0 with a breaking auth change: the default anon behavior flipped to False, so code that previously hit public Azure blobs anonymously now tries DefaultAzureCredential unless anon=True is set explicitly. that matches the CI failure here.

this pins `adlfs==2026.2.0` to temporarily unblock failing changes when bumping to latest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pins `adlfs` to an older version to work around an Azure public-container ingest regression, which can affect Azure connector behavior at runtime. The rest is CI-only fixture update plumbing and is low risk.
> 
> **Overview**
> Pins `adlfs` to `==2026.2.0` via `pyproject.toml` UV constraints (and updates `uv.lock`) to avoid a regression affecting anonymous access to public Azure blob containers.
> 
> Updates the `ingest-test-fixtures-update-pr` GitHub Actions workflow to also generate and include `expected-structured-output-markdown` fixtures in the auto-created PRs, and records this change in the `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a78015429a54820bdbbcc26c59ab9af3dcdc7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->