### PR TITLE
fix(ci): stabilize partition benchmark with a rolling-median baseline

### DIFF
--- a/.github/workflows/partition-benchmark.yaml
+++ b/.github/workflows/partition-benchmark.yaml
@@ -1,13 +1,21 @@
 name: Partition Benchmark
 
 # PRs are gated against a rolling median baseline; pushes to main record a new
-# baseline sample. Can also be triggered manually to inspect a run.
+# baseline sample. Can also be triggered manually to inspect a run, or with
+# `self_test: true` to exercise the full record+upload path against a throwaway
+# `-selftest` prefix (so the write path can be validated on a branch, before merge,
+# without touching the real baseline).
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      self_test:
+        description: "Record + upload to a throwaway -selftest prefix (does not touch the real baseline)."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -86,8 +94,32 @@ jobs:
           key: hf-models-${{ runner.os }}-${{ env.CACHE_VERSION }}-${{ github.sha }}
 
 
-      # Pull the whole history prefix (one object per past main run). On fork PRs
-      # the S3 secrets are absent, so this no-ops -> empty dir -> warm-up/pass.
+      # Decide, in one place, which baseline mode this run is in:
+      #   push:main                       -> record + upload to the real prefix
+      #   workflow_dispatch + self_test    -> record + upload to a throwaway -selftest prefix
+      #   pull_request / plain dispatch    -> read-only, real prefix (gate only, never write)
+      - name: Resolve baseline mode
+        id: mode
+        run: |
+          prefix="${{ env.S3_HISTORY_PREFIX }}"
+          record=""
+          upload="false"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            record="--record"; upload="true"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
+               [ "${{ inputs.self_test }}" = "true" ]; then
+            prefix="${prefix}-selftest"; record="--record"; upload="true"
+          fi
+          {
+            echo "prefix=$prefix"
+            echo "record=$record"
+            echo "upload=$upload"
+          } >> "$GITHUB_OUTPUT"
+          echo "mode: prefix=$prefix record='$record' upload=$upload"
+
+
+      # Pull the whole history prefix (one object per past run). On fork PRs the S3
+      # secrets are absent, so this no-ops -> empty dir -> warm-up/pass.
       - name: Download benchmark history from S3
         continue-on-error: true
         env:
@@ -96,30 +128,28 @@ jobs:
         run: |
           mkdir -p bench_history
           aws s3 cp --recursive \
-            "s3://${{ env.S3_METRICS_BUCKET_KEY }}/${{ env.S3_HISTORY_PREFIX }}/" \
+            "s3://${{ env.S3_METRICS_BUCKET_KEY }}/${{ steps.mode.outputs.prefix }}/" \
             bench_history/
 
 
-      # Gate against the rolling median. On pushes to main, --record also writes
-      # this run's record into bench_history/ for the upload step below.
+      # Gate against the rolling median. When recording (push, or dispatch self-test),
+      # --record also writes this run's record into bench_history/ for the upload below.
       - name: Compare against rolling baseline
         id: compare
         run: |
-          RECORD=""
-          if [ "${{ github.event_name }}" = "push" ]; then RECORD="--record"; fi
           uv run --no-sync python scripts/performance/compare_benchmark.py \
             benchmark_results.json \
             bench_history \
             --threshold ${{ env.REGRESSION_THRESHOLD }} \
             --window ${{ env.BASELINE_WINDOW }} \
             --min-samples ${{ env.BASELINE_MIN_SAMPLES }} \
-            $RECORD
+            ${{ steps.mode.outputs.record }}
 
 
-      # Only main pushes extend the baseline. `sync` (no --delete) uploads the one
-      # new record written above; existing objects are unchanged. PR runs never write.
+      # Extend the baseline. `sync` (no --delete) uploads the one new record written
+      # above; existing objects are unchanged. PR/read-only runs skip this entirely.
       - name: Upload new baseline record to S3
-        if: github.event_name == 'push'
+        if: steps.mode.outputs.upload == 'true'
         continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_EVAL_ACCESS_KEY }}
@@ -127,7 +157,7 @@ jobs:
         run: |
           aws s3 sync \
             bench_history/ \
