### PR TITLE
refactor: centralize URL fetching with host validation and default timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.24.0
+
+### Enhancements
+
+- **Centralize outbound URL fetching**: `partition`, `partition_html`, and `partition_md` now route `url=` fetches through a single shared helper (`unstructured/safe_http.py`) instead of ad-hoc `requests.get` calls. The helper applies an `http`/`https` scheme allowlist, a hostname denylist with IDNA normalization, address validation performed at connect time, manual redirect handling with per-hop re-validation, refusal of proxied requests, and a default `(connect, read)` timeout. **Behavior change:** fetches that resolve to non-routable, loopback, or link-local addresses are now rejected by default. Set `UNSTRUCTURED_ALLOW_PRIVATE_URL=1` (or pass `allow_private=True`) to opt out for controlled local usage.
+
 ## 0.23.3
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-- **Centralize outbound URL fetching**: `partition`, `partition_html`, and `partition_md` now route `url=` fetches through a single shared helper (`unstructured/safe_http.py`) instead of ad-hoc `requests.get` calls. The helper applies an `http`/`https` scheme allowlist, a hostname denylist with IDNA normalization, address validation performed at connect time, manual redirect handling with per-hop re-validation, refusal of proxied requests, and a default `(connect, read)` timeout. **Behavior change:** fetches that resolve to non-routable, loopback, or link-local addresses are now rejected by default. Set `UNSTRUCTURED_ALLOW_PRIVATE_URL=1` (or pass `allow_private=True`) to opt out for controlled local usage.
+- **Centralize outbound URL fetching**: `partition`, `partition_html`, and `partition_md` now route `url=` fetches through a single shared helper (`unstructured/safe_http.py`) instead of ad-hoc `requests.get` calls. The helper applies an `http`/`https` scheme allowlist, a hostname denylist with IDNA normalization, address validation performed at connect time, manual redirect handling with per-hop re-validation (dropping credential material on cross-origin hops), refusal of proxied requests, and a default `(connect, read)` timeout. **Behavior change:** fetches that resolve to non-routable, loopback, or link-local addresses are now rejected by default. Set `UNSTRUCTURED_ALLOW_PRIVATE_URL=1` (or pass `allow_private=True`) to opt out for controlled local usage.
 
 ## 0.23.3
 

--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -108,8 +108,8 @@ def test_partition_html_accepts_an_html_str():
     assert len(elements) > 0
 
 
