### PR TITLE
fix(chunking): prevent infinite loop in token-based overlap splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.25.2
+
+### Fixes
+
+- **Token-based chunking with overlap no longer hangs on long unbroken tokens**: chunking with `max_tokens` combined with `overlap` (or `overlap_all`) entered an unbounded CPU loop on any element containing a whitespace-free run longer than `max_tokens` — a long URL, hash, base64/JWT blob, filesystem path, or biological sequence — affecting the public `chunk_elements` (basic) and `chunk_by_title` APIs. In token mode the splitter prepended the overlap tail plus a synthetic separator space to the remainder, which could regrow the remainder back to the full input; the next split then landed on that inserted space and reproduced the input verbatim, so the driving `while remainder:` loop never terminated. The token splitter now applies overlap only when the resulting remainder is strictly shorter than its input, falling back to the un-overlapped remainder otherwise, so every split makes forward progress and chunking always terminates. The character-mode path and token mode with `overlap=0` were unaffected.
+
 ## 0.25.1
 
 ### Fixes
@@ -17,12 +23,6 @@
 ### Fixes
 
 - **Update README.md**: readme-only changes; added the Unstructured Transform MCP to the README. No library behavior changes.
-
-## 0.24.1
-
-### Fixes
-
-- **Fix stored XSS in v2 (ontology) HTML output** (GHSA-v5mq-3xhg-98m9): `partition_html(html_parser_version="v2")`, `elements_to_html()`, and `metadata.text_as_html` previously emitted untrusted document markup without output encoding, allowing attacker-controlled content (`on*` handlers, `javascript:` links, tag/attribute breakout) to execute when the HTML was viewed. Output is now sanitized — text and attribute values are HTML-escaped, event-handler attributes are dropped, tags/attributes are allowlisted, and URL schemes are filtered (`http`/`https`/`mailto`/`tel`/relative preserved; `data:` limited to raster image MIME types on `img[src]`). Legitimate formatting is unaffected.
 
 ## 0.24.0
 

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -456,6 +456,41 @@ class DescribeTextSplitterTokenMode:
         assert fragment2 == "seven eight nine ten eleven twelve"
         assert remainder2 == ""
 
+    def it_makes_progress_on_a_long_whitespace_free_token_with_overlap(
+        self, _tiktoken_installed: None
+    ):
+        """Regression: overlap must not spin the split loop forever on a long unbroken token.
+
+        A whitespace-free run longer than `max_tokens` (a long URL, hash, base64 blob, etc.)
+        combined with token-mode overlap used to regrow the remainder back to the full input,
+        so `PreChunk._iter_text_splits` (`while remainder: split(remainder)`) never terminated.
+        Each split must strictly shrink the remainder.
+        """
+        opts = ChunkingOptions(max_tokens=10, tokenizer="cl100k_base", overlap=5)
+        split = _TextSplitter(opts)
+
+        # -- 2000 chars, no whitespace, far more than 10 tokens --
+        text = "xyzq" * 500
+
+        # -- drive the same loop `_iter_text_splits` uses; this spins forever on the pre-fix
+        # -- splitter (there is deliberately no internal iteration cap here) --
+        fragment, remainder = split(text)
+        fragments = [fragment]
+        remainder_lengths = [len(remainder)]
+        while remainder:
+            fragment, remainder = split(remainder)
+            fragments.append(fragment)
+            remainder_lengths.append(len(remainder))
+
+        # -- the loop terminated and split into multiple fragments --
+        assert remainder == ""
+        assert len(fragments) > 1
+        # -- every split strictly shrank the remainder, which is what guarantees termination --
+        assert all(b < a for a, b in zip(remainder_lengths, remainder_lengths[1:]))
+        # -- no fragment exceeds the token limit and no original character is lost --
+        assert all(opts.measure(f) <= 10 for f in fragments if f)
+        assert "xyzq" * 3 in "".join(fragments)
+
 
 # ================================================================================================
 # PRE-CHUNKER

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.25.1"  # pragma: no cover
+__version__ = "0.25.2"  # pragma: no cover

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -1490,7 +1490,15 @@ class _TextSplitter:
                         # -- token-based overlap: find tail with ~overlap tokens --
                         tail = self._get_token_overlap_tail(fragment, overlap)
                         overlapped_remainder = tail + " " + raw_remainder