-            "s3://${{ env.S3_METRICS_BUCKET_KEY }}/${{ env.S3_HISTORY_PREFIX }}/"
+            "s3://${{ env.S3_METRICS_BUCKET_KEY }}/${{ steps.mode.outputs.prefix }}/"
 
 
       - name: Upload benchmark artifacts

--- a/.github/workflows/partition-benchmark.yaml
+++ b/.github/workflows/partition-benchmark.yaml
@@ -1,9 +1,11 @@
 name: Partition Benchmark
 
-# Runs on every PR targeting main to detect regressions.
-# Can also be triggered manually to establish or inspect a new baseline.
+# PRs are gated against a rolling median baseline; pushes to main record a new
+# baseline sample. Can also be triggered manually to inspect a run.
 on:
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
   workflow_dispatch:
 
@@ -15,13 +17,19 @@ env:
   PYTHON_VERSION: "3.12"
   # Number of times to run the full benchmark suite.
   NUM_ITERATIONS: "3"
-  # 20% threshold for now and tune later
-  REGRESSION_THRESHOLD: "0.20"
+  # Allowance over the rolling median baseline. Sized to absorb runner-speed
+  # variance on shared ubuntu-latest runners (observed ~1.6x), not just a code delta.
+  REGRESSION_THRESHOLD: "0.30"
+  # How many recent main-run samples the baseline median is taken over.
+  BASELINE_WINDOW: "20"
+  # Below this many samples, the gate is in warm-up (records, does not fail).
+  BASELINE_MIN_SAMPLES: "5"
   # Increment to change cache key when benchmark-affecting dependencies are updated, to ensure clean slate runs.
   CACHE_VERSION: "v2"
   # S3 location for metrics – matches core-product convention.
   S3_METRICS_BUCKET_KEY: utic-metrics/ci-metrics
-  S3_BENCHMARK_PATH: open-source/partition-benchmark/benchmark_best.json
+  # Prefix holding one immutable JSON record per main run (the rolling history).
+  S3_HISTORY_PREFIX: open-source/partition-benchmark/history
 
 jobs:
   setup:
@@ -78,35 +86,48 @@ jobs:
           key: hf-models-${{ runner.os }}-${{ env.CACHE_VERSION }}-${{ github.sha }}
 
 
-      - name: Download previous best from S3
+      # Pull the whole history prefix (one object per past main run). On fork PRs
+      # the S3 secrets are absent, so this no-ops -> empty dir -> warm-up/pass.
+      - name: Download benchmark history from S3
         continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_EVAL_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_EVAL_SECRET_KEY }}
         run: |
-          aws s3 cp \
-            "s3://${{ env.S3_METRICS_BUCKET_KEY }}/${{ env.S3_BENCHMARK_PATH }}" \
-            benchmark_best.json
+          mkdir -p bench_history
+          aws s3 cp --recursive \
+            "s3://${{ env.S3_METRICS_BUCKET_KEY }}/${{ env.S3_HISTORY_PREFIX }}/" \
+            bench_history/
 
 
-      - name: Compare results against stored best
+      # Gate against the rolling median. On pushes to main, --record also writes
+      # this run's record into bench_history/ for the upload step below.
+      - name: Compare against rolling baseline
         id: compare
         run: |
+          RECORD=""
+          if [ "${{ github.event_name }}" = "push" ]; then RECORD="--record"; fi
           uv run --no-sync python scripts/performance/compare_benchmark.py \
             benchmark_results.json \
-            benchmark_best.json \
-            ${{ env.REGRESSION_THRESHOLD }}
+            bench_history \
+            --threshold ${{ env.REGRESSION_THRESHOLD }} \
+            --window ${{ env.BASELINE_WINDOW }} \
+            --min-samples ${{ env.BASELINE_MIN_SAMPLES }} \
+            $RECORD
 
 
-      - name: Upload best result to S3
+      # Only main pushes extend the baseline. `sync` (no --delete) uploads the one
+      # new record written above; existing objects are unchanged. PR runs never write.
+      - name: Upload new baseline record to S3
+        if: github.event_name == 'push'
         continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_EVAL_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_EVAL_SECRET_KEY }}
         run: |
