### PR TITLE
fix: use deepcopy instead of shallow copy when stripping orig_elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - **Update README.md**: readme-only changes; added a link to Unstructured Pipelines to the README. No library behavior changes.
+- **`Chunker._orig_elements` no longer mutates the caller's original elements**: `copy.copy(e)` created a shallow copy whose `.metadata` was the *same object* as the original element's `.metadata`; clearing `orig_elements` on the copy (`orig_element.metadata.orig_elements = None`) mutated the caller's original element in place, contradicting the code's own comment that these elements "don't belong to us." Now uses `copy.deepcopy(e)`, matching the sibling `_TableChunker._orig_elements`'s existing correct pattern.
 
 ## 0.25.0
 

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -1267,6 +1267,21 @@ class Describe_Chunker:
         # -- computation is only on first call, all chunks get exactly the same orig-elements --
         assert chunker._orig_elements is orig_elements
 
+    def it_does_not_mutate_the_callers_original_element_when_stripping_orig_elements(self):
+        """The elements passed in don't belong to `_Chunker`; it must not mutate them."""
+        opts = ChunkingOptions(include_orig_elements=True)
+        inner = Text("Porta volupat.")
+        element = CompositeElement(
+            "In rhoncus ipsum sed lectus porta volutpat.",
+            metadata=ElementMetadata(orig_elements=[inner]),
+        )
+        chunker = _Chunker([element], text=element.text, opts=opts)
+
+        chunker._orig_elements
+
+        # -- the caller's own element must still have its original `.orig_elements` value --
+        assert element.metadata.orig_elements == [inner]
+
 
 class Describe_TableChunker:
     """Unit-test suite for `unstructured.chunking.base._TableChunker` objects."""

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -945,7 +945,7 @@ class _Chunker:
                     continue
                 # -- make copy of any element we're going to mutate because these elements don't
                 # -- belong to us (the user may have downstream purposes for them).
-                orig_element = copy.copy(e)
+                orig_element = copy.deepcopy(e)
                 # -- prevent recursive .orig_elements when element is a chunk (has orig-elements of
                 # -- its own)
                 orig_element.metadata.orig_elements = None


### PR DESCRIPTION
## Problem

`_Chunker._orig_elements` copies each element before clearing its `metadata.orig_elements`, with an explicit comment stating this is because "these elements don't belong to us (the user may have downstream purposes for them)." But `copy.copy()` is a **shallow** copy — the copy's `.metadata` is the *same object* as the original's `.metadata` — so `orig_element.metadata.orig_elements = None` mutates the caller's own element in place, exactly contradicting the stated intent.

Sibling `_TableChunker._orig_elements` already does this correctly with `copy.deepcopy(self._table)`.

## Fix

Use `copy.deepcopy` instead of `copy.copy`, matching the already-correct sibling implementation.

## Testing

- Added a regression test confirming a caller's element still has its original `.metadata.orig_elements` value after `_Chunker._orig_elements` is computed.
- Confirmed red→green: reverting only `base.py` reproduces the caller mutation (`assert None == [inner]`); reapplying passes.
- Full `test_unstructured/chunking/` suite: 334 passed.
- `ruff check` — clean.
- xref: no open PR touches this shallow/deep-copy site (checked #4392, #4383, #4382, #4197 — none overlap; #4382/#4197 have unrelated `include_orig_elements` matches, a different parameter name).

## AI-Generated disclosure

I used an AI coding assistant (Claude) to help identify this bug and draft the fix. I independently reproduced the caller mutation with a throwaway script before writing the test, cross-checked against the already-correct sibling `_TableChunker` implementation, and ran the full local test suite before preparing this change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

