### PR TITLE
fix(partition): skip ProcessingInstruction nodes in HTML parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.22.31
 
+### Fixes
+
+- **Fix HTML parser crash on ProcessingInstruction nodes**: The HTML parser raised `AttributeError` when encountering `lxml.etree._ProcessingInstruction` nodes (e.g. `<?xml ... ?>` inside markdown code blocks). PI and Comment nodes are now silently skipped during child iteration. Regression of #3578.
+
 ### Enhancements
 
 - **Rename `isolate_tables` chunking option to `isolate_table`**: the option added in 0.22.30 has been renamed for naming consistency. Callers passing `isolate_tables=` must update to `isolate_table=`.

--- a/test_unstructured/partition/html/test_parser.py
+++ b/test_unstructured/partition/html/test_parser.py
@@ -1517,3 +1517,45 @@ class DescribeDefaultElement:
             "O Deep Thought computer, he said, The task we have designed you to perform is this.",
             "We want you to tell us.... he paused,",
         ]
+
+
+class DescribeProcessingInstructionHandling:
+    """ProcessingInstruction nodes in HTML must not crash the parser."""
+
+    def it_skips_pi_nodes_in_flow_elements(self):
+        """PI nodes (e.g. injected by lxml during HTML/XML parsing) should be silently skipped."""
+        from lxml import etree as raw_etree
+
+        root = etree.fromstring(
+            "<div><p>Before.</p><p>After.</p></div>",
+            html_parser,
+        )
+        div = root.find(".//body/div")
+        assert div is not None
+
+        # Inject a PI node between the two paragraphs
+        pi = raw_etree.ProcessingInstruction("xml-stylesheet", 'type="text/xsl"')
+        div.insert(1, pi)
+
+        # Should not raise AttributeError on PI nodes
+        elements = list(div.iter_elements())
+        texts = [e.text for e in elements if e.text]
+        assert any("Before" in t for t in texts)
+        assert any("After" in t for t in texts)
+
+    def it_skips_pi_nodes_in_phrasing_elements(self):
+        """PI nodes inside phrasing elements should be silently skipped."""
+        from lxml import etree as raw_etree
+
+        root = etree.fromstring(
+            "<div><p>Hello <b>world</b></p></div>",
+            html_parser,
+        )
+        div = root.find(".//body/div")
+        p = div.find(".//p")
+        # Inject a PI node into the paragraph
+        pi = raw_etree.ProcessingInstruction("mypi", 'test="value"')
+        p.insert(1, pi)
+
+        elements = list(div.iter_elements())
+        assert any("Hello" in (e.text or "") for e in elements)

--- a/unstructured/partition/html/parser.py
+++ b/unstructured/partition/html/parser.py
@@ -366,8 +366,11 @@ class Flow(etree.ElementBase):
 
     def iter_elements(self) -> Iterator[Element]:
         """Generate paragraph string for each block item within."""
-        # -- place child elements in a queue --
-        q: deque[Flow | Phrasing] = deque(self)
+        # -- place child elements in a queue, filtering out non-Element nodes
+        # -- (e.g. ProcessingInstruction, Comment) that lack is_phrasing --
+        q: deque[Flow | Phrasing] = deque(
+            child for child in self if isinstance(child, (Flow, Phrasing))
+        )
 
         yield from self._element_from_text_or_tail(self.text or "", q, self._ElementCls)
 
@@ -638,7 +641,9 @@ class Phrasing(etree.ElementBase):
         All generated text segments will be annotated with `emphasis` when it is other than the
         empty string.
         """
-        q: deque[Flow | Phrasing] = deque(self)
+        q: deque[Flow | Phrasing] = deque(
+            child for child in self if isinstance(child, (Flow, Phrasing))
+        )
         # -- Recurse into any nested tags. Phrasing children contribute `TextSegment`s to the
         # -- stream. Block children contribute document `Element`s. Note however that a phrasing
         # -- child can also produce an `Element` from any nested block element.
@@ -734,8 +739,11 @@ class Anchor(Phrasing):
 
     def _iter_phrases_and_elements(self, emphasis: str) -> Iterator[Phrase | Element]:
         """Divide contents (text+children, but not tail) into phrases and document-elements."""
-        # -- place child elements in a queue, method calls use some and leave the rest --
-        q: deque[Flow | Phrasing] = deque(self)
+        # -- place child elements in a queue, filtering out non-Element nodes
+        # -- (e.g. ProcessingInstruction, Comment) that lack is_phrasing --
+        q: deque[Flow | Phrasing] = deque(
+            child for child in self if isinstance(child, (Flow, Phrasing))
+        )
 
         yield from self._iter_phrasing(self.text or "", q, emphasis)
 


### PR DESCRIPTION
## Summary

Fixes #4358

The HTML parser raises `AttributeError: '_ProcessingInstruction' object has no attribute 'is_phrasing'` when lxml injects `ProcessingInstruction` or `_Comment` nodes into the element tree. This is a regression of #3578 (the fix from PR #4034 was lost during a refactor).

## Root Cause

`Flow.iter_elements()`, `Phrasing._iter_child_text_segments()`, and `Anchor._iter_phrases_and_elements()` build a deque from `self` children and access `.is_phrasing` on each — but PI/Comment nodes bypass lxml's `ElementNamespaceClassLookup` and are raw lxml types without that attribute.

## Fix

Filter children to only `Flow`/`Phrasing` instances at all three `deque(self)` call sites (lines 370, 641, 743). Non-Element nodes (PI, Comment) are silently skipped.

## Test

Added `DescribeProcessingInstructionHandling` with two tests verifying PI nodes in both flow and phrasing contexts don't crash the parser. All 135 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent HTML parser crashes when `lxml` injects ProcessingInstruction or comment nodes by skipping non-`Flow`/`Phrasing` children during iteration. This fixes AttributeError on nodes without `is_phrasing` and keeps parsing stable.

- **Bug Fixes**
  - Filter non-`Flow`/`Phrasing` children when queuing in `Flow.iter_elements`, `Phrasing._iter_child_text_segments`, and `Anchor._iter_phrases_and_elements`.
  - Add tests covering PI nodes in flow and phrasing contexts; update changelog.

<sup>Written for commit 52877bbddfd03502ff1850467b6899f4cd187375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

