### PR TITLE
Fix br tail text handling in HTML tables

### DIFF
--- a/test_unstructured/common/test_html_table.py
+++ b/test_unstructured/common/test_html_table.py
@@ -66,6 +66,22 @@ class DescribeHtmlTable:
         assert isinstance(html_table, HtmlTable)
         assert html_table._table.tag == "table"
 
+    def test_from_html_text_preserves_br_tail_text(self):
+        html_text = """
+        <table>
+        <tr>
+        <td>This is 1st line.<br/>2nd line.<br/>3rd line.</td>
+        </tr>
+        </table>
+        """
+
+        html_table = HtmlTable.from_html_text(html_text)
+
+        assert html_table.html == (
+            "<table><tr><td>This is 1st line.<br/>2nd line.<br/>3rd line.</td></tr></table>"
+        )
+        assert html_table.text == "This is 1st line. 2nd line. 3rd line."
+
     def but_it_raises_when_no_table_element_is_present_in_the_html(self):
         with pytest.raises(ValueError, match="`html_text` contains no `<table>` element"):
             HtmlTable.from_html_text("<html><body><tr><td>foobar</td></tr></body></html>")

--- a/unstructured/common/html_table.py
+++ b/unstructured/common/html_table.py
@@ -104,9 +104,8 @@ class HtmlTable:
             if e.text:
                 e.text = " ".join(e.text.split())
 
-            # -- remove all tails, those are newline + indent if anything --
             if e.tail:
-                e.tail = None
+                e.tail = " ".join(e.tail.split()) if e.tag == "br" else None
 
         return cls(table, header_row_idxs=header_row_idxs, source_row_htmls=source_row_htmls)
 


### PR DESCRIPTION
Fixes #3899.

## Summary

This PR fixes text loss when normalizing HTML tables that contain `<br/>` tags inside table cells.

`HtmlTable.from_html_text()` previously removed all element tail text during normalization. For `<br/>` elements, the text after the tag is stored as tail text, so content after line breaks was dropped from the normalized HTML output.

## Problem

Given an HTML table cell like:

`This is 1st line.<br/>2nd line.<br/>3rd line.`

the normalized table output preserved the `<br/>` tags but dropped the text after them, resulting in loss of `2nd line.` and `3rd line.`.

## Solution

This change preserves normalized tail text for `<br/>` elements while continuing to remove tail text for other elements.

This keeps the existing cleanup behavior for table normalization but avoids dropping valid content that follows line break tags.

## Changes

- Preserve tail text for `<br/>` elements in `HtmlTable.from_html_text()`.
- Continue removing tail text for non-`br` elements.
- Add regression coverage for preserving text after `<br/>` tags in HTML table cells.

## How to test

Run the targeted regression test:

```bash
python -m pytest test_unstructured/common/test_html_table.py::DescribeHtmlTable::test_from_html_text_preserves_br_tail_text -q
```

Expected result:

```text
1 passed
```

## Validation

I reproduced the issue locally before applying the fix.

Before the fix, this input lost the text after `<br/>` tags:

`This is 1st line.<br/>2nd line.<br/>3rd line.`

After the fix, the normalized table preserves all lines:

`This is 1st line.<br/>2nd line.<br/>3rd line.`

The targeted regression test passes locally.