### PR TITLE
feat(staging): render list bullets and title heading depth in markdown `element_to_md()` function

### DIFF
--- a/test_unstructured/staging/test_base.py
+++ b/test_unstructured/staging/test_base.py
@@ -592,6 +592,19 @@ def test_elements_to_md_conversion(json_filename: str, expected_md_filename: str
     ("element", "expected_markdown", "exclude_binary"),
     [
         (Title("Test Title"), "# Test Title", False),
+        (
+            Title("Second Level", metadata=ElementMetadata(category_depth=2)),
+            "## Second Level",
+            False,
+        ),
+        (
+            Title("Third Level", metadata=ElementMetadata(category_depth=3)),
+            "### Third Level",
+            False,
+        ),
+        (Title("No Depth"), "# No Depth", False),
+        (ListItem("Buy milk"), "- Buy milk", False),
+        (ListItem("Another item"), "- Another item", False),
         (NarrativeText("This is some narrative text."), "This is some narrative text.", False),
         (Formula(r"\int_a^b x^2 dx"), "$$\n\\int_a^b x^2 dx\n$$", False),
         (

--- a/unstructured/staging/base.py
+++ b/unstructured/staging/base.py
@@ -18,6 +18,7 @@ from unstructured.documents.elements import (
     ElementMetadata,
     Formula,
     Image,
+    ListItem,
     Table,
     Title,
 )
@@ -278,8 +279,16 @@ def element_to_md(
     formula_markdown_style: str = FORMULA_MARKDOWN_AUTO,
 ) -> str:
     match element:
-        case Title(text=text):
-            return f"# {text}"
+        case Title(text=text, metadata=metadata):
+            depth = metadata.category_depth if metadata.category_depth else 1
+            if not isinstance(depth, int):
+                try:
+                    depth = int(depth) if isinstance(depth, (str, float)) else 1
+                except (TypeError, ValueError):
+                    depth = 1
+            return f"{'#' * depth} {text}"
+        case ListItem(text=text):
+            return f"- {text}"
         case Formula(text=text):
             return _emit_formula_markdown(
                 text,


### PR DESCRIPTION
Hello! 👋

I wrote a custom json/dict-to-markdown mapper back in 2024 and found recently you have a built-in mapper now! This PR attempts to fill the parity/feature gap between your built-in native markdown mapper and my custom mapper, so that hopefully I can stop maintaining the custom one. 😀

Specifically, this adds:
1. L2 and L3 header support (current implementation always generates top-level headers (`# Header` instead of `## Header` or `### Header`)
2. List item handling (`- item one` instead of `item one`)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

