### PR TITLE
feat: add enrichment origins metadata field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.23.0
+
+### Enhancements
+
+- **Add `enrichment_origins` metadata field for per-attribute model provenance**: `ElementMetadata` gains a serialized `enrichment_origins` field mapping a written attribute name (e.g. `text`, `text_as_html`, `embeddings`) to a list of records `{"type", "provider", "model"}`, in application order. Enrichment producers stamp which model wrote (or contributed to) each attribute; authoring enrichments overwrite the list while additive ones append, preserving the prior author. A new `ConsolidationStrategy.DICT_LIST_UNIQUE` merges these dicts across elements during chunking (union keys, concatenate then dedupe records, preserving first-seen order).
+
 ## 0.22.33
 
 ### Fixes

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -1164,6 +1164,45 @@ class Describe_Chunker:
             "languages": ["lat", "eng"],
         }
 
+    def and_it_merges_and_dedupes_enrichment_origins_across_elements(self):
+        """enrichment_origins has DICT_LIST_UNIQUE: union keys, concat+dedupe per-key records."""
+        shared = {"type": "enrichment_shared", "provider": "a", "model": "m"}
+        elements = [
+            Title(
+                "Lorem Ipsum",
+                metadata=ElementMetadata(
+                    enrichment_origins={
+                        "text": [
+                            {"type": "enrichment_foo", "provider": "a", "model": "m"},
+                            shared,
+                        ]
+                    },
+                ),
+            ),
+            Text(
+                "Lorem ipsum dolor.",
+                metadata=ElementMetadata(
+                    enrichment_origins={
+                        "text": [
+                            {"type": "enrichment_bar", "provider": "a", "model": "m"},
+                            dict(shared),  # -- identical record, must collapse to one --
+                        ]
+                    },
+                ),
+            ),
+        ]
+        chunker = _Chunker(
+            elements, text="Lorem Ipsum\n\nLorem ipsum dolor.", opts=ChunkingOptions()
+        )
+
+        assert chunker._meta_kwargs["enrichment_origins"] == {
+            "text": [
+                {"type": "enrichment_foo", "provider": "a", "model": "m"},
+                shared,
+                {"type": "enrichment_bar", "provider": "a", "model": "m"},
+            ]
+        }
+
     def it_computes_the_original_elements_list_to_help(self):
         opts = ChunkingOptions(include_orig_elements=True)
         element = Title("Introduction")

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -1017,6 +1017,23 @@ class Describe_Chunker:
 
         assert [c.metadata.is_continuation for c in chunk_iter] == [None, True, True]
 
+    def and_each_split_chunk_gets_its_own_enrichment_origins_dict(self):
+        """Split chunks must not share `enrichment_origins`, an in-place-mutated dict-of-lists."""
+        # --    |--------------------- 48 ---------------------|
+        text = "'Lorem ipsum dolor' means 'Thank you very much'."
+        metadata = ElementMetadata(
+            enrichment_origins={"text": [{"type": "ocr", "provider": "p", "model": "m"}]},
+        )
+        elements = [Text(text, metadata=metadata)]
+
+        chunks = list(_Chunker.iter_chunks(elements, text, opts=ChunkingOptions(max_characters=20)))
+
+        origins = [c.metadata.enrichment_origins for c in chunks]
+        # -- a downstream additive enrichment mutating one chunk in place must not leak to others --
+        origins[0]["text"].append({"type": "caption", "provider": "p2", "model": "m2"})
+        assert origins[0]["text"] is not origins[1]["text"]
+        assert len(origins[1]["text"]) == 1
+
     def but_it_generates_no_chunks_when_the_pre_chunk_contains_no_text(self):
         metadata = ElementMetadata()
 

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -961,7 +961,7 @@ class Describe_Chunker:
             "e feugiat efficitur.\n\nIntroduction\n\nLorem ipsum dolor sit amet consectetur"
             " adipiscing elit. In rhoncus ipsum sed lectus porta volutpat.",
         )