-          aws s3 cp \
-            benchmark_best.json \
-            "s3://${{ env.S3_METRICS_BUCKET_KEY }}/${{ env.S3_BENCHMARK_PATH }}"
+          aws s3 sync \
+            bench_history/ \
+            "s3://${{ env.S3_METRICS_BUCKET_KEY }}/${{ env.S3_HISTORY_PREFIX }}/"
 
 
       - name: Upload benchmark artifacts
@@ -116,5 +137,5 @@ jobs:
           name: benchmark-results-${{ github.sha }}
           path: |
             benchmark_results.json
-            benchmark_best.json
+            bench_history/
           retention-days: 30

--- a/.github/workflows/partition-benchmark.yaml
+++ b/.github/workflows/partition-benchmark.yaml
@@ -1,21 +1,18 @@
 name: Partition Benchmark
 
 # PRs are gated against a rolling median baseline; pushes to main record a new
-# baseline sample. Can also be triggered manually to inspect a run, or with
-# `self_test: true` to exercise the full record+upload path against a throwaway
-# `-selftest` prefix (so the write path can be validated on a branch, before merge,
-# without touching the real baseline).
+# baseline sample. A manual run (workflow_dispatch) on main is a read-only
+# inspection; a manual run on any OTHER branch is a self-test that records +
+# uploads to a throwaway `-selftest` prefix -- so the write path can be validated
+# on a branch, before merge, without touching the real baseline. (Keying on the
+# ref rather than an input is deliberate: dispatch inputs are validated against
+# the default-branch workflow, so a branch-only input can't be passed pre-merge.)
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      self_test:
-        description: "Record + upload to a throwaway -selftest prefix (does not touch the real baseline)."
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -95,9 +92,9 @@ jobs:
 
 
       # Decide, in one place, which baseline mode this run is in:
-      #   push:main                       -> record + upload to the real prefix
-      #   workflow_dispatch + self_test    -> record + upload to a throwaway -selftest prefix
-      #   pull_request / plain dispatch    -> read-only, real prefix (gate only, never write)
+      #   push:main                          -> record + upload to the real prefix
+      #   workflow_dispatch on a non-main ref -> record + upload to a throwaway -selftest prefix
+      #   pull_request / dispatch on main     -> read-only, real prefix (gate only, never write)
       - name: Resolve baseline mode
         id: mode
         run: |
