### PR TITLE
fix: parse UNSTRUCTURED_INCLUDE_DEBUG_METADATA env var as a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - **Update README.md**: readme-only changes; added a link to Unstructured Pipelines to the README. No library behavior changes.
+- **`UNSTRUCTURED_INCLUDE_DEBUG_METADATA` now parses its env var value as a boolean**: previously `os.getenv("UNSTRUCTURED_INCLUDE_DEBUG_METADATA", False)` treated any explicitly-set string value (including `"false"` or `"0"`) as truthy, so setting the variable to explicitly disable debug metadata actually enabled it. Now parses the value the same way `ENVConfig._get_bool` already does elsewhere in the codebase (`"true"`/`"1"`/`"t"`, case-insensitive, is `True`; everything else, including unset, is `False`).
 
 ## 0.25.0
 

--- a/test_unstructured/partition/utils/test_config.py
+++ b/test_unstructured/partition/utils/test_config.py
@@ -1,8 +1,44 @@
+import importlib
 import shutil
 import tempfile
 from pathlib import Path
 
 import pytest
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("true", True),
+        ("1", True),
+        ("t", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+    ],
+)
+def test_include_debug_metadata_parses_bool_string(monkeypatch, env_value, expected):
+    from unstructured.partition.utils import constants
+
+    monkeypatch.setenv("UNSTRUCTURED_INCLUDE_DEBUG_METADATA", env_value)
+    try:
+        importlib.reload(constants)
+        assert constants.UNSTRUCTURED_INCLUDE_DEBUG_METADATA is expected
+    finally:
+        monkeypatch.undo()
+        importlib.reload(constants)
+
+
+def test_include_debug_metadata_defaults_to_false_when_unset(monkeypatch):
+    from unstructured.partition.utils import constants
+
+    monkeypatch.delenv("UNSTRUCTURED_INCLUDE_DEBUG_METADATA", raising=False)
+    try:
+        importlib.reload(constants)
+        assert constants.UNSTRUCTURED_INCLUDE_DEBUG_METADATA is False
+    finally:
+        monkeypatch.undo()
+        importlib.reload(constants)
 
 
 def test_default_config():

--- a/unstructured/partition/utils/constants.py
+++ b/unstructured/partition/utils/constants.py
@@ -50,7 +50,13 @@ STT_AGENT_MODULES_WHITELIST = os.getenv(
     "unstructured.partition.utils.speech_to_text.whisper_stt",
 ).split(",")
 
-UNSTRUCTURED_INCLUDE_DEBUG_METADATA = os.getenv("UNSTRUCTURED_INCLUDE_DEBUG_METADATA", False)
+UNSTRUCTURED_INCLUDE_DEBUG_METADATA = os.getenv(
+    "UNSTRUCTURED_INCLUDE_DEBUG_METADATA", ""
+).lower() in (
+    "true",
+    "1",
+    "t",
+)
 
 # this field is defined by unstructured_pytesseract
 TESSERACT_TEXT_HEIGHT = "height"


### PR DESCRIPTION
## Problem

```python
UNSTRUCTURED_INCLUDE_DEBUG_METADATA = os.getenv("UNSTRUCTURED_INCLUDE_DEBUG_METADATA", False)
```

`os.getenv` always returns a string when the variable is set, and any non-empty string is truthy in Python — so setting the variable to explicitly *disable* debug metadata (`UNSTRUCTURED_INCLUDE_DEBUG_METADATA=false` or `=0`) actually *enables* it, the opposite of the operator's intent. Only leaving the variable completely unset gives the intended `False`.

The codebase already has a correct helper for exactly this pattern elsewhere:

```python
# partition/utils/config.py
def _get_bool(self, var: str, default_value: bool) -> bool:
    if value := os.environ.get(var):
        return value.lower() in ("true", "1", "t")
    return default_value
```

## Fix

Parse the raw env var value the same way `ENVConfig._get_bool` does: `"true"`/`"1"`/`"t"` (case-insensitive) is `True`, everything else (including unset) is `False`.

## Testing

Added `test_include_debug_metadata_parses_bool_string`, parametrized over `"true"/"1"/"t"` (expect `True`) and `"false"/"0"/"no"` (expect `False`), reloading the `constants` module after `monkeypatch.setenv` to pick up the change. Confirmed it fails against the pre-fix code (e.g. `assert 'false' is False` — got the string `'false'`, not the bool) and passes after.

- `pytest test_unstructured/partition/utils/test_config.py` — 11/11 passed.
- `ruff check`/`ruff format --check` clean.
- Updated `CHANGELOG.md` and bumped `__version__.py` to `0.25.1` per the contributing checklist. Note: two other open PRs (#4397, #4398) from this same debut day independently propose the same `0.25.1` bump from the same `0.25.0` base — whichever merges first "claims" `0.25.1`; the others (including this one, if it lands last) will need a quick rebase to the next patch version. Flagging so it's not a surprise at merge time.

## AI disclosure

Developed with AI assistance (Claude Code), which located the boolean-parsing bug while auditing environment-variable handling across the codebase and noticed the existing correct pattern in `ENVConfig._get_bool` that this constant didn't follow. I reviewed the diff, independently reproduced the bug and the fix by executing both, and ran the tests/linters myself before opening this PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