-def test_partition_html_accepts_a_url_to_an_HTML_document(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_html_accepts_a_url_to_an_HTML_document(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text=example_doc_text("example-10k-1p.html"),
         status_code=200,
         headers={"Content-Type": "text/html"},
@@ -117,7 +117,7 @@ def test_partition_html_accepts_a_url_to_an_HTML_document(requests_get_: Mock):
 
     elements = partition_html(url="https://fake.url")
 
-    requests_get_.assert_called_once_with("https://fake.url", headers={}, verify=True)
+    safe_get_.assert_called_once_with("https://fake.url", headers={}, verify=True)
     assert len(elements) > 0
 
 
@@ -212,8 +212,8 @@ def test_emoji_appears_with_emoji_utf8_code():
 # -- partition_html() from URL -------------------------------------------------------------------
 
 
-def test_partition_html_from_url_raises_on_failure_response_status_code(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_html_from_url_raises_on_failure_response_status_code(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text=example_doc_text("example-10k-1p.html"),
         status_code=500,
         headers={"Content-Type": "text/html"},
@@ -223,8 +223,8 @@ def test_partition_html_from_url_raises_on_failure_response_status_code(requests
         partition_html(url="https://fake.url")
 
 
-def test_partition_html_from_url_raises_on_response_of_wrong_content_type(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_html_from_url_raises_on_response_of_wrong_content_type(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text=example_doc_text("example-10k-1p.html"),
         status_code=200,
         headers={"Content-Type": "application/json"},
@@ -234,8 +234,8 @@ def test_partition_html_from_url_raises_on_response_of_wrong_content_type(reques
         partition_html(url="https://fake.url")
 
 
-def test_partition_from_url_includes_provided_headers_in_request(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_from_url_includes_provided_headers_in_request(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text="<html><head></head><body><p>What do I know? Who needs to know it?</p></body></html>",
         status_code=200,
         headers={"Content-Type": "text/html"},
@@ -243,7 +243,7 @@ def test_partition_from_url_includes_provided_headers_in_request(requests_get_: 
 
     partition_html(url="https://example.com", headers={"User-Agent": "test"})
 
-    requests_get_.assert_called_once_with(
+    safe_get_.assert_called_once_with(
         "https://example.com", headers={"User-Agent": "test"}, verify=True
     )
 
@@ -1211,8 +1211,8 @@ def test_partition_html_applies_text_as_html_metadata_for_tables(
 # -- .metadata.url -------------------------------------------------------------------------------
 
 
-def test_partition_html_from_url_adds_url_to_metadata(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_html_from_url_adds_url_to_metadata(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text=example_doc_text("example-10k-1p.html"),
         status_code=200,
         headers={"Content-Type": "text/html"},
@@ -1220,7 +1220,7 @@ def test_partition_html_from_url_adds_url_to_metadata(requests_get_: Mock):
 
     elements = partition_html(url="https://trusttheforceluke.com")
 
-    requests_get_.assert_called_once_with("https://trusttheforceluke.com", headers={}, verify=True)
+    safe_get_.assert_called_once_with("https://trusttheforceluke.com", headers={}, verify=True)
     assert len(elements) > 0
     assert all(e.metadata.url == "https://trusttheforceluke.com" for e in elements)
 
@@ -1273,8 +1273,8 @@ def opts_args() -> dict[str, Any]:
 
 
 @pytest.fixture
-def requests_get_(request: pytest.FixtureRequest):
-    return function_mock(request, "unstructured.partition.html.partition.requests.get")
+def safe_get_(request: pytest.FixtureRequest):
+    return function_mock(request, "unstructured.partition.html.partition.safe_get")
 
 
 # ================================================================================================
@@ -1334,9 +1334,9 @@ class DescribeHtmlPartitionerOptions:
         assert opts.html_text == "<html><body><p>Hello World!</p></body></html>"
 
     def and_it_gets_the_HTML_from_the_url_when_one_is_provided(
-        self, requests_get_: Mock, opts_args: dict[str, Any]
+        self, safe_get_: Mock, opts_args: dict[str, Any]
     ):
-        requests_get_.return_value = FakeResponse(
+        safe_get_.return_value = FakeResponse(
             text="<html><body><p>I just flew over the internet!</p></body></html>",
             status_code=200,
             headers={"Content-Type": "text/html"},

--- a/test_unstructured/partition/test_md.py
+++ b/test_unstructured/partition/test_md.py
@@ -4,7 +4,6 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-import requests
 from markdown.extensions.fenced_code import FencedCodeExtension
 from pytest_mock import MockFixture
 
@@ -61,7 +60,7 @@ def test_partition_md_from_url():
         status_code=200,
         headers={"Content-Type": "text/markdown"},
     )
-    with patch.object(requests, "get", return_value=response) as _:
+    with patch("unstructured.partition.md.safe_get", return_value=response) as _:
         elements = partition_md(url="https://fake.url")
 
     assert len(elements) > 0
@@ -78,7 +77,10 @@ def test_partition_md_from_url_raises_with_bad_status_code():
         status_code=500,
         headers={"Content-Type": "text/html"},
     )
-    with patch.object(requests, "get", return_value=response) as _, pytest.raises(ValueError):
+    with (
+        patch("unstructured.partition.md.safe_get", return_value=response) as _,
+        pytest.raises(ValueError),
+    ):
         partition_md(url="https://fake.url")
 
 
@@ -92,7 +94,10 @@ def test_partition_md_from_url_raises_with_bad_content_type():
         status_code=200,
         headers={"Content-Type": "application/json"},
     )
-    with patch.object(requests, "get", return_value=response) as _, pytest.raises(ValueError):
+    with (
+        patch("unstructured.partition.md.safe_get", return_value=response) as _,
+        pytest.raises(ValueError),
+    ):
         partition_md(url="https://fake.url")
 
 

--- a/test_unstructured/test_safe_http.py
+++ b/test_unstructured/test_safe_http.py
@@ -9,10 +9,12 @@ import requests
 
 from unstructured.safe_http import (
     UnsafeURLError,
+    _is_cross_origin,
     _is_ip_blocked,
     _normalize_hostname,
     _safe_create_connection,
     _SafeHTTPAdapter,
+    _strip_sensitive_headers,
     _validate_url,
     safe_get,
 )
@@ -134,6 +136,16 @@ class Describe_validate_url:
     def test_rejects_missing_hostname(self):
         with pytest.raises(UnsafeURLError, match="hostname"):
             _validate_url("http://")
+
+    @pytest.mark.parametrize(
+        "url",
+        ["http://example.com:65536/", "http://example.com:99999/"],
+        ids=["over_max", "way_over"],
+    )
+    def test_rejects_out_of_range_port(self, url: str):
+        # Out-of-range ports must fail closed as UnsafeURLError, not leak later.
+        with pytest.raises(UnsafeURLError):
+            _validate_url(url)
 
     @pytest.mark.parametrize(
         "hostname",
@@ -409,3 +421,74 @@ class Describe_SafeHTTPAdapter:
         adapter = _SafeHTTPAdapter()
         with pytest.raises(UnsafeURLError, match="Proxied requests"):
             adapter.proxy_manager_for("http://proxy:8080")
+
+
+# ---------------------------------------------------------------------------
+# _is_cross_origin / _strip_sensitive_headers (redirect credential handling)
+# ---------------------------------------------------------------------------
+
+
+class Describe_is_cross_origin:
+    def test_same_origin_not_cross(self):
+        assert _is_cross_origin("https://example.com/a", "https://example.com/b") is False
+
+    def test_different_host_is_cross(self):
+        assert _is_cross_origin("https://a.com/", "https://b.com/") is True
+
+    def test_http_to_https_upgrade_is_not_cross(self):
+        assert _is_cross_origin("http://example.com/", "https://example.com/") is False
+
+    def test_downgrade_on_same_nondefault_port_is_cross(self):
+        assert _is_cross_origin("https://host:9000/a", "http://host:9000/b") is True
+
+    def test_explicit_default_port_same_origin_not_cross(self):
+        assert _is_cross_origin("https://example.com:443/a", "https://example.com/b") is False
+
+    def test_unparseable_port_fails_safe(self):
+        assert _is_cross_origin("http://a.com:abc/", "http://a.com/") is True
+
+
+class Describe_strip_sensitive_headers:
+    def test_removes_credential_headers(self):
+        kwargs = {
+            "headers": {
+                "Authorization": "Bearer x",
+                "Cookie": "s=y",
+                "Proxy-Authorization": "Basic z",
+                "User-Agent": "tests",
+            }
+        }
+        _strip_sensitive_headers(kwargs)
+        assert kwargs["headers"] == {"User-Agent": "tests"}
+
+    def test_removes_auth_and_cookies_kwargs(self):
+        kwargs = {"auth": ("u", "p"), "cookies": {"s": "y"}, "timeout": 5}
+        _strip_sensitive_headers(kwargs)
+        assert "auth" not in kwargs
+        assert "cookies" not in kwargs
+        assert kwargs["timeout"] == 5
+
+    def test_no_headers_is_noop(self):
+        kwargs: dict = {}
+        _strip_sensitive_headers(kwargs)
+        assert kwargs == {}
+
+
+class Describe_safe_get_redirect_auth_strip:
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_strips_credentials_on_cross_origin_redirect(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "https://evil.com/x"}
+        redirect_response.url = "https://trusted.com/doc"
+        final_response = MagicMock(spec=requests.Response)
+        final_response.is_redirect = False
+        session_instance = MockSession.return_value
+        session_instance.get.side_effect = [redirect_response, final_response]
+
+        safe_get("https://trusted.com/doc", headers={"Authorization": "Bearer secret"})
+
+        second_call_headers = session_instance.get.call_args_list[1][1].get("headers", {})
+        assert "Authorization" not in second_call_headers

--- a/test_unstructured/test_safe_http.py
+++ b/test_unstructured/test_safe_http.py
@@ -1,0 +1,411 @@
+"""Tests for centralized URL fetching with host validation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from unstructured.safe_http import (
+    UnsafeURLError,
+    _is_ip_blocked,
+    _normalize_hostname,
+    _safe_create_connection,
+    _SafeHTTPAdapter,
+    _validate_url,
+    safe_get,
+)
+
+# ---------------------------------------------------------------------------
+# _is_ip_blocked
+# ---------------------------------------------------------------------------
+
+
+class Describe_is_ip_blocked:
+    """Verify that blocked and allowed IP ranges are classified correctly."""
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.0.1",
+            "169.254.169.254",
+            "0.0.0.0",
+            "255.255.255.255",
+            "168.63.129.16",
+            "224.0.0.1",
+            "240.0.0.1",
+            "100.64.0.1",
+        ],
+        ids=[
+            "loopback",
+            "class_a_private",
+            "class_b_private",
+            "class_c_private",
+            "link_local",
+            "this_network",
+            "broadcast",
+            "azure_wireserver",
+            "multicast",
+            "reserved_class_e",
+            "cgnat",
+        ],
+    )
+    def test_blocks_non_routable_ipv4(self, ip: str):
+        assert _is_ip_blocked(ip) is True
+
+    @pytest.mark.parametrize(
+        "ip",
+        ["::1", "fe80::1", "fc00::1", "fd00::1", "::"],
+        ids=["loopback", "link_local", "unique_local_fc", "unique_local_fd", "unspecified"],
+    )
+    def test_blocks_non_routable_ipv6(self, ip: str):
+        assert _is_ip_blocked(ip) is True
+
+    def test_blocks_ipv4_mapped_ipv6(self):
+        assert _is_ip_blocked("::ffff:127.0.0.1") is True
+        assert _is_ip_blocked("::ffff:169.254.169.254") is True
+
+    def test_blocks_sixtofour_embedded(self):
+        # 2002:a9fe:a9fe:: wraps 169.254.169.254
+        assert _is_ip_blocked("2002:a9fe:a9fe::") is True
+
+    def test_blocks_nat64_and_ipv4_compat_embedded(self):
+        assert _is_ip_blocked("64:ff9b::169.254.169.254") is True
+        assert _is_ip_blocked("64:ff9b:1::169.254.169.254") is True
+        assert _is_ip_blocked("::169.254.169.254") is True
+
+    @pytest.mark.parametrize(
+        "ip",
+        ["8.8.8.8", "93.184.216.34", "1.1.1.1", "2607:f8b0:4004:800::200e"],
+        ids=["google_dns", "example_com", "cloudflare", "google_ipv6"],
+    )
+    def test_allows_public_addresses(self, ip: str):
+        assert _is_ip_blocked(ip) is False
+
+    def test_fails_closed_on_unparseable_input(self):
+        assert _is_ip_blocked("not-an-ip") is True
+        assert _is_ip_blocked("") is True
+
+
+# ---------------------------------------------------------------------------
+# _normalize_hostname
+# ---------------------------------------------------------------------------
+
+
+class Describe_normalize_hostname:
+    def test_returns_lowercase_for_ascii_input(self):
+        assert _normalize_hostname("Example.COM") == "example.com"
+
+    def test_strips_trailing_dot(self):
+        assert _normalize_hostname("example.com.") == "example.com"
+
+    def test_empty_string(self):
+        assert _normalize_hostname("") == ""
+
+    def test_idn_collapses_to_punycode(self):
+        # A valid IDN encodes to its xn-- form.
+        assert _normalize_hostname("Bücher.example").startswith("xn--")
+
+
+# ---------------------------------------------------------------------------
+# _validate_url
+# ---------------------------------------------------------------------------
+
+
+class Describe_validate_url:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/file",
+            "file:///etc/passwd",
+            "gopher://evil.com/",
+            "data:text/html,<h1>hi</h1>",
+            "javascript:alert(1)",
+        ],
+    )
+    def test_rejects_non_http_scheme(self, url: str):
+        with pytest.raises(UnsafeURLError, match="scheme"):
+            _validate_url(url)
+
+    def test_rejects_missing_hostname(self):
+        with pytest.raises(UnsafeURLError, match="hostname"):
+            _validate_url("http://")
+
+    @pytest.mark.parametrize(
+        "hostname",
+        [
+            "localhost",
+            "metadata.google.internal",
+            "metadata.gke.internal",
+            "metadata.azure.com",
+            "kubernetes.default",
+            "kubernetes.default.svc",
+            "kubernetes.default.svc.cluster.local",
+        ],
+    )
+    def test_rejects_blocked_hostname(self, hostname: str):
+        with pytest.raises(UnsafeURLError, match="blocked hostname"):
+            _validate_url(f"http://{hostname}/")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/path",
+            "http://169.254.169.254/latest/",
+            "http://10.0.0.1/internal",
+            "http://[::1]/path",
+            "http://[::ffff:169.254.169.254]/",
+        ],
+        ids=["loopback", "link_local", "rfc1918", "ipv6_loopback", "ipv4_mapped"],
+    )
+    def test_rejects_blocked_ip_literals(self, url: str):
+        with pytest.raises(UnsafeURLError, match="blocked"):
+            _validate_url(url)
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    def test_rejects_hostname_resolving_to_non_routable(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.1", 0))]
+        with pytest.raises(UnsafeURLError, match="blocked address"):
+            _validate_url("http://evil.example.com/")
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    def test_allows_public_hostname(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        _validate_url("https://example.com/doc.pdf")  # should not raise
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    def test_rejects_when_any_resolved_ip_is_blocked(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+            (2, 1, 6, "", ("10.0.0.1", 0)),
+        ]
+        with pytest.raises(UnsafeURLError, match="blocked address"):
+            _validate_url("http://split.example.com/")
+
+    def test_skips_validation_with_allow_private(self):
+        _validate_url("http://127.0.0.1/", allow_private=True)  # should not raise
+
+    def test_skips_validation_with_env_var(self, monkeypatch):
+        monkeypatch.setenv("UNSTRUCTURED_ALLOW_PRIVATE_URL", "1")
+        _validate_url("http://127.0.0.1/")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# _safe_create_connection
+# ---------------------------------------------------------------------------
+
+
+class Describe_safe_create_connection:
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    def test_rejects_blocked_resolved_address_at_connect(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.1", 0))]
+        with pytest.raises(UnsafeURLError, match="blocked address"):
+            _safe_create_connection("evil.example.com", 80, None, None, None)
+
+    @patch("unstructured.safe_http.socket.socket")
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    def test_connects_to_validated_public_address(self, mock_getaddrinfo, MockSocket):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 80))]
+        sock = MockSocket.return_value
+        result = _safe_create_connection("example.com", 80, None, None, None)
+        assert result is sock
+        sock.connect.assert_called_once_with(("93.184.216.34", 80))
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    def test_strips_ipv6_brackets(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(10, 1, 6, "", ("::1", 80, 0, 0))]
+        with pytest.raises(UnsafeURLError):
+            _safe_create_connection("[::1]", 80, None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# safe_get
+# ---------------------------------------------------------------------------
+
+
+class Describe_safe_get:
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_returns_response_for_public_url(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.is_redirect = False
+        session_instance = MockSession.return_value
+        session_instance.get.return_value = mock_response
+
+        result = safe_get("https://example.com/doc.pdf")
+
+        assert result is mock_response
+        session_instance.get.assert_called_once()
+        session_instance.close.assert_called_once()
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_applies_default_timeout(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.is_redirect = False
+        MockSession.return_value.get.return_value = mock_response
+
+        safe_get("https://example.com/doc.pdf")
+
+        assert MockSession.return_value.get.call_args[1]["timeout"] == (10, 300)
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_respects_explicit_timeout(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.is_redirect = False
+        MockSession.return_value.get.return_value = mock_response
+
+        safe_get("https://example.com/doc.pdf", timeout=5)
+
+        assert MockSession.return_value.get.call_args[1]["timeout"] == 5
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_forces_allow_redirects_false(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.is_redirect = False
+        MockSession.return_value.get.return_value = mock_response
+
+        safe_get("https://example.com/doc.pdf", allow_redirects=True)
+
+        assert MockSession.return_value.get.call_args[1]["allow_redirects"] is False
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_validates_redirect_targets(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.side_effect = [
+            [(2, 1, 6, "", ("93.184.216.34", 0))],  # initial URL
+            [(2, 1, 6, "", ("10.0.0.1", 0))],  # redirect target
+        ]
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "http://internal.corp/secret"}
+        redirect_response.url = "https://example.com/doc.pdf"
+        MockSession.return_value.get.return_value = redirect_response
+
+        with pytest.raises(UnsafeURLError, match="blocked address"):
+            safe_get("https://example.com/doc.pdf")
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_follows_valid_redirect_chain(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "https://cdn.example.com/doc.pdf"}
+        redirect_response.url = "https://example.com/doc.pdf"
+        final_response = MagicMock(spec=requests.Response)
+        final_response.is_redirect = False
+        MockSession.return_value.get.side_effect = [redirect_response, final_response]
+
+        result = safe_get("https://example.com/doc.pdf")
+
+        assert result is final_response
+        assert MockSession.return_value.get.call_count == 2
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_enforces_max_redirects(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "https://example.com/again"}
+        redirect_response.url = "https://example.com/doc.pdf"
+        MockSession.return_value.get.return_value = redirect_response
+
+        with pytest.raises(UnsafeURLError, match="Too many redirects"):
+            safe_get("https://example.com/doc.pdf")
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_returns_response_on_missing_location_header(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.is_redirect = True
+        redirect_response.headers = {}
+        redirect_response.url = "https://example.com/doc.pdf"
+        MockSession.return_value.get.return_value = redirect_response
+
+        result = safe_get("https://example.com/doc.pdf")
+        assert result is redirect_response
+
+    def test_rejects_non_routable_url_without_fetch(self):
+        with pytest.raises(UnsafeURLError):
+            safe_get("http://169.254.169.254/latest/meta-data/")
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_session_closed_on_validation_error(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.side_effect = [
+            [(2, 1, 6, "", ("93.184.216.34", 0))],
+            [(2, 1, 6, "", ("10.0.0.1", 0))],
+        ]
+        redirect_response = MagicMock(spec=requests.Response)
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "http://internal.corp/"}
+        redirect_response.url = "https://example.com/doc.pdf"
+        MockSession.return_value.get.return_value = redirect_response
+
+        with pytest.raises(UnsafeURLError):
+            safe_get("https://example.com/doc.pdf")
+        MockSession.return_value.close.assert_called_once()
+
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    def test_rejects_proxies_kwarg(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        with pytest.raises(UnsafeURLError, match="proxies"):
+            safe_get("https://example.com/doc.pdf", proxies={"https": "http://proxy:8080"})
+
+
+# ---------------------------------------------------------------------------
+# safe_get adapter mounting / opt-out
+# ---------------------------------------------------------------------------
+
+
+class Describe_safe_get_mounts_adapter:
+    @patch("unstructured.safe_http.socket.getaddrinfo")
+    @patch("unstructured.safe_http.requests.Session")
+    def test_mounts_safe_adapter_and_disables_trust_env(self, MockSession, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.is_redirect = False
+        session_instance = MockSession.return_value
+        session_instance.get.return_value = mock_response
+
+        safe_get("https://example.com/doc.pdf")
+
+        assert session_instance.trust_env is False
+        mounted = [c.args[1] for c in session_instance.mount.call_args_list]
+        assert all(isinstance(a, _SafeHTTPAdapter) for a in mounted)
+
+    @patch("unstructured.safe_http.requests.Session")
+    def test_allow_private_skips_adapter_and_permits_proxies(self, MockSession):
+        mock_response = MagicMock(spec=requests.Response)
+        mock_response.is_redirect = False
+        session_instance = MockSession.return_value
+        session_instance.get.return_value = mock_response
+
+        # No getaddrinfo patch: allow_private must skip resolution entirely.
+        result = safe_get(
+            "http://127.0.0.1/internal",
+            allow_private=True,
+            proxies={"http": "http://proxy:8080"},
+        )
+        assert result is mock_response
+        session_instance.mount.assert_not_called()
+
+
+class Describe_SafeHTTPAdapter:
+    def test_proxy_manager_is_refused(self):
+        adapter = _SafeHTTPAdapter()
+        with pytest.raises(UnsafeURLError, match="Proxied requests"):
+            adapter.proxy_manager_for("http://proxy:8080")

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.23.3"  # pragma: no cover
+__version__ = "0.24.0"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -7,7 +7,6 @@ import importlib
 import io
 from typing import IO, Any, Callable, Optional
 
-import requests
 from typing_extensions import TypeAlias
 
 from unstructured.documents.elements import DataSourceMetadata, Element
@@ -22,6 +21,7 @@ from unstructured.partition.common import UnsupportedFileFormatError
 from unstructured.partition.common.common import exactly_one
 from unstructured.partition.common.lang import check_language_args
 from unstructured.partition.utils.constants import PartitionStrategy
+from unstructured.safe_http import safe_get
 from unstructured.utils import dependency_exists
 
 Partitioner: TypeAlias = Callable[..., list[Element]]
@@ -307,7 +307,7 @@ def file_and_type_from_url(
     ssl_verify: bool = True,
     request_timeout: Optional[int] = None,
 ) -> tuple[io.BytesIO, FileType]:
-    response = requests.get(url, headers=headers, verify=ssl_verify, timeout=request_timeout)
+    response = safe_get(url, headers=headers, verify=ssl_verify, timeout=request_timeout)
     file = io.BytesIO(response.content)
 
     if content_type := content_type or response.headers.get("Content-Type", None):

--- a/unstructured/partition/html/partition.py
+++ b/unstructured/partition/html/partition.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from functools import cached_property
 from typing import IO, Any, Callable, Iterator, List, Literal, Optional, cast
 
-import requests
 from lxml import etree
 
 from unstructured.chunking import add_chunking_strategy
@@ -20,6 +19,7 @@ from unstructured.partition.html.transformations import (
     ontology_to_unstructured_elements,
     parse_html_to_ontology,
 )
+from unstructured.safe_http import safe_get
 from unstructured.utils import is_temp_file_path
 
 
@@ -158,7 +158,7 @@ class HtmlPartitionerOptions:
             return str(self._text)
 
         if self._url:
-            response = requests.get(self._url, headers=self._headers, verify=self._ssl_verify)
+            response = safe_get(self._url, headers=self._headers, verify=self._ssl_verify)
             if not response.ok:
                 raise ValueError(
                     f"Error status code on GET of provided URL: {response.status_code}"

--- a/unstructured/partition/md.py
+++ b/unstructured/partition/md.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import IO, Any, Optional
 
 import markdown
-import requests
 from markdown.extensions import Extension
 
 from unstructured.documents.elements import Element
@@ -12,6 +11,7 @@ from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import exactly_one
 from unstructured.partition.common.metadata import get_last_modified_date
 from unstructured.partition.html import partition_html
+from unstructured.safe_http import safe_get
 
 
 def optional_decode(contents: str | bytes) -> str:
@@ -94,7 +94,7 @@ def partition_md(
         _, text = read_txt_file(file=file)
 
     elif url is not None:
-        response = requests.get(url)
+        response = safe_get(url)
         if not response.ok:
             raise ValueError(f"URL return an error: {response.status_code}")
 

--- a/unstructured/safe_http.py
+++ b/unstructured/safe_http.py
@@ -1,0 +1,374 @@
+"""Centralized URL fetching with host validation and default timeouts.
+
+All HTTP fetches of user-supplied URLs should go through :func:`safe_get` so
+that scheme, hostname, and IP-range checks are applied consistently.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+from typing import Any, Optional
+from urllib.parse import urljoin, urlparse
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.exceptions import NameResolutionError
+from urllib3.poolmanager import PoolManager
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Blocked network ranges
+# ---------------------------------------------------------------------------
+
+# Ranges that ipaddress category flags don't classify but must still be blocked.
+_EXTRA_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("100.64.0.0/10"),  # RFC 6598 CGNAT
+]
+
+# NAT64 (RFC 6052/8215) and IPv4-compatible IPv6 embed an IPv4 in the low 32 bits.
+_NAT64_NETWORKS = [
+    ipaddress.ip_network("64:ff9b::/96"),
+    ipaddress.ip_network("64:ff9b:1::/48"),
+]
+_IPV4_COMPAT_NETWORK = ipaddress.ip_network("::/96")
+
+_BLOCKED_HOSTNAMES = frozenset(
+    [
+        "localhost",
+        "metadata.google.internal",
+        "metadata.gke.internal",
+        "metadata.azure.com",
+        "kubernetes.default",
+        "kubernetes.default.svc",
+        "kubernetes.default.svc.cluster.local",
+    ]
+)
+
+_BLOCKED_IPS = frozenset(
+    [
+        "255.255.255.255",
+        "168.63.129.16",  # Azure wireserver
+    ]
+)
+
+_DEFAULT_TIMEOUT = (10, 300)  # (connect, read) seconds
+_MAX_REDIRECTS = 10
+_ENV_VAR = "UNSTRUCTURED_ALLOW_PRIVATE_URL"
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes"})
+
+
+def _env_allows_private() -> bool:
+    """Return True when the escape-hatch env var is set to a truthy value."""
+    return os.environ.get(_ENV_VAR, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL targets a blocked or non-routable address."""
+
+
+# ---------------------------------------------------------------------------
+# IP / hostname helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_ip_blocked(ip_str: str) -> bool:
+    """Return True if *ip_str* is non-routable/internal. Fail-closed on parse errors."""
+    if ip_str in _BLOCKED_IPS:
+        return True
+
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True  # fail closed
+
+    # Unwrap IPv6 forms that embed an IPv4 address, then re-check the inner v4.
+    if isinstance(addr, ipaddress.IPv6Address):
+        if addr.ipv4_mapped is not None:  # ::ffff:0:0/96
+            return _is_ip_blocked(str(addr.ipv4_mapped))
+        if addr.sixtofour is not None:  # 2002::/16
+            return _is_ip_blocked(str(addr.sixtofour))
+        if any(addr in net for net in _NAT64_NETWORKS) or addr in _IPV4_COMPAT_NETWORK:
+            return _is_ip_blocked(str(ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF)))
+
+    # Category flags cover loopback/private/link-local/reserved/multicast/
+    # unspecified for both v4 and v6; _EXTRA_BLOCKED_NETWORKS adds ranges the
+    # stdlib doesn't classify (CGNAT).
+    if (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    ):
+        return True
+    return any(addr in net for net in _EXTRA_BLOCKED_NETWORKS)
+
+
+def _normalize_hostname(hostname: str) -> str:
+    """Lowercase, strip trailing dots, and IDNA-encode for denylist comparison.
+
+    Falls back to the lowercased form when IDNA encoding can't proceed; the
+    subsequent DNS resolution step then catches outright-invalid names.
+    """
+    base = hostname.lower().rstrip(".")
+    if not base:
+        return base
+    try:
+        return base.encode("idna").decode("ascii").lower().rstrip(".")
+    except UnicodeError:
+        return base
+
+
+# ---------------------------------------------------------------------------
+# Pre-request URL validation (fast-fail UX layer)
+# ---------------------------------------------------------------------------
+
+
+def _validate_url(url: str, allow_private: bool = False) -> None:
+    """Pre-request validation. Connect-time check in _SafeHTTPConnection is authoritative.
+
+    Skipped entirely when ``allow_private`` is True or the
+    ``UNSTRUCTURED_ALLOW_PRIVATE_URL`` env var is truthy.
+    """
+    if allow_private or _env_allows_private():
+        return
+
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise UnsafeURLError(
+            f"URL scheme {parsed.scheme!r} is not allowed; only http and https are accepted"
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UnsafeURLError("URL is missing a hostname")
+
+    normalized = _normalize_hostname(hostname)
+    if normalized in _BLOCKED_HOSTNAMES:
+        raise UnsafeURLError("URL targets a blocked hostname")
+
+    # Catch literal IPs (decimal/hex/octal variants ipaddress can parse) up front.
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        if _is_ip_blocked(hostname):
+            raise UnsafeURLError("URL targets a blocked IP address")
+
+    # Fast-fail DNS check.  Authoritative check happens at connect time in
+    # _SafeHTTPConnection — this one just avoids a wasted TCP handshake.
+    try:
+        results = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise UnsafeURLError("Failed to resolve hostname") from exc
+
+    for _family, _socktype, _proto, _canonname, sockaddr in results:
+        ip = sockaddr[0]
+        if _is_ip_blocked(ip):
+            logger.warning("URL hostname %r resolves to blocked address %s", hostname, ip)
+            raise UnsafeURLError("URL hostname resolves to a blocked address")
+
+
+# ---------------------------------------------------------------------------
+# Connect-time validation
+# ---------------------------------------------------------------------------
+
+
+def _safe_create_connection(
+    host: str,
+    port: int,
+    timeout: Any,
+    source_address: Optional[tuple],
+    socket_options: Any,
+) -> socket.socket:
+    """Resolve, validate, and connect — all in one atomic step.
+
+    The resolved IP we validate is the IP we connect to, eliminating the
+    DNS-rebinding window between pre-request resolution and TCP connect.
+    """
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+
+    try:
+        infos = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror:
+        raise
+
+    # Reject if *any* resolved address is blocked. A split-DNS response of
+    # [public, private] should not let us connect to the public one — the
+    # presence of the private one is a strong signal of a rebinding probe.
+    for _family, _socktype, _proto, _canonname, sockaddr in infos:
+        ip = sockaddr[0]
+        if _is_ip_blocked(ip):
+            raise UnsafeURLError(f"Hostname resolved to blocked address {ip} at connect time")
+
+    last_err: Optional[Exception] = None
+    for family, socktype, proto, _canonname, sockaddr in infos:
+        sock = None
+        try:
+            sock = socket.socket(family, socktype, proto)
+            if socket_options:
+                for opt in socket_options:
+                    sock.setsockopt(*opt)
+            # socket._GLOBAL_DEFAULT_TIMEOUT is the sentinel urllib3 passes when
+            # the caller didn't specify one; don't call settimeout in that case
+            # so the socket inherits Python's process-wide default.
+            if timeout is not None and timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+                sock.settimeout(timeout)
+            if source_address:
+                sock.bind(source_address)
+            sock.connect(sockaddr)
+            return sock
+        except OSError as e:
+            last_err = e
+            if sock is not None:
+                sock.close()
+
+    if last_err is not None:
+        raise last_err
+    raise OSError(f"getaddrinfo returned no usable addresses for {host!r}")
+
+
+class _SafeHTTPConnection(HTTPConnection):
+    """urllib3 ``HTTPConnection`` that validates the resolved IP at socket-create time."""
+
+    def _new_conn(self) -> socket.socket:
+        try:
+            return _safe_create_connection(
+                self._dns_host,
+                self.port,
+                self.timeout,
+                self.source_address,
+                self.socket_options,
+            )
+        except UnsafeURLError:
+            raise
+        except socket.gaierror as e:
+            raise NameResolutionError(self.host, self, e) from e
+
+
+class _SafeHTTPSConnection(_SafeHTTPConnection, HTTPSConnection):
+    """HTTPS counterpart — inherits ``_new_conn`` from :class:`_SafeHTTPConnection`.
+
+    TLS handshake / SNI handling is unchanged (we override only the socket
+    creation step, not the wrapping that follows).
+    """
+
+
+class _SafeHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = _SafeHTTPConnection
+
+
+class _SafeHTTPSConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = _SafeHTTPSConnection
+
+
+class _SafePoolManager(PoolManager):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.pool_classes_by_scheme = {
+            "http": _SafeHTTPConnectionPool,
+            "https": _SafeHTTPSConnectionPool,
+        }
+
+
+class _SafeHTTPAdapter(HTTPAdapter):
+    """``requests`` adapter that routes through :class:`_SafePoolManager`.
+
+    Proxy paths are refused: a proxied connection reaches the proxy host
+    first, so the connection-level IP check would validate the proxy
+    rather than the real target, and the proxy could then relay to any
+    internal address.  Callers needing proxy support must opt out of
+    validation via ``allow_private=True``.
+    """
+
+    def init_poolmanager(
+        self,
+        connections: int,
+        maxsize: int,
+        block: bool = False,
+        **pool_kwargs: Any,
+    ) -> None:
+        self.poolmanager = _SafePoolManager(
+            num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs
+        )
+
+    def proxy_manager_for(self, proxy: str, **proxy_kwargs: Any) -> Any:
+        raise UnsafeURLError("Proxied requests are not permitted through the safe HTTP adapter")
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def safe_get(
+    url: str,
+    *,
+    allow_private: bool = False,
+    **kwargs: Any,
+) -> requests.Response:
+    """Fetch *url* with pre-request validation and connect-time IP validation.
+
+    Redirects are followed manually (``allow_redirects`` is always forced to
+    ``False``); each hop is re-validated. A default timeout of ``(10, 300)``
+    (connect, read) is applied when none is provided.
+
+    Parameters
+    ----------
+    url:
+        Target URL.
+    allow_private:
+        When True, URL validation and connect-time IP validation are
+        skipped, and ``proxies=`` may be supplied. Also settable via the
+        ``UNSTRUCTURED_ALLOW_PRIVATE_URL`` environment variable.
+    **kwargs:
+        Forwarded to ``requests.Session.get``.
+    """
+    _validate_url(url, allow_private=allow_private)
+
+    bypass_mode = allow_private or _env_allows_private()
+    if not bypass_mode and "proxies" in kwargs:
+        # Proxies route through a third-party host that we can't apply the
+        # connection-level IP check to; refuse rather than silently weakening
+        # the guarantee.
+        raise UnsafeURLError("proxies kwarg is not permitted; set allow_private=True to bypass")
+
+    if kwargs.get("timeout") is None:
+        kwargs["timeout"] = _DEFAULT_TIMEOUT
+    kwargs["allow_redirects"] = False
+
+    session = requests.Session()
+    if not bypass_mode:
+        # Disable auto-pickup of HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars,
+        # plus netrc and CA bundle env-var overrides.
+        session.trust_env = False
+        adapter = _SafeHTTPAdapter()
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+
+    try:
+        for _ in range(_MAX_REDIRECTS):
+            response = session.get(url, **kwargs)
+            if not response.is_redirect:
+                return response
+
+            location = response.headers.get("Location")
+            if not location:
+                return response  # malformed redirect — return as-is
+
+            new_url = urljoin(response.url, location)
+            _validate_url(new_url, allow_private=allow_private)
+            url = new_url
+        raise UnsafeURLError(f"Too many redirects (>{_MAX_REDIRECTS})")
+    finally:
+        session.close()

--- a/unstructured/safe_http.py
+++ b/unstructured/safe_http.py
@@ -140,7 +140,11 @@ def _validate_url(url: str, allow_private: bool = False) -> None:
     if allow_private or _env_allows_private():
         return
 
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
+        _ = parsed.port  # out-of-range ports raise ValueError here, not later
+    except ValueError as exc:
+        raise UnsafeURLError("URL could not be parsed") from exc
 
     if parsed.scheme not in ("http", "https"):
         raise UnsafeURLError(
@@ -168,7 +172,7 @@ def _validate_url(url: str, allow_private: bool = False) -> None:
     # _SafeHTTPConnection — this one just avoids a wasted TCP handshake.
     try:
         results = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
-    except socket.gaierror as exc:
+    except (socket.gaierror, UnicodeError, ValueError) as exc:
         raise UnsafeURLError("Failed to resolve hostname") from exc
 
     for _family, _socktype, _proto, _canonname, sockaddr in results:
@@ -307,6 +311,41 @@ class _SafeHTTPAdapter(HTTPAdapter):
 
 
 # ---------------------------------------------------------------------------
+# Cross-origin redirect handling
+# ---------------------------------------------------------------------------
+
+
+# Credential-bearing headers that must not carry to a new origin on redirect.
+_REDIRECT_SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "proxy-authorization"})
+
+# Stateless holder for requests' own redirect-auth logic; issues no requests.
+_REDIRECT_AUTH_PROBE = requests.Session()
+
+
+def _is_cross_origin(old_url: str, new_url: str) -> bool:
+    """Return True when credential material must not carry from *old_url* to *new_url*.
+
+    Delegates to :meth:`requests.Session.should_strip_auth`; fails safe (strip)
+    on unparseable input.
+    """
+    try:
+        return _REDIRECT_AUTH_PROBE.should_strip_auth(old_url, new_url)
+    except ValueError:
+        return True
+
+
+def _strip_sensitive_headers(kwargs: dict) -> None:
+    """Drop credential headers and the ``auth``/``cookies`` kwargs before a cross-origin hop."""
+    headers = kwargs.get("headers")
+    if headers:
+        kwargs["headers"] = {
+            k: v for k, v in headers.items() if k.lower() not in _REDIRECT_SENSITIVE_HEADERS
+        }
+    kwargs.pop("auth", None)
+    kwargs.pop("cookies", None)
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -368,6 +407,9 @@ def safe_get(
 
             new_url = urljoin(response.url, location)
             _validate_url(new_url, allow_private=allow_private)
+            # Drop credential material on cross-origin hops (matches requests).
+            if _is_cross_origin(url, new_url):
+                _strip_sensitive_headers(kwargs)
             url = new_url
         raise UnsafeURLError(f"Too many redirects (>{_MAX_REDIRECTS})")
     finally:


### PR DESCRIPTION
## Summary

Introduces `unstructured/safe_http.py` as a single, shared entry point for
outbound URL fetches, and routes the `url=` code paths in `partition`,
`partition_html`, and `partition_md` through it. Previously each of these
called `requests.get` directly with inconsistent (and in some cases absent)
timeout and validation behavior; this centralizes that logic in one place so
it stays consistent and testable.

## What changed

- **New `unstructured/safe_http.py`** — a `safe_get()` helper that all three
  partitioners now use instead of calling `requests.get` directly.
- The helper applies, consistently:
  - an `http`/`https` scheme allowlist
  - a hostname denylist with IDNA normalization
  - address validation performed at TCP connect time, so the address
    validated is the address actually connected to
  - manual redirect following with per-hop re-validation, dropping
    credential material (`Authorization`/`Cookie`/proxy auth, plus
    `auth=`/`cookies=`) on cross-origin hops via requests' own
    `should_strip_auth`
  - default `(connect, read)` timeouts, and refusal of proxied requests
  - an opt-out via `allow_private=` / the `UNSTRUCTURED_ALLOW_PRIVATE_URL`
    environment variable for controlled local usage

## Behavior changes (why this is a minor release)

Fetches that resolve to non-routable, loopback, or link-local addresses are
now rejected by default. Outbound fetches also now carry default timeouts
where some previously had none. Callers that legitimately need to reach a
private/internal host can opt out with `UNSTRUCTURED_ALLOW_PRIVATE_URL=1` (or
`allow_private=True`).

## Tests

Adds `test_unstructured/test_safe_http.py` covering IP/hostname
classification, connect-time validation, redirect re-validation, cross-origin
credential stripping, and the opt-out.

## Version

Bumps to `0.24.0` (see CHANGELOG) — minor, reflecting the behavior changes
above.