@@ -107,7 +104,7 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             record="--record"; upload="true"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
-               [ "${{ inputs.self_test }}" = "true" ]; then
+               [ "${{ github.ref_name }}" != "main" ]; then
             prefix="${prefix}-selftest"; record="--record"; upload="true"
           fi
           {

--- a/.github/workflows/partition-benchmark.yaml
+++ b/.github/workflows/partition-benchmark.yaml
@@ -145,8 +145,12 @@ jobs:
 
       # Extend the baseline. `sync` (no --delete) uploads the one new record written
       # above; existing objects are unchanged. PR/read-only runs skip this entirely.
+      # `!cancelled()` (instead of the implicit success() &&) so the record still
+      # persists when the compare step fails the gate on a regression -- otherwise a
+      # red run never reaches S3 and the baseline can't track the new reality. The
+      # record is written before the gate check, so the local file exists either way.
       - name: Upload new baseline record to S3
-        if: steps.mode.outputs.upload == 'true'
+        if: ${{ !cancelled() && steps.mode.outputs.upload == 'true' }}
         continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_EVAL_ACCESS_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.23.2
+
+### Fixes
+
+- **Stabilize the partition-runtime benchmark CI check**: the gate compared each run against a single all-time-minimum runtime, which a one-off fast runner could poison into an unbeatable floor (a frozen ~81s baseline vs a real ~130s fleet), failing every PR. It now compares against a rolling median of recent `main` runs with a warm-up period, so runner-speed variance can't block unrelated PRs. CI/tooling only; no library behavior changes.
+
 ## 0.23.1
 
 ### Enhancements

--- a/scripts/performance/compare_benchmark.py
+++ b/scripts/performance/compare_benchmark.py
@@ -86,8 +86,20 @@ def _runner_info() -> dict:
     return {"cpu_model": cpu_model, "nproc": os.cpu_count()}
 
 
+def _is_number(value: object) -> bool:
+    """True for real numeric values; bool is rejected (it's a subclass of int)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
 def load_history(history_dir: Path) -> list[dict]:
-    """Load every per-run record from HISTORY_DIR, sorted oldest -> newest."""
+    """Load every per-run record from HISTORY_DIR, sorted oldest -> newest.
+
+    Records are deduped by sha (keeping the newest per sha by timestamp) so the
+    median is correct even if S3 still holds legacy timestamped objects that share
+    a sha. Records without a sha are kept individually -- they're never collapsed
+    together. Records whose ``total`` is missing or non-numeric are skipped so a
+    malformed object can't crash ``statistics.median``.
+    """
     if not history_dir.is_dir():
         return []
     records: list[dict] = []
@@ -97,10 +109,26 @@ def load_history(history_dir: Path) -> list[dict]:
         except (json.JSONDecodeError, OSError) as e:
             logger.warning(f"skipping unreadable history record {f.name}: {e}")
             continue
-        if "total" in rec:
+        if isinstance(rec, dict) and _is_number(rec.get("total")):
             records.append(rec)
+        else:
+            logger.warning(f"skipping history record {f.name}: missing/non-numeric 'total'")
     records.sort(key=lambda r: r.get("timestamp") or "")
-    return records
+
+    # Dedupe by sha, keeping the newest record per sha. Records sort oldest->newest
+    # above, so a later same-sha record overwrites the earlier one. Empty/absent sha
+    # is kept per-record (do not collapse all sha-less records together).
+    deduped: list[dict] = []
+    by_sha: dict[str, int] = {}
+    for rec in records:
+        sha = rec.get("sha") or ""
+        if sha and sha in by_sha:
+            deduped[by_sha[sha]] = rec
+        else:
+            if sha:
+                by_sha[sha] = len(deduped)
+            deduped.append(rec)
+    return deduped
 
 
 def build_record(current: dict) -> dict:
@@ -122,19 +150,23 @@ def build_record(current: dict) -> dict:
 
 
 def write_record(history_dir: Path, record: dict) -> Path:
-    """Write the record into HISTORY_DIR, replacing any prior record for this sha."""
+    """Write the record into HISTORY_DIR, replacing any prior record for this sha.
+
+    The object name is keyed by sha alone (not timestamped), so a re-run of the
+    same commit overwrites the same object. This is what keeps the rolling median
+    from double-counting a commit: the workflow's ``aws s3 sync`` (no ``--delete``)
+    would otherwise leave a stale, differently-named same-sha object behind. The
+    timestamp survives as a record field, which is what load/sort uses.
+    """
     history_dir.mkdir(parents=True, exist_ok=True)
     sha = record.get("sha") or ""
-    # Dedupe: a re-run of the same commit supersedes its earlier record.
     if sha:
-        for f in history_dir.glob("*.json"):
-            try:
-                if json.loads(f.read_text()).get("sha") == sha:
-                    f.unlink()
-            except (json.JSONDecodeError, OSError):
-                continue
-    ts_compact = record["timestamp"].replace("-", "").replace(":", "")
-    out = history_dir / f"{ts_compact}-{sha[:12]}.json"
+        name = f"{sha[:12]}.json"
+    else:
+        # No sha (e.g. local/manual): fall back to a timestamp-derived name. Keep it
+        # filesystem-safe by stripping the separators, as the old naming did.
+        name = record["timestamp"].replace("-", "").replace(":", "") + ".json"
+    out = history_dir / name
     out.write_text(json.dumps(record, indent=2) + "\n")
     return out
 
@@ -145,7 +177,9 @@ def _median_per_file(window: list[dict]) -> dict[str, float]:
         files.update(r.get("per_file", {}).keys())
     medians: dict[str, float] = {}
     for fname in files:
-        vals = [r["per_file"][fname] for r in window if fname in r.get("per_file", {})]
+        vals = [
+            r["per_file"][fname] for r in window if _is_number(r.get("per_file", {}).get(fname))
+        ]
         if vals:
             medians[fname] = statistics.median(vals)
     return medians
@@ -164,6 +198,13 @@ def main() -> None:
         "--record", action="store_true", help="write this run into the history (main runs)"
     )
     args = ap.parse_args()
+
+    # --window is used as history[-args.window:]; 0 silently means "all history"
+    # ([-0:] == [0:]) and negatives slice from the wrong end. Require >= 1.
+    if args.window < 1:
+        ap.error("--window must be >= 1")
+    if args.min_samples < 0:
+        ap.error("--min-samples must be >= 0")
 
     current: dict[str, float] = json.loads(args.current_results.read_text())
     current_total: float = current["__total__"]

--- a/scripts/performance/compare_benchmark.py
+++ b/scripts/performance/compare_benchmark.py
@@ -128,7 +128,10 @@ def load_history(history_dir: Path) -> list[dict]:
             if sha:
                 by_sha[sha] = len(deduped)
             deduped.append(rec)
-    return deduped
+    # Overwriting a same-sha record in place keeps the *first* occurrence's slot but
+    # the *newer* record's timestamp, which can leave deduped out of chronological
+    # order. Re-sort so callers can rely on history[-window:] being the newest runs.
+    return sorted(deduped, key=lambda r: r.get("timestamp") or "")
 
 
 def build_record(current: dict) -> dict:
@@ -219,8 +222,10 @@ def main() -> None:
         rec_path = write_record(args.history_dir, build_record(current))
         logger.info(f"recorded this run -> {rec_path.name}")
 
-    # Warm-up: not enough history to gate yet. Observe and pass.
-    if len(window) < args.min_samples:
+    # Warm-up: not enough history to gate yet. Observe and pass. An empty window can
+    # never produce a baseline (statistics.median([]) raises), so it is always warm-up
+    # regardless of --min-samples (which may be 0).
+    if not window or len(window) < args.min_samples:
         logger.info(
             f"WARM-UP: {len(window)} of {args.min_samples} baseline samples present "
             f"-- recording only, not gating. (current total {current_total:.2f}s)"

--- a/scripts/performance/compare_benchmark.py
+++ b/scripts/performance/compare_benchmark.py
@@ -1,24 +1,49 @@
 #!/usr/bin/env python3
-"""Compare current benchmark results against the stored best runtime.
+"""Compare this run's partition() benchmark against a rolling baseline.
+
+Why a rolling baseline (and not a single stored "best"):
+    GitHub's shared ``ubuntu-latest`` runners vary in speed by ~1.6x run-to-run,
+    and that variance scales the whole benchmark (partition work *and* fixed
+    overhead). A single all-time-minimum baseline is therefore unbeatable the
+    moment one lucky-fast runner records it -- every later run on a normal runner
+    exceeds best*(1+threshold) and the check fails for everyone. (That is exactly
+    what happened: a frozen 81s "best" vs a real ~130s fleet.)
+
+    Instead we keep the last ``--window`` runs from ``main`` and compare against
+    their **median**, which a single fast/slow outlier can't poison. The baseline
+    tracks reality over time rather than ratcheting to an unrepeatable minimum.
+
+Storage:
+    Each ``main`` run is one immutable JSON record under ``HISTORY_DIR`` (synced
+    to/from S3 by the workflow). This script never talks to S3 -- it only reads
+    the local history dir and, with ``--record``, writes this run's record there
+    for the workflow to upload. Pruning of old objects is an S3 lifecycle rule.
 
 Usage:
     uv run --no-sync python scripts/performance/compare_benchmark.py \
         benchmark_results.json \
-        benchmark_best.json \
-        [threshold]
+        HISTORY_DIR \
+        [--threshold 0.30] [--window 20] [--min-samples 5] [--record]
 
-    current.json  JSON produced by benchmark_partition.py for this run
-    best.json     JSON produced by a previous run (the stored best); may not
-                  exist yet on the very first run
-    threshold     Float regression allowance, e.g. 0.20 for 20% (default 0.20)
+    benchmark_results.json  this run's results from benchmark_partition.py
+    HISTORY_DIR             dir of per-run history records (may be empty/missing)
+    --threshold            regression allowance over the median (default 0.30)
+    --window               number of most-recent records to median over (default 20)
+    --min-samples          below this many records, warm-up (record + pass, no gate)
+    --record               write this run's record into HISTORY_DIR (main runs only);
+                           recording happens regardless of pass/fail so the baseline
+                           can't get stuck.
 """
 
 from __future__ import annotations
 
+import argparse
+import datetime as dt
 import json
 import logging
 import math
 import os
+import statistics
 import sys
 from pathlib import Path
 
@@ -35,99 +60,176 @@ def _github_output(key: str, value: str) -> None:
 
 
 def _fmt(seconds: float) -> str:
-    """Format a duration, handling NaN for files missing from one side."""
-    if math.isnan(seconds):
+    if seconds is None or math.isnan(seconds):
         return "    n/a"
     return f"{seconds:7.2f}s"
 
 
-def _pct_diff(current: float, best: float) -> str:
-    if best == 0:
+def _pct_diff(current: float, baseline: float) -> str:
+    if not baseline:
         return "   n/a"
-    diff = (current - best) / best * 100
+    diff = (current - baseline) / baseline * 100
     sign = "+" if diff >= 0 else ""
     return f"{sign}{diff:.1f}%"
 
 
+def _runner_info() -> dict:
+    """Best-effort CPU/nproc capture, purely for later visibility of variance."""
+    cpu_model = None
+    try:
+        for line in Path("/proc/cpuinfo").read_text().splitlines():
+            if line.lower().startswith("model name"):
+                cpu_model = line.split(":", 1)[1].strip()
+                break
+    except OSError:
+        pass
+    return {"cpu_model": cpu_model, "nproc": os.cpu_count()}
+
+
+def load_history(history_dir: Path) -> list[dict]:
+    """Load every per-run record from HISTORY_DIR, sorted oldest -> newest."""
+    if not history_dir.is_dir():
+        return []
+    records: list[dict] = []
+    for f in history_dir.glob("*.json"):
+        try:
+            rec = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"skipping unreadable history record {f.name}: {e}")
+            continue
+        if "total" in rec:
+            records.append(rec)
+    records.sort(key=lambda r: r.get("timestamp") or "")
+    return records
+
+
+def build_record(current: dict) -> dict:
+    """Build this run's history record from results + CI environment metadata."""
+    now = dt.datetime.now(dt.timezone.utc)
+    sha = os.environ.get("GITHUB_SHA", "")
+    return {
+        "sha": sha,
+        "run_id": int(os.environ["GITHUB_RUN_ID"]) if os.environ.get("GITHUB_RUN_ID") else None,
+        "timestamp": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "event": os.environ.get("GITHUB_EVENT_NAME"),
+        "ref": os.environ.get("GITHUB_REF_NAME"),
+        "seed": False,
+        "iterations": int(os.environ.get("NUM_ITERATIONS", "0")) or None,
+        "runner": _runner_info(),
+        "total": round(current["__total__"], 2),
+        "per_file": {k: round(v, 4) for k, v in current.items() if k != "__total__"},
+    }
+
+
+def write_record(history_dir: Path, record: dict) -> Path:
+    """Write the record into HISTORY_DIR, replacing any prior record for this sha."""
+    history_dir.mkdir(parents=True, exist_ok=True)
+    sha = record.get("sha") or ""
+    # Dedupe: a re-run of the same commit supersedes its earlier record.
+    if sha:
+        for f in history_dir.glob("*.json"):
+            try:
+                if json.loads(f.read_text()).get("sha") == sha:
+                    f.unlink()
+            except (json.JSONDecodeError, OSError):
+                continue
+    ts_compact = record["timestamp"].replace("-", "").replace(":", "")
+    out = history_dir / f"{ts_compact}-{sha[:12]}.json"
+    out.write_text(json.dumps(record, indent=2) + "\n")
+    return out
+
+
+def _median_per_file(window: list[dict]) -> dict[str, float]:
+    files: set[str] = set()
+    for r in window:
+        files.update(r.get("per_file", {}).keys())
+    medians: dict[str, float] = {}
+    for fname in files:
+        vals = [r["per_file"][fname] for r in window if fname in r.get("per_file", {})]
+        if vals:
+            medians[fname] = statistics.median(vals)
+    return medians
+
+
 def main() -> None:
