### PR TITLE
fix: cache yolox model in docker build to prevent 429 cloud run errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,8 @@ ENV UV_PYTHON_DOWNLOADS=never
 RUN uv sync --locked --all-extras --no-group dev --no-group lint --no-group test --no-group release && \
     uv run --no-sync $PYTHON -c "from unstructured.nlp.tokenize import _get_nlp; print('spaCy model loaded:', _get_nlp().meta['name'])" && \
     uv run --no-sync $PYTHON -c "from unstructured.partition.model_init import initialize; initialize()" && \
-    uv run --no-sync $PYTHON -c "from unstructured_inference.models.tables import UnstructuredTableTransformerModel; model = UnstructuredTableTransformerModel(); model.initialize('microsoft/table-transformer-structure-recognition')"
+    uv run --no-sync $PYTHON -c "from unstructured_inference.models.tables import UnstructuredTableTransformerModel; model = UnstructuredTableTransformerModel(); model.initialize('microsoft/table-transformer-structure-recognition')" && \
+    uv run --no-sync $PYTHON -c "from unstructured_inference.models.base import get_model; get_model('yolox')"
 
 # Replace PyPI opencv wheels (which bundle vulnerable ffmpeg 5.1.x with 14 CVEs)
 # with a source-built opencv-contrib-python-headless wheel compiled with


### PR DESCRIPTION
Description
This PR resolves a deployment bottleneck where 429 Too Many Requests errors occur on Google Cloud Run when multiple container instances simultaneously attempt to download the yolox model weights at runtime.

The Fix:
I shifted the model download left into the build phase. By caching the yolox model during the Dockerfile build (alongside spaCy and TableTransformer), the model weights are now baked directly into the container image. This eliminates network dependencies at runtime and prevents rate-limiting crashes.

Related Issue
Closes #4110

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

