### PR TITLE
fix: map long-s-t ligature (U+FB05) to 'st' not 'ft'

### DIFF
--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -75,7 +75,7 @@ def test_clean_ordered_bullets(text, expected):
         ("She had a ﬂower in her hair.", "She had a flower in her hair."),
         ("The coﬃn was placed in the grave.", "The coffin was placed in the grave."),
         ("The buﬄe zone was clearly marked.", "The buffle zone was clearly marked."),
-        ("The craﬅsman worked with dedication.", "The craftsman worked with dedication."),
+        ("The laﬅ chapter was the best.", "The last chapter was the best."),
         ("The symbol ʪ is very rare.", "The symbol ls is very rare."),
         ("The word 'cœur' means 'heart' in French.", "The word 'coeur' means 'heart' in French."),
         ("The word 'Œuvre' refers to the works", "The word 'OEuvre' refers to the works"),

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -89,7 +89,7 @@ def clean_ligatures(text) -> str:
         "ﬂ": "fl",
         "ﬃ": "ffi",
         "ﬄ": "ffl",
-        "ﬅ": "ft",
+        "ﬅ": "st",  # U+FB05 LATIN SMALL LIGATURE LONG S T -> "st" (per Unicode NFKC)
         "ʪ": "ls",
         "œ": "oe",
         "Œ": "OE",


### PR DESCRIPTION
## Summary

`clean_ligatures` maps **U+FB05** `ﬅ` (`LATIN SMALL LIGATURE LONG S T`) to `"ft"`. That's incorrect — the glyph is the *long-s + t* ligature (ſt), so it represents **"st"**, not "ft". As a result, real text that uses this ligature is silently corrupted:

| word (with U+FB05) | current output | correct |
|---|---|---|
| la`ﬅ` | la**ft** | la**st** |
| fir`ﬅ` | fir**ft** | fir**st** |
| be`ﬅ` | be**ft** | be**st** |

This flows straight into partitioned/cleaned text and downstream chunks, so RAG pipelines ingest `laft` / `firft` / `beft` instead of `last` / `first` / `best`.

## Why "st" is correct

- Unicode NFKC settles it: `unicodedata.normalize("NFKC", "ﬅ") == "st"` (name: `LATIN SMALL LIGATURE LONG S T`).
- The table is already internally inconsistent: the adjacent **U+FB06** `ﬆ` (`LATIN SMALL LIGATURE ST`) — which also NFKC-normalizes to `"st"` — is correctly mapped to `"st"` two lines below. U+FB05 and U+FB06 are both "st" ligatures and should map identically.
- There is no "ft" ligature in the Alphabetic Presentation Forms block (U+FB00–FB06 = ff, fi, fl, ffi, ffl, ſt, st); the original `"ft"` appears to have mistaken the long-s (ſ) for an f.

## Change

- `unstructured/cleaners/core.py` — `clean_ligatures`: `"ﬅ": "ft"` → `"ﬅ": "st"`.
- `test_unstructured/cleaners/test_core.py` — the existing case encoded the old behavior by using the st-ligature to spell "cra**ft**sman" (`"The craﬅsman…" → "The craftsman…"`), which the glyph can't represent. Replaced with a correct example: `"The laﬅ chapter was the best." → "The last chapter was the best."`

## Testing

`pytest test_unstructured/cleaners/test_core.py::test_clean_ligatures` → **14 passed**. Pure-Python, no network/models.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

