### PR TITLE
feat: Track the table extraction method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.26
+
+### Enhancements
+
+- Add `table_extraction_method` field to `ElementMetadata` to track which algorithm produced a table (grid, tatr, vlm). Propagated from `LayoutElement` during PDF partitioning.
+
 ## 0.22.25
 
 ### Enhancements

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.25"  # pragma: no cover
+__version__ = "0.22.26"  # pragma: no cover

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -12,7 +12,7 @@ import uuid
 from functools import cached_property
 from itertools import groupby
 from types import MappingProxyType
-from typing import Any, Callable, FrozenSet, Optional, Sequence, cast
+from typing import Any, Callable, FrozenSet, Literal, Optional, Sequence, cast
 
 from typing_extensions import ParamSpec, TypeAlias, TypedDict
 
@@ -213,6 +213,7 @@ class ElementMetadata:
     text_as_html: Optional[str]
     is_extracted: Optional[str]
     table_as_cells: Optional[dict[str, str | int]]
+    table_extraction_method: Optional[Literal["grid", "tatr", "vlm"]]
 
     # -- used for TableChunk elements to enable table reconstruction --
     table_id: Optional[str]
@@ -267,6 +268,7 @@ class ElementMetadata:
         signature: Optional[str] = None,
         subject: Optional[str] = None,
         table_as_cells: Optional[dict[str, str | int]] = None,
+        table_extraction_method: Optional[Literal["grid", "tatr", "vlm"]] = None,
         table_id: Optional[str] = None,
         chunk_index: Optional[int] = None,
         num_carried_over_header_rows: Optional[int] = None,
@@ -320,6 +322,7 @@ class ElementMetadata:
         self.subject = subject
         self.text_as_html = text_as_html
         self.table_as_cells = table_as_cells
+        self.table_extraction_method = table_extraction_method
         self.table_id = table_id
         self.chunk_index = chunk_index
         self.num_carried_over_header_rows = num_carried_over_header_rows
@@ -548,6 +551,7 @@ class ConsolidationStrategy(enum.Enum):
             "subject": cls.FIRST,
             "text_as_html": cls.STRING_CONCATENATE,
             "table_as_cells": cls.FIRST,  # -- only occurs in Table --
+            "table_extraction_method": cls.FIRST,
             "table_id": cls.DROP,  # -- added by chunking, not before --
             "chunk_index": cls.DROP,  # -- added by chunking, not before --
             "num_carried_over_header_rows": cls.DROP,  # -- added by chunking, not before --

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -12,7 +12,7 @@ import uuid
 from functools import cached_property
 from itertools import groupby
 from types import MappingProxyType
-from typing import Any, Callable, FrozenSet, Literal, Optional, Sequence, cast
+from typing import Any, Callable, FrozenSet, Optional, Sequence, cast
 
 from typing_extensions import ParamSpec, TypeAlias, TypedDict
 
@@ -213,7 +213,7 @@ class ElementMetadata:
     text_as_html: Optional[str]
     is_extracted: Optional[str]
     table_as_cells: Optional[dict[str, str | int]]
-    table_extraction_method: Optional[Literal["grid", "tatr", "vlm"]]
+    table_extraction_method: Optional[str]  # "grid", "tatr", or "vlm"
 
     # -- used for TableChunk elements to enable table reconstruction --
     table_id: Optional[str]
@@ -268,7 +268,7 @@ class ElementMetadata:
         signature: Optional[str] = None,
         subject: Optional[str] = None,
         table_as_cells: Optional[dict[str, str | int]] = None,
-        table_extraction_method: Optional[Literal["grid", "tatr", "vlm"]] = None,
+        table_extraction_method: Optional[str] = None,
         table_id: Optional[str] = None,
         chunk_index: Optional[int] = None,
         num_carried_over_header_rows: Optional[int] = None,

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -1443,6 +1443,9 @@ def document_to_element_list(
                     element.metadata.last_modified = last_modification_date
                 element.metadata.text_as_html = getattr(layout_element, "text_as_html", None)
                 element.metadata.table_as_cells = getattr(layout_element, "table_as_cells", None)
+                element.metadata.table_extraction_method = getattr(
+                    layout_element, "table_extraction_method", None
+                )
 
                 if (isinstance(element, Title) and element.metadata.category_depth is None) and (
                     has_headline


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new optional metadata field and wires it through PDF partitioning; behavior is additive and low risk aside from potential downstream consumers expecting a fixed metadata schema.
> 
> **Overview**
> **Adds table-provenance metadata for extracted tables.** `ElementMetadata` now includes an optional `table_extraction_method` (e.g., `grid`, `tatr`, `vlm`) and includes it in metadata consolidation.
> 
> During PDF partitioning, the value is propagated from each `LayoutElement` onto the resulting element metadata, enabling downstream consumers to identify which table-extraction algorithm produced a given table. Version is bumped to `0.22.26` and the changelog is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6135af306bc3fb6fbe28db3aa5dc477c4f2ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->