### PR TITLE
fix: strip leading UTF-8 BOM before JSON content-shape detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - **Update README.md**: readme-only changes; added a link to Unstructured Pipelines to the README. No library behavior changes.
+- **Fix JSON misdetection for UTF-8 BOM-prefixed content without a file extension**: `detect_filetype()` decoded textual content head as plain `"utf-8"`, leaving a leading byte-order-mark as a literal `U+FEFF` character. This defeated the JSON content-shape check (which requires the first non-whitespace character to be `[` or `{`), so a BOM-prefixed JSON payload with no `.json`/`.ndjson` extension and a generic `text/plain` MIME guess fell through to `FileType.TXT` instead of `FileType.JSON`. The leading BOM is now stripped before content-shape differentiation.
 
 ## 0.25.0
 

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -1342,6 +1342,18 @@ def test_json_content_type_is_disambiguated_for_ndjson():
     assert predicted_type == FileType.NDJSON
 
 
+def test_it_identifies_json_with_a_leading_utf8_bom_and_no_extension():
+    json_bytes = b"\xef\xbb\xbf" + json.dumps([{"example": "data"}]).encode("utf-8")
+
+    file_buffer = io.BytesIO(json_bytes)
+    predicted_type = detect_filetype(file=file_buffer, metadata_file_path="filename.pdf")
+    assert predicted_type == FileType.JSON
+
+    file_buffer.name = "filename.pdf"
+    predicted_type = detect_filetype(file=file_buffer)
+    assert predicted_type == FileType.JSON
+
+
 def test_office_files_when_document_archive_has_non_standard_prefix():
     predicted_type = detect_filetype(
         file_path=input_path("file_type/test_document_from_office365.docx")

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -1147,6 +1147,15 @@ class Describe_FileTypeDetectionContext:
         assert len(text_head) == 188
         assert text_head.startswith("This is a test document to use for unit tests.\n\n    Doyle")
 
+    def it_strips_only_the_leading_utf8_bom_and_not_a_later_literal_ufeff_char(self):
+        """Only one BOM can ever be produced by decoding; a 2nd U+FEFF is real content."""
+        file = io.BytesIO(b"\xef\xbb\xbf\xef\xbb\xbf{}")
+        ctx = _FileTypeDetectionContext(file=file)
+
+        text_head = ctx.text_head
+
+        assert text_head == "﻿{}"
+
     # TODO: this fails because `.text_head` ignores decoding errors on a file open for binary
     # reading. Probably better if it used chardet in that case as it does for a file-path.
     @pytest.mark.xfail(reason="WIP", raises=AssertionError, strict=True)

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -700,8 +700,10 @@ class _FileTypeDetectionContext:
 
         # -- a leading UTF-8 BOM survives a plain "utf-8" decode as a literal U+FEFF character,
         # -- which defeats content-shape checks (e.g. JSON's leading "[" or "{" test) that assume
-        # -- the text starts with actual content --
-        return text.lstrip("\ufeff")
+        # -- the text starts with actual content. Only one BOM can ever be produced by decoding,
+        # -- so remove at most one; `.lstrip()` would also strip a legitimate U+FEFF appearing in
+        # -- the actual content immediately after it. --
+        return text.removeprefix("\ufeff")
 
     @cached_property
     def json_disambiguation_text(self) -> tuple[str, bool]:

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -681,22 +681,27 @@ class _FileTypeDetectionContext:
             file.seek(0)
             content = file.read(4096)
             file.seek(0)
-            return (
+            text = (
                 content
                 if isinstance(content, str)
                 else content.decode(encoding=self.encoding, errors="ignore")
             )
+        else:
+            file_path = self.file_path
+            assert file_path is not None  # -- guaranteed by `._validate` --
 
-        file_path = self.file_path
-        assert file_path is not None  # -- guaranteed by `._validate` --
+            try:
+                with open(file_path, encoding=self.encoding) as f:
+                    text = f.read(4096)
+            except UnicodeDecodeError:
+                encoding, _ = detect_file_encoding(filename=file_path)
+                with open(file_path, encoding=encoding) as f:
+                    text = f.read(4096)
 
-        try:
-            with open(file_path, encoding=self.encoding) as f:
-                return f.read(4096)
-        except UnicodeDecodeError:
-            encoding, _ = detect_file_encoding(filename=file_path)
-            with open(file_path, encoding=encoding) as f:
-                return f.read(4096)
+        # -- a leading UTF-8 BOM survives a plain "utf-8" decode as a literal U+FEFF character,
+        # -- which defeats content-shape checks (e.g. JSON's leading "[" or "{" test) that assume
+        # -- the text starts with actual content --
+        return text.lstrip("\ufeff")
 
     @cached_property
     def json_disambiguation_text(self) -> tuple[str, bool]:


### PR DESCRIPTION
## Problem

`detect_filetype()` decodes a file's text head as plain `"utf-8"`. If the source has a leading UTF-8 byte-order-mark, that BOM survives the decode as a literal `U+FEFF` character at the start of the text.

`_TextFileDifferentiator._is_json` requires the first non-whitespace character to be `[` or `{`:

```python
if text_head.lstrip()[0] not in "[{":
    return False
```

`str.lstrip()` doesn't strip `U+FEFF` (it's not whitespace), so this check fails immediately for BOM-prefixed content — `_is_json` returns `False` without even attempting to parse it. When this happens for a payload with no `.json`/`.ndjson` extension and libmagic guesses a generic `text/plain` MIME type (which it does for BOM-prefixed content — confirmed BOM changes libmagic's own guess from `application/json`/`application/x-ndjson` to `text/plain`), the file falls all the way through to `FileType.TXT` instead of `FileType.JSON`.

## Repro

```python
import io, json
from unstructured.file_utils.filetype import detect_filetype

json_bytes = b"\xef\xbb\xbf" + json.dumps([{"example": "data"}]).encode("utf-8")
detect_filetype(file=io.BytesIO(json_bytes), metadata_file_path="filename.pdf")
# -> FileType.TXT  (before this fix)
# -> FileType.JSON (after this fix, matching the non-BOM case)
```

## Fix

Strip a leading BOM once in `_FileTypeDetectionContext.text_head` (the property consumed by `_is_json`/`_is_csv`/`_is_eml`), rather than changing the `.encoding` property itself — an existing test (`it_knows_the_encoding_asserted_by_the_caller_and_normalizes_it`) asserts `.encoding` returns the literal string `"utf-8"`, so I kept that contract untouched and fixed the actual text consumption point instead.

Per the contribution checklist, bumped `unstructured/__version__.py` to `0.25.1` and added a `CHANGELOG.md` entry.

## Testing

- Added `test_it_identifies_json_with_a_leading_utf8_bom_and_no_extension` to `test_unstructured/file_utils/test_filetype.py`; confirmed it fails against the pre-fix code (`FileType.TXT` instead of `FileType.JSON`, verified via `git stash`) and passes with the fix.
- Ran the full `test_unstructured/file_utils/` suite (380 passed, 1 xfailed — no regressions) plus `test_json.py`/`test_ndjson.py`/`test_csv.py`/`test_text.py` (189 passed) since those partitioners consume `text_head` indirectly through detection.
- `ruff check` / `ruff format --check` clean on all changed files; `scripts/version-sync.sh -c` confirms the version bump is consistent.

Disclosure: I used an AI coding assistant (Claude) to help identify this bug and draft the fix. The initial hypothesis about the exact failure mechanism was actually wrong (it pointed at a different function than the true cause), so I traced through `_FileTypeDetector`'s multi-strategy dispatch myself to find where the fix needed to land, wrote/verified the regression test in both red and green states, and ran the broader test suites above before opening this PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

