### PR TITLE
Detect Confluence-exported DOC files stored in FileContents stream

### DIFF
--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -968,6 +968,25 @@ class Describe_OleFileDetector:
 
         assert _OleFileDetector.file_type(ctx) is expected_value
 
+    def it_detects_confluence_exported_doc_files(self, monkeypatch: pytest.MonkeyPatch):
+        """Detect Confluence-exported DOC files that store content in FileContents."""
+        with open(example_doc_path("simple.doc"), "rb") as f:
+            file = io.BytesIO(f.read())
+        ctx = _FileTypeDetectionContext(file=file)
+
+        class MockStream:
+            name = "FileContents"
+
+        class MockStorage:
+            streams = [MockStream()]
+
+        monkeypatch.setattr(
+            "unstructured.file_utils.filetype.Storage.from_ole",
+            lambda _: MockStorage(),
+        )
+
+        assert _OleFileDetector.file_type(ctx) is FileType.DOC
+
 
 class Describe_TextFileDifferentiator:
     """Unit-test suite for `unstructured.file_utils.filetype._TextFileDifferentiator`."""

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -715,6 +715,9 @@ class _OleFileDetector:
         for stream in root_storage.streams:
             if stream.name == "WordDocument":
                 return FileType.DOC
+            elif stream.name == "FileContents":
+                # Confluence-exported legacy DOC files store content in this stream.
+                return FileType.DOC
             elif stream.name == "PowerPoint Document":
                 return FileType.PPT
             elif stream.name == "Workbook":


### PR DESCRIPTION
## Summary

Fixes #3980.

Some Confluence-exported legacy `.doc` files are stored as OLE/CFB containers but do not contain the standard `WordDocument` stream used for DOC detection. Instead, they store document content in a `FileContents` stream.

This change extends `_OleFileDetector` to recognize `FileContents` as a valid DOC indicator and return `FileType.DOC`.

## Changes

* Detect OLE files containing a `FileContents` stream as `FileType.DOC`
* Add a unit test covering Confluence-exported DOC detection

## Testing

```bash
python3 -m compileall unstructured/file_utils/filetype.py
python3 -m pytest test_unstructured/file_utils/test_filetype.py -k OleFileDetector -v
```

Result:

* 6 tests passed
* Existing OLE file detection tests continue to pass
