### PR TITLE
Optimize XLSX subtable detection memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.32
+
+### Enhancements
+
+- **Optimize XLSX subtable detection memory usage**: replace dense worksheet-sized graph construction with sparse connected-component traversal over populated cells, preserving existing `partition_xlsx()` output while reducing peak memory on sparse sheets.
+
 ## 0.22.31
 
 ### Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ tsv = [
 ]
 xlsx = [
     "msoffcrypto-tool>=6.0.0, <7.0.0",
-    "networkx>=3.2.0, <4.0.0",
     "openpyxl>=3.1.5, <4.0.0",
     "pandas>=2.0.0, <3.0.0",
     "xlrd>=2.0.1, <3.0.0",

--- a/scripts/performance/benchmark_xlsx_connected_components.py
+++ b/scripts/performance/benchmark_xlsx_connected_components.py
@@ -87,9 +87,7 @@ def main() -> None:
 
     with _workspace(args.work_dir) as work_dir:
         print(f"Generated worksheet directory: {work_dir}")
-        print(
-            "case,algorithm,components,seconds,baseline_rss_mb,peak_rss_mb,peak_delta_mb"
-        )
+        print("case,algorithm,components,seconds,baseline_rss_mb,peak_rss_mb,peak_delta_mb")
 
         for case in cases:
             worksheet_path = _write_worksheet(case, work_dir, args.storage)
@@ -237,9 +235,7 @@ def _measure_worker(args: argparse.Namespace) -> Measurement:
 
     worksheet_df = _read_worksheet(args.input_path, args.storage)
     benchmark_function = (
-        _sparse_connected_components
-        if args.algorithm == "sparse"
-        else _dense_connected_components
+        _sparse_connected_components if args.algorithm == "sparse" else _dense_connected_components
     )
     return _measure(lambda: benchmark_function(worksheet_df))
 
@@ -300,6 +296,7 @@ def _measure(benchmark_function: Callable[[], list[_ConnectedComponent]]) -> Mea
         peak_delta_mb=(peak_rss - baseline_rss) / 1024 / 1024,
         component_count=len(components),
     )
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/performance/benchmark_xlsx_connected_components.py
+++ b/scripts/performance/benchmark_xlsx_connected_components.py
@@ -1,0 +1,305 @@
+"""Benchmark XLSX connected-component detection on generated worksheets.
+
+This local utility compares the current sparse implementation against a dense
+NetworkX grid-graph reference that mirrors the previous implementation.
+
+Run from the repository root:
+
+    uv run --extra xlsx --with networkx python \
+        scripts/performance/benchmark_xlsx_connected_components.py
+
+Use ``--case`` to run one generated shape, or ``--work-dir`` to keep the generated
+XLSX files for inspection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import psutil
+
+from unstructured.partition.xlsx import _ConnectedComponent, _ConnectedComponents
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    name: str
+    rows: int
+    cols: int
+    builder: Callable[[int, int], pd.DataFrame]
+
+
+@dataclass(frozen=True)
+class Measurement:
+    seconds: float
+    baseline_rss_mb: float
+    peak_rss_mb: float
+    peak_delta_mb: float
+    component_count: int
+
+    @classmethod
+    def from_json(cls, value: str) -> Measurement:
+        measurement_dict = json.loads(value)
+        return cls(
+            seconds=measurement_dict["seconds"],
+            baseline_rss_mb=measurement_dict["baseline_rss_mb"],
+            peak_rss_mb=measurement_dict["peak_rss_mb"],
+            peak_delta_mb=measurement_dict["peak_delta_mb"],
+            component_count=measurement_dict["component_count"],
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "seconds": self.seconds,
+                "baseline_rss_mb": self.baseline_rss_mb,
+                "peak_rss_mb": self.peak_rss_mb,
+                "peak_delta_mb": self.peak_delta_mb,
+                "component_count": self.component_count,
+            }
+        )
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.worker:
+        print(_measure_worker(args).to_json())
+        return
+
+    cases = [case for case in _cases() if args.case in (None, case.name)]
+    if not cases:
+        available_cases = ", ".join(case.name for case in _cases())
+        raise SystemExit(f"Unknown case {args.case!r}. Available cases: {available_cases}")
+
+    with _workspace(args.work_dir) as work_dir:
+        print(f"Generated worksheet directory: {work_dir}")
+        print(
+            "case,algorithm,components,seconds,baseline_rss_mb,peak_rss_mb,peak_delta_mb"
+        )
+
+        for case in cases:
+            worksheet_path = _write_worksheet(case, work_dir, args.storage)
+
+            for algorithm_name in ("sparse", "dense"):
+                measurement = _measure_in_subprocess(
+                    algorithm_name, worksheet_path, args.storage, args.repeat
+                )
+                print(
+                    f"{case.name},{algorithm_name},{measurement.component_count},"
+                    f"{measurement.seconds:.4f},{measurement.baseline_rss_mb:.1f},"
+                    f"{measurement.peak_rss_mb:.1f},{measurement.peak_delta_mb:.1f}"
+                )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--case",
+        choices=[case.name for case in _cases()],
+        help="Run only one generated worksheet shape.",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=3,
+        help="Number of times to repeat each connected-components measurement.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        help="Directory for generated XLSX files. Defaults to a temporary directory.",
+    )
+    parser.add_argument(
+        "--storage",
+        choices=["xlsx", "pickle"],
+        default="xlsx",
+        help=(
+            "How to pass generated worksheets to worker subprocesses. Use xlsx for end-to-end "
+            "generated files, or pickle when XLSX writer dependencies are unavailable."
+        ),
+    )
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--algorithm", choices=["sparse", "dense"], help=argparse.SUPPRESS)
+    parser.add_argument("--input-path", type=Path, help=argparse.SUPPRESS)
+    return parser.parse_args()
+
+
+@contextmanager
+def _workspace(work_dir: Path | None) -> Iterator[Path]:
+    if work_dir is not None:
+        work_dir.mkdir(parents=True, exist_ok=True)
+        yield work_dir
+        return
+
+    with tempfile.TemporaryDirectory(prefix="xlsx-components-") as tmp_dir:
+        yield Path(tmp_dir)
+
+
+def _cases() -> list[BenchmarkCase]:
+    return [
+        BenchmarkCase("dense_table", 800, 30, _dense_table),
+        BenchmarkCase("sparse_wide_edges", 2500, 600, _sparse_wide_edges),
+        BenchmarkCase("separated_blocks", 1800, 120, _separated_blocks),
+    ]
+
+
+def _write_worksheet(case: BenchmarkCase, work_dir: Path, storage: str) -> Path:
+    worksheet_df = case.builder(case.rows, case.cols)
+    if storage == "xlsx":
+        xlsx_path = work_dir / f"{case.name}.xlsx"
+        worksheet_df.to_excel(xlsx_path, index=False, header=False)
+        return xlsx_path
+
+    pickle_path = work_dir / f"{case.name}.pkl"
+    worksheet_df.to_pickle(pickle_path)
+    return pickle_path
+
+
+def _dense_table(rows: int, cols: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        [[f"r{row_idx}c{col_idx}" for col_idx in range(cols)] for row_idx in range(rows)]
+    )
+
+
+def _sparse_wide_edges(rows: int, cols: int) -> pd.DataFrame:
+    worksheet = pd.DataFrame(None, index=range(rows), columns=range(cols), dtype=object)
+    for row_idx in range(0, rows, 100):
+        worksheet.iat[row_idx, 0] = f"left-{row_idx}"
+        worksheet.iat[row_idx, cols - 1] = f"right-{row_idx}"
+
+    worksheet.iat[rows - 2, cols - 2] = "footer"
+    worksheet.iat[rows - 2, cols - 1] = "value"
+    worksheet.iat[rows - 1, cols - 2] = "total"
+    worksheet.iat[rows - 1, cols - 1] = 100
+    return worksheet
+
+
+def _separated_blocks(rows: int, cols: int) -> pd.DataFrame:
+    worksheet = pd.DataFrame(None, index=range(rows), columns=range(cols), dtype=object)
+    block_width = 8
+    block_height = 12
+
+    for block_idx, start_row in enumerate(range(0, rows - block_height, 80)):
+        start_col = (block_idx * 17) % (cols - block_width)
+        worksheet.iat[start_row, start_col] = f"Block {block_idx}"
+        for row_offset in range(1, block_height):
+            for col_offset in range(block_width):
+                worksheet.iat[start_row + row_offset, start_col + col_offset] = (
+                    f"{block_idx}-{row_offset}-{col_offset}"
+                )
+
+    return worksheet
+
+
+def _measure_in_subprocess(
+    algorithm_name: str, worksheet_path: Path, storage: str, repeat: int
+) -> Measurement:
+    measurements = []
+    for _ in range(repeat):
+        completed_process = subprocess.run(
+            [
+                sys.executable,
+                __file__,
+                "--worker",
+                "--algorithm",
+                algorithm_name,
+                "--input-path",
+                str(worksheet_path),
+                "--storage",
+                storage,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        measurements.append(Measurement.from_json(completed_process.stdout))
+
+    return min(measurements, key=lambda measurement: measurement.seconds)
+
+
+def _measure_worker(args: argparse.Namespace) -> Measurement:
+    if args.algorithm is None or args.input_path is None:
+        raise SystemExit("--worker requires --algorithm and --input-path")
+
+    worksheet_df = _read_worksheet(args.input_path, args.storage)
+    benchmark_function = (
+        _sparse_connected_components
+        if args.algorithm == "sparse"
+        else _dense_connected_components
+    )
+    return _measure(lambda: benchmark_function(worksheet_df))
+
+
+def _read_worksheet(input_path: Path, storage: str) -> pd.DataFrame:
+    if storage == "xlsx":
+        return pd.read_excel(input_path, header=None)
+
+    return pd.read_pickle(input_path)
+
+
+def _sparse_connected_components(worksheet_df: pd.DataFrame) -> list[_ConnectedComponent]:
+    return list(_ConnectedComponents.from_worksheet_df(worksheet_df))
+
+
+def _dense_connected_components(worksheet_df: pd.DataFrame) -> list[_ConnectedComponent]:
+    max_row, max_col = worksheet_df.shape
+    node_array = np.indices((max_row, max_col)).T
+    empty_cells = worksheet_df.isna().T
+    nodes_to_remove = [tuple(pair) for pair in node_array[empty_cells]]
+
+    graph = nx.grid_2d_graph(max_row, max_col)
+    graph.remove_nodes_from(nodes_to_remove)
+
+    connected_components = [
+        _ConnectedComponent(worksheet_df, component_node_set)
+        for component_node_set in nx.connected_components(graph)
+    ]
+    return list(_ConnectedComponents(worksheet_df)._merge_overlapping_tables(connected_components))
+
+
+def _measure(benchmark_function: Callable[[], list[_ConnectedComponent]]) -> Measurement:
+    gc.collect()
+    process = psutil.Process()
+    baseline_rss = process.memory_info().rss
+    peak_rss = baseline_rss
+    stop_sampling = threading.Event()
+
+    def sample_rss() -> None:
+        nonlocal peak_rss
+        while not stop_sampling.is_set():
+            peak_rss = max(peak_rss, process.memory_info().rss)
+            time.sleep(0.005)
+
+    sampler = threading.Thread(target=sample_rss)
+    sampler.start()
+    start_time = time.perf_counter()
+    components = benchmark_function()
+    seconds = time.perf_counter() - start_time
+    peak_rss = max(peak_rss, process.memory_info().rss)
+    stop_sampling.set()
+    sampler.join()
+
+    return Measurement(
+        seconds=seconds,
+        baseline_rss_mb=baseline_rss / 1024 / 1024,
+        peak_rss_mb=peak_rss / 1024 / 1024,
+        peak_delta_mb=(peak_rss - baseline_rss) / 1024 / 1024,
+        component_count=len(components),
+    )
+
+if __name__ == "__main__":
+    main()

--- a/test_unstructured/partition/test_xlsx.py
+++ b/test_unstructured/partition/test_xlsx.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import io
 import sys
 import tempfile
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -297,6 +298,100 @@ def test_partition_xlsx_with_more_than_1k_cells():
         sys.setrecursionlimit(old_recursion_limit)
 
 
+def test_partition_xlsx_generated_dense_table_preserves_text_and_html(tmp_path: Path):
+    xlsx_path = _write_generated_xlsx(
+        tmp_path,
+        [
+            ["Team", "Location", "Stanley Cups"],
+            ["Blues", "STL", 1],
+            ["Flyers", "PHI", 2],
+        ],
+    )
+
+    elements = partition_xlsx(str(xlsx_path))
+
+    assert elements == [Table("Team Location Stanley Cups Blues STL 1 Flyers PHI 2")]
+    assert elements[0].metadata.text_as_html == (
+        "<table>"
+        "<tr><td>Team</td><td>Location</td><td>Stanley Cups</td></tr>"
+        "<tr><td>Blues</td><td>STL</td><td>1</td></tr>"
+        "<tr><td>Flyers</td><td>PHI</td><td>2</td></tr>"
+        "</table>"
+    )
+    assert elements[0].metadata.page_name == "Sheet1"
+    assert elements[0].metadata.page_number == 1
+
+
+def test_partition_xlsx_generated_sparse_far_edge_cells_preserves_text_and_html(tmp_path: Path):
+    rows = [[None for _ in range(10)] for _ in range(8)]
+    rows[0][0] = "Far Edge Title"
+    rows[6][8] = "Key"
+    rows[6][9] = "Value"
+    rows[7][8] = "answer"
+    rows[7][9] = 42
+    xlsx_path = _write_generated_xlsx(tmp_path, rows)
+
+    elements = partition_xlsx(str(xlsx_path))
+
+    assert elements == [Title("Far Edge Title"), Table("Key Value answer 42")]
+    assert elements[1].metadata.text_as_html == (
+        "<table>"
+        "<tr><td>Key</td><td>Value</td></tr>"
+        "<tr><td>answer</td><td>42</td></tr>"
+        "</table>"
+    )
+
+
+def test_partition_xlsx_generated_separated_blocks_and_single_cell_rows(tmp_path: Path):
+    xlsx_path = _write_generated_xlsx(
+        tmp_path,
+        [
+            ["North Report", None, None, None, None, None],
+            ["Region", "Revenue", None, None, None, None],
+            ["North", 100, None, None, None, None],
+            [None, "Reviewed", None, None, None, None],
+            [None, None, None, None, None, None],
+            [None, None, None, "South Report", None, None],
+            [None, None, None, "Region", "Revenue", None],
+            [None, None, None, "EU", 200, None],
+            [None, None, None, None, "Approved", None],
+            [None, None, None, None, None, None],
+            ["A", "B", None, None, "C", "D"],
+            [1, 2, None, None, 3, 4],
+        ],
+    )
+
+    elements = partition_xlsx(str(xlsx_path))
+
+    assert elements == [
+        Title("North Report"),
+        Table("Region Revenue North 100"),
+        Title("Reviewed"),
+        Title("South Report"),
+        Table("Region Revenue EU 200"),
+        Title("Approved"),
+        Table("A B C D 1 2 3 4"),
+    ]
+    assert elements[1].metadata.text_as_html == (
+        "<table>"
+        "<tr><td>Region</td><td>Revenue</td></tr>"
+        "<tr><td>North</td><td>100</td></tr>"
+        "</table>"
+    )
+    assert elements[4].metadata.text_as_html == (
+        "<table>"
+        "<tr><td>Region</td><td>Revenue</td></tr>"
+        "<tr><td>EU</td><td>200</td></tr>"
+        "</table>"
+    )
+    assert elements[6].metadata.text_as_html == (
+        "<table>"
+        "<tr><td>A</td><td>B</td><td/><td/><td>C</td><td>D</td></tr>"
+        "<tr><td>1</td><td>2</td><td/><td/><td>3</td><td>4</td></tr>"
+        "</table>"
+    )
+
+
 # ================================================================================================
 # OTHER ARGS
 # ================================================================================================
@@ -340,6 +435,12 @@ def test_partition_xlsx_with_find_subtables_False_and_infer_table_structure_Fals
 # These test components used by `partition_xlsx()` in isolation such that all edge cases can be
 # exercised.
 # ------------------------------------------------------------------------------------------------
+
+
+def _write_generated_xlsx(tmp_path: Path, rows: list[list[Any]]) -> Path:
+    xlsx_path = tmp_path / "generated.xlsx"
+    pd.DataFrame(rows).to_excel(xlsx_path, index=False, header=False)
+    return xlsx_path
 
 
 class Describe_XlsxPartitionerOptions:

--- a/test_unstructured/partition/test_xlsx.py
+++ b/test_unstructured/partition/test_xlsx.py
@@ -335,10 +335,7 @@ def test_partition_xlsx_generated_sparse_far_edge_cells_preserves_text_and_html(
 
     assert elements == [Title("Far Edge Title"), Table("Key Value answer 42")]
     assert elements[1].metadata.text_as_html == (
-        "<table>"
-        "<tr><td>Key</td><td>Value</td></tr>"
-        "<tr><td>answer</td><td>42</td></tr>"
-        "</table>"
+        "<table><tr><td>Key</td><td>Value</td></tr><tr><td>answer</td><td>42</td></tr></table>"
     )
 
 
@@ -373,16 +370,10 @@ def test_partition_xlsx_generated_separated_blocks_and_single_cell_rows(tmp_path
         Table("A B C D 1 2 3 4"),
     ]
     assert elements[1].metadata.text_as_html == (
-        "<table>"
-        "<tr><td>Region</td><td>Revenue</td></tr>"
-        "<tr><td>North</td><td>100</td></tr>"
-        "</table>"
+        "<table><tr><td>Region</td><td>Revenue</td></tr><tr><td>North</td><td>100</td></tr></table>"
     )
     assert elements[4].metadata.text_as_html == (
-        "<table>"
-        "<tr><td>Region</td><td>Revenue</td></tr>"
-        "<tr><td>EU</td><td>200</td></tr>"
-        "</table>"
+        "<table><tr><td>Region</td><td>Revenue</td></tr><tr><td>EU</td><td>200</td></tr></table>"
     )
     assert elements[6].metadata.text_as_html == (
         "<table>"

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.31"  # pragma: no cover
+__version__ = "0.22.32"  # pragma: no cover

--- a/unstructured/partition/xlsx.py
+++ b/unstructured/partition/xlsx.py
@@ -6,7 +6,6 @@ import io
 from functools import cached_property
 from typing import IO, Any, Iterator, Optional
 
-import networkx as nx
 import numpy as np
 import pandas as pd
 from msoffcrypto import OfficeFile
@@ -291,30 +290,47 @@ class _ConnectedComponents:
     @cached_property
     def _connected_components(self) -> list[_ConnectedComponent]:
         """The `_ConnectedComponent` objects comprising this collection."""
-        # -- produce a 2D-graph representing the populated cells of the worksheet (or subsheet).
-        # -- A 2D-graph relates each populated cell to the one above, below, left, and right of it.
-        max_row, max_col = self._worksheet_df.shape
-        node_array = np.indices((max_row, max_col)).T
-        empty_cells = self._worksheet_df.isna().T
-        nodes_to_remove = [tuple(pair) for pair in node_array[empty_cells]]  # pyright: ignore
-
-        graph: nx.Graph = nx.grid_2d_graph(max_row, max_col)  # pyright: ignore
-        graph.remove_nodes_from(nodes_to_remove)  # pyright: ignore
-
-        # -- compute sets of nodes representing each connected-component --
-        connected_node_sets: Iterator[set[_CellCoordinate]]
-        connected_node_sets = nx.connected_components(  # pyright: ignore[reportUnknownMemberType]
-            graph
-        )
-
         return list(
             self._merge_overlapping_tables(
                 [
                     _ConnectedComponent(self._worksheet_df, component_node_set)
-                    for component_node_set in connected_node_sets
+                    for component_node_set in self._iter_connected_node_sets()
                 ]
             )
         )
+
+    def _iter_connected_node_sets(self) -> Iterator[set[_CellCoordinate]]:
+        """Sets of 4-neighbor connected populated-cell coordinates in row-major order."""
+        populated_cell_mask = self._worksheet_df.notna().to_numpy()
+        row_indices, col_indices = np.nonzero(populated_cell_mask)
+        row_coordinates, col_coordinates = row_indices.tolist(), col_indices.tolist()
+        unvisited_cells = set(zip(row_coordinates, col_coordinates))
+
+        for cell in zip(row_coordinates, col_coordinates):
+            if cell not in unvisited_cells:
+                continue
+
+            component_node_set: set[_CellCoordinate] = set()
+            cells_to_visit = [cell]
+            unvisited_cells.remove(cell)
+
+            while cells_to_visit:
+                row_idx, col_idx = cells_to_visit.pop()
+                component_node_set.add((row_idx, col_idx))
+
+                for neighbor in (
+                    (row_idx - 1, col_idx),
+                    (row_idx + 1, col_idx),
+                    (row_idx, col_idx - 1),
+                    (row_idx, col_idx + 1),
+                ):
+                    if neighbor not in unvisited_cells:
+                        continue
+
+                    unvisited_cells.remove(neighbor)
+                    cells_to_visit.append(neighbor)
+
+            yield component_node_set
 
     def _merge_overlapping_tables(
         self, connected_components: list[_ConnectedComponent]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -2068,9 +2068,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
     { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
     { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
     { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
     { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
     { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
     { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
@@ -2078,9 +2076,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -2088,9 +2084,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
     { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
     { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
     { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
     { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
     { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
     { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
@@ -7109,13 +7103,9 @@ name = "triton"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190, upload-time = "2026-01-20T16:16:00.523Z" },
     { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
-    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
     { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
 ]
 
@@ -7257,7 +7247,6 @@ all-docs = [
     { name = "google-cloud-vision" },
     { name = "markdown" },
     { name = "msoffcrypto-tool" },
-    { name = "networkx" },
     { name = "openai-whisper" },
     { name = "openpyxl" },
     { name = "pandas" },
@@ -7313,7 +7302,6 @@ local-inference = [
     { name = "google-cloud-vision" },
     { name = "markdown" },
     { name = "msoffcrypto-tool" },
-    { name = "networkx" },
     { name = "openai-whisper" },
     { name = "openpyxl" },
     { name = "pandas" },
@@ -7370,7 +7358,6 @@ tsv = [
 ]
 xlsx = [
     { name = "msoffcrypto-tool" },
-    { name = "networkx" },
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "xlrd" },
@@ -7427,9 +7414,6 @@ requires-dist = [
     { name = "msoffcrypto-tool", marker = "extra == 'all-docs'", specifier = ">=6.0.0,<7.0.0" },
     { name = "msoffcrypto-tool", marker = "extra == 'local-inference'", specifier = ">=6.0.0,<7.0.0" },
     { name = "msoffcrypto-tool", marker = "extra == 'xlsx'", specifier = ">=6.0.0,<7.0.0" },
-    { name = "networkx", marker = "extra == 'all-docs'", specifier = ">=3.2.0,<4.0.0" },
-    { name = "networkx", marker = "extra == 'local-inference'", specifier = ">=3.2.0,<4.0.0" },
-    { name = "networkx", marker = "extra == 'xlsx'", specifier = ">=3.2.0,<4.0.0" },
     { name = "numba", specifier = ">=0.60.0,<1.0.0" },
     { name = "numpy", specifier = ">=1.26.0,<3.0.0" },
     { name = "openai-whisper", marker = "extra == 'all-docs'", specifier = ">=20231117,<20270000" },


### PR DESCRIPTION
## Summary
Replace worksheet-sized NetworkX graph construction with traversal over populated cells. Preserve four-neighbor connectivity, row-overlap merging, element ordering, text, HTML, and metadata. NetworkX remains a test dependency for comparison with the previous algorithm, and is removed from the XLSX runtime extra.

## Compatibility
No new file-size, row, cell, or processing limit is introduced. Parsing, populated-cell semantics, and table rendering are unchanged. Exact serialized output matches the old algorithm for generated multi-sheet workbooks across header/HTML options and six existing XLSX fixtures. This is evidence of compatibility, not a guarantee for every possible workbook. Pandas still materializes worksheet data and a boolean mask; memory is reduced, not capped.

## Validation
Synced with current main on September 14, 2026.
- XLSX suite: 88 passed, including all 512 possible 3x3 occupancy patterns compared with the legacy NetworkX algorithm.
- Exact serialized-output parity: six existing workbooks and generated multi-sheet workbooks with four header/HTML combinations.
- Ruff and lock consistency checks passed.
- Fresh component-detection benchmark, three repetitions per case:

| Case | Sparse seconds / additional peak MB | Dense seconds / additional peak MB |
| --- | --- | --- |
| Dense table | 0.0100 / 6.4 | 0.0318 / 19.1 |
| Sparse wide edges | 0.0035 / 1.9 | 5.8608 / 1573.5 |
| Separated blocks | 0.0034 / 0.2 | 0.8578 / 200.7 |

These measure component detection, not total API latency. The previous CI unit failure was a shared metrics-output-directory race; the previous aggregate runtime gate exceeded its historical baseline. Fresh full CI still needs to complete.
