### PR TITLE
Guard clean_ordered_bullets and extract_ordered_bullets against empty text

### DIFF
--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -59,6 +59,9 @@ def test_clean_bullets(text, expected):
         ("1..2.3 four", "1..2.3 four"),
         ("Fig. 2: The relationship", "Fig. 2: The relationship"),
         ("23 is everywhere", "23 is everywhere"),
+        ("", ""),
+        ("   ", "   "),
+        ("\n\t", "\n\t"),
     ],
 )
 def test_clean_ordered_bullets(text, expected):

--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -100,6 +100,9 @@ def test_extract_us_phone_number(text, expected):
         ("1..2.3 four", (None, None, None)),
         ("Fig. 2: The relationship", (None, None, None)),
         ("23 is everywhere", (None, None, None)),
+        ("", (None, None, None)),
+        ("   ", (None, None, None)),
+        ("\n\t", (None, None, None)),
     ],
 )
 def test_extract_ordered_bullets(text, expected):

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -59,6 +59,8 @@ def clean_ordered_bullets(text) -> str:
     a.b This is a very important point -> This is a very important point
     """
     text_sp = text.split()
+    if not text_sp:
+        return text
     text_cl = " ".join(text_sp[1:])
     if any(["." not in text_sp[0], ".." in text_sp[0]]):
         return text

--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -118,6 +118,8 @@ def extract_ordered_bullets(text) -> tuple:
     """
     a, b, c, temp = None, None, None, None
     text_sp = text.split()
+    if not text_sp:
+        return a, b, c
     if any(["." not in text_sp[0], ".." in text_sp[0]]):
         return a, b, c
 


### PR DESCRIPTION
`clean_ordered_bullets` and `extract_ordered_bullets` call `text.split()` then index `text_sp[0]` without a guard, so an empty or whitespace-only string raises `IndexError: list index out of range`. Both are public cleaning bricks, and the sibling `clean_bullets` already returns the text unchanged when there is no match.

This returns the input unchanged (`clean_ordered_bullets`) / `(None, None, None)` (`extract_ordered_bullets`) for empty input, matching that graceful-degradation contract. Added empty and whitespace-only cases to the existing parametrized tests for both functions.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