-        assert chunk.metadata is chunker._consolidated_metadata
+        assert chunk.metadata == chunker._consolidated_metadata
         assert chunk.metadata.orig_elements == elements
         # --
         with pytest.raises(StopIteration):
@@ -982,16 +982,14 @@ class Describe_Chunker:
         chunk_iter = chunker._iter_chunks()
 
         # -- Note that .metadata.orig_elements is the same single original element, "repeated" for
-        # -- each text-split chunk. This behavior emerges without explicit command as a consequence
-        # -- of using `._consolidated_metadata` (and `._continuation_metadata` which extends
-        # -- `._consolidated_metadata)` for each text-split chunk.
+        # -- each text-split chunk.
         chunk = next(chunk_iter)
         assert chunk == CompositeElement(
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
             " tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim"
             " veniam, quis nostrud exercitation ullamco laboris nisi ut"
         )
-        assert chunk.metadata is chunker._consolidated_metadata
+        assert chunk.metadata == chunker._consolidated_metadata
         assert chunk.metadata.orig_elements == elements
         # --
         chunk = next(chunk_iter)
@@ -1036,6 +1034,24 @@ class Describe_Chunker:
         origins[0]["text"].append({"type": "caption", "provider": "p2", "model": "m2"})
         assert all(o["text"] is not origins[0]["text"] for o in origins[1:])
         assert all(len(o["text"]) == 1 for o in origins[1:])
+
+    def and_first_split_chunk_mutation_does_not_affect_lazily_produced_continuations(self):
+        """The first yielded chunk must not be the mutable base for later continuation metadata."""
+        # --    |--------------------- 48 ---------------------|
+        text = "'Lorem ipsum dolor' means 'Thank you very much'."
+        origin = {"type": "ocr", "provider": "p", "model": "m"}
+        metadata = ElementMetadata(enrichment_origins={"text": [origin]})
+        elements = [Text(text, metadata=metadata)]
+
+        chunk_iter = _Chunker.iter_chunks(elements, text, opts=ChunkingOptions(max_characters=20))
+
+        first_chunk = next(chunk_iter)
+        first_chunk.metadata.enrichment_origins["text"].append(
+            {"type": "caption", "provider": "p2", "model": "m2"}
+        )
+        second_chunk = next(chunk_iter)
+
+        assert second_chunk.metadata.enrichment_origins == {"text": [origin]}
 
     def but_it_generates_no_chunks_when_the_pre_chunk_contains_no_text(self):
         metadata = ElementMetadata()

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -996,7 +996,7 @@ class Describe_Chunker:
         # --
         chunk = next(chunk_iter)
         assert chunk == CompositeElement("aliquip ex ea commodo consequat.")
-        assert chunk.metadata is chunker._continuation_metadata
+        assert chunk.metadata.is_continuation
         assert chunk.metadata.orig_elements == elements
         # --
         with pytest.raises(StopIteration):
@@ -1028,11 +1028,14 @@ class Describe_Chunker:
 
         chunks = list(_Chunker.iter_chunks(elements, text, opts=ChunkingOptions(max_characters=20)))
 
+        # -- one head + two continuation chunks (the latter previously shared a single cached
+        # -- metadata object, so they cross-mutated each other) --
+        assert len(chunks) >= 3
         origins = [c.metadata.enrichment_origins for c in chunks]
         # -- a downstream additive enrichment mutating one chunk in place must not leak to others --
         origins[0]["text"].append({"type": "caption", "provider": "p2", "model": "m2"})
-        assert origins[0]["text"] is not origins[1]["text"]
-        assert len(origins[1]["text"]) == 1
+        assert all(o["text"] is not origins[0]["text"] for o in origins[1:])
+        assert all(len(o["text"]) == 1 for o in origins[1:])
 
     def but_it_generates_no_chunks_when_the_pre_chunk_contains_no_text(self):
         metadata = ElementMetadata()

--- a/test_unstructured/documents/test_elements.py
+++ b/test_unstructured/documents/test_elements.py
@@ -388,6 +388,23 @@ class DescribeElementMetadata:
             "page_number": 2,
         }
 
