### PR TITLE
fix: chunking dropping table content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.28
+
+### Fixes
+
+- **Preserve mixed-content tail text in table HTML**: `HtmlTable` compactification previously cleared every element's `.tail`, silently dropping real text between inline children. Pure-whitespace tails are still removed, but tails carrying content are now kept with internal whitespace collapsed.
+
 ## 0.22.27
 
 ### Fixes

--- a/test_unstructured/common/test_html_table.py
+++ b/test_unstructured/common/test_html_table.py
@@ -125,6 +125,28 @@ class DescribeHtmlTable:
         )
         assert html_table.html == "<table><tr><td>abc def ghi</td></tr></table>"
 
+    def it_preserves_tail_text_in_mixed_content_cells(self):
+        """Tail text (between inline children) carries real content and must not be dropped."""
+        html_table = HtmlTable.from_html_text(
+            "<table><tr>"
+            "<td><b>foo</b> bar <b>baz</b></td>"
+            "<td><b>x</b><br/>y<br/>z</td>"
+            "</tr></table>"
+        )
+        assert html_table.html == (
+            "<table><tr>"
+            "<td><b>foo</b> bar <b>baz</b></td>"
+            "<td><b>x</b><br/>y<br/>z</td>"
+            "</tr></table>"
+        )
+
+    def and_it_normalizes_whitespace_within_tail_text(self):
+        """Tail whitespace runs are collapsed, but leading/trailing spaces are kept."""
+        html_table = HtmlTable.from_html_text(
+            "<table><tr><td><b>a</b>   b\n  c  <b>d</b></td></tr></table>"
+        )
+        assert html_table.html == "<table><tr><td><b>a</b> b c <b>d</b></td></tr></table>"
+
     def it_can_serialize_the_table_element_to_str_html_text(self):
         table = fragment_fromstring("<table><tr><td>foobar</td></tr></table>")
         html_table = HtmlTable(table)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.27"  # pragma: no cover
+__version__ = "0.22.28"  # pragma: no cover

--- a/unstructured/common/html_table.py
+++ b/unstructured/common/html_table.py
@@ -104,9 +104,19 @@ class HtmlTable:
             if e.text:
                 e.text = " ".join(e.text.split())
 
-            # -- remove all tails, those are newline + indent if anything --
+            # -- normalize tails. A tail is the text between an element's closing tag and the
+            # -- start of the next sibling. Pure-whitespace tails are pretty-printing noise and
+            # -- can be dropped, but tails can also carry real content (e.g. mixed inline
+            # -- markup like `<b>foo</b> bar <b>baz</b>` or text between `<br/>` tags), which
+            # -- must be preserved.
             if e.tail:
-                e.tail = None
+                parts = e.tail.split()
+                if not parts:
+                    e.tail = None
+                else:
+                    prefix = " " if e.tail[0].isspace() else ""
+                    suffix = " " if e.tail[-1].isspace() else ""
+                    e.tail = prefix + " ".join(parts) + suffix
 
         return cls(table, header_row_idxs=header_row_idxs, source_row_htmls=source_row_htmls)
 


### PR DESCRIPTION
## Preserve mixed-content tail text in table HTML

### Summary
`HtmlTable.from_html_text` compactification cleared every element's `.tail`, silently dropping any text between inline children of a `<td>`. In practice this deleted real content like `": do not..."` after `<b>NOTICE</b>`, bullet lines following each `<br/>`, and any inter-tag prose in rich table cells — visible whenever a table was chunked (any strategy: `basic`, `by_title`, `by_page`).

Pure-whitespace tails are still stripped (those are just pretty-print indent). Tails carrying content are now kept, with internal whitespace runs collapsed and a single leading/trailing space preserved so adjacent text doesn't run together.

### Changes
- `unstructured/common/html_table.py`: replace the blanket `e.tail = None` with whitespace-aware normalization.
- `test_unstructured/common/test_html_table.py`: two regression tests covering mixed inline markup, `<br/>`-separated lines, and whitespace collapsing.
- Bump to `0.22.28` + changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized change to table HTML minification that preserves previously-dropped text; main risk is minor whitespace/serialization differences in downstream table chunking output.
> 
> **Overview**
> Fixes `HtmlTable.from_html_text()` compactification to **stop deleting meaningful mixed-content tail text** (text between inline children like `<b>foo</b> bar` or between `<br/>` siblings), while still dropping pure formatting/indent whitespace and collapsing internal whitespace runs.
> 
> Adds regression tests for mixed inline markup and `<br/>`-separated cell content, and bumps the library to `0.22.28` with a changelog entry describing the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe27d3582a40cf1d27e8617491d9b1214057605e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->