### PR TITLE
feat(cli): add unstructured doctor diagnostics command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.25
+
+### Enhancements
+
+- **`unstructured doctor` CLI**: Add a `unstructured` console script and `python -m unstructured` entry point with a `doctor` subcommand for dependency and capability diagnostics (environment, optional system tools such as libmagic, tesseract, pandoc, ffmpeg, and LibreOffice, and per file-type extras). Supports `doctor --for <type>` (including `image` and `audio` families) and `doctor --file <path>`; exits non-zero when the requested capability is not available.
+
 ## 0.22.24
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,9 @@ ingest = [
     "unstructured-ingest[airtable,astradb,azure,azure-ai-search,bedrock,biomed,box,chroma,confluence,couchbase,databricks-volumes,delta-table,discord,dropbox,elasticsearch,gcs,github,gitlab,google-drive,hubspot,huggingface,jira,kafka,kdbai,milvus,mongodb,notion,octoai,onedrive,openai,opensearch,outlook,pinecone,postgres,qdrant,reddit,remote,s3,salesforce,sftp,sharepoint,singlestore,slack,vectara,vertexai,voyageai,weaviate,wikipedia]>=1.4.0, <2.0.0; platform_system == 'Windows' and python_version < '3.13'",
 ]
 
+[project.scripts]
+unstructured = "unstructured.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/Unstructured-IO/unstructured"
 
