### PR TITLE
feat: replace PyPI opencv wheels with ffmpeg-free builds in Dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.21
+
+### Security
+
+- **Replace PyPI opencv wheels with ffmpeg-free builds in Docker image**: After `uv sync`, the Dockerfile now substitutes all PyPI opencv-python variants with a source-built `opencv-contrib-python-headless` wheel compiled with `WITH_FFMPEG=OFF`, eliminating 14 bundled ffmpeg CVEs. The contrib-headless variant is a strict superset of the cv2 API (core + contrib modules, no GUI) so a single wheel replaces `opencv-python`, `opencv-python-headless`, and `opencv-contrib-python`.
+
 ## 0.22.20
 
 ### Enhancements

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,16 +90,22 @@ RUN uv sync --locked --all-extras --no-group dev --no-group lint --no-group test
 # would silently no-op for the non-matching names.
 #
 # See: https://github.com/opencv/opencv-python/issues/1212
+#
+# Note: uv.lock resolves opencv packages to 4.13.0.92, but our wheel is pinned
+# to 4.12.0.88 because 4.13.0.92 has no sdist on PyPI — our GHA workflow
+# (build-opencv-wheels.yml) compiles from source and requires an sdist.
+# Bump this when a newer version publishes an sdist.
 ARG OPENCV_WHEEL_TAG=opencv-4.12.0.88
 ARG OPENCV_WHEEL_VERSION=4.12.0.88
 RUN ARCH=$(uname -m) && \
-    wget -q -O /tmp/opencv.whl \
-      "https://github.com/Unstructured-IO/unstructured/releases/download/${OPENCV_WHEEL_TAG}/opencv_contrib_python_headless-${OPENCV_WHEEL_VERSION}-cp312-cp312-linux_${ARCH}.whl" && \
+    WHEEL="opencv_contrib_python_headless-${OPENCV_WHEEL_VERSION}-cp312-cp312-linux_${ARCH}.whl" && \
+    wget -q -O /tmp/"${WHEEL}" \
+      "https://github.com/Unstructured-IO/unstructured/releases/download/${OPENCV_WHEEL_TAG}/${WHEEL}" && \
     uv pip uninstall \
       opencv-python opencv-python-headless \
       opencv-contrib-python opencv-contrib-python-headless && \
-    uv pip install --no-deps /tmp/opencv.whl && \
-    rm /tmp/opencv.whl
+    uv pip install --no-deps /tmp/"${WHEEL}" && \
+    rm /tmp/"${WHEEL}"
 
 ENV PATH="/app/.venv/bin:${PATH}"
 ENV HF_HUB_OFFLINE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,30 @@ RUN uv sync --locked --all-extras --no-group dev --no-group lint --no-group test
     uv run --no-sync $PYTHON -c "from unstructured.partition.model_init import initialize; initialize()" && \
     uv run --no-sync $PYTHON -c "from unstructured_inference.models.tables import UnstructuredTableTransformerModel; model = UnstructuredTableTransformerModel(); model.initialize('microsoft/table-transformer-structure-recognition')"
 
+# Replace PyPI opencv wheels (which bundle vulnerable ffmpeg 5.1.x with 14 CVEs)
+# with a source-built opencv-contrib-python-headless wheel compiled with
+# WITH_FFMPEG=OFF + ENABLE_CONTRIB=1 + ENABLE_HEADLESS=1.
+#
+# The contrib-headless variant is a strict superset of the cv2 API exposed by
+# opencv-python, opencv-python-headless, and opencv-contrib-python (all of
+# which are pulled in transitively by unstructured-paddleocr / unstructured-
+# inference). One wheel can therefore replace all three. Because the wheel's
+# metadata name only matches opencv-contrib-python-headless, we have to
+# uninstall the other variants first - `uv pip install --reinstall-package`
+# would silently no-op for the non-matching names.
+#
+# See: https://github.com/opencv/opencv-python/issues/1212
+ARG OPENCV_WHEEL_TAG=opencv-4.12.0.88
+ARG OPENCV_WHEEL_VERSION=4.12.0.88
+RUN ARCH=$(uname -m) && \
+    wget -q -O /tmp/opencv.whl \
+      "https://github.com/Unstructured-IO/unstructured/releases/download/${OPENCV_WHEEL_TAG}/opencv_contrib_python_headless-${OPENCV_WHEEL_VERSION}-cp312-cp312-linux_${ARCH}.whl" && \
+    uv pip uninstall \
+      opencv-python opencv-python-headless \
+      opencv-contrib-python opencv-contrib-python-headless && \
+    uv pip install --no-deps /tmp/opencv.whl && \
+    rm /tmp/opencv.whl
+
 ENV PATH="/app/.venv/bin:${PATH}"
 ENV HF_HUB_OFFLINE=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,10 +97,16 @@ RUN uv sync --locked --all-extras --no-group dev --no-group lint --no-group test
 # Bump this when a newer version publishes an sdist.
 ARG OPENCV_WHEEL_TAG=opencv-4.12.0.88
 ARG OPENCV_WHEEL_VERSION=4.12.0.88
