### PR TITLE
fix: preserve numeric text in table HTML metadata

### DIFF
--- a/test_unstructured/common/test_html_table.py
+++ b/test_unstructured/common/test_html_table.py
@@ -53,6 +53,8 @@ class Describe_htmlify_dataframe:
             [
                 ["revenue", "478923"],
                 ["ticker", "000001"],
+                ["account", "000123"],
+                ["clause", "007"],
                 ["ratio", "0.000123"],
             ],
             columns=["metric", "value"],
@@ -63,6 +65,8 @@ class Describe_htmlify_dataframe:
             "<tr><td>metric</td><td>value</td></tr>"
             "<tr><td>revenue</td><td>478923</td></tr>"
             "<tr><td>ticker</td><td>000001</td></tr>"
+            "<tr><td>account</td><td>000123</td></tr>"
+            "<tr><td>clause</td><td>007</td></tr>"
             "<tr><td>ratio</td><td>0.000123</td></tr>"
             "</table>"
         )

--- a/test_unstructured/common/test_html_table.py
+++ b/test_unstructured/common/test_html_table.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import pandas as pd
 import pytest
 from lxml.html import fragment_fromstring
 
@@ -11,6 +12,7 @@ from unstructured.common.html_table import (
     HtmlCell,
     HtmlRow,
     HtmlTable,
+    htmlify_dataframe,
     htmlify_matrix_of_cell_texts,
 )
 
@@ -41,6 +43,29 @@ class Describe_htmlify_matrix_of_cell_texts:
 
     def test_htmlify_matrix_handles_empty_matrix(self):
         assert htmlify_matrix_of_cell_texts([]) == ""
+
+
+class Describe_htmlify_dataframe:
+    """Unit-test suite for `unstructured.common.html_table.htmlify_dataframe()`."""
+
+    def it_preserves_numeric_text_when_rendering_dataframe_cell_values(self):
+        dataframe = pd.DataFrame(
+            [
+                ["revenue", "478923"],
+                ["ticker", "000001"],
+                ["ratio", "0.000123"],
+            ],
+            columns=["metric", "value"],
+        )
+
+        assert htmlify_dataframe(dataframe, include_header=True) == (
+            "<table>"
+            "<tr><td>metric</td><td>value</td></tr>"
+            "<tr><td>revenue</td><td>478923</td></tr>"
+            "<tr><td>ticker</td><td>000001</td></tr>"
+            "<tr><td>ratio</td><td>0.000123</td></tr>"
+            "</table>"
+        )
 
 
 class DescribeHtmlTable:

--- a/test_unstructured/common/test_html_table.py
+++ b/test_unstructured/common/test_html_table.py
@@ -67,6 +67,23 @@ class Describe_htmlify_dataframe:
             "</table>"
         )
 
+    def it_renders_dataframe_null_values_as_empty_cells(self):
+        dataframe = pd.DataFrame(
+            [
+                ["real nulls", None, float("nan"), pd.NA],
+                ["literal text", "None", "nan", "<NA>"],
+            ],
+            columns=["kind", "a", "b", "c"],
+        )
+
+        assert htmlify_dataframe(dataframe, include_header=True) == (
+            "<table>"
+            "<tr><td>kind</td><td>a</td><td>b</td><td>c</td></tr>"
+            "<tr><td>real nulls</td><td/><td/><td/></tr>"
+            "<tr><td>literal text</td><td>None</td><td>nan</td><td>&lt;NA&gt;</td></tr>"
+            "</table>"
+        )
+
 
 class DescribeHtmlTable:
     """Unit-test suite for `unstructured.common.html_table.HtmlTable`."""

--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -203,6 +203,43 @@ def test_partition_html_processes_chinese_chracters():
     assert elements[0].text == "每日新闻"
 
 
