### PR TITLE
Fix parallel PDF API script env handling

### DIFF
--- a/scripts/user/process-pdf-parallel-through-api.sh
+++ b/scripts/user/process-pdf-parallel-through-api.sh
@@ -50,7 +50,20 @@ fi
 
 PDF_FILE="$1"
 PDF_NAME=$(basename "$PDF_FILE" .pdf)
-MD5_SUM=$(md5sum "$PDF_FILE" | awk '{ print $1 }')
+
+checksum_file() {
+  local file="$1"
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$file" | awk '{ print $1 }'
+  elif command -v md5 >/dev/null 2>&1; then
+    md5 -q "$file"
+  else
+    echo "Error: neither md5sum nor md5 is available." >&2
+    exit 1
+  fi
+}
+
+MD5_SUM=$(checksum_file "$PDF_FILE")
 PDF_DIR="$PDF_SPLITS_DIR/$PDF_NAME-${MD5_SUM}_split-${SPLIT_SIZE}"
 PDF_OUTPUT_DIR="$PDF_SPLITS_DIR/${PDF_NAME}-output-${MD5_SUM}_split-${SPLIT_SIZE}_strat-${STRATEGY}"
 

--- a/scripts/user/process-pdf-parallel-through-api.sh
+++ b/scripts/user/process-pdf-parallel-through-api.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Usage: ./process-pdf-parallel-through-api.sh filename.pdf
-
 set -eu -o pipefail
 
 if [ $# -ne 1 ]; then
@@ -10,36 +8,48 @@ if [ $# -ne 1 ]; then
   echo "Usage: $0 <pdf_filename>"
   echo "Please provide a PDF filename as the first argument."
   echo
-  echo "Optionally, set the following env vars: "
+  echo "Required env vars:"
   echo
+  echo "* UNST_API_KEY"
+  echo
+  echo "Optionally, set the following env vars:"
+  echo
+  echo "* UNST_API_ENDPOINT (default https://api.unstructuredapp.io/general/v0/general)"
   echo "* STRATEGY (default hi_res)"
   echo "* BATCH_SIZE (default 30) as the number of parts (AKA splits) to process in parallel"
   echo "* PDF_SPLIT_PAGE_SIZE (default 10) as the number of pages per split"
+  echo "* PDF_SPLITS_DIR (default \$HOME/tmp/pdf-splits)"
   echo
-  echo "BATCH_SIZE=20 PDF_SPLIT_PAGE_SIZE=6 STRATEGY=hi_res ./process-pdf-parallel-through-api.sh example-docs/pdf/layout-parser-paper.pdf"
+  echo "UNST_API_KEY=<your-api-key> BATCH_SIZE=20 PDF_SPLIT_PAGE_SIZE=6 STRATEGY=hi_res ./process-pdf-parallel-through-api.sh example-docs/pdf/layout-parser-paper.pdf"
   exit 1
 fi
 
 ALLOWED_STRATEGIES=("hi_res" "fast" "auto")
+API_ENDPOINT=${UNST_API_ENDPOINT:-"https://api.unstructuredapp.io/general/v0/general"}
+STRATEGY=${STRATEGY:-hi_res}
+BATCH_SIZE=${BATCH_SIZE:-30}
+DEFAULT_SPLIT_SIZE=10
+SPLIT_SIZE=${PDF_SPLIT_PAGE_SIZE:-$DEFAULT_SPLIT_SIZE}
+DEFAULT_DIR="$HOME/tmp/pdf-splits"
+PDF_SPLITS_DIR="${PDF_SPLITS_DIR:-$DEFAULT_DIR}"
 
 # Validate STRATEGY environment variable if it's set
-if [ -n "${STRATEGY:-}" ] && [[ ! " ${ALLOWED_STRATEGIES[*]} " =~ ${STRATEGY} ]]; then
-  echo "Error: STRATEGY must be one of ${ALLOWED_STRATEGIES[*]}" >&2
-  exit 1
-fi
+case " ${ALLOWED_STRATEGIES[*]} " in
+  *" ${STRATEGY} "*) ;;
+  *)
+    echo "Error: STRATEGY must be one of ${ALLOWED_STRATEGIES[*]}" >&2
+    exit 1
+    ;;
+esac
 
 # Check if UNST_API_KEY is set