+# SHA-256 hashes of the wheels we built in build-opencv-wheels.yml.
+# Update these when bumping OPENCV_WHEEL_VERSION.
+ARG OPENCV_SHA256_aarch64=498fbb787dbfe7d6bc853ddad4ea1154e8fbefbfafd05aafb417f576e27850d5
+ARG OPENCV_SHA256_x86_64=50545ffc1efabf06cd70894b65a7fbca56786f560f452bf67a42c1bbd7a85961
 RUN ARCH=$(uname -m) && \
     WHEEL="opencv_contrib_python_headless-${OPENCV_WHEEL_VERSION}-cp312-cp312-linux_${ARCH}.whl" && \
     wget -q -O /tmp/"${WHEEL}" \
       "https://github.com/Unstructured-IO/unstructured/releases/download/${OPENCV_WHEEL_TAG}/${WHEEL}" && \
+    EXPECTED=$(eval echo "\$OPENCV_SHA256_${ARCH}") && \
+    echo "${EXPECTED}  /tmp/${WHEEL}" | sha256sum -c - && \
     uv pip uninstall \
       opencv-python opencv-python-headless \
       opencv-contrib-python opencv-contrib-python-headless && \

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.20"  # pragma: no cover
+__version__ = "0.22.21"  # pragma: no cover


### PR DESCRIPTION
## Summary
- After `uv sync`, the Dockerfile downloads a source-built `opencv-contrib-python-headless` wheel (compiled with `WITH_FFMPEG=OFF`, `ENABLE_CONTRIB=1`, `ENABLE_HEADLESS=1`) from the GitHub release and substitutes it for all PyPI opencv-python variants
- The contrib-headless variant is a strict superset of the cv2 API (core + contrib modules, no GUI), so a single wheel replaces `opencv-python`, `opencv-python-headless`, and `opencv-contrib-python`, eliminating 14 bundled ffmpeg CVEs
- Validated end-to-end: PaddleOCR model load + detection + recognition on a real document image succeeds with the substituted wheel on wolfi-base arm64

## Dependencies
> **Depends on #4335** — the GHA workflow that builds and publishes the opencv wheels must be merged and run first so the GitHub release exists for the Dockerfile to download from. ✅ Merged and release published.

## Test plan
- [x] Merge and run the workflow in #4335 to create the wheel release
- [x] Local smoke test: PaddleOCR OCR on a real document image with substituted wheel (wolfi-base arm64)
- [ ] Build the main `Dockerfile` and verify opencv imports work without `.libs`
- [ ] Confirm no ffmpeg-related CVEs remain in a container scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes a core transitive native dependency in the Docker image (OpenCV), which could affect OCR/inference behavior or break builds if the wheel/arch tag mismatch occurs, despite hash verification.
> 
> **Overview**
> **Hardens the Docker image against ffmpeg CVEs** by replacing all PyPI `opencv-*` packages after `uv sync` with a downloaded, hash-verified `opencv-contrib-python-headless` wheel built with `WITH_FFMPEG=OFF`.
> 
> The Docker build now selects the wheel by architecture (`x86_64`/`aarch64`), uninstalls any existing OpenCV variants, installs the pinned wheel version, and bumps the library version/changelog to `0.22.22`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58f84268570f1f6d6f638b4f61011cdf2d6e617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->