+def test_partition_html_preserves_numeric_table_cell_text_in_chunked_html():
+    html_text = """
+    <html>
+      <body>
+        <h1>Financial metrics</h1>
+        <table>
+          <tr><th>metric</th><th>value</th></tr>
+          <tr><td>revenue</td><td>478923</td></tr>
+          <tr><td>shares</td><td>1234567</td></tr>
+          <tr><td>ticker</td><td>000001</td></tr>
+          <tr><td>ratio</td><td>0.000123</td></tr>
+          <tr><td>market cap</td><td>999999999999999999</td></tr>
+        </table>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(
+        text=html_text,
+        chunking_strategy="by_title",
+        max_characters=80,
+        new_after_n_chars=80,
+    )
+
+    table_html = "".join(
+        e.metadata.text_as_html or "" for e in elements if isinstance(e, TableChunk)
+    )
+
+    assert "<td>478923</td>" in table_html
+    assert "<td>1234567</td>" in table_html
+    assert "<td>000001</td>" in table_html
+    assert "<td>0.000123</td>" in table_html
+    assert "<td>999999999999999999</td>" in table_html
+    assert "e+" not in table_html.lower()
+    assert "e-" not in table_html.lower()
+
+
 def test_emoji_appears_with_emoji_utf8_code():
     assert partition_html(text='<html charset="utf-8"><p>Hello &#128512;</p></html>') == [
         Text("Hello 😀")

--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -213,6 +213,8 @@ def test_partition_html_preserves_numeric_table_cell_text_in_chunked_html():
           <tr><td>revenue</td><td>478923</td></tr>
           <tr><td>shares</td><td>1234567</td></tr>
           <tr><td>ticker</td><td>000001</td></tr>
+          <tr><td>account</td><td>000123</td></tr>
+          <tr><td>clause</td><td>007</td></tr>
           <tr><td>ratio</td><td>0.000123</td></tr>
           <tr><td>market cap</td><td>999999999999999999</td></tr>
         </table>
@@ -234,6 +236,8 @@ def test_partition_html_preserves_numeric_table_cell_text_in_chunked_html():
     assert "<td>478923</td>" in table_html
     assert "<td>1234567</td>" in table_html
     assert "<td>000001</td>" in table_html
+    assert "<td>000123</td>" in table_html
+    assert "<td>007</td>" in table_html
     assert "<td>0.000123</td>" in table_html
     assert "<td>999999999999999999</td>" in table_html
     assert "e+" not in table_html.lower()

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -121,6 +121,8 @@ def test_partition_csv_preserves_numeric_cell_text_in_table_html(tmp_path):
         "revenue,478923\n"
         "shares,1234567\n"
         "ticker,000001\n"
+        "account,000123\n"
+        "clause,007\n"
         "ratio,0.000123\n"
         "market cap,999999999999999999\n",
         encoding="utf-8",
@@ -134,6 +136,8 @@ def test_partition_csv_preserves_numeric_cell_text_in_table_html(tmp_path):
         "<tr><td>revenue</td><td>478923</td></tr>"
         "<tr><td>shares</td><td>1234567</td></tr>"
         "<tr><td>ticker</td><td>000001</td></tr>"
+        "<tr><td>account</td><td>000123</td></tr>"
+        "<tr><td>clause</td><td>007</td></tr>"
         "<tr><td>ratio</td><td>0.000123</td></tr>"
         "<tr><td>market cap</td><td>999999999999999999</td></tr>"
         "</table>"

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -114,6 +114,32 @@ def test_partition_csv_from_file_with_metadata_filename():
     assert elements[0].metadata.filename == "test"
 
 
+def test_partition_csv_preserves_numeric_cell_text_in_table_html(tmp_path):
+    file_path = tmp_path / "financial-metrics.csv"
+    file_path.write_text(
+        "metric,value\n"
+        "revenue,478923\n"
+        "shares,1234567\n"
+        "ticker,000001\n"
+        "ratio,0.000123\n"
+        "market cap,999999999999999999\n",
+        encoding="utf-8",
+    )
+
+    table = partition_csv(filename=str(file_path))[0]
+
+    assert table.metadata.text_as_html == (
+        "<table>"
+        "<tr><td>metric</td><td>value</td></tr>"
+        "<tr><td>revenue</td><td>478923</td></tr>"
+        "<tr><td>shares</td><td>1234567</td></tr>"
+        "<tr><td>ticker</td><td>000001</td></tr>"
+        "<tr><td>ratio</td><td>0.000123</td></tr>"
+        "<tr><td>market cap</td><td>999999999999999999</td></tr>"
+        "</table>"
+    )
+
+
 # -- .metadata.last_modified ---------------------------------------------------------------------
 
 

--- a/test_unstructured/partition/test_tsv.py
+++ b/test_unstructured/partition/test_tsv.py
@@ -82,6 +82,8 @@ def test_partition_tsv_preserves_numeric_cell_text_in_table_html(tmp_path):
         "revenue\t478923\n"
         "shares\t1234567\n"
         "ticker\t000001\n"
+        "account\t000123\n"
+        "clause\t007\n"
         "ratio\t0.000123\n"
         "market cap\t999999999999999999\n",
         encoding="utf-8",
@@ -95,6 +97,8 @@ def test_partition_tsv_preserves_numeric_cell_text_in_table_html(tmp_path):
         "<tr><td>revenue</td><td>478923</td></tr>"
         "<tr><td>shares</td><td>1234567</td></tr>"
         "<tr><td>ticker</td><td>000001</td></tr>"
+        "<tr><td>account</td><td>000123</td></tr>"
+        "<tr><td>clause</td><td>007</td></tr>"
         "<tr><td>ratio</td><td>0.000123</td></tr>"
         "<tr><td>market cap</td><td>999999999999999999</td></tr>"
         "</table>"
@@ -102,7 +106,14 @@ def test_partition_tsv_preserves_numeric_cell_text_in_table_html(tmp_path):
 
 
 def test_partition_tsv_from_file_preserves_numeric_cell_text_in_table_html():
-    file = io.BytesIO(b"metric\tvalue\nrevenue\t478923\nticker\t000001\nratio\t0.000123\n")
+    file = io.BytesIO(
+        b"metric\tvalue\n"
+        b"revenue\t478923\n"
+        b"ticker\t000001\n"
+        b"account\t000123\n"
+        b"clause\t007\n"
+        b"ratio\t0.000123\n"
+    )
 
     table = partition_tsv(file=file, include_header=False)[0]
 
@@ -111,6 +122,8 @@ def test_partition_tsv_from_file_preserves_numeric_cell_text_in_table_html():
         "<tr><td>metric</td><td>value</td></tr>"
         "<tr><td>revenue</td><td>478923</td></tr>"
         "<tr><td>ticker</td><td>000001</td></tr>"
+        "<tr><td>account</td><td>000123</td></tr>"
+        "<tr><td>clause</td><td>007</td></tr>"
         "<tr><td>ratio</td><td>0.000123</td></tr>"
         "</table>"
     )

--- a/test_unstructured/partition/test_tsv.py
+++ b/test_unstructured/partition/test_tsv.py
@@ -73,6 +73,32 @@ def test_partition_tsv_from_file_with_metadata_filename():
     assert all(element.metadata.filename == "test" for element in elements)
 
 
+def test_partition_tsv_preserves_numeric_cell_text_in_table_html(tmp_path):
+    file_path = tmp_path / "financial-metrics.tsv"
+    file_path.write_text(
+        "metric\tvalue\n"
+        "revenue\t478923\n"
+        "shares\t1234567\n"
+        "ticker\t000001\n"
+        "ratio\t0.000123\n"
+        "market cap\t999999999999999999\n",
+        encoding="utf-8",
+    )
+
+    table = partition_tsv(filename=str(file_path), include_header=False)[0]
+
+    assert table.metadata.text_as_html == (
+        "<table>"
+        "<tr><td>metric</td><td>value</td></tr>"
+        "<tr><td>revenue</td><td>478923</td></tr>"
+        "<tr><td>shares</td><td>1234567</td></tr>"
+        "<tr><td>ticker</td><td>000001</td></tr>"
+        "<tr><td>ratio</td><td>0.000123</td></tr>"
+        "<tr><td>market cap</td><td>999999999999999999</td></tr>"
+        "</table>"
+    )
+
+
 # -- .metadata.last_modified ---------------------------------------------------------------------
 
 

--- a/test_unstructured/partition/test_tsv.py
+++ b/test_unstructured/partition/test_tsv.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import io
+
 import pytest
 from pytest_mock import MockFixture
 
@@ -95,6 +97,21 @@ def test_partition_tsv_preserves_numeric_cell_text_in_table_html(tmp_path):
         "<tr><td>ticker</td><td>000001</td></tr>"
         "<tr><td>ratio</td><td>0.000123</td></tr>"
         "<tr><td>market cap</td><td>999999999999999999</td></tr>"
+        "</table>"
+    )
+
+
+def test_partition_tsv_from_file_preserves_numeric_cell_text_in_table_html():
+    file = io.BytesIO(b"metric\tvalue\nrevenue\t478923\nticker\t000001\nratio\t0.000123\n")
+
+    table = partition_tsv(file=file, include_header=False)[0]
+
+    assert table.metadata.text_as_html == (
+        "<table>"
+        "<tr><td>metric</td><td>value</td></tr>"
+        "<tr><td>revenue</td><td>478923</td></tr>"
+        "<tr><td>ticker</td><td>000001</td></tr>"
+        "<tr><td>ratio</td><td>0.000123</td></tr>"
         "</table>"
     )
 

--- a/unstructured/common/html_table.py
+++ b/unstructured/common/html_table.py
@@ -50,6 +50,7 @@ def htmlify_matrix_of_cell_texts(matrix: Sequence[Sequence[str]]) -> str:
 
 def htmlify_dataframe(dataframe: Any, include_header: bool) -> str:
     """Render a dataframe as table HTML without pandas numeric formatting."""
+    # Preserve missing cells as empty cells instead of leaking pandas null tokens like "nan".
     rows = [
         ["" if isna else str(value) for value, isna in zip(value_row, isna_row)]
         for value_row, isna_row in zip(

--- a/unstructured/common/html_table.py
+++ b/unstructured/common/html_table.py
@@ -50,7 +50,13 @@ def htmlify_matrix_of_cell_texts(matrix: Sequence[Sequence[str]]) -> str:
 
 def htmlify_dataframe(dataframe: Any, include_header: bool) -> str:
     """Render a dataframe as table HTML without pandas numeric formatting."""
-    rows = dataframe.astype(str).values.tolist()
+    rows = [
+        ["" if isna else str(value) for value, isna in zip(value_row, isna_row)]
+        for value_row, isna_row in zip(
+            dataframe.to_numpy(dtype=object).tolist(),
+            dataframe.isna().to_numpy().tolist(),
+        )
+    ]
     matrix = [[str(column) for column in dataframe.columns]] + rows if include_header else rows
     return htmlify_matrix_of_cell_texts(matrix)
 

--- a/unstructured/common/html_table.py
+++ b/unstructured/common/html_table.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import html
 from functools import cached_property
-from typing import TYPE_CHECKING, Iterator, Sequence, cast
+from typing import TYPE_CHECKING, Any, Iterator, Sequence, cast
 
 from lxml import etree
 from lxml.html import fragment_fromstring
@@ -46,6 +46,13 @@ def htmlify_matrix_of_cell_texts(matrix: Sequence[Sequence[str]]) -> str:
             yield f"<td>{cell_text}</td>" if cell_text else "<td/>"
 
     return f"<table>{''.join(iter_trs(matrix))}</table>" if matrix else ""
+
+
+def htmlify_dataframe(dataframe: Any, include_header: bool) -> str:
+    """Render a dataframe as table HTML without pandas numeric formatting."""
+    rows = dataframe.astype(str).values.tolist()
+    matrix = [[str(column) for column in dataframe.columns]] + rows if include_header else rows
+    return htmlify_matrix_of_cell_texts(matrix)
 
 
 class HtmlTable:

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -8,7 +8,7 @@ from typing import IO, Any, Iterator
 import pandas as pd
 
 from unstructured.chunking import add_chunking_strategy
-from unstructured.common.html_table import HtmlTable, htmlify_matrix_of_cell_texts
+from unstructured.common.html_table import HtmlTable, htmlify_dataframe
 from unstructured.documents.elements import Element, ElementMetadata, Table
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.metadata import apply_metadata, get_last_modified_date
@@ -70,7 +70,7 @@ def partition_csv(
             read_kw["engine"] = "python"
         dataframe = pd.read_csv(file, **read_kw)
 
-    html_table = HtmlTable.from_html_text(_dataframe_to_html_text(dataframe, include_header))
+    html_table = HtmlTable.from_html_text(htmlify_dataframe(dataframe, include_header))
 
     metadata = ElementMetadata(
         filename=filename,
@@ -80,13 +80,6 @@ def partition_csv(
 
     # -- a CSV file becomes a single `Table` element --
     return [Table(text=html_table.text, metadata=metadata, detection_origin=DETECTION_ORIGIN)]
-
-
-def _dataframe_to_html_text(dataframe: pd.DataFrame, include_header: bool) -> str:
-    """Render a dataframe as table HTML without pandas numeric formatting."""
-    rows = dataframe.astype(str).values.tolist()
-    matrix = [[str(column) for column in dataframe.columns]] + rows if include_header else rows
-    return htmlify_matrix_of_cell_texts(matrix)
 
 
 class _CsvPartitioningContext:

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -8,7 +8,7 @@ from typing import IO, Any, Iterator
 import pandas as pd
 
 from unstructured.chunking import add_chunking_strategy
-from unstructured.common.html_table import HtmlTable
+from unstructured.common.html_table import HtmlTable, htmlify_matrix_of_cell_texts
 from unstructured.documents.elements import Element, ElementMetadata, Table
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.metadata import apply_metadata, get_last_modified_date
@@ -58,15 +58,19 @@ def partition_csv(
 
     csv.field_size_limit(CSV_FIELD_LIMIT)
     with ctx.open() as file:
-        read_kw: dict = {"header": ctx.header, "sep": ctx.delimiter, "encoding": ctx.encoding}
+        read_kw: dict = {
+            "header": ctx.header,
+            "sep": ctx.delimiter,
+            "encoding": ctx.encoding,
+            "dtype": str,
+            "keep_default_na": False,
+        }
         # sep=None is not supported by the C engine; use Python engine to avoid ParserWarning.
         if ctx.delimiter is None:
             read_kw["engine"] = "python"
         dataframe = pd.read_csv(file, **read_kw)
 
-    html_table = HtmlTable.from_html_text(
-        dataframe.to_html(index=False, header=include_header, na_rep="")
-    )
+    html_table = HtmlTable.from_html_text(_dataframe_to_html_text(dataframe, include_header))
 
     metadata = ElementMetadata(
         filename=filename,
@@ -76,6 +80,13 @@ def partition_csv(
 
     # -- a CSV file becomes a single `Table` element --
     return [Table(text=html_table.text, metadata=metadata, detection_origin=DETECTION_ORIGIN)]
+
+
+def _dataframe_to_html_text(dataframe: pd.DataFrame, include_header: bool) -> str:
+    """Render a dataframe as table HTML without pandas numeric formatting."""
+    rows = dataframe.astype(str).values.tolist()
+    matrix = [[str(column) for column in dataframe.columns]] + rows if include_header else rows
+    return htmlify_matrix_of_cell_texts(matrix)
 
 
 class _CsvPartitioningContext:

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -5,7 +5,7 @@ from typing import IO, Any, Optional
 import pandas as pd
 
 from unstructured.chunking import add_chunking_strategy
-from unstructured.common.html_table import HtmlTable, htmlify_matrix_of_cell_texts
+from unstructured.common.html_table import HtmlTable, htmlify_dataframe
 from unstructured.documents.elements import Element, ElementMetadata, Table
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import (
@@ -56,7 +56,7 @@ def partition_tsv(
         f = spooled_to_bytes_io_if_needed(file)
         dataframe = pd.read_csv(f, **read_kw)
 
-    html_table = HtmlTable.from_html_text(_dataframe_to_html_text(dataframe, include_header))
+    html_table = HtmlTable.from_html_text(htmlify_dataframe(dataframe, include_header))
 
     metadata = ElementMetadata(
         filename=filename,
@@ -66,10 +66,3 @@ def partition_tsv(
     metadata.detection_origin = DETECTION_ORIGIN
 
     return [Table(text=html_table.text, metadata=metadata)]
-
-
-def _dataframe_to_html_text(dataframe: pd.DataFrame, include_header: bool) -> str:
-    """Render a dataframe as table HTML without pandas numeric formatting."""
-    rows = dataframe.astype(str).values.tolist()
-    matrix = [[str(column) for column in dataframe.columns]] + rows if include_header else rows
-    return htmlify_matrix_of_cell_texts(matrix)

--- a/unstructured/partition/tsv.py
+++ b/unstructured/partition/tsv.py
@@ -5,7 +5,7 @@ from typing import IO, Any, Optional
 import pandas as pd
 
 from unstructured.chunking import add_chunking_strategy
-from unstructured.common.html_table import HtmlTable
+from unstructured.common.html_table import HtmlTable, htmlify_matrix_of_cell_texts
 from unstructured.documents.elements import Element, ElementMetadata, Table
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import (
@@ -41,18 +41,22 @@ def partition_tsv(
 
     header = 0 if include_header else None
 
+    read_kw: dict[str, Any] = {
+        "sep": "\t",
+        "header": header,
+        "dtype": str,
+        "keep_default_na": False,
+    }
     if filename:
-        dataframe = pd.read_csv(filename, sep="\t", header=header)
+        dataframe = pd.read_csv(filename, **read_kw)
     else:
         assert file is not None
         # -- Note(scanny): `SpooledTemporaryFile` on Python<3.11 does not implement `.readable()`
         # -- which triggers an exception on `pd.DataFrame.read_csv()` call.
         f = spooled_to_bytes_io_if_needed(file)
-        dataframe = pd.read_csv(f, sep="\t", header=header)
+        dataframe = pd.read_csv(f, **read_kw)
 
-    html_table = HtmlTable.from_html_text(
-        dataframe.to_html(index=False, header=include_header, na_rep="")
-    )
+    html_table = HtmlTable.from_html_text(_dataframe_to_html_text(dataframe, include_header))
 
     metadata = ElementMetadata(
         filename=filename,
@@ -62,3 +66,10 @@ def partition_tsv(
     metadata.detection_origin = DETECTION_ORIGIN
 
     return [Table(text=html_table.text, metadata=metadata)]
+
+
+def _dataframe_to_html_text(dataframe: pd.DataFrame, include_header: bool) -> str:
+    """Render a dataframe as table HTML without pandas numeric formatting."""
+    rows = dataframe.astype(str).values.tolist()
+    matrix = [[str(column) for column in dataframe.columns]] + rows if include_header else rows
+    return htmlify_matrix_of_cell_texts(matrix)


### PR DESCRIPTION
## Summary

Refs #3871.

This updates table HTML generation so delimited table partitioners preserve numeric-looking cell text in `metadata.text_as_html` instead of letting pandas serialize numeric columns through `DataFrame.to_html()`.

Changes:

- read CSV and TSV data as strings with default NA coercion disabled, preserving source lexemes such as `478923`, `000001`, `000123`, `007`, `0.000123`, and very large integer-like values
- render CSV/TSV table HTML through a shared `htmlify_dataframe()` helper backed by `htmlify_matrix_of_cell_texts()`, avoiding pandas float/scientific-notation formatting
- preserve dataframe null values as empty table cells instead of serializing them as `nan`, `None`, or `<NA>` text
- add regression coverage for CSV and TSV `metadata.text_as_html`, including TSV file-like input and explicit leading-zero identifiers
- keep the existing `partition_html(..., chunking_strategy="by_title")` regression guard for numeric table cells, now including explicit leading-zero values

## Notes

I still could not reproduce the scientific-notation conversion through current `partition_html()` alone with a minimal HTML table fixture. I confirmed the current HTML table partition path does not do an `HTML -> DataFrame -> to_html()` round-trip: `TableBlock.iter_elements()` builds table data directly from DOM cell text and renders it through `htmlify_matrix_of_cell_texts()`.

The reproducible lossy path is the DataFrame-backed CSV/TSV table serialization path, which matches the pandas `to_html()` failure mode discussed in #3871.

## Testing

```bash
python -m pytest -q test_unstructured\common\test_html_table.py test_unstructured\partition\test_csv.py test_unstructured\partition\test_tsv.py
python -m ruff check unstructured\common\html_table.py unstructured\partition\csv.py unstructured\partition\tsv.py test_unstructured\common\test_html_table.py test_unstructured\partition\test_csv.py test_unstructured\partition\test_tsv.py test_unstructured\partition\html\test_partition.py
python -m ruff format --check unstructured\common\html_table.py unstructured\partition\csv.py unstructured\partition\tsv.py test_unstructured\common\test_html_table.py test_unstructured\partition\test_csv.py test_unstructured\partition\test_tsv.py test_unstructured\partition\html\test_partition.py
git diff --check
```
