### PR TITLE
fix: add SSRF host validation to partition url= fetch paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.24.0
+
+### Fixes
+
+- **Validate outbound URLs against SSRF (`partition(url=...)`, `partition_html`, `partition_md`)**: the `url=` fetch paths previously called `requests.get` directly with no host validation — and, for two of the three, no timeout — letting a caller-supplied URL reach loopback/private/link-local/cloud-metadata addresses and return the response body (a full-read server-side request forgery). Fetches now route through a shared `unstructured.safe_http.safe_get`, which enforces an `http`/`https` scheme allowlist, blocks non-routable/internal targets using the *resolved* IP checked at TCP-connect time (closing the DNS-rebinding window), follows redirects manually with per-hop re-validation and credential-header stripping on cross-origin hops, and applies a default `(connect, read)` timeout. **Behavior change (hence the minor bump):** fetches resolving to non-routable, loopback, or link-local addresses are now rejected by default; set `UNSTRUCTURED_ALLOW_PRIVATE_URL=1` (or pass `allow_private=True`) to opt out for controlled internal usage.
+
 ## 0.23.3
 
 ### Fixes

--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -108,8 +108,8 @@ def test_partition_html_accepts_an_html_str():
     assert len(elements) > 0
 
 
-def test_partition_html_accepts_a_url_to_an_HTML_document(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_html_accepts_a_url_to_an_HTML_document(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text=example_doc_text("example-10k-1p.html"),
         status_code=200,
         headers={"Content-Type": "text/html"},
@@ -117,7 +117,7 @@ def test_partition_html_accepts_a_url_to_an_HTML_document(requests_get_: Mock):
 
     elements = partition_html(url="https://fake.url")
 
-    requests_get_.assert_called_once_with("https://fake.url", headers={}, verify=True)
+    safe_get_.assert_called_once_with("https://fake.url", headers={}, verify=True)
     assert len(elements) > 0
 
 
@@ -212,8 +212,8 @@ def test_emoji_appears_with_emoji_utf8_code():
 # -- partition_html() from URL -------------------------------------------------------------------
 
 
-def test_partition_html_from_url_raises_on_failure_response_status_code(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_html_from_url_raises_on_failure_response_status_code(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text=example_doc_text("example-10k-1p.html"),
         status_code=500,
         headers={"Content-Type": "text/html"},
@@ -223,8 +223,8 @@ def test_partition_html_from_url_raises_on_failure_response_status_code(requests
         partition_html(url="https://fake.url")
 
 
-def test_partition_html_from_url_raises_on_response_of_wrong_content_type(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_html_from_url_raises_on_response_of_wrong_content_type(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text=example_doc_text("example-10k-1p.html"),
         status_code=200,
         headers={"Content-Type": "application/json"},
@@ -234,8 +234,8 @@ def test_partition_html_from_url_raises_on_response_of_wrong_content_type(reques
         partition_html(url="https://fake.url")
 
 
-def test_partition_from_url_includes_provided_headers_in_request(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_from_url_includes_provided_headers_in_request(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text="<html><head></head><body><p>What do I know? Who needs to know it?</p></body></html>",
         status_code=200,
         headers={"Content-Type": "text/html"},
@@ -243,7 +243,7 @@ def test_partition_from_url_includes_provided_headers_in_request(requests_get_: 
 
     partition_html(url="https://example.com", headers={"User-Agent": "test"})
 
-    requests_get_.assert_called_once_with(
+    safe_get_.assert_called_once_with(
         "https://example.com", headers={"User-Agent": "test"}, verify=True
     )
 
@@ -1211,8 +1211,8 @@ def test_partition_html_applies_text_as_html_metadata_for_tables(
 # -- .metadata.url -------------------------------------------------------------------------------
 
 
-def test_partition_html_from_url_adds_url_to_metadata(requests_get_: Mock):
-    requests_get_.return_value = FakeResponse(
+def test_partition_html_from_url_adds_url_to_metadata(safe_get_: Mock):
+    safe_get_.return_value = FakeResponse(
         text=example_doc_text("example-10k-1p.html"),
         status_code=200,
         headers={"Content-Type": "text/html"},
@@ -1220,7 +1220,7 @@ def test_partition_html_from_url_adds_url_to_metadata(requests_get_: Mock):
 
     elements = partition_html(url="https://trusttheforceluke.com")
 
-    requests_get_.assert_called_once_with("https://trusttheforceluke.com", headers={}, verify=True)
+    safe_get_.assert_called_once_with("https://trusttheforceluke.com", headers={}, verify=True)
     assert len(elements) > 0
     assert all(e.metadata.url == "https://trusttheforceluke.com" for e in elements)
 
@@ -1273,8 +1273,8 @@ def opts_args() -> dict[str, Any]:
 
 
 @pytest.fixture
-def requests_get_(request: pytest.FixtureRequest):
-    return function_mock(request, "unstructured.partition.html.partition.requests.get")
+def safe_get_(request: pytest.FixtureRequest):
+    return function_mock(request, "unstructured.partition.html.partition.safe_get")
 
 
 # ================================================================================================
@@ -1334,9 +1334,9 @@ class DescribeHtmlPartitionerOptions:
         assert opts.html_text == "<html><body><p>Hello World!</p></body></html>"
 
     def and_it_gets_the_HTML_from_the_url_when_one_is_provided(
-        self, requests_get_: Mock, opts_args: dict[str, Any]
+        self, safe_get_: Mock, opts_args: dict[str, Any]
     ):
-        requests_get_.return_value = FakeResponse(
+        safe_get_.return_value = FakeResponse(
             text="<html><body><p>I just flew over the internet!</p></body></html>",
             status_code=200,
             headers={"Content-Type": "text/html"},

--- a/test_unstructured/partition/test_md.py
+++ b/test_unstructured/partition/test_md.py
@@ -4,7 +4,6 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-import requests
 from markdown.extensions.fenced_code import FencedCodeExtension
 from pytest_mock import MockFixture
 
@@ -61,7 +60,7 @@ def test_partition_md_from_url():
         status_code=200,
         headers={"Content-Type": "text/markdown"},
     )
-    with patch.object(requests, "get", return_value=response) as _:
+    with patch("unstructured.partition.md.safe_get", return_value=response) as _:
         elements = partition_md(url="https://fake.url")
 
     assert len(elements) > 0
@@ -78,7 +77,10 @@ def test_partition_md_from_url_raises_with_bad_status_code():
         status_code=500,
         headers={"Content-Type": "text/html"},
     )
-    with patch.object(requests, "get", return_value=response) as _, pytest.raises(ValueError):
+    with (
+        patch("unstructured.partition.md.safe_get", return_value=response) as _,
+        pytest.raises(ValueError),
+    ):
         partition_md(url="https://fake.url")
 
 
@@ -92,7 +94,10 @@ def test_partition_md_from_url_raises_with_bad_content_type():
         status_code=200,
         headers={"Content-Type": "application/json"},
     )
-    with patch.object(requests, "get", return_value=response) as _, pytest.raises(ValueError):
+    with (
+        patch("unstructured.partition.md.safe_get", return_value=response) as _,
+        pytest.raises(ValueError),
+    ):
         partition_md(url="https://fake.url")
 
 

--- a/test_unstructured/test_safe_http.py
+++ b/test_unstructured/test_safe_http.py
@@ -1,0 +1,300 @@
+"""Tests for `unstructured.safe_http` SSRF validation."""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from unstructured.safe_http import (
+    UnsafeURLError,
+    _is_cross_origin,
+    _is_ip_blocked,
+    _safe_create_connection,
+    _SafeHTTPAdapter,
+    _strip_sensitive_headers,
+    _validate_url,
+    safe_get,
+)
+
+
+def _addrinfo(*ips: str):
+    """Build getaddrinfo-shaped results for the given IPs."""
+    return [
+        (socket.AF_INET6 if ":" in ip else socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))
+        for ip in ips
+    ]
+
+
+def _getaddrinfo_for(mapping: dict[str, list[str]]):
+    def _fake(host: str, *_args, **_kwargs):
+        if host not in mapping:
+            raise socket.gaierror(f"unknown host {host!r}")
+        return _addrinfo(*mapping[host])
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# _is_ip_blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "127.0.0.1",
+        "127.255.255.255",
+        "10.0.0.1",
+        "172.16.0.1",
+        "192.168.1.1",
+        "169.254.169.254",  # link-local — cloud metadata
+        "100.64.0.1",  # CGNAT
+        "168.63.129.16",  # Azure wireserver
+        "0.0.0.0",
+        "255.255.255.255",
+        "::1",
+        "fe80::1",
+        "fc00::1",
+        "fd00::1",
+        "::",
+        "::ffff:127.0.0.1",  # IPv4-mapped loopback
+        "::ffff:169.254.169.254",  # IPv4-mapped metadata
+        "64:ff9b::169.254.169.254",  # NAT64-embedded metadata
+        "not-an-ip",  # fail closed
+    ],
+)
+def test_is_ip_blocked_blocks_internal_and_unparseable(ip: str):
+    assert _is_ip_blocked(ip) is True
+
+
+@pytest.mark.parametrize("ip", ["8.8.8.8", "93.184.216.34", "1.1.1.1", "2606:4700:4700::1111"])
+def test_is_ip_blocked_allows_public(ip: str):
+    assert _is_ip_blocked(ip) is False
+
+
+# ---------------------------------------------------------------------------
+# _validate_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url", ["ftp://example.com", "file:///etc/passwd", "gopher://x/", "data:,x"]
+)
+def test_validate_url_rejects_non_http_scheme(url: str):
+    with pytest.raises(UnsafeURLError):
+        _validate_url(url)
+
+
+def test_validate_url_rejects_missing_hostname():
+    with pytest.raises(UnsafeURLError):
+        _validate_url("http:///path")
+
+
+@pytest.mark.parametrize(
+    "url", ["http://127.0.0.1/admin", "https://169.254.169.254/latest/meta-data", "http://[::1]/"]
+)
+def test_validate_url_rejects_literal_blocked_ip(url: str):
+    with pytest.raises(UnsafeURLError):
+        _validate_url(url)
+
+
+def test_validate_url_rejects_host_resolving_to_blocked():
+    with patch(
+        "unstructured.safe_http.socket.getaddrinfo", _getaddrinfo_for({"evil.test": ["10.0.0.5"]})
+    ):
+        with pytest.raises(UnsafeURLError):
+            _validate_url("http://evil.test/")
+
+
+def test_validate_url_rejects_split_dns_with_any_blocked():
+    with patch(
+        "unstructured.safe_http.socket.getaddrinfo",
+        _getaddrinfo_for({"rebind.test": ["93.184.216.34", "10.0.0.5"]}),
+    ):
+        with pytest.raises(UnsafeURLError):
+            _validate_url("http://rebind.test/")
+
+
+def test_validate_url_allows_host_resolving_to_public():
+    with patch(
+        "unstructured.safe_http.socket.getaddrinfo",
+        _getaddrinfo_for({"good.test": ["93.184.216.34"]}),
+    ):
+        _validate_url("http://good.test/")  # no raise
+
+
+def test_validate_url_fails_closed_on_resolution_error():
+    with patch("unstructured.safe_http.socket.getaddrinfo", side_effect=socket.gaierror):
+        with pytest.raises(UnsafeURLError):
+            _validate_url("http://nxdomain.test/")
+
+
+def test_validate_url_skipped_by_allow_private():
+    _validate_url("http://127.0.0.1/", allow_private=True)  # no raise
+
+
+def test_validate_url_skipped_by_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("UNSTRUCTURED_ALLOW_PRIVATE_URL", "1")
+    _validate_url("http://127.0.0.1/")  # no raise
+
+
+# ---------------------------------------------------------------------------
+# cross-origin credential handling
+# ---------------------------------------------------------------------------
+
+
+def test_is_cross_origin_true_for_different_host():
+    assert _is_cross_origin("https://a.test/x", "https://b.test/y") is True
+
+
+def test_is_cross_origin_false_for_same_host():
+    assert _is_cross_origin("https://a.test/x", "https://a.test/y") is False
+
+
+def test_strip_sensitive_headers_removes_credentials():
+    kwargs = {
+        "headers": {"Authorization": "secret", "Cookie": "s=1", "User-Agent": "ua"},
+        "auth": ("u", "p"),
+        "cookies": {"c": "1"},
+    }
+    _strip_sensitive_headers(kwargs)
+    assert kwargs["headers"] == {"User-Agent": "ua"}
+    assert "auth" not in kwargs
+    assert "cookies" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# safe_get
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status_code: int = 200, headers=None, url: str = "https://example.test/"):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.url = url
+
+    @property
+    def is_redirect(self) -> bool:
+        return self.status_code in (301, 302, 303, 307, 308) and "Location" in self.headers
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.get_calls: list[tuple] = []
+        self.trust_env = True
+        self.mounts: dict = {}
+
+    def mount(self, prefix, adapter):
+        self.mounts[prefix] = adapter
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return self._responses.pop(0)
+
+    def close(self):
+        pass
+
+
+@contextlib.contextmanager
+def _fake_http(responses, resolves: str = "93.184.216.34"):
+    """Patch the outbound Session and DNS resolution used by `safe_get`."""
+    fake = _FakeSession(responses)
+    with (
+        patch("unstructured.safe_http.requests.Session", return_value=fake),
+        patch("unstructured.safe_http.socket.getaddrinfo", lambda *a, **k: _addrinfo(resolves)),
+    ):
+        yield fake
+
+
+def test_safe_get_applies_default_timeout_and_disables_redirects():
+    with _fake_http([_FakeResp(200)]) as fake:
+        resp = safe_get("https://example.test/doc")
+
+    assert resp.status_code == 200
+    _url, kwargs = fake.get_calls[0]
+    assert kwargs["timeout"] == (10, 300)
+    assert kwargs["allow_redirects"] is False
+    assert fake.trust_env is False
+
+
+def test_safe_get_preserves_caller_timeout():
+    with _fake_http([_FakeResp(200)]) as fake:
+        safe_get("https://example.test/doc", timeout=5)
+    assert fake.get_calls[0][1]["timeout"] == 5
+
+
+def test_safe_get_refuses_proxies_in_secure_mode():
+    with _fake_http([_FakeResp(200)]):
+        with pytest.raises(UnsafeURLError):
+            safe_get("https://example.test/", proxies={"http": "http://p"})
+
+
+def test_safe_get_rejects_redirect_to_blocked_target():
+    responses = [_FakeResp(302, {"Location": "http://169.254.169.254/imds"})]
+    with _fake_http(responses):
+        with pytest.raises(UnsafeURLError):
+            safe_get("https://example.test/start")
+
+
+def test_safe_get_strips_credentials_on_cross_origin_redirect():
+    responses = [
+        _FakeResp(302, {"Location": "https://evil.test/"}, url="https://example.test/"),
+        _FakeResp(200, url="https://evil.test/"),
+    ]
+    with _fake_http(responses) as fake:
+        safe_get("https://example.test/start", headers={"Authorization": "secret", "X-Keep": "1"})
+
+    assert fake.get_calls[0][1]["headers"].get("Authorization") == "secret"
+    assert "Authorization" not in fake.get_calls[1][1]["headers"]
+    assert fake.get_calls[1][1]["headers"].get("X-Keep") == "1"
+
+
+def test_safe_get_keeps_credentials_on_same_origin_redirect():
+    responses = [
+        _FakeResp(302, {"Location": "https://example.test/next"}, url="https://example.test/"),
+        _FakeResp(200, url="https://example.test/next"),
+    ]
+    with _fake_http(responses) as fake:
+        safe_get("https://example.test/start", headers={"Authorization": "secret"})
+    assert fake.get_calls[1][1]["headers"].get("Authorization") == "secret"
+
+
+def test_safe_get_raises_on_too_many_redirects():
+    responses = [
+        _FakeResp(302, {"Location": "https://example.test/loop"}, url="https://example.test/")
+        for _ in range(10)
+    ]
+    with _fake_http(responses):
+        with pytest.raises(UnsafeURLError, match="Too many redirects"):
+            safe_get("https://example.test/start")
+
+
+def test_safe_get_allow_private_bypasses_validation_and_adapter():
+    with _fake_http([_FakeResp(200)]) as fake:
+        resp = safe_get("http://127.0.0.1/admin", allow_private=True)
+
+    assert resp.status_code == 200
+    assert fake.trust_env is True  # bypass mode leaves proxy/env handling intact
+    assert fake.mounts == {}  # no safe adapter mounted
+
+
+# ---------------------------------------------------------------------------
+# connect-time validation + adapter
+# ---------------------------------------------------------------------------
+
+
+def test_safe_create_connection_rejects_blocked_resolved_address():
+    with patch("unstructured.safe_http.socket.getaddrinfo", lambda *a, **k: _addrinfo("10.0.0.9")):
+        with pytest.raises(UnsafeURLError):
+            _safe_create_connection("internal.test", 80, None, None, None)
+
+
+def test_safe_adapter_refuses_proxies():
+    adapter = _SafeHTTPAdapter()
+    with pytest.raises(UnsafeURLError):
+        adapter.proxy_manager_for("http://proxy.test:8080")

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.23.3"  # pragma: no cover
+__version__ = "0.24.0"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -7,7 +7,6 @@ import importlib
 import io
 from typing import IO, Any, Callable, Optional
 
-import requests
 from typing_extensions import TypeAlias
 
 from unstructured.documents.elements import DataSourceMetadata, Element
@@ -22,6 +21,7 @@ from unstructured.partition.common import UnsupportedFileFormatError
 from unstructured.partition.common.common import exactly_one
 from unstructured.partition.common.lang import check_language_args
 from unstructured.partition.utils.constants import PartitionStrategy
+from unstructured.safe_http import safe_get
 from unstructured.utils import dependency_exists
 
 Partitioner: TypeAlias = Callable[..., list[Element]]
@@ -307,7 +307,7 @@ def file_and_type_from_url(
     ssl_verify: bool = True,
     request_timeout: Optional[int] = None,
 ) -> tuple[io.BytesIO, FileType]:
-    response = requests.get(url, headers=headers, verify=ssl_verify, timeout=request_timeout)
+    response = safe_get(url, headers=headers, verify=ssl_verify, timeout=request_timeout)
     file = io.BytesIO(response.content)
 
     if content_type := content_type or response.headers.get("Content-Type", None):

--- a/unstructured/partition/html/partition.py
+++ b/unstructured/partition/html/partition.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from functools import cached_property
 from typing import IO, Any, Callable, Iterator, List, Literal, Optional, cast
 
-import requests
 from lxml import etree
 
 from unstructured.chunking import add_chunking_strategy
@@ -20,6 +19,7 @@ from unstructured.partition.html.transformations import (
     ontology_to_unstructured_elements,
     parse_html_to_ontology,
 )
+from unstructured.safe_http import safe_get
 from unstructured.utils import is_temp_file_path
 
 
@@ -158,7 +158,7 @@ class HtmlPartitionerOptions:
             return str(self._text)
 
         if self._url:
-            response = requests.get(self._url, headers=self._headers, verify=self._ssl_verify)
+            response = safe_get(self._url, headers=self._headers, verify=self._ssl_verify)
             if not response.ok:
                 raise ValueError(
                     f"Error status code on GET of provided URL: {response.status_code}"

--- a/unstructured/partition/md.py
+++ b/unstructured/partition/md.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import IO, Any, Optional
 
 import markdown
-import requests
 from markdown.extensions import Extension
 
 from unstructured.documents.elements import Element
@@ -12,6 +11,7 @@ from unstructured.file_utils.model import FileType
 from unstructured.partition.common.common import exactly_one
 from unstructured.partition.common.metadata import get_last_modified_date
 from unstructured.partition.html import partition_html
+from unstructured.safe_http import safe_get
 
 
 def optional_decode(contents: str | bytes) -> str:
@@ -94,7 +94,7 @@ def partition_md(
         _, text = read_txt_file(file=file)
 
     elif url is not None:
-        response = requests.get(url)
+        response = safe_get(url)
         if not response.ok:
             raise ValueError(f"URL return an error: {response.status_code}")
 

--- a/unstructured/safe_http.py
+++ b/unstructured/safe_http.py
@@ -1,0 +1,320 @@
+"""Centralized URL fetching with SSRF host validation and default timeouts.
+
+All fetches of user-supplied URLs (``partition(url=...)``, ``partition_html``,
+``partition_md``) route through :func:`safe_get`, which rejects requests that
+resolve to non-routable addresses. The address check runs at TCP-connect time,
+so the address we validate is the address we actually connect to — closing the
+DNS-rebinding window that a resolve-then-connect check would leave open.
+
+The connection/pool/adapter subclasses below reach into urllib3 internals
+(``_new_conn``, ``pool_classes_by_scheme``); a urllib3 major upgrade may require
+revisiting them.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+from typing import Any, Optional
+from urllib.parse import urljoin, urlparse
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.exceptions import NameResolutionError
+from urllib3.poolmanager import PoolManager
+
+logger = logging.getLogger(__name__)
+
+# Ranges the ipaddress category flags don't classify but that still front
+# internal infrastructure and so must be blocked.
+_EXTRA_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("100.64.0.0/10"),  # RFC 6598 carrier-grade NAT
+]
+
+# NAT64 (RFC 6052/8215), 6to4, and IPv4-compatible IPv6 all embed an IPv4
+# address; the embedded v4 is re-checked so an internal target can't be
+# smuggled through a v6 wrapper.
+_NAT64_NETWORKS = [
+    ipaddress.ip_network("64:ff9b::/96"),
+    ipaddress.ip_network("64:ff9b:1::/48"),
+]
+_IPV4_COMPAT_NETWORK = ipaddress.ip_network("::/96")
+
+# Routable-looking addresses that nonetheless reach internal services.
+_BLOCKED_IPS = frozenset({"168.63.129.16"})  # Azure wireserver / host agent
+
+_DEFAULT_TIMEOUT = (10, 300)  # (connect, read) seconds
+_MAX_REDIRECTS = 10
+_ENV_VAR = "UNSTRUCTURED_ALLOW_PRIVATE_URL"
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes"})
+
+# Credential-bearing headers that must not follow a redirect to a new origin.
+_REDIRECT_SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "proxy-authorization"})
+
+
+class UnsafeURLError(ValueError):
+    """Raised when a URL targets a blocked, non-routable, or unresolvable address."""
+
+
+def _env_allows_private() -> bool:
+    return os.environ.get(_ENV_VAR, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def _is_ip_blocked(ip_str: str) -> bool:
+    """Return True if *ip_str* is non-routable/internal. Fail closed on parse errors."""
+    if ip_str in _BLOCKED_IPS:
+        return True
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True  # fail closed
+
+    # Re-check the embedded IPv4 for the v6 forms that wrap one; category flags
+    # on the v6 address alone don't see the inner v4.
+    if isinstance(addr, ipaddress.IPv6Address):
+        if addr.ipv4_mapped is not None:
+            return _is_ip_blocked(str(addr.ipv4_mapped))
+        if addr.sixtofour is not None:
+            return _is_ip_blocked(str(addr.sixtofour))
+        if any(addr in net for net in _NAT64_NETWORKS) or addr in _IPV4_COMPAT_NETWORK:
+            return _is_ip_blocked(str(ipaddress.IPv4Address(int(addr) & 0xFFFFFFFF)))
+
+    if (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    ):
+        return True
+    return any(addr in net for net in _EXTRA_BLOCKED_NETWORKS)
+
+
+def _validate_url(url: str, allow_private: bool = False) -> None:
+    """Fast-fail scheme/host validation; the connect-time check is authoritative.
+
+    Relying on the *resolved* address (rather than string-matching hostnames)
+    also covers obfuscated literals like ``http://2130706433`` and IDN/case
+    variants, since the resolver normalizes them before we classify the result.
+
+    Skipped entirely when *allow_private* or ``UNSTRUCTURED_ALLOW_PRIVATE_URL``
+    is set, for controlled fetches of internal hosts.
+    """
+    if allow_private or _env_allows_private():
+        return
+
+    try:
+        parsed = urlparse(url)
+        scheme, hostname = parsed.scheme, parsed.hostname
+        _ = parsed.port  # out-of-range ports raise here rather than at connect time
+    except ValueError as exc:
+        raise UnsafeURLError("URL could not be parsed") from exc
+
+    if scheme not in ("http", "https"):
+        raise UnsafeURLError(f"URL scheme {scheme!r} is not allowed; use http or https")
+    if not hostname:
+        raise UnsafeURLError("URL is missing a hostname")
+
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass  # not a literal IP; the resolution check below handles it
+    else:
+        if _is_ip_blocked(hostname):
+            raise UnsafeURLError("URL targets a blocked IP address")
+
+    try:
+        results = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except (socket.gaierror, UnicodeError, ValueError) as exc:
+        raise UnsafeURLError("Failed to resolve hostname") from exc
+    for *_, sockaddr in results:
+        if _is_ip_blocked(sockaddr[0]):
+            logger.warning("URL host %r resolves to blocked address %s", hostname, sockaddr[0])
+            raise UnsafeURLError("URL hostname resolves to a blocked address")
+
+
+def _safe_create_connection(
+    host: str,
+    port: int,
+    timeout: Any,
+    source_address: Optional[tuple],
+    socket_options: Any,
+) -> socket.socket:
+    """Resolve, validate, and connect in one step so the validated IP is the IP
+    we connect to (eliminates the resolve-then-connect rebinding window)."""
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+
+    infos = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)
+
+    # Reject if *any* resolved address is blocked. A split-DNS answer of
+    # [public, private] must not let us connect to the public one.
+    for *_, sockaddr in infos:
+        if _is_ip_blocked(sockaddr[0]):
+            raise UnsafeURLError(f"Hostname resolved to blocked address {sockaddr[0]}")
+
+    last_err: Optional[Exception] = None
+    for family, socktype, proto, _canonname, sockaddr in infos:
+        sock = None
+        try:
+            sock = socket.socket(family, socktype, proto)
+            if socket_options:
+                for opt in socket_options:
+                    sock.setsockopt(*opt)
+            # _GLOBAL_DEFAULT_TIMEOUT is urllib3's "caller didn't set one" sentinel;
+            # leave the socket at Python's process default in that case.
+            if timeout is not None and timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:
+                sock.settimeout(timeout)
+            if source_address:
+                sock.bind(source_address)
+            sock.connect(sockaddr)
+            return sock
+        except OSError as e:
+            last_err = e
+            if sock is not None:
+                sock.close()
+
+    if last_err is not None:
+        raise last_err
+    raise OSError(f"getaddrinfo returned no usable addresses for {host!r}")
+
+
+class _SafeHTTPConnection(HTTPConnection):
+    """urllib3 connection that validates the resolved IP at socket-create time."""
+
+    def _new_conn(self) -> socket.socket:
+        try:
+            return _safe_create_connection(
+                self._dns_host,
+                self.port,
+                self.timeout,
+                self.source_address,
+                self.socket_options,
+            )
+        except UnsafeURLError:
+            raise
+        except socket.gaierror as e:
+            raise NameResolutionError(self.host, self, e) from e
+
+
+class _SafeHTTPSConnection(_SafeHTTPConnection, HTTPSConnection):
+    """HTTPS counterpart; only socket creation is overridden, so TLS/SNI is unchanged."""
+
+
+class _SafeHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = _SafeHTTPConnection
+
+
+class _SafeHTTPSConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = _SafeHTTPSConnection
+
+
+class _SafePoolManager(PoolManager):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.pool_classes_by_scheme = {
+            "http": _SafeHTTPConnectionPool,
+            "https": _SafeHTTPSConnectionPool,
+        }
+
+
+class _SafeHTTPAdapter(HTTPAdapter):
+    """Routes requests through :class:`_SafePoolManager`.
+
+    Proxies are refused: a proxied connection reaches the proxy first, so the
+    connection-level IP check would validate the proxy rather than the real
+    target, which the proxy could then relay to any internal address.
+    """
+
+    def init_poolmanager(
+        self, connections: int, maxsize: int, block: bool = False, **pool_kwargs: Any
+    ) -> None:
+        self.poolmanager = _SafePoolManager(
+            num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs
+        )
+
+    def proxy_manager_for(self, proxy: str, **proxy_kwargs: Any) -> Any:
+        raise UnsafeURLError("Proxied requests are not permitted by the safe HTTP adapter")
+
+
+# Stateless holder for requests' own redirect-auth logic; issues no requests.
+_REDIRECT_AUTH_PROBE = requests.Session()
+
+
+def _is_cross_origin(old_url: str, new_url: str) -> bool:
+    """Whether credential headers must be dropped moving *old_url* → *new_url*.
+
+    Delegates to requests' own logic so the decision tracks the library; fails
+    safe (strip) on unparseable input.
+    """
+    try:
+        return _REDIRECT_AUTH_PROBE.should_strip_auth(old_url, new_url)
+    except ValueError:
+        return True
+
+
+def _strip_sensitive_headers(kwargs: dict) -> None:
+    """Drop credential-bearing headers/kwargs before a cross-origin redirect hop."""
+    headers = kwargs.get("headers")
+    if headers:
+        kwargs["headers"] = {
+            k: v for k, v in headers.items() if k.lower() not in _REDIRECT_SENSITIVE_HEADERS
+        }
+    kwargs.pop("auth", None)
+    kwargs.pop("cookies", None)
+
+
+def safe_get(url: str, *, allow_private: bool = False, **kwargs: Any) -> requests.Response:
+    """Fetch *url* with SSRF validation, a default timeout, and safe redirects.
+
+    Redirects are followed manually (``allow_redirects`` is forced to ``False``)
+    so each hop is re-validated and credential headers are dropped on
+    cross-origin hops. A default ``(connect, read)`` timeout of ``(10, 300)`` is
+    applied when the caller supplies none.
+
+    Set *allow_private* (or the ``UNSTRUCTURED_ALLOW_PRIVATE_URL`` environment
+    variable) to fetch internal hosts in controlled environments; that also
+    permits a ``proxies=`` kwarg. All other kwargs are forwarded to
+    ``requests.Session.get``.
+    """
+    _validate_url(url, allow_private=allow_private)
+    bypass_mode = allow_private or _env_allows_private()
+
+    if not bypass_mode and "proxies" in kwargs:
+        raise UnsafeURLError("proxies kwarg is not permitted; set allow_private=True to bypass")
+    if kwargs.get("timeout") is None:
+        kwargs["timeout"] = _DEFAULT_TIMEOUT
+    kwargs["allow_redirects"] = False
+
+    session = requests.Session()
+    if not bypass_mode:
+        # Ignore HTTP(S)_PROXY / NO_PROXY / netrc: a proxy would bypass the
+        # connection-level IP check.
+        session.trust_env = False
+        adapter = _SafeHTTPAdapter()
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+
+    try:
+        for _ in range(_MAX_REDIRECTS):
+            response = session.get(url, **kwargs)
+            if not response.is_redirect:
+                return response
+
+            location = response.headers.get("Location")
+            if not location:
+                return response  # malformed redirect — return as-is
+
+            new_url = urljoin(response.url, location)
+            _validate_url(new_url, allow_private=allow_private)
+            if _is_cross_origin(url, new_url):
+                _strip_sensitive_headers(kwargs)
+            url = new_url
+        raise UnsafeURLError(f"Too many redirects (>{_MAX_REDIRECTS})")
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary

`partition(url=)`, `partition_html(url=)`, and `partition_md(url=)` fetched caller-supplied URLs with a bare `requests.get` — no host validation, and no timeout on two of the three — then returned the response body as element text. That is a full-read SSRF: a caller-supplied URL can reach loopback, private, link-local, and cloud-metadata addresses and read back the response.

This routes all three sinks through a single shared `unstructured/safe_http.py::safe_get`.

## Approach

`safe_get` applies, in one place:

- an `http`/`https` scheme allowlist;
- rejection of non-routable/internal targets using the **resolved IP validated at TCP-connect time** — the address we validate is the address we connect to, which closes the DNS-rebinding (TOCTOU) window a resolve-then-connect check leaves open, while leaving TLS/SNI and certificate verification unchanged;
- manual redirect following (`allow_redirects` forced `False`) with per-hop re-validation and credential-header stripping on cross-origin hops, so a redirect can't bounce to an internal target or leak the caller's `Authorization`/`Cookie`;
- a default `(connect, read)` timeout; and
- an `allow_private=True` / `UNSTRUCTURED_ALLOW_PRIVATE_URL=1` opt-out for controlled internal fetches.

## Relationship to #4388

This is a leaner alternative to #4388 with the same core defense (connect-time IP validation + redirect re-validation + timeout + opt-out). Relative to that PR it intentionally drops:

- **the Unicode "visual confusables" fold table** — the connect-time IP check is authoritative, so hostname string-matching isn't needed; validating the *resolved* IP also covers obfuscated literals (e.g. `http://2130706433`) and case/IDN variants with no denylist;
- **the RFC 7230 header sanitizer** — header injection is a distinct vulnerability class, and the headers come from the trusted caller rather than the attacker-controlled URL, so it's better handled separately; and
- **the explicit hostname denylist / IDNA normalization** — subsumed by the resolved-IP check.

Result: a ~320-line helper + ~300-line test file (50 cases) vs ~597 + ~1130 (175 cases), with the same SSRF properties.

## Behavior change

Fetches resolving to non-routable, loopback, or link-local addresses are now rejected by default — hence the `0.24.0` minor bump. Set `UNSTRUCTURED_ALLOW_PRIVATE_URL=1` (or pass `allow_private=True`) to opt out. The secure path also sets `trust_env=False` and refuses a `proxies=` kwarg, since a proxy would bypass the connection-level IP check; proxied or internal egress must use the opt-out.

## Tests

`test_unstructured/test_safe_http.py` (50 cases): IP classification, scheme/host validation, split-DNS rejection, connect-time validation, redirect re-validation + credential stripping, timeout, and the opt-out. Existing `partition_html`/`partition_md` URL tests updated to mock `safe_get`. `ruff check` / `ruff format --check` and the version/CHANGELOG sync check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