@@ -257,6 +260,12 @@ python_functions = ["test_", "it_", "they_", "but_", "and_"]
 testpaths = [
     "test_unstructured",
     "test_unstructured_ingest",
+]
+
+[tool.coverage.run]
+omit = [
+    # Entrypoint only; exercised via `unstructured` console script, not imports in tests.
+    "unstructured/__main__.py",
 ]
 
 [tool.coverage.report]

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -251,7 +251,10 @@ def test_save_elements(
 
 @pytest.mark.parametrize("storage_enabled", [False, True])
 def test_save_elements_with_output_dir_path_none(monkeypatch, storage_enabled):
-    monkeypatch.setenv("GLOBAL_WORKING_DIR_ENABLED", storage_enabled)
+    monkeypatch.setenv(
+        "GLOBAL_WORKING_DIR_ENABLED",
+        "true" if storage_enabled else "false",
+    )
     with (
         patch("PIL.Image.open"),
         patch("unstructured.partition.pdf_image.pdf_image_utils.write_image"),

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -234,7 +234,7 @@ def test_contains_exceeds_cap_ratio(text, expected, monkeypatch):
 def test_set_caps_ratio_with_environment_variable(monkeypatch):
     monkeypatch.setattr(text_type, "word_tokenize", mock_word_tokenize)
     monkeypatch.setattr(text_type, "sent_tokenize", mock_sent_tokenize)
-    monkeypatch.setenv("UNSTRUCTURED_NARRATIVE_TEXT_CAP_THRESHOLD", 0.8)
+    monkeypatch.setenv("UNSTRUCTURED_NARRATIVE_TEXT_CAP_THRESHOLD", str(0.8))
 
     text = "All The King's Horses. And All The King's Men."
     with patch.object(text_type, "exceeds_cap_ratio", return_value=False) as mock_exceeds:
@@ -246,7 +246,7 @@ def test_set_caps_ratio_with_environment_variable(monkeypatch):
 def test_set_title_non_alpha_threshold_with_environment_variable(monkeypatch):
     monkeypatch.setattr(text_type, "word_tokenize", mock_word_tokenize)
     monkeypatch.setattr(text_type, "sent_tokenize", mock_sent_tokenize)
-    monkeypatch.setenv("UNSTRUCTURED_TITLE_NON_ALPHA_THRESHOLD", 0.8)
+    monkeypatch.setenv("UNSTRUCTURED_TITLE_NON_ALPHA_THRESHOLD", str(0.8))
 
     text = "/--------------- All the king's horses----------------/"
     with patch.object(text_type, "under_non_alpha_ratio", return_value=False) as mock_exceeds:
@@ -258,7 +258,7 @@ def test_set_title_non_alpha_threshold_with_environment_variable(monkeypatch):
 def test_set_narrative_text_non_alpha_threshold_with_environment_variable(monkeypatch):
     monkeypatch.setattr(text_type, "word_tokenize", mock_word_tokenize)
     monkeypatch.setattr(text_type, "sent_tokenize", mock_sent_tokenize)
-    monkeypatch.setenv("UNSTRUCTURED_NARRATIVE_TEXT_NON_ALPHA_THRESHOLD", 0.8)
+    monkeypatch.setenv("UNSTRUCTURED_NARRATIVE_TEXT_NON_ALPHA_THRESHOLD", str(0.8))
 
     text = "/--------------- All the king's horses----------------/"
     with patch.object(text_type, "under_non_alpha_ratio", return_value=False) as mock_exceeds:
@@ -270,7 +270,7 @@ def test_set_narrative_text_non_alpha_threshold_with_environment_variable(monkey
 def test_set_title_max_word_length_with_environment_variable(monkeypatch):
     monkeypatch.setattr(text_type, "word_tokenize", mock_word_tokenize)
     monkeypatch.setattr(text_type, "sent_tokenize", mock_sent_tokenize)
-    monkeypatch.setenv("UNSTRUCTURED_TITLE_MAX_WORD_LENGTH", 5)
+    monkeypatch.setenv("UNSTRUCTURED_TITLE_MAX_WORD_LENGTH", str(5))
 
     text = "Intellectual Property in the United States"
     assert text_type.is_possible_narrative_text(text) is False

--- a/test_unstructured/partition/utils/test_config.py
+++ b/test_unstructured/partition/utils/test_config.py
@@ -12,7 +12,7 @@ def test_default_config():
 
 
 def test_env_override(monkeypatch):
-    monkeypatch.setenv("IMAGE_CROP_PAD", 1)
+    monkeypatch.setenv("IMAGE_CROP_PAD", str(1))
     from unstructured.partition.utils.config import env_config
 
     assert env_config.IMAGE_CROP_PAD == 1

--- a/test_unstructured/test_cli_doctor.py
+++ b/test_unstructured/test_cli_doctor.py
@@ -1,0 +1,358 @@
+"""Tests for :mod:`unstructured.cli` and :mod:`unstructured.doctor`."""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from unstructured.cli import _cmd_doctor, main
+from unstructured.doctor import (
+    _libmagic_status,
+    _needs_pandoc_runtime,
+    _pip_hint_for_file_type,
+    _tool_status,
+    build_report,
+    environment_rows,
+    evaluate_file_type_capability,
+    evaluate_specifier,
+    file_path_to_capability,
+    format_table,
+    python_import_deps_ok,
+    resolve_specifier,
+    system_tool_rows,
+)
+from unstructured.file_utils.model import FileType
+
+
+def test_resolve_specifier_pdf() -> None:
+    fts = resolve_specifier("pdf")
+    assert fts == [FileType.PDF]
+
+
+def test_resolve_specifier_jpg_exact() -> None:
+    assert resolve_specifier("jpg") == [FileType.JPG]
+
+
+def test_resolve_specifier_image_family() -> None:
+    fts = resolve_specifier("image")
+    assert len(fts) >= 1
+    assert all(ft.extra_name == "image" for ft in fts)
+
+
+def test_resolve_specifier_audio_family() -> None:
+    fts = resolve_specifier("audio")
+    assert len(fts) >= 1
+    assert all(ft.extra_name == "audio" for ft in fts)
+
+
+def test_resolve_specifier_email_partitioner_shortname() -> None:
+    assert FileType.EML in resolve_specifier("email")
+
+
+def test_resolve_specifier_unknown() -> None:
+    with pytest.raises(ValueError, match="Unknown"):
+        resolve_specifier("not-a-real-type-xyz")
+
+
+def test_resolve_specifier_empty() -> None:
+    with pytest.raises(ValueError, match="Empty"):
+        resolve_specifier("   ")
+
+
+def test_evaluate_specifier_dedupes_image_family() -> None:
+    with mock.patch("unstructured.doctor.evaluate_file_type_capability") as ev:
+        ev.return_value = mock.Mock(ready=True, messages=())
+        r = evaluate_specifier("image")
+        assert r.ready is True
+        assert ev.call_count == 1
+
+
+def test_evaluate_specifier_multiple_targets() -> None:
+    def _cap(ready: bool, *msgs: str) -> mock.Mock:
+        m = mock.Mock()
+        m.ready = ready
+        m.messages = tuple(msgs)
+        return m
+
+    with (
+        mock.patch(
+            "unstructured.doctor.resolve_specifier",
+            return_value=[FileType.PDF, FileType.CSV],
+        ),
+        mock.patch(
+            "unstructured.doctor.evaluate_file_type_capability",
+            side_effect=[_cap(False, "a"), _cap(True)],
+        ),
+    ):
+        r = evaluate_specifier("x")
+        assert r.ready is False
+        assert "[PDF] a" in r.messages
+
+
+def test_evaluate_specifier_dedupes_repeated_message_lines() -> None:
+    with (
+        mock.patch("unstructured.doctor.resolve_specifier", return_value=[FileType.PDF]),
+        mock.patch(
+            "unstructured.doctor.evaluate_file_type_capability",
+            return_value=mock.Mock(ready=False, messages=("dup", "dup")),
+        ),
+    ):
+        r = evaluate_specifier("pdf")
+        assert r.messages.count("[PDF] dup") == 1
+
+
+def test_main_doctor_invocation() -> None:
+    with mock.patch("unstructured.cli._cmd_doctor", return_value=0) as m:
+        assert main(["doctor"]) == 0
+        m.assert_called_once_with([])
+
+
+def test_main_no_argv_reads_sys_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.argv", ["unstructured", "doctor", "--for", "txt"])
+    with mock.patch("unstructured.cli._cmd_doctor", return_value=0) as m:
+        assert main(None) == 0
+        m.assert_called_once_with(["--for", "txt"])
+
+
+def test_main_unknown() -> None:
+    assert main(["nope"]) == 2
+
+
+def test_main_help_returns_zero() -> None:
+    assert main(["--help"]) == 0
+
+
+def test_cmd_doctor_for_missing_dep_exit_code() -> None:
+    with mock.patch(
+        "unstructured.doctor.evaluate_specifier",
+        return_value=mock.Mock(ready=False, messages=("missing",)),
+    ):
+        assert _cmd_doctor(["--for", "pdf"]) == 1
+
+
+def test_cmd_doctor_for_ok() -> None:
+    with mock.patch(
+        "unstructured.doctor.evaluate_specifier",
+        return_value=mock.Mock(ready=True, messages=()),
+    ):
+        assert _cmd_doctor(["--for", "pdf"]) == 0
+
+
+def test_cmd_doctor_for_prints_messages(capsys: pytest.CaptureFixture[str]) -> None:
+    with mock.patch(
+        "unstructured.doctor.evaluate_specifier",
+        return_value=mock.Mock(ready=True, messages=("note",)),
+    ):
+        assert _cmd_doctor(["--for", "pdf"]) == 0
+    assert "note" in capsys.readouterr().out
+
+
+def test_cmd_doctor_file_not_found(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.pdf"
+    assert _cmd_doctor(["--file", str(missing)]) == 1
+
+
+def test_cmd_doctor_file_txt_ok(tmp_path: Path) -> None:
+    pytest.importorskip("olefile")
+    f = tmp_path / "a.txt"
+    f.write_text("hello", encoding="utf-8")
+    assert _cmd_doctor(["--file", str(f)]) == 0
+
+
+def test_cmd_doctor_file_prints_messages(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    f = tmp_path / "b.txt"
+    f.write_text("x", encoding="utf-8")
+    with mock.patch(
+        "unstructured.doctor.file_path_to_capability",
+        return_value=mock.Mock(ready=True, messages=("hi",)),
+    ):
+        assert _cmd_doctor(["--file", str(f)]) == 0
+    assert "hi" in capsys.readouterr().out
+
+
+def test_cmd_doctor_for_and_file_mutually_exclusive_returns_2() -> None:
+    assert _cmd_doctor(["--for", "pdf", "--file", "any.pdf"]) == 2
+
+
+def test_cmd_doctor_invalid_for_returns_2() -> None:
+    assert _cmd_doctor(["--for", "not-a-real-type-xyz"]) == 2
+
+
+def test_cmd_doctor_default_prints_report(capsys: pytest.CaptureFixture[str]) -> None:
+    assert _cmd_doctor([]) == 0
+    out = capsys.readouterr().out
+    assert "Environment" in out
+    assert "Partitionable file types" in out
+
+
+def test_evaluate_doc_requires_soffice_when_deps_ok() -> None:
+    with mock.patch("unstructured.doctor.python_import_deps_ok", return_value=(True, [])):
+        with mock.patch("unstructured.doctor._libreoffice_on_path", return_value=None):
+            r = evaluate_file_type_capability(FileType.DOC)
+            assert r.ready is False
+            assert "soffice" in "".join(r.messages).lower()
+
+
+def test_evaluate_epub_requires_pandoc_binary_when_python_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with mock.patch("unstructured.doctor.python_import_deps_ok", return_value=(True, [])):
+
+        def _which(cmd: str) -> str | None:
+            if cmd == "pandoc":
+                return None
+            return "/fake/bin/" + cmd
+
+        monkeypatch.setattr("unstructured.doctor.shutil.which", _which)
+        r = evaluate_file_type_capability(FileType.EPUB)
+        assert r.ready is False
+        assert "Pandoc" in "".join(r.messages)
+
+
+def test_evaluate_zip_not_partitionable() -> None:
+    r = evaluate_file_type_capability(FileType.ZIP)
+    assert r.ready is False
+    assert "not partitionable" in r.messages[0]
+
+
+def test_evaluate_html_no_extra() -> None:
+    r = evaluate_file_type_capability(FileType.HTML)
+    assert r.ready is True
+    assert not r.messages
+
+
+def test_evaluate_audio_not_ready_without_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> None:
+    import shutil
+
+    real_which = shutil.which
+
+    def _which(cmd: str) -> str | None:
+        if cmd == "ffmpeg":
+            return None
+        return real_which(cmd)
+
+    monkeypatch.setattr("unstructured.doctor.shutil.which", _which)
+    with mock.patch("unstructured.doctor._audio_extra_import_ok", return_value=True):
+        r = evaluate_file_type_capability(FileType.MP3)
+    assert r.ready is False
+    assert "ffmpeg" in " ".join(r.messages).lower()
+
+
+def test_python_import_deps_ok_returns_missing() -> None:
+    ok, missing = python_import_deps_ok(FileType.PDF)
+    assert isinstance(ok, bool)
+    assert isinstance(missing, list)
+
+
+def test_format_table_empty_rows() -> None:
+    out = format_table(("A", "B"), [])
+    assert "(no rows)" in out
+
+
+def test_format_table_with_rows() -> None:
+    out = format_table(("Col",), [("val",)])
+    assert "Col" in out
+    assert "val" in out
+
+
+def test_environment_rows() -> None:
+    rows = environment_rows()
+    labels = [r[0] for r in rows]
+    assert "Python" in labels
+    assert "unstructured" in labels
+
+
+def test_system_tool_rows_shape() -> None:
+    rows = system_tool_rows()
+    assert len(rows) >= 5
+    assert all(len(r) == 3 for r in rows)
+
+
+def test_tool_status_branches() -> None:
+    assert _tool_status("x", True)[0] == "ok"
+    assert _tool_status("x", False)[0] == "missing"
+
+
+def test_pip_hint_for_file_type() -> None:
+    assert "pdf" in _pip_hint_for_file_type(FileType.PDF)
+    assert _pip_hint_for_file_type(FileType.HTML) == "pip install unstructured"
+
+
+def test_needs_pandoc_runtime() -> None:
+    assert _needs_pandoc_runtime(FileType.EPUB) is True
+    assert _needs_pandoc_runtime(FileType.HTML) is False
+
+
+def test_build_report_smoke() -> None:
+    report = build_report()
+    assert "Environment" in report
+    assert "System tools" in report
+    assert "Partitionable file types" in report
+
+
+def test_file_path_to_capability_txt(tmp_path: Path) -> None:
+    pytest.importorskip("olefile")
+    f = tmp_path / "n.txt"
+    f.write_text("x", encoding="utf-8")
+    r = file_path_to_capability(f)
+    assert r.ready is True
+
+
+def test_file_path_to_capability_zip(tmp_path: Path) -> None:
+    pytest.importorskip("olefile")
+    zp = tmp_path / "empty.zip"
+    with zipfile.ZipFile(zp, "w"):
+        pass
+    r = file_path_to_capability(zp)
+    assert r.ready is False
+    assert "not partitionable" in r.messages[0]
+
+
+def test_file_path_to_capability_missing_path(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.txt"
+    r = file_path_to_capability(missing)
+    assert r.ready is False
+    assert "Not a file" in r.messages[0]
+
+
+def test_libmagic_status_ok_with_mocked_magic(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = mock.MagicMock()
+    fake.from_buffer = mock.MagicMock(return_value="application/pdf")
+    monkeypatch.setitem(sys.modules, "magic", fake)
+    st, msg = _libmagic_status()
+    assert st == "ok"
+    assert "OK" in msg or "ok" in msg
+
+
+def test_libmagic_status_warn_when_from_buffer_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = mock.MagicMock()
+    fake.from_buffer = mock.MagicMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setitem(sys.modules, "magic", fake)
+    st, msg = _libmagic_status()
+    assert st == "warn"
+    assert "libmagic" in msg.lower()
+
+
+def test_libmagic_status_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _imp(name: str, *args, **kwargs):
+        if name == "magic":
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _imp)
+    st, msg = _libmagic_status()
+    assert st == "warn"
+    assert "magic" in msg.lower() or "fallback" in msg.lower()

--- a/unstructured/__main__.py
+++ b/unstructured/__main__.py
@@ -1,0 +1,6 @@
+"""Allow ``python -m unstructured``."""
+
+from unstructured.cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.24"  # pragma: no cover
+__version__ = "0.22.25"  # pragma: no cover

--- a/unstructured/cli.py
+++ b/unstructured/cli.py
@@ -1,0 +1,87 @@
+"""Command-line interface for :mod:`unstructured`."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def _cmd_doctor(argv: list[str] | None = None) -> int:
+    from unstructured.doctor import build_report, evaluate_specifier, file_path_to_capability
+
+    parser = argparse.ArgumentParser(
+        prog="unstructured doctor",
+        description="Print dependency and capability diagnostics for partitioning.",
+    )
+    parser.add_argument(
+        "--for",
+        dest="for_cap",
+        metavar="TYPE",
+        help="Check readiness for a file type or family (e.g. pdf, docx, image, audio).",
+    )
+    parser.add_argument(
+        "--file",
+        dest="file_path",
+        metavar="PATH",
+        help="Infer file type from PATH and check readiness for that type.",
+    )
+    ns = parser.parse_args(argv)
+
+    if ns.for_cap and ns.file_path:
+        print("Use either --for or --file, not both.", file=sys.stderr)
+        return 2
+
+    if ns.for_cap:
+        try:
+            result = evaluate_specifier(ns.for_cap)
+        except ValueError as e:
+            print(str(e), file=sys.stderr)
+            return 2
+        if result.messages:
+            print("\n".join(result.messages))
+        if not result.ready:
+            return 1
+        return 0
+
+    if ns.file_path:
+        result = file_path_to_capability(ns.file_path)
+        if result.messages:
+            print("\n".join(result.messages))
+        if not result.ready:
+            return 1
+        return 0
+
+    print(build_report(), end="")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``unstructured`` console script."""
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    if not argv or argv[0] in ("-h", "--help"):
+        parser = argparse.ArgumentParser(
+            prog="unstructured",
+            description="Unstructured document processing utilities.",
+        )
+        parser.add_argument(
+            "command",
+            nargs="?",
+            choices=["doctor"],
+            help="Subcommand to run.",
+        )
+        parser.print_help()
+        return 0
+
+    if argv[0] == "doctor":
+        return _cmd_doctor(argv[1:])
+
+    print(
+        f"unstructured: unknown command {argv[0]!r}. Try `unstructured --help`.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/unstructured/doctor.py
+++ b/unstructured/doctor.py
@@ -1,0 +1,296 @@
+"""Environment and capability diagnostics for optional dependencies and system tools."""
+
+from __future__ import annotations
+
+import importlib.util
+import platform
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from unstructured.__version__ import __version__
+from unstructured.file_utils.model import FileType
+from unstructured.utils import dependency_exists
+
+Status = Literal["ok", "missing", "warn"]
+
+# File types that rely on LibreOffice for conversion (see partition/common/common.py).
+_FILE_TYPES_NEEDING_SOFFICE: frozenset[FileType] = frozenset({FileType.DOC, FileType.PPT})
+
+
+@dataclass(frozen=True)
+class CapabilityResult:
+    """Result of checking whether partitioning is viable for a target file type."""
+
+    ready: bool
+    """True when Python deps and required external tools for this type are satisfied."""
+    messages: tuple[str, ...]
+    """Human-readable issues (blocking or informational)."""
+
+
+def _pip_hint_for_file_type(file_type: FileType) -> str:
+    extra = file_type.extra_name
+    if extra:
+        return f'pip install "unstructured[{extra}]"'
+    return "pip install unstructured"
+
+
+def _needs_pandoc_runtime(file_type: FileType) -> bool:
+    return "pypandoc" in file_type.importable_package_dependencies
+
+
+def _audio_extra_import_ok() -> bool:
+    return importlib.util.find_spec("whisper") is not None
+
+
+def _libmagic_status() -> tuple[Status, str]:
+    try:
+        import magic
+
+        _ = magic.from_buffer(b"%PDF-1.4\n", mime=True)
+    except ImportError:
+        return "warn", "python `magic` module not available (filetype fallback still works)"
+    except Exception as exc:  # noqa: BLE001 — surface libmagic load/binary issues
+        return "warn", f"libmagic not usable: {exc!s}"[:200]
+    else:
+        return "ok", "libmagic (python-magic) OK"
+
+
+def _tool_status(name: str, on_path: bool) -> tuple[Status, str]:
+    if on_path:
+        return "ok", f"{name} found on PATH"
+    return "missing", f"{name} not found on PATH"
+
+
+def python_import_deps_ok(file_type: FileType) -> tuple[bool, list[str]]:
+    """Return whether declared importable dependencies for `file_type` are importable."""
+    missing: list[str] = []
+    for mod in file_type.importable_package_dependencies:
+        if not dependency_exists(mod):
+            missing.append(mod)
+    return len(missing) == 0, missing
+
+
+def evaluate_file_type_capability(file_type: FileType) -> CapabilityResult:
+    """Check partitioning readiness for a single :class:`FileType`."""
+    if not file_type.is_partitionable:
+        return CapabilityResult(
+            ready=False,
+            messages=(f"{file_type.name} is not partitionable.",),
+        )
+
+    ok, missing = python_import_deps_ok(file_type)
+    messages: list[str] = []
+    if not ok:
+        messages.append(
+            f"Missing Python module(s): {', '.join(missing)}. "
+            f"Install with: {_pip_hint_for_file_type(file_type)}",
+        )
+
+    if _needs_pandoc_runtime(file_type) and ok and shutil.which("pandoc") is None:
+        ok = False
+        messages.append(
+            "Pandoc executable not found on PATH (required by pypandoc). "
+            "Install pandoc from https://pandoc.org/installing.html",
+        )
+
+    if file_type in _FILE_TYPES_NEEDING_SOFFICE and ok and _libreoffice_on_path() is None:
+        ok = False
+        messages.append(
+            "soffice (LibreOffice CLI) not found on PATH. "
+            "Required to convert legacy .doc / .ppt to Open XML formats.",
+        )
+
+    # Audio partitioner uses the `audio` extra (Whisper); FileType members only list empty deps.
+    if file_type.extra_name == "audio":
+        if not _audio_extra_import_ok():
+            ok = False
+            messages.append(
+                "Missing audio extra (e.g. Whisper). "
+                'Install with: pip install "unstructured[audio]"',
+            )
+        if shutil.which("ffmpeg") is None:
+            ok = False
+            messages.append(
+                "ffmpeg not on PATH - required for Whisper audio decoding "
+                "(https://ffmpeg.org/download.html).",
+            )
+
+    return CapabilityResult(ready=ok, messages=tuple(messages))
+
+
+def _libreoffice_on_path() -> str | None:
+    """Return ``soffice`` on PATH; matches :func:`convert_office_doc` in ``partition.common``."""
+    return shutil.which("soffice")
+
+
+def resolve_specifier(spec: str) -> list[FileType]:
+    """Map a user string (e.g. ``pdf``, ``png``, ``image``) to :class:`FileType` members."""
+    raw = spec.strip()
+    if not raw:
+        raise ValueError("Empty specifier")
+    lower = raw.lower()
+
+    if lower == "image":
+        return [ft for ft in FileType if ft.is_partitionable and ft.extra_name == "image"]
+    if lower == "audio":
+        return [ft for ft in FileType if ft.is_partitionable and ft.extra_name == "audio"]
+
+    matches: list[FileType] = []
+    for ft in FileType:
+        if not ft.is_partitionable:
+            continue
+        if ft.name.lower() == lower or ft.value == lower:
+            matches.append(ft)
+            continue
+        if ft.partitioner_shortname and ft.partitioner_shortname.lower() == lower:
+            matches.append(ft)
+
+    if not matches:
+        valid = sorted(
+            {ft.value for ft in FileType if ft.is_partitionable}
+            | {ft.name.lower() for ft in FileType if ft.is_partitionable}
+            | {"image", "audio"},
+        )
+        sample = ", ".join(valid[:20])
+        raise ValueError(f"Unknown file type or alias {spec!r}. Examples: {sample}...")
+
+    # Prefer exact value/name matches over partitioner_shortname duplicates.
+    exact = [ft for ft in matches if ft.value == lower or ft.name.lower() == lower]
+    return exact or matches
+
+
+def evaluate_specifier(spec: str) -> CapabilityResult:
+    """Combine evaluation for all file types matched by :func:`resolve_specifier`."""
+    targets = resolve_specifier(spec)
+    if (
+        len(targets) > 1
+        and targets[0].extra_name in ("image", "audio")
+        and all(t.extra_name == targets[0].extra_name for t in targets)
+    ):
+        targets = [targets[0]]
+    combined_ready = True
+    all_messages: list[str] = []
+    for ft in targets:
+        result = evaluate_file_type_capability(ft)
+        if not result.ready:
+            combined_ready = False
+        for m in result.messages:
+            all_messages.append(f"[{ft.name}] {m}")
+    # De-duplicate messages while preserving order
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for m in all_messages:
+        if m not in seen:
+            seen.add(m)
+            deduped.append(m)
+    return CapabilityResult(ready=combined_ready, messages=tuple(deduped))
+
+
+def environment_rows() -> list[tuple[str, str, str]]:
+    """Rows for the environment section: (name, status, detail)."""
+    return [
+        ("Python", "ok", platform.python_version()),
+        ("Platform", "ok", platform.platform()),
+        ("unstructured", "ok", __version__),
+    ]
+
+
+def system_tool_rows() -> list[tuple[str, Status, str]]:
+    """Rows for optional system tools."""
+    rows: list[tuple[str, Status, str]] = []
+    st, detail = _libmagic_status()
+    rows.append(("libmagic (MIME detection)", st, detail))
+
+    for label, cmd in (
+        ("tesseract (OCR)", "tesseract"),
+        ("pandoc", "pandoc"),
+        ("ffmpeg (audio/codecs)", "ffmpeg"),
+    ):
+        status, msg = _tool_status(label, shutil.which(cmd) is not None)
+        rows.append((label, status, msg))
+    lo = _libreoffice_on_path()
+    rows.append(
+        (
+            "soffice (LibreOffice CLI)",
+            "ok" if lo else "missing",
+            f"found: {lo}" if lo else "not found on PATH",
+        ),
+    )
+    return rows
+
+
+def partitionable_file_type_rows() -> list[tuple[str, str, str, str]]:
+    """One row per partitionable file type: type, deps OK, extra, notes."""
+    out: list[tuple[str, str, str, str]] = []
+    for ft in sorted(
+        (m for m in FileType if m.is_partitionable),
+        key=lambda x: x.name,
+    ):
+        py_ok, _missing = python_import_deps_ok(ft)
+        deps_cell = "yes" if py_ok else "no"
+        extra = ft.extra_name or "-"
+        cap = evaluate_file_type_capability(ft)
+        notes = " | ".join(cap.messages) if cap.messages else "-"
+        out.append((ft.name, deps_cell, extra, notes))
+    return out
+
+
+def format_table(headers: tuple[str, ...], rows: list[tuple[str, ...]]) -> str:
+    """Render a simple fixed-width table (no third-party deps)."""
+    if not rows:
+        return " | ".join(headers) + "\n(no rows)\n"
+    col_widths = [len(h) for h in headers]
+    str_rows: list[list[str]] = []
+    for row in rows:
+        cells = [str(c) for c in row]
+        str_rows.append(cells)
+        for i, cell in enumerate(cells):
+            col_widths[i] = max(col_widths[i], len(cell))
+    sep = "-+-".join("-" * w for w in col_widths)
+    lines = [
+        " | ".join(headers[i].ljust(col_widths[i]) for i in range(len(headers))),
+        sep,
+    ]
+    for cells in str_rows:
+        lines.append(" | ".join(cells[i].ljust(col_widths[i]) for i in range(len(headers))))
+    return "\n".join(lines) + "\n"
+
+
+def build_report() -> str:
+    """Full diagnostic report for :command:`unstructured doctor` with no filter."""
+    parts: list[str] = []
+    parts.append("Environment\n")
+    parts.append(format_table(("Component", "Status", "Detail"), environment_rows()))
+
+    parts.append("System tools (optional but commonly needed)\n")
+    sys_rows = system_tool_rows()
+    parts.append(format_table(("Tool", "Status", "Detail"), sys_rows))
+
+    parts.append("Partitionable file types (Python extras)\n")
+    p_rows = partitionable_file_type_rows()
+    parts.append(
+        format_table(
+            ("File type", "Python deps OK", "pip extra", "Notes"),
+            [tuple(r) for r in p_rows],
+        ),
+    )
+    return "".join(parts)
+
+
+def file_path_to_capability(path: str | Path) -> CapabilityResult:
+    """Infer file type from ``path`` and evaluate capability."""
+    p = Path(path)
+    if not p.is_file():
+        return CapabilityResult(ready=False, messages=(f"Not a file or not found: {p}",))
+
+    from unstructured.file_utils.filetype import detect_filetype
+
+    ft = detect_filetype(file_path=str(p.resolve()))
+    if not ft.is_partitionable:
+        return CapabilityResult(
+            ready=False,
+            messages=(f"Detected type {ft.name} is not partitionable.",),
+        )
+    return evaluate_file_type_capability(ft)

--- a/unstructured/metrics/evaluate.py
+++ b/unstructured/metrics/evaluate.py
@@ -292,7 +292,8 @@ class TableStructureMetricsCalculator(BaseMetricsCalculator):
 
         if self.include_false_positives:
             # we give false positive tables a 1 table worth of weight in computing table level acc
-            df["_table_weights"][df.total_tables.eq(0) & df.total_predicted_tables.gt(0)] = 1
+            _fp_mask = df.total_tables.eq(0) & df.total_predicted_tables.gt(0)
+            df.loc[_fp_mask, "_table_weights"] = 1
 
         # filter down to only those with actual and/or predicted tables
         has_tables_df = df[df["_table_weights"] > 0]

--- a/unstructured/metrics/utils.py
+++ b/unstructured/metrics/utils.py
@@ -109,10 +109,12 @@ def _write_to_file(
         raise ValueError("Mode not supported. Mode must be one of [w, a].")
     if directory:
         Path(directory).mkdir(exist_ok=True)
+    # Operate on a copy so callers can pass a view/slice without chained-assignment warnings.
+    df = df.copy()
     if "count" in df.columns:
         df["count"] = df["count"].astype(int)
     if "filename" in df.columns and "connector" in df.columns:
-        df.sort_values(by=["connector", "filename"], inplace=True)
+        df = df.sort_values(by=["connector", "filename"])
     if not overwrite:
         filename = _get_non_duplicated_filename(directory, filename)
     df.to_csv(

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -58,7 +58,11 @@ def partition_csv(
 
     csv.field_size_limit(CSV_FIELD_LIMIT)
     with ctx.open() as file:
-        dataframe = pd.read_csv(file, header=ctx.header, sep=ctx.delimiter, encoding=ctx.encoding)
+        read_kw: dict = {"header": ctx.header, "sep": ctx.delimiter, "encoding": ctx.encoding}
+        # sep=None is not supported by the C engine; use Python engine to avoid ParserWarning.
+        if ctx.delimiter is None:
+            read_kw["engine"] = "python"
+        dataframe = pd.read_csv(file, **read_kw)
 
     html_table = HtmlTable.from_html_text(
         dataframe.to_html(index=False, header=include_header, na_rep="")


### PR DESCRIPTION
## Summary
Adds a first-class unstructured doctor command so users can verify Python extras, optional system tools, and partitioning readiness before hitting runtime import or tool errors.

Closes #4341

## What’s included

- Console script: unstructured (see [project.scripts] in pyproject.toml).
- Module entry: python -m unstructured → doctor (and __main__.py).
- unstructured doctor: tables for environment, system tools (libmagic smoke, tesseract, pandoc, ffmpeg, LibreOffice), and partitionable file types with pip install "unstructured[extra]" hints.
- unstructured doctor --for <type>: e.g. pdf, docx, image, audio; exits 1 if the requested capability is not ready, 2 on unknown type.
- unstructured doctor --file <path>: infer type via detect_filetype, same exit semantics.
- Tests: test_unstructured/test_cli_doctor.py.
- Release notes: version 0.22.23 and CHANGELOG.md entry.

## How to verify

- unstructured doctor
- unstructured doctor --for pdf
- unstructured doctor --file path/to/some.pdf
- python -m pytest test_unstructured/test_cli_doctor.py -q


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to introducing a new CLI entrypoint and changing CSV parsing behavior (engine selection) plus tweaks to metrics DataFrame writes; failures would mainly affect tooling/metrics rather than core partitioning output.
> 
> **Overview**
> Introduces a first-class `unstructured` CLI (and `python -m unstructured`) with a `doctor` subcommand that reports environment details, optional system tool availability (e.g., libmagic/tesseract/pandoc/ffmpeg/LibreOffice), and per-filetype partitioning readiness; adds `--for` and `--file` modes with non-zero exit codes when capabilities are missing.
> 
> Also tightens pandas usage to avoid chained-assignment issues in metrics reporting, adjusts CSV partitioning to use the Python engine when delimiter inference is needed (`sep=None`), and fixes tests to set environment variables as strings; adds comprehensive tests for the new doctor command and bumps version/docs to `0.22.25`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 580e27b97a6259f19861660692a37b9bff544738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->