### PR TITLE
fix: avoid false-positive Title classification for long no-space text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.28
+
+### Fixes
+
+- **Reduce false-positive `Title` classification for no-space text (e.g., Chinese OCR)**: Add a max-length guard for whitespace-free title candidates in `is_possible_title()` so long body text without spaces is not treated as a single-word title. Adds `UNSTRUCTURED_TITLE_MAX_NO_SPACE_LENGTH` (default `40`) and regression coverage for Chinese short-title vs long-body cases.
+
 ## 0.22.27
 
 ### Fixes
@@ -9,6 +15,9 @@
 ### Enhancements
 
 - Add `table_extraction_method` field to `ElementMetadata` to track which algorithm produced a table (grid, tatr, vlm). Propagated from `LayoutElement` during PDF partitioning.
+=======
+- **Reduce false-positive `Title` classification for Chinese no-space text**: Add a Han-script max-length guard for whitespace-free title candidates in `is_possible_title()` so long Chinese body text without spaces is not treated as a single-word title. Adds `UNSTRUCTURED_TITLE_MAX_NO_SPACE_LENGTH` (default `120`) and regression coverage for Chinese short-title vs long-body cases without affecting non-Han no-space scripts.
+>>>>>>> 33b7dfb3f (fix: update)
 
 ## 0.22.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@
 ### Enhancements
 
 - Add `table_extraction_method` field to `ElementMetadata` to track which algorithm produced a table (grid, tatr, vlm). Propagated from `LayoutElement` during PDF partitioning.
-=======
-- **Reduce false-positive `Title` classification for Chinese no-space text**: Add a Han-script max-length guard for whitespace-free title candidates in `is_possible_title()` so long Chinese body text without spaces is not treated as a single-word title. Adds `UNSTRUCTURED_TITLE_MAX_NO_SPACE_LENGTH` (default `120`) and regression coverage for Chinese short-title vs long-body cases without affecting non-Han no-space scripts.
->>>>>>> 33b7dfb3f (fix: update)
 
 ## 0.22.25
 

--- a/test_unstructured/partition/test_text_type.py
+++ b/test_unstructured/partition/test_text_type.py
@@ -130,6 +130,28 @@ def test_title_language_checks():
     assert text_type.is_possible_narrative_text(text, language_checks=True) is False
 
 
+def test_is_possible_title_handles_chinese_without_spaces(monkeypatch):
+    monkeypatch.setenv("UNSTRUCTURED_LANGUAGE_CHECKS", "false")
+
+    short_title = "市场风险"
+    long_body = (
+        "这是一个用于测试标题分类的中文段落没有空格并且长度明显超过标题合理范围用于避免误判"
+        "这是一个用于测试标题分类的中文段落没有空格并且长度明显超过标题合理范围用于避免误判"
+        "这是一个用于测试标题分类的中文段落没有空格并且长度明显超过标题合理范围用于避免误判"
+    )
+
+    assert text_type.is_possible_title(short_title) is True
+    assert text_type.is_possible_title(long_body) is False
+
+
+def test_is_possible_title_does_not_apply_no_space_guard_to_non_han_text(monkeypatch):
+    monkeypatch.setenv("UNSTRUCTURED_LANGUAGE_CHECKS", "false")
+
+    long_non_han_no_space = "የሰው፡ልጅ፡ሁሉ፡ሲወለድ፡ነጻና፡በክብርና፡በመብትም፡እኩልነት፡ያለው፡ነው።"
+
+    assert text_type.is_possible_title(long_non_han_no_space) is True
+
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.27"  # pragma: no cover
+__version__ = "0.22.28"  # pragma: no cover

--- a/unstructured/partition/text_type.py
+++ b/unstructured/partition/text_type.py
@@ -22,6 +22,7 @@ from unstructured.nlp.tokenize import pos_tag, sent_tokenize, word_tokenize
 POS_VERB_TAGS: Final[List[str]] = ["VB", "VBG", "VBD", "VBN", "VBP", "VBZ"]
 ENGLISH_WORD_SPLIT_RE = re.compile(r"[\s\-,.!?_\/]+")
 NON_LOWERCASE_ALPHA_RE = re.compile(r"[^a-z]")
+HAN_IDEOGRAPH_RE = re.compile(r"[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]")
 
 
 def is_possible_narrative_text(
@@ -128,9 +129,21 @@ def is_possible_title(
     title_max_word_length = int(
         os.environ.get("UNSTRUCTURED_TITLE_MAX_WORD_LENGTH", title_max_word_length),
     )
+    title_max_no_space_length = int(
+        os.environ.get("UNSTRUCTURED_TITLE_MAX_NO_SPACE_LENGTH", 120),
+    )
     # NOTE(robinson) - splitting on spaces here instead of word tokenizing because it
     # is less expensive and actual tokenization doesn't add much value for the length check
     if len(text.split(" ")) > title_max_word_length:
+        return False
+    # NOTE: Chinese text is commonly written without spaces. Without this guard, long body text
+    # can be misclassified as a title because it appears as a single "word". Scope this to Han
+    # ideograph text to avoid regressions for other no-space scripts.
+    if (
+        HAN_IDEOGRAPH_RE.search(text) is not None
+        and not any(char.isspace() for char in text)
+        and len(text) > title_max_no_space_length
+    ):
         return False
 
     non_alpha_threshold = float(


### PR DESCRIPTION
## Summary
- add a no-space length guard in `is_possible_title()` to handle CJK text better
- introduce `UNSTRUCTURED_TITLE_MAX_NO_SPACE_LENGTH` (default: `40`) for tuning
- add regression tests for Chinese text without spaces (short heading vs long body)
Closes #3930 

## Why
Chinese OCR output often has no spaces, so long narrative text could be interpreted as a single "word" and incorrectly classified as `Title`. This change reduces those false positives while preserving expected short-title behavior.

## Test plan
- [x] Added unit test coverage in `test_unstructured/partition/test_text_type.py`
- [ ] Run: `pytest -q test_unstructured/partition/test_text_type.py -k "title or chinese"`
- [ ] Verify OCR-only PDF flow no longer maps long Chinese body text to `Title`
- [ ] Sanity-check English title classification is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `is_possible_title()` heuristics for Han-ideograph text, which can affect downstream element classification and chunking behavior; env-default tuning mismatch could surprise users if relied upon implicitly.
> 
> **Overview**
> Reduces false-positive `Title` classification for long whitespace-free CJK/Han text by adding a Han-ideograph regex and a max-length guard in `is_possible_title()` (configurable via `UNSTRUCTURED_TITLE_MAX_NO_SPACE_LENGTH`).
> 
> Adds regression tests covering short Chinese headings vs long Chinese body text and ensuring the new guard doesn’t apply to other no-space scripts. Bumps version to `0.22.28` and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda9fe4606dd2f58afb249fd2a06318b0209d418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->