### PR TITLE
fix: derive crop box from coordinate extent in `save_elements`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.22.35
+
+### Fixes
+
+- **Fix `ValueError: Coordinate 'lower' is less than 'upper'` when extracting figure/table images**: `save_elements` assumed `points[0]`/`points[2]` were always the top-left/bottom-right corners in screen orientation. For elements whose coordinates carried (or were converted from) a y-up orientation, that ordering inverted the PIL crop box and raised the error, which was then silently swallowed and the image dropped. The crop box is now derived from the extent (min/max) of all coordinate points, so it is always valid regardless of point ordering.
+
 ## 0.22.34
 
 ### Fixes

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -249,6 +249,40 @@ def test_save_elements(
                 assert not el.metadata.image_mime_type
 
 
+def test_save_elements_with_inverted_point_ordering(monkeypatch):
+    """Regression: points whose ordering puts points[0] below points[2] (as happens when
+    coordinates come from / were converted from a y-up CARTESIAN system) must not raise
+    PIL's "Coordinate 'lower' is less than 'upper'" ValueError."""
+    filename = example_doc_path("img/layout-parser-paper-fast.jpg")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # points[0] is the bottom-left (larger y) and points[2] the top-right (smaller y),
+        # i.e. the reverse of the usual ((x1,y1),(x1,y2),(x2,y2),(x2,y1)) screen ordering.
+        element = Image(
+            text="Inverted Image",
+            coordinates=((78, 519), (78, 86), (512, 86), (512, 519)),
+            coordinate_system=PixelSpace(width=1575, height=1166),
+            metadata=ElementMetadata(page_number=1),
+        )
+
+        pdf_image_utils.save_elements(
+            elements=[element],
+            starting_page_number=1,
+            element_category_to_save=ElementType.IMAGE,
+            pdf_image_dpi=200,
+            filename=filename,
+            is_image=True,
+            output_dir_path=str(tmpdir),
+        )
+
+        expected_image_path = os.path.join(str(tmpdir), "figure-1-1.jpg")
+        assert os.path.isfile(expected_image_path)
+        assert element.metadata.image_path == expected_image_path
+        # The crop box is taken from the extent of all points regardless of their order.
+        image = PILImg.open(expected_image_path)
+        assert image.width == 512 - 78
+        assert image.height == 519 - 86
+
+
 @pytest.mark.parametrize("storage_enabled", [False, True])
 def test_save_elements_with_output_dir_path_none(monkeypatch, storage_enabled):
     monkeypatch.setenv(

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.34"  # pragma: no cover
+__version__ = "0.22.35"  # pragma: no cover

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -181,8 +181,15 @@ def save_elements(
                 continue
 
             points = coordinates.points
-            x1, y1 = points[0]
-            x2, y2 = points[2]
+            # Don't assume a fixed corner ordering: depending on the element's
+            # coordinate-system orientation, points[0]/points[2] are not reliably the
+            # top-left/bottom-right in the page image's screen space. Trusting them can
+            # yield an inverted PIL crop box and raise "Coordinate 'lower' is less than
+            # 'upper'". Take the extent of all points instead.
+            xs = [p[0] for p in points]
+            ys = [p[1] for p in points]
+            x1, y1 = min(xs), min(ys)
+            x2, y2 = max(xs), max(ys)
             h_padding = env_config.EXTRACT_IMAGE_BLOCK_CROP_HORIZONTAL_PAD
             v_padding = env_config.EXTRACT_IMAGE_BLOCK_CROP_VERTICAL_PAD
             padded_bbox = cast(


### PR DESCRIPTION
`save_elements` assumed `points[0]` and `points[2]` were always the top-left and bottom-right corners. For elements whose coordinates carry (or were converted from) a y-up orientation, that ordering inverts the PIL crop box and raises `ValueError: Coordinate 'lower' is less than 'upper'`. The error was silently swallowed, so the figure/table image was dropped.

The crop box is now computed from the min/max of all coordinate points, so it's always valid regardless of point ordering.

**Changes**
- `pdf_image_utils.save_elements`: use `min/max` over all points instead of fixed corner indices
- Added a regression test for inverted/rotated coordinate ordering
- CHANGELOG + version bump to `0.22.35`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix image cropping in `pdf_image_utils.save_elements` by deriving the crop box from the coordinate extent. This prevents the PIL "Coordinate 'lower' is less than 'upper'" error and stops figure/table images from being dropped.

- **Bug Fixes**
  - Compute the crop box with min/max over all points instead of assuming fixed corners.
  - Add a regression test for inverted/rotated coordinate ordering.

<sup>Written for commit 0ea49ae7a0c0102e938994a808ad243c6d281a4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