+    def and_it_round_trips_an_enrichment_origins_dict_of_lists_through_a_dict(self):
+        enrichment_origins = {
+            "text": [
+                {"type": "enrichment_foo", "provider": "provider_a", "model": "model_x"},
+                {"type": "enrichment_bar", "provider": "provider_a", "model": "model_x"},
+            ],
+            "embeddings": [
+                {"type": "enrichment_baz", "provider": "provider_b", "model": "model_y"},
+            ],
+        }
+        meta = ElementMetadata(enrichment_origins=enrichment_origins)
+
+        # -- it serializes verbatim (no special-casing needed) --
+        assert meta.to_dict()["enrichment_origins"] == enrichment_origins
+        # -- and rehydrates to an equal value --
+        assert ElementMetadata.from_dict(meta.to_dict()).enrichment_origins == enrichment_origins
+
     def and_it_serializes_an_orig_elements_sub_object_to_base64_when_it_is_present(self):
         elements = assign_hash_ids([Title("Lorem"), Text("Lorem Ipsum")])
         meta = ElementMetadata(

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.33"  # pragma: no cover
+__version__ = "0.23.0"  # pragma: no cover

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -865,10 +865,17 @@ class _Chunker:
         Unused for non-oversized pre-chunks since those are not subject to text-splitting.
         """
         # -- we need to make a copy, otherwise adding a field would also change metadata value
-        # -- already assigned to another chunk (e.g. the first text-split chunk). Deep-copy is not
-        # -- required though since we're not changing any collection fields.
+        # -- already assigned to another chunk (e.g. the first text-split chunk). A shallow copy
+        # -- suffices for scalar fields, but `enrichment_origins` is a mutable dict-of-lists that
+        # -- a downstream additive enrichment may mutate in place; deep-copy it so split chunks
+        # -- don't cross-mutate each other's provenance. (Deep-copying the whole metadata is
+        # -- avoided because it may carry the full `orig_elements`.)
         continuation_metadata = copy.copy(self._consolidated_metadata)
         continuation_metadata.is_continuation = True
+        if continuation_metadata.enrichment_origins is not None:
+            continuation_metadata.enrichment_origins = copy.deepcopy(
+                continuation_metadata.enrichment_origins
+            )
         return continuation_metadata
 
     @cached_property

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -897,6 +897,20 @@ class _Chunker:
                     yield field_name, list(ordered_unique_keys.keys())
                 elif strategy is CS.STRING_CONCATENATE:
                     yield field_name, " ".join(val.strip() for val in values)
+                # -- merge dict-of-list values: union keys, per key concatenate then dedupe
+                # -- records, preserving first-seen order --
+                elif strategy is CS.DICT_LIST_UNIQUE:
+                    merged: dict[str, list[Any]] = {}
+                    for value in values:
+                        for key, records in value.items():
+                            seen = merged.setdefault(key, [])
+                            seen_ids = {tuple(sorted(r.items())) for r in seen}
+                            for record in records:
+                                record_id = tuple(sorted(record.items()))
+                                if record_id not in seen_ids:
+                                    seen_ids.add(record_id)
+                                    seen.append(record)
+                    yield field_name, merged
                 elif strategy is CS.DROP:
                     continue
                 else:  # pragma: no cover

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -804,7 +804,7 @@ class _Chunker:
         # -- Note these get continuation_metadata which includes is_continuation=True.
         while remainder:
             s, remainder = split(remainder)
-            yield CompositeElement(text=s, metadata=self._continuation_metadata)
+            yield CompositeElement(text=s, metadata=self._continuation_metadata())
 
     @cached_property
     def _all_metadata_values(self) -> dict[str, list[Any]]:
@@ -857,19 +857,22 @@ class _Chunker:
             consolidated_metadata.orig_elements = self._orig_elements
         return consolidated_metadata
 
-    @cached_property
     def _continuation_metadata(self) -> ElementMetadata:
-        """Metadata applicable to the second and later text-split chunks of the pre-chunk.
+        """Fresh metadata for one second-or-later text-split chunk of the pre-chunk.
 
         The same metadata as the first text-split chunk but includes `.is_continuation = True`.
         Unused for non-oversized pre-chunks since those are not subject to text-splitting.
+
+        A new object is produced on each call (not cached) because each continuation chunk needs
+        its own copy: `enrichment_origins` is a mutable dict-of-lists that a downstream additive
+        enrichment may mutate in place, and a shared object would let one chunk's mutation leak
+        into its siblings.
         """
         # -- we need to make a copy, otherwise adding a field would also change metadata value
         # -- already assigned to another chunk (e.g. the first text-split chunk). A shallow copy
-        # -- suffices for scalar fields, but `enrichment_origins` is a mutable dict-of-lists that
-        # -- a downstream additive enrichment may mutate in place; deep-copy it so split chunks
-        # -- don't cross-mutate each other's provenance. (Deep-copying the whole metadata is
-        # -- avoided because it may carry the full `orig_elements`.)
+        # -- suffices for scalar fields, but `enrichment_origins` is mutable, so deep-copy it.
+        # -- (Deep-copying the whole metadata is avoided because it may carry the full
+        # -- `orig_elements`.)
         continuation_metadata = copy.copy(self._consolidated_metadata)
         continuation_metadata.is_continuation = True
         if continuation_metadata.enrichment_origins is not None:

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -798,7 +798,7 @@ class _Chunker:
 
         # -- emit first chunk --
         s, remainder = split(self._text)
-        yield CompositeElement(text=s, metadata=self._consolidated_metadata)
+        yield CompositeElement(text=s, metadata=self._chunk_metadata())
 
         # -- an oversized pre-chunk will have a remainder, split that up into additional chunks.
         # -- Note these get continuation_metadata which includes is_continuation=True.
@@ -868,18 +868,20 @@ class _Chunker:
         enrichment may mutate in place, and a shared object would let one chunk's mutation leak
         into its siblings.
         """
-        # -- we need to make a copy, otherwise adding a field would also change metadata value
-        # -- already assigned to another chunk (e.g. the first text-split chunk). A shallow copy
-        # -- suffices for scalar fields, but `enrichment_origins` is mutable, so deep-copy it.
-        # -- (Deep-copying the whole metadata is avoided because it may carry the full
-        # -- `orig_elements`.)
-        continuation_metadata = copy.copy(self._consolidated_metadata)
+        continuation_metadata = self._chunk_metadata()
         continuation_metadata.is_continuation = True
-        if continuation_metadata.enrichment_origins is not None:
-            continuation_metadata.enrichment_origins = copy.deepcopy(
-                continuation_metadata.enrichment_origins
-            )
         return continuation_metadata
+
+    def _chunk_metadata(self) -> ElementMetadata:
+        """Fresh metadata for one text-split chunk of the pre-chunk."""
+        # -- we need to make a copy, otherwise adding a field would also change metadata value
+        # -- already assigned to another chunk. A shallow copy suffices for scalar fields, but
+        # -- `enrichment_origins` is mutable, so deep-copy it. (Deep-copying the whole metadata is
+        # -- avoided because it may carry the full `orig_elements`.)
+        metadata = copy.copy(self._consolidated_metadata)
+        if metadata.enrichment_origins is not None:
+            metadata.enrichment_origins = copy.deepcopy(metadata.enrichment_origins)
+        return metadata
 
     @cached_property
     def _meta_kwargs(self) -> dict[str, Any]:

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -168,6 +168,11 @@ class ElementMetadata:
     detection_class_prob: Optional[float]
     # -- DEBUG field, the detection mechanism that emitted this element --
     detection_origin: Optional[str]
+    # -- per-attribute model provenance for enrichments. Maps a written attribute name (e.g.
+    # -- "text", "text_as_html", "embeddings") to a list of records in application order, each
+    # -- {"type", "provider", "model"}. Authoring enrichments overwrite (reset the list);
+    # -- additive enrichments append (preserving the prior author). --
+    enrichment_origins: Optional[dict[str, list[dict[str, str]]]]
     emphasized_text_contents: Optional[list[str]]
     emphasized_text_tags: Optional[list[str]]
     file_directory: Optional[str]
@@ -239,6 +244,7 @@ class ElementMetadata:
         coordinates: Optional[CoordinatesMetadata] = None,
         data_source: Optional[DataSourceMetadata] = None,
         detection_class_prob: Optional[float] = None,
+        enrichment_origins: Optional[dict[str, list[dict[str, str]]]] = None,
         emphasized_text_contents: Optional[list[str]] = None,
         emphasized_text_tags: Optional[list[str]] = None,
         file_directory: Optional[str] = None,
@@ -284,6 +290,7 @@ class ElementMetadata:
         self.coordinates = coordinates
         self.data_source = data_source
         self.detection_class_prob = detection_class_prob
+        self.enrichment_origins = enrichment_origins
         self.emphasized_text_contents = emphasized_text_contents
         self.emphasized_text_tags = emphasized_text_tags
 
@@ -502,6 +509,11 @@ class ConsolidationStrategy(enum.Enum):
     LIST_UNIQUE = "list_unique"
     """Union list values across elements, preserving order. Only suitable for `List` fields."""
 
+    DICT_LIST_UNIQUE = "dict_list_unique"
+    """Merge dict-of-list values across elements: union keys, and per key concatenate the lists
+    then drop duplicate records, preserving first-seen order. Suitable for `dict[str, list]`
+    fields like `enrichment_origins`."""
+
     @classmethod
     def field_consolidation_strategies(cls) -> dict[str, ConsolidationStrategy]:
         """Mapping from ElementMetadata field-name to its consolidation strategy.
@@ -519,6 +531,7 @@ class ConsolidationStrategy(enum.Enum):
             "data_source": cls.FIRST,
             "detection_class_prob": cls.DROP,
             "detection_origin": cls.DROP,
+            "enrichment_origins": cls.DICT_LIST_UNIQUE,
             "emphasized_text_contents": cls.LIST_CONCATENATE,
             "emphasized_text_tags": cls.LIST_CONCATENATE,
             "file_directory": cls.FIRST,


### PR DESCRIPTION
### Summary
Adds a new `enrichment_origins` field to `ElementMetadata` that tracks which model wrote (or contributed to) each enriched attribute.

### What's new
- **`ElementMetadata.enrichment_origins`** — a serialized `dict[str, list[dict[str, str]]]` mapping a written attribute name (e.g. `text`, `text_as_html`, `embeddings`) to a list of `{"type", "provider", "model"}` records, in application order. Authoring enrichments overwrite the list; additive enrichments append, preserving the prior author.
- **`ConsolidationStrategy.DICT_LIST_UNIQUE`** — a new chunking consolidation strategy for `dict[str, list]` fields. It unions keys across elements and, per key, concatenates then dedupes records while preserving first-seen order. Wired up as the strategy for `enrichment_origins`.

### Testing
- Unit tests for the new metadata field (`test_elements.py`).
- Unit tests for the `DICT_LIST_UNIQUE` merge behavior during chunking (`test_base.py`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-attribute enrichment provenance via `ElementMetadata.enrichment_origins` and a dict-list merge strategy, and isolates per-chunk metadata so provenance updates can’t leak across split chunks.

- **New Features**
  - `ElementMetadata.enrichment_origins`: maps an attribute to a list of `{"type","provider","model"}` in application order. Authoring overwrites; additive appends.
  - `ConsolidationStrategy.DICT_LIST_UNIQUE`: unions keys and per-key concat+dedupes while preserving order; used for `enrichment_origins` in chunking.

- **Bug Fixes**
  - First and continuation split chunks each get a fresh metadata object.
  - Deep-copies `enrichment_origins` per chunk and sets `is_continuation` on later chunks, preventing any in-place updates from leaking to siblings or lazy continuations.

<sup>Written for commit 7a03b8c9886b6cbdbfcfe647984482f5daaa6724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