-    if len(sys.argv) < 3:
-        print(__doc__, file=sys.stderr)
-        sys.exit(2)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("current_results", type=Path)
+    ap.add_argument("history_dir", type=Path)
+    ap.add_argument("--threshold", type=float, default=0.30)
+    ap.add_argument("--window", type=int, default=20)
+    ap.add_argument("--min-samples", type=int, default=5)
+    ap.add_argument(
+        "--record", action="store_true", help="write this run into the history (main runs)"
+    )
+    args = ap.parse_args()
 
-    current_path = Path(sys.argv[1])
-    best_path = Path(sys.argv[2])
-    threshold = float(sys.argv[3]) if len(sys.argv) > 3 else 0.20
-
-    current: dict[str, float] = json.loads(current_path.read_text())
+    current: dict[str, float] = json.loads(args.current_results.read_text())
     current_total: float = current["__total__"]
 
-    if not best_path.exists():
-        logger.info("No stored best found – saving current run as the baseline.")
-        logger.info(f"  Total: {current_total:.2f}s")
-        best_path.parent.mkdir(parents=True, exist_ok=True)
-        best_path.write_text(current_path.read_text())
-        _github_output("new_best", "true")
+    history = load_history(args.history_dir)
+    window = history[-args.window :]
+
+    # Record first (main runs only) so the baseline always reflects reality,
+    # regardless of whether this run passes the gate -- the opposite of the old
+    # min-ratchet, which could only ever lower the bar and so got stuck.
+    if args.record:
+        rec_path = write_record(args.history_dir, build_record(current))
+        logger.info(f"recorded this run -> {rec_path.name}")
+
+    # Warm-up: not enough history to gate yet. Observe and pass.
+    if len(window) < args.min_samples:
+        logger.info(
+            f"WARM-UP: {len(window)} of {args.min_samples} baseline samples present "
+            f"-- recording only, not gating. (current total {current_total:.2f}s)"
+        )
         _github_output("regression", "false")
