### PR TITLE
fix: stop decimating embedded text on dense PDF pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.33
+
+### Fixes
+
+- **Fix over-aggressive de-duplication of embedded text on dense PDF pages**: `remove_duplicate_elements` chunks its IoU computation for pages with more than ~2000 extracted elements, but the per-chunk "keep" mask was not offset by the chunk's global start index. As a result, every element in a chunk after the first was compared against itself (and earlier elements) and wrongly dropped, so dense pages (large tables, engineering drawings) lost a large fraction of their extracted text. The diagonal offset is now applied per chunk so only genuine later-duplicate boxes are removed.
+
 ## 0.22.32
 
 ### Fixes

--- a/test_unstructured/partition/pdf_image/test_pdfminer_processing.py
+++ b/test_unstructured/partition/pdf_image/test_pdfminer_processing.py
@@ -276,6 +276,31 @@ def test_remove_duplicate_elements():
     assert result.element_coords.tolist() == [[0, 0, 10, 10], [20, 20, 30, 30]]
 
 
+def test_remove_duplicate_elements_dense_page_is_not_decimated():
+    """Pages with more than ~2000 elements are chunked internally; the dedup mask for each
+    chunk must be offset by the chunk's global index. Otherwise rows in later chunks match
+    themselves and are wrongly dropped, decimating dense pages."""
+    # 2500 unique, non-overlapping boxes on a 50x50 grid (zero IoU between any two)
+    unique = [
+        EmbeddedTextRegion(
+            bbox=Rectangle((i % 50) * 20, (i // 50) * 20, (i % 50) * 20 + 10, (i // 50) * 20 + 10),
+            text=f"Text {i}",
+        )
+        for i in range(2500)
+    ]
+    # one exact duplicate of the first box, appended last so the pair spans two chunks
+    duplicate = EmbeddedTextRegion(bbox=Rectangle(0, 0, 10, 10), text="Text 0 dup")
+    sample_elements = TextRegions.from_list([*unique, duplicate])
+
+    result = remove_duplicate_elements(sample_elements)
+
+    # only the single cross-chunk duplicate pair collapses; every unique box is kept
+    assert len(result) == 2500
+    # the later element of the duplicate pair is the one retained
+    assert "Text 0 dup" in result.texts.tolist()
+    assert "Text 0" not in result.texts.tolist()
+
+
 def test_process_file_with_pdfminer():
     layout, links = process_file_with_pdfminer(example_doc_path("pdf/layout-parser-paper-fast.pdf"))
     assert len(layout)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.32"  # pragma: no cover
+__version__ = "0.22.33"  # pragma: no cover

--- a/unstructured/partition/pdf_image/pdfminer_processing.py
+++ b/unstructured/partition/pdf_image/pdfminer_processing.py
@@ -804,12 +804,22 @@ def remove_duplicate_elements(
     # experiments show 2e3 is the block size that constrains the peak memory around 1Gb for this
     # function; that accounts for all the intermediate matricies allocated and memory for storing
     # final results
-    memory_cap_in_gb = os.getenv("UNST_MATMUL_MEMORY_CAP_IN_GB", 1)
+    memory_cap_in_gb = float(os.getenv("UNST_MATMUL_MEMORY_CAP_IN_GB", 1))
     n_split = np.ceil(coords.shape[0] / 2e3 / memory_cap_in_gb)
     splits = np.array_split(coords, n_split, axis=0)
 
-    ious = [~np.triu(boxes_iou(split, coords, threshold), k=1).any(axis=1) for split in splits]
-    return elements.slice(np.concatenate(ious))
+    # A box is dropped only when it near-duplicates a *later* box (higher global index) -- the
+    # strict upper triangle of the full IoU matrix. Each split is a contiguous block of rows
+    # compared against all coords, so the triangle's diagonal must be offset by the split's
+    # global start index; otherwise rows in later splits match themselves (and earlier boxes)
+    # and get wrongly removed, decimating dense pages (> 2000 elements).
+    keep_masks = []
+    offset = 0
+    for split in splits:
+        iou = boxes_iou(split, coords, threshold)
+        keep_masks.append(~np.triu(iou, k=1 + offset).any(axis=1))
+        offset += split.shape[0]
+    return elements.slice(np.concatenate(keep_masks))
 
 
 def _aggregated_iou(box1s, box2):

--- a/unstructured/partition/pdf_image/pdfminer_processing.py
+++ b/unstructured/partition/pdf_image/pdfminer_processing.py
@@ -805,6 +805,8 @@ def remove_duplicate_elements(
     # function; that accounts for all the intermediate matricies allocated and memory for storing
     # final results
     memory_cap_in_gb = float(os.getenv("UNST_MATMUL_MEMORY_CAP_IN_GB", 1))
+    if memory_cap_in_gb <= 0:
+        raise ValueError("UNST_MATMUL_MEMORY_CAP_IN_GB must be > 0")
     n_split = np.ceil(coords.shape[0] / 2e3 / memory_cap_in_gb)
     splits = np.array_split(coords, n_split, axis=0)
 


### PR DESCRIPTION
## Problem

`remove_duplicate_elements` removes near-duplicate pdfminer text boxes by keeping, for each box, only those that are *not* a duplicate of a later (higher-index) box — i.e. the strict upper triangle of the IoU matrix. To bound memory it splits the computation into chunks of ~2000 rows when a page has more than ~2000 extracted elements:

```python
ious = [~np.triu(boxes_iou(split, coords, threshold), k=1).any(axis=1) for split in splits]
```

Each `split` is compared against **all** `coords`, but `np.triu(..., k=1)` uses the *submatrix* row index as the diagonal reference. For every chunk after the first, the chunk's global start offset is missing, so each row is compared against itself (IoU = 1) and against earlier boxes, and is wrongly dropped as a duplicate.

The effect is severe on dense pages (large tables, engineering drawings): a page yielding ~6200 extracted elements was reduced to ~1550, and the surviving boxes covered only a fraction of the page — a large portion of the extracted text silently disappeared from the merged output.

## Fix

Offset the upper-triangle diagonal by each chunk's global start index so the "is this a duplicate of a *later* box" comparison is correct across chunk boundaries:

```python
keep_masks = []
offset = 0
for split in splits:
    iou = boxes_iou(split, coords, threshold)
    keep_masks.append(~np.triu(iou, k=1 + offset).any(axis=1))
    offset += split.shape[0]
```

For a single chunk (≤ ~2000 elements) the behavior is unchanged (`k=1`). Also cast `UNST_MATMUL_MEMORY_CAP_IN_GB` to `float` so a custom value doesn't break the chunk-count arithmetic.

## Tests

- Added a regression test with 2500 unique boxes plus one cross-chunk duplicate: all 2500 unique boxes are retained and only the genuine duplicate pair collapses. This test fails on the previous implementation (returns 1250) and passes with the fix.
- Existing `remove_duplicate_elements` and pdfminer processing tests pass unchanged.

This is an independent, pre-existing bug (reproducible on `main`); it is not tied to any other in-flight change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes over-aggressive de-duplication that was dropping most embedded text on dense PDF pages. IoU comparisons are now offset across chunks so only true later duplicates are removed.

- **Bug Fixes**
  - Offset the per-chunk upper-triangular mask in `remove_duplicate_elements` to prevent self-matches in later chunks.
  - Cast `UNST_MATMUL_MEMORY_CAP_IN_GB` to float and validate it is > 0 to keep chunk sizing stable with custom values.

- **Tests**
  - Added a regression with 2500 unique boxes plus one cross-chunk duplicate; keeps all unique boxes and collapses only the pair, retaining the later element.

<sup>Written for commit 57b9d40df63c3c8d8362ae87550c06fe53e8a925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

