### PR TITLE
fix: catch UnicodeDecodeError in _is_json to avoid crashing detect_filetype()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - **Update README.md**: readme-only changes; added a link to Unstructured Pipelines to the README. No library behavior changes.
+- **Fix crash on non-UTF-8 bracket-prefixed text with no extension**: `detect_filetype()` called `json.load()` directly on the raw file bytes when probing whether `text/plain`-guessed content is actually JSON. If the content started with `[`/`{` but contained non-UTF-8 bytes, `json.load()` raised an uncaught `UnicodeDecodeError` (not the `json.JSONDecodeError` the code caught), crashing detection instead of falling back to `FileType.TXT`. Both exception types are now caught.
 
 ## 0.25.0
 

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -1346,7 +1346,7 @@ def test_it_does_not_crash_on_non_utf8_bracket_prefixed_text_with_no_extension()
     non_utf8_bytes = b"{not json at all just braces \xe9 text} and more padding to fill the head"
 
     file_buffer = io.BytesIO(non_utf8_bytes)
-    predicted_type = detect_filetype(file=file_buffer, metadata_file_path="filename.pdf")
+    predicted_type = detect_filetype(file=file_buffer)
 
     assert predicted_type == FileType.TXT
 

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -1342,6 +1342,15 @@ def test_json_content_type_is_disambiguated_for_ndjson():
     assert predicted_type == FileType.NDJSON
 
 
+def test_it_does_not_crash_on_non_utf8_bracket_prefixed_text_with_no_extension():
+    non_utf8_bytes = b"{not json at all just braces \xe9 text} and more padding to fill the head"
+
+    file_buffer = io.BytesIO(non_utf8_bytes)
+    predicted_type = detect_filetype(file=file_buffer, metadata_file_path="filename.pdf")
+
+    assert predicted_type == FileType.TXT
+
+
 def test_office_files_when_document_archive_has_non_standard_prefix():
     predicted_type = detect_filetype(
         file_path=input_path("file_type/test_document_from_office365.docx")

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -960,7 +960,7 @@ class _TextFileDifferentiator:
             with self._ctx.open() as file:
                 json.load(file)
             return True
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             return False
 
 


### PR DESCRIPTION
## Problem

`_TextFileDifferentiator._is_json` calls `json.load()` directly on the raw file bytes when libmagic guesses a generic `text/plain` MIME type and the content starts with `[`/`{`:

```python
try:
    with self._ctx.open() as file:
        json.load(file)
    return True
except json.JSONDecodeError:
    return False
```

If the bytes aren't valid UTF-8, `json.load()` raises `UnicodeDecodeError` (via its internal `detect_encoding` step) — a different exception type than `json.JSONDecodeError`, so it's not caught. It propagates straight out of the public `detect_filetype()` API instead of falling back to `FileType.TXT`, the behavior for any other content libmagic can't identify more specifically.

## Repro

```python
import io
from unstructured.file_utils.filetype import detect_filetype

data = b"{not json at all just braces \xe9 text} and more padding"
detect_filetype(file=io.BytesIO(data), metadata_file_path="filename.pdf")
# UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 29: invalid continuation byte
```

## Fix

Broaden the `except` clause to also catch `UnicodeDecodeError`.

## Testing

- Added `test_it_does_not_crash_on_non_utf8_bracket_prefixed_text_with_no_extension`, confirming `detect_filetype()` returns `FileType.TXT` instead of raising. Confirmed it fails against the pre-fix code and passes after.
- Ran the full `test_unstructured/file_utils/` suite (380 passed, 1 xfailed — no regressions).
- `ruff check`/`ruff format --check` clean. Bumped `unstructured/__version__.py` and added a `CHANGELOG.md` entry per the contribution checklist.

Note: this bumps to the same `0.25.1` as my other open PR (#4397), both branched from the same base — whichever merges second will likely need a quick rebase on the version files, happy to handle that when the time comes.

Disclosure: I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I independently reproduced the crash before writing the regression test and ran the full local test suite before opening this PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