+        _github_output("warmup", "true")
         sys.exit(0)
 
-    best: dict[str, float] = json.loads(best_path.read_text())
-    best_total: float = best["__total__"]
-    limit: float = best_total * (1.0 + threshold)
+    baseline = statistics.median(r["total"] for r in window)
+    limit = baseline * (1.0 + args.threshold)
+    per_file_baseline = _median_per_file(window)
 
-    # Collect all file keys (exclude the __total__ sentinel)
-    all_files = sorted((set(current.keys()) | set(best.keys())) - {"__total__"})
-
+    all_files = sorted((set(current) | set(per_file_baseline)) - {"__total__"})
     col_w = max((len(f) for f in all_files), default=40) + 2
-    header = f"{'File':<{col_w}} {'Current':>9}  {'Best':>9}  {'Delta':>8}"
+    header = f"{'File':<{col_w}} {'Current':>9}  {'Median':>9}  {'Delta':>8}"
     logger.info("=" * len(header))
-    logger.info("Partition benchmark comparison")
+    logger.info(f"Partition benchmark vs rolling median of last {len(window)} main runs")
     logger.info("=" * len(header))
     logger.info(header)
     logger.info("-" * len(header))
-
     for fname in all_files:
         c = current.get(fname, float("nan"))
-        b = best.get(fname, float("nan"))
+        b = per_file_baseline.get(fname, float("nan"))
         logger.info(f"{fname:<{col_w}} {_fmt(c)}  {_fmt(b)}  {_pct_diff(c, b):>8}")