-                        return fragment, overlapped_remainder
+                        # -- NOTE(otiscuilei): only apply the overlap when the remainder still
+                        # -- shrinks. Prepending the overlap tail (plus a synthetic separator
+                        # -- space) can regrow the remainder back to `s`; the next split then
+                        # -- lands on that inserted space and reproduces `s` verbatim, spinning
+                        # -- `_iter_text_splits` forever on a whitespace-free run longer than
+                        # -- `maxlen`. `raw_remainder` is always strictly shorter than `s`, so
+                        # -- fall back to it to guarantee forward progress.
+                        if len(overlapped_remainder) < len(s):
+                            return fragment, overlapped_remainder
                     return fragment, raw_remainder
 
         # -- fallback: split on whitespace boundary using binary search to find token limit --
@@ -1525,7 +1533,9 @@ class _TextSplitter:
         if overlap > 0 and fragment:
             tail = self._get_token_overlap_tail(fragment, overlap)
             overlapped_remainder = tail + " " + raw_remainder
-            return fragment, overlapped_remainder
+            # -- only overlap when it makes forward progress (see note in the separator branch) --
+            if len(overlapped_remainder) < len(s):
+                return fragment, overlapped_remainder
 
         return fragment, raw_remainder
 


### PR DESCRIPTION
### Summary

Token-based chunking (`max_tokens` + `tokenizer`) combined with `overlap` (or `overlap_all`) hangs in an unbounded CPU loop whenever an element contains a whitespace-free run longer than `max_tokens` — a long URL, hash, base64/JWT blob, filesystem path, or biological sequence. It is reachable from the documented public `chunk_elements` (basic) and `chunk_by_title` APIs on realistic input, with no error surfaced.

### Root cause

`_TextSplitter._split_by_tokens` in `unstructured/chunking/base.py` does not guarantee forward progress when `overlap > 0`. For a long unbroken token:

1. The binary-search fallback emits a ~`max_tokens` fragment and returns `overlapped_remainder = tail + " " + raw_remainder`, inserting a space that was not in the original text.
2. On the next call that inserted space is now a separator, so the right-to-left separator search splits exactly at it (`fragment = tail`) and re-prepends `tail + " "`, producing a remainder byte-for-byte identical to the input.

`PreChunk._iter_text_splits` (`while remainder: s, remainder = split(remainder)`) then loops forever. Observed: `iter0 -> input=2000, remainder=1990; iter1 -> input=1990, remainder=1990` (identical), spinning at 100% CPU.

The character-mode path already enforces this invariant (`pos = overlap + 1`, plus a `len(remainder) >= len(s): continue` guard). Token mode was missing it.

### Fix

In both overlap branches of `_split_by_tokens`, apply the overlap only when the resulting remainder is strictly shorter than the input; otherwise fall back to the un-overlapped `raw_remainder`, which is always strictly shorter than `s`. Every split now makes forward progress, so `_iter_text_splits` always terminates. Character mode and token mode with `overlap=0` are unaffected.

### Reproduction

Hangs on `main`, returns after this fix:

```python
from unstructured.documents.elements import Text
from unstructured.chunking.basic import chunk_elements

txt = "See https://example.com/" + "a" * 300 + "/path?q=" + "b" * 300 + " for details."
# On main this never returns; with this fix it returns 8 chunks.
chunk_elements([Text(text=txt)], max_tokens=32, tokenizer="cl100k_base", overlap=8)
```

Controls that already worked, and still do: the same input with `overlap=0`, and character mode with `max_characters=64, overlap=8`.

### Testing

A regression test drives the real split loop with no iteration cap, so it reproduces the true hang on the unfixed code, and asserts termination plus strictly shrinking remainders:

```
pytest "test_unstructured/chunking/test_base.py::DescribeTextSplitterTokenMode::it_makes_progress_on_a_long_whitespace_free_token_with_overlap" -q
```

On this branch it passes in under a second. Reverting only `unstructured/chunking/base.py` to `main` and running the same test under `timeout 25 pytest ...` exits 124 (killed by the timeout, i.e. the hang). The full `test_unstructured/chunking/test_base.py` suite (225 tests) passes, and `ruff check` / `ruff format --check` are clean.

### Changelog

```
## 0.24.1

### Fixes

- **Token-based chunking with overlap no longer hangs on long unbroken tokens**: chunking with `max_tokens` combined with `overlap` (or `overlap_all`) entered an unbounded CPU loop on any element containing a whitespace-free run longer than `max_tokens`. In token mode the splitter prepended the overlap tail plus a synthetic separator space to the remainder, which could regrow the remainder back to the full input; the next split then landed on that inserted space and reproduced the input verbatim, so the driving `while remainder:` loop never terminated. The token splitter now applies overlap only when the resulting remainder is strictly shorter than its input, falling back to the un-overlapped remainder otherwise.
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