-if [ -z "${UNST_API_KEY}" ]; then
+if [ -z "${UNST_API_KEY:-}" ]; then
   echo "Error: UNST_API_KEY is not set or is empty" >&2
   exit 1
 fi
 
 PDF_FILE="$1"
-DEFAULT_SPLIT_SIZE=10
-SPLIT_SIZE=${PDF_SPLIT_PAGE_SIZE:-$DEFAULT_SPLIT_SIZE}
 PDF_NAME=$(basename "$PDF_FILE" .pdf)
-DEFAULT_DIR="$HOME/tmp/pdf-splits"
-PDF_SPLITS_DIR="${PDF_SPLITS_DIR:-$DEFAULT_DIR}"
 MD5_SUM=$(md5sum "$PDF_FILE" | awk '{ print $1 }')
 PDF_DIR="$PDF_SPLITS_DIR/$PDF_NAME-${MD5_SUM}_split-${SPLIT_SIZE}"
 PDF_OUTPUT_DIR="$PDF_SPLITS_DIR/${PDF_NAME}-output-${MD5_SUM}_split-${SPLIT_SIZE}_strat-${STRATEGY}"
@@ -67,11 +77,11 @@ process_file_part() {
     return
   fi
 
-  curl -q -X POST https://api.unstructuredapp.io/general/v0/general \
+  curl -q -X POST "$API_ENDPOINT" \
     -H "unstructured-api-key: $UNST_API_KEY" \
     -H 'accept: application/json' \
     -H 'Content-Type: multipart/form-data' \
-    -F strategy="${STRATEGY:-hi_res}" \
+    -F strategy="${STRATEGY}" \
     -F 'skip_infer_table_types="[]"' \
     -F starting_page_number="$STARTING_PAGE_NUMBER" \
     -F files=@"$file;filename=$PDF_FILE" \
@@ -101,11 +111,15 @@ process_batch() {
   wait
 }
 
-# Read PDF parts into an array
-mapfile -t pdf_parts < <(find "$PDF_DIR" -name '*.pdf' -print)
+# Read PDF parts into an array. Avoid mapfile so the script works with the
+# default Bash 3.2 shipped on macOS.
+pdf_parts=()
+while IFS= read -r -d '' pdf_part; do
+  pdf_parts+=("$pdf_part")
+done < <(find "$PDF_DIR" -name '*.pdf' -print0)
 
 # Process PDF parts in batches of 30, by default
-batch_size=${BATCH_SIZE:-30}
+batch_size=${BATCH_SIZE}
 for ((i = 0; i < ${#pdf_parts[@]}; i += batch_size)); do
   process_batch "${pdf_parts[@]:i:batch_size}"
 done

--- a/scripts/user/process-pdf-parallel-through-api.sh
+++ b/scripts/user/process-pdf-parallel-through-api.sh
@@ -42,6 +42,16 @@ case " ${ALLOWED_STRATEGIES[*]} " in
     ;;
 esac
 
+if ! [[ "$BATCH_SIZE" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: BATCH_SIZE must be a positive integer." >&2
+  exit 1
+fi
+
+if ! [[ "$SPLIT_SIZE" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: PDF_SPLIT_PAGE_SIZE must be a positive integer." >&2
+  exit 1
+fi
+
 # Check if UNST_API_KEY is set
 if [ -z "${UNST_API_KEY:-}" ]; then
   echo "Error: UNST_API_KEY is not set or is empty" >&2
@@ -64,6 +74,10 @@ checksum_file() {
 }
 
 MD5_SUM=$(checksum_file "$PDF_FILE")
+if [ -z "$MD5_SUM" ]; then
+  echo "Error: could not compute checksum for $PDF_FILE." >&2
+  exit 1
+fi
 PDF_DIR="$PDF_SPLITS_DIR/$PDF_NAME-${MD5_SUM}_split-${SPLIT_SIZE}"
 PDF_OUTPUT_DIR="$PDF_SPLITS_DIR/${PDF_NAME}-output-${MD5_SUM}_split-${SPLIT_SIZE}_strat-${STRATEGY}"
 

--- a/scripts/user/split-pdf.sh
+++ b/scripts/user/split-pdf.sh
@@ -17,7 +17,20 @@ fi
 DEFAULT_DIR="$HOME/tmp/pdf-splits"
 PDF_SPLITS_DIR="${PDF_SPLITS_DIR:-$DEFAULT_DIR}"
 PDF_NAME=$(basename "$PDF_FILE" .pdf)
-MD5_SUM=$(md5sum "$PDF_FILE" | awk '{ print $1 }')
+
+checksum_file() {
+  local file="$1"
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$file" | awk '{ print $1 }'
+  elif command -v md5 >/dev/null 2>&1; then
+    md5 -q "$file"
+  else
+    echo "Error: neither md5sum nor md5 is available." >&2
+    exit 1
+  fi
+}
+
+MD5_SUM=$(checksum_file "$PDF_FILE")
 PDF_DIR="$PDF_SPLITS_DIR/$PDF_NAME-${MD5_SUM}_split-${SPLIT_SIZE}"
 
 # Create directory if it does not exist

--- a/scripts/user/split-pdf.sh
+++ b/scripts/user/split-pdf.sh
@@ -8,9 +8,9 @@ PDF_FILE="$1"
 DEFAULT_SPLIT_SIZE=5
 SPLIT_SIZE=${PDF_SPLIT_PAGE_SIZE:-$DEFAULT_SPLIT_SIZE}
 
-# Validate that SPLIT_SIZE is an integer
-if ! [[ "$SPLIT_SIZE" =~ ^[0-9]+$ ]]; then
-  echo "Error: PDF_SPLIT_PAGE_SIZE must be an integer."
+# Validate that SPLIT_SIZE is a positive integer.
+if ! [[ "$SPLIT_SIZE" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: PDF_SPLIT_PAGE_SIZE must be a positive integer."
   exit 1
 fi
 
@@ -31,6 +31,10 @@ checksum_file() {
 }
 
 MD5_SUM=$(checksum_file "$PDF_FILE")
+if [ -z "$MD5_SUM" ]; then
+  echo "Error: could not compute checksum for $PDF_FILE." >&2
+  exit 1
+fi
 PDF_DIR="$PDF_SPLITS_DIR/$PDF_NAME-${MD5_SUM}_split-${SPLIT_SIZE}"
 
 # Create directory if it does not exist


### PR DESCRIPTION
## Summary

Fixes `scripts/user/process-pdf-parallel-through-api.sh` so it can be run with documented environment overrides and on the default Bash shipped with macOS.

Changes:
- Documents `UNST_API_KEY` as required.
- Adds `UNST_API_ENDPOINT` support instead of hard-coding the public endpoint.
- Gives `STRATEGY`, `BATCH_SIZE`, `PDF_SPLIT_PAGE_SIZE`, and `PDF_SPLITS_DIR` defaults before use.
- Avoids unbound-variable failures when `UNST_API_KEY` is missing.
- Replaces `mapfile` usage with a Bash 3.2-compatible loop.
- Supports both `md5sum` and BSD/macOS `md5 -q` in the parallel script and split helper.

## Validation

I tested the script against the hosted API with a valid `UNST_API_KEY` using a one-page split of `example-docs/pdf/layout-parser-paper-fast.pdf`:

```bash
PDF_SPLITS_DIR="$tmp" \
BATCH_SIZE=1 \
STRATEGY=fast \
scripts/user/process-pdf-parallel-through-api.sh "$pdf"
```

The script produced a valid split JSON file, combined it successfully, and the combined output contained 25 JSON elements:

```bash
jq length "$tmp/${base}-output-${md5}_split-10_strat-fast/${base}_combined.json"
# 25
```

I also checked the updated shell scripts with bash -n.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