-
     logger.info("-" * len(header))
     logger.info(
-        f"{'TOTAL':<{col_w}} {_fmt(current_total)}  {_fmt(best_total)}"
-        f"  {_pct_diff(current_total, best_total):>8}"
+        f"{'TOTAL':<{col_w}} {_fmt(current_total)}  {_fmt(baseline)}"
+        f"  {_pct_diff(current_total, baseline):>8}"
     )
     logger.info("")
-    logger.info(f"Threshold : {threshold * 100:.0f}%  (fail if current > {limit:.2f}s)")
+    logger.info(
+        f"Baseline : median of {len(window)} runs = {baseline:.2f}s  "
+        f"(threshold {args.threshold * 100:.0f}%, fail if > {limit:.2f}s)"
+    )
     logger.info("")
 
-    # fail on regression beyond threshold
     if current_total > limit:
-        excess_pct = (current_total - best_total) / best_total * 100
+        excess_pct = (current_total - baseline) / baseline * 100
         logger.error(
-            f"FAIL: current runtime {current_total:.2f}s exceeds best "
-            f"{best_total:.2f}s by {excess_pct:.1f}% "
-            f"(threshold {threshold * 100:.0f}%, limit {limit:.2f}s)."
+            f"FAIL: current runtime {current_total:.2f}s exceeds the median baseline "
+            f"{baseline:.2f}s by {excess_pct:.1f}% (threshold {args.threshold * 100:.0f}%, "
+            f"limit {limit:.2f}s)."
         )
