### PR TITLE
ci: pin ludeeus/action-shellcheck to a full commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
 
   shfmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
Pin `ludeeus/action-shellcheck@master` → `00b27aa…` in `ci.yml` (tag kept in a trailing comment).

### Why
`@master` is a moving reference — whatever it points to at run time runs in CI. `ci.yml` is a
secret-heavy workflow (`UNS_API_KEY`, `HF_TOKEN`, Confluence/Box/Airtable tokens, …), so removing a
mutable third-party ref here is worthwhile defense-in-depth: if the action's `master` were moved
(compromise or an accidental change), the new code would run in CI — the class of issue behind the 2025
`tj-actions/changed-files` incident. Pinning to a SHA closes that.

### Scope / safety
- Behaviour unchanged — the SHA is the current tip of the action's `master`. Signed-off.
- Renovate/Dependabot can still bump a SHA pin (the tag comment keeps it readable).

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow and the pinned SHA myself.</sub>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