-        _github_output("new_best", "false")
         _github_output("regression", "true")
         sys.exit(1)
 
-    # pass: current is within threshold of best; update best if current is faster
-    if current_total < best_total:
-        improvement_pct = (best_total - current_total) / best_total * 100
-        logger.info(
-            f"PASS (new best): {current_total:.2f}s is {improvement_pct:.1f}% "
-            f"faster than the previous best {best_total:.2f}s – updating in S3."
-        )
-        best_path.write_text(current_path.read_text())
-        _github_output("new_best", "true")
-    else:
-        slack_pct = (current_total - best_total) / best_total * 100
-        logger.info(
-            f"PASS: {current_total:.2f}s is {slack_pct:.1f}% slower than best "
-            f"{best_total:.2f}s (within {threshold * 100:.0f}% threshold)."
-        )
-        _github_output("new_best", "false")
-
+    logger.info(
+        f"PASS: {current_total:.2f}s is within {args.threshold * 100:.0f}% of the "
+        f"median baseline {baseline:.2f}s."
+    )
     _github_output("regression", "false")
     sys.exit(0)
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.23.1"  # pragma: no cover
+__version__ = "0.23.2"  # pragma: no cover


### PR DESCRIPTION
## Problem

The Partition Benchmark gates every PR against a **single all-time-minimum** runtime stored in S3 (`benchmark_best.json`), updated by any run that comes in faster. On GitHub's shared `ubuntu-latest` runners the whole benchmark scales **~1.6× with runner speed** (partition work *and* fixed model/import overhead alike), so one lucky-fast run set an unbeatable floor — a frozen **81 s "best" vs a real ~130 s fleet** — and every PR since failed by ~60%.

Evidence: across the last 25 runs, **0 passed** (12 failures on multiple unrelated branches, all `current ≈ 130 s` vs `best 81.13 s`, limit `97.36 s`). It was blocking unrelated PRs.

## Fix

Replace the min-ratchet with a **rolling median of the last N `main` runs**:

- **`push: main` records** one immutable per-run JSON object under a `history/` prefix. **PRs read** the window and gate against its **median** — read-only, so PRs can no longer write (and poison) the baseline.
- A single fast/slow outlier can't move a median, so the gate tracks the real fleet instead of an unrepeatable minimum.
- **Warm-up:** below `--min-samples` records, the gate records-and-passes — it self-bootstraps, and degrades gracefully to pass when S3 creds are absent (fork PRs).
- **Recording happens regardless of pass/fail**, so the baseline can't get stuck the way the min could.
- Threshold `0.20 → 0.30` to absorb runner variance; window/min-samples are env-tunable. Records keep per-file timings + runner info for later tuning.

The job name (`Measure and compare partition() runtime`) is **unchanged**, so required-check config keeps matching.

## Validation

Ran the new comparator locally against real recent run data (median 130.2 s):
- typical run (131 s) → **PASS** (within 30%)
- regressed run (200 s) → **FAIL** (exit 1)
- < min-samples history → **WARM-UP** pass
- `--record` writes a record and dedupes by sha (re-run replaces)

`ruff check` + `ruff format --check` clean.

## Deploy steps (outside this PR — need the metrics-bucket creds)

1. Seed the `history/` prefix with recent real runs (so the baseline is live on day one rather than warming up).
2. Remove the stale `benchmark_best.json`.
3. Optional: add a lifecycle rule to expire `history/` objects older than ~90 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

