### PR TITLE
fix(email): degrade gracefully on malformed address headers

### DIFF
--- a/test_unstructured/partition/test_email.py
+++ b/test_unstructured/partition/test_email.py
@@ -59,6 +59,16 @@ def test_partition_email_from_file_can_partition_an_email():
         assert partition_email(file=f) == EXPECTED_OUTPUT
 
 
+def test_partition_email_does_not_crash_on_a_malformed_address_header():
+    elements = partition_email(
+        file=io.BytesIO(
+            b'To: "\r\nFrom: sender@example.com\r\nSubject: Greeting\r\n\r\nHello there.\r\n'
+        )
+    )
+    assert [e.text for e in elements] == ["Hello there."]
+    assert elements[0].metadata.sent_from == ["sender@example.com"]
+
+
 def test_partition_email_from_spooled_temp_file_can_partition_an_email():
     with tempfile.SpooledTemporaryFile() as file:
         with open(example_doc_path("eml/fake-email.eml"), "rb") as f:
@@ -432,6 +442,12 @@ class DescribeEmailPartitionerOptions:
         ctx = EmailPartitioningContext(example_doc_path("eml/simple-rfc-822.eml"))
         assert ctx.bcc_addresses is None
 
+    def and_it_degrades_to_the_recoverable_Bcc_addresses_when_the_header_is_malformed(self):
+        ctx = EmailPartitioningContext(
+            file=io.BytesIO(b'Bcc: Ann <ann@example.com>, "\r\nSubject: x\r\n\r\nbody\r\n')
+        )
+        assert ctx.bcc_addresses == ["Ann <ann@example.com>"]
+
     # -- .body_part ------------------------------
 
     def it_returns_the_html_body_part_when_there_is_one_by_default(self):
@@ -470,6 +486,12 @@ class DescribeEmailPartitionerOptions:
         ctx = EmailPartitioningContext(example_doc_path("eml/simple-rfc-822.eml"))
         assert ctx.cc_addresses is None
 
+    def and_it_degrades_to_the_recoverable_Cc_addresses_when_the_header_is_malformed(self):
+        ctx = EmailPartitioningContext(
+            file=io.BytesIO(b'Cc: Amy <amy@example.com>, "\r\nSubject: x\r\n\r\nbody\r\n')
+        )
+        assert ctx.cc_addresses == ["Amy <amy@example.com>"]
+
     # -- .content_type_preference ----------------
 
     @pytest.mark.parametrize(
@@ -494,6 +516,10 @@ class DescribeEmailPartitionerOptions:
     def it_knows_the_From_address_of_the_email(self):
         ctx = EmailPartitioningContext(example_doc_path("eml/mime-simple.eml"))
         assert ctx.from_address == "sender@example.com"
+
+    def and_it_returns_None_when_the_From_header_is_malformed(self):
+        ctx = EmailPartitioningContext(file=io.BytesIO(b'From: "\r\nSubject: x\r\n\r\nbody\r\n'))
+        assert ctx.from_address is None
 
     # -- .message_id -----------------------------
 
@@ -615,6 +641,16 @@ class DescribeEmailPartitionerOptions:
 
     def but_it_returns_None_when_there_are_no_To_addresses(self):
         ctx = EmailPartitioningContext(example_doc_path("eml/mime-no-to.eml"))
+        assert ctx.to_addresses is None
+
+    def and_it_degrades_to_the_recoverable_To_addresses_when_the_header_is_malformed(self):
+        ctx = EmailPartitioningContext(
+            file=io.BytesIO(b'To: Bob <bob@example.com>, "\r\nSubject: x\r\n\r\nbody\r\n')
+        )
+        assert ctx.to_addresses == ["Bob <bob@example.com>"]
+
+    def and_it_returns_None_when_the_To_header_is_wholly_malformed(self):
+        ctx = EmailPartitioningContext(file=io.BytesIO(b'To: "\r\nSubject: x\r\n\r\nbody\r\n'))
         assert ctx.to_addresses is None
 
     # -- fixtures --------------------------------------------------------------------------------

--- a/unstructured/partition/email.py
+++ b/unstructured/partition/email.py
@@ -12,6 +12,7 @@ import email.utils
 import io
 import os
 from email.message import EmailMessage, MIMEPart
+from email.parser import BytesHeaderParser
 from functools import cached_property
 from typing import IO, Any, Final, Iterator, cast
 
@@ -119,14 +120,26 @@ class EmailPartitioningContext:
             kwargs=kwargs,
         )._validate()
 
+    def _addresses(self, header_name: str) -> list[str] | None:
+        """Best-effort address list for an address header (To/From/Cc/Bcc).
+
+        `policy.default`'s structured address parser raises (e.g. IndexError from CPython
+        email._header_value_parser) on some malformed headers, so fall back to a lenient raw
+        parse and degrade instead of crashing the whole partition.
+        """
+        try:
+            values = self.msg.get_all(header_name)
+        except (IndexError, AttributeError, TypeError, UnboundLocalError):
+            values = BytesHeaderParser().parsebytes(self._source_bytes).get_all(header_name)
+        if not values:
+            return None
+        addrs = [a for a in email.utils.getaddresses([str(v) for v in values]) if a != ("", "")]
+        return [email.utils.formataddr(addr) for addr in addrs] or None
+
     @cached_property
     def bcc_addresses(self) -> list[str] | None:
         """The "blind carbon-copy" Bcc: addresses of the message."""
-        bccs = self.msg.get_all("Bcc")
-        if not bccs:
-            return None
-        addrs = email.utils.getaddresses(bccs)
-        return [email.utils.formataddr(addr) for addr in addrs]
+        return self._addresses("Bcc")
 
     @cached_property
     def body_part(self) -> MIMEPart | None:
@@ -140,11 +153,7 @@ class EmailPartitioningContext:
     @cached_property
     def cc_addresses(self) -> list[str] | None:
         """The "carbon-copy" Cc: addresses of the message."""
-        ccs = self.msg.get_all("Cc")
-        if not ccs:
-            return None
-        addrs = email.utils.getaddresses(ccs)
-        return [email.utils.formataddr(addr) for addr in addrs]
+        return self._addresses("Cc")
 
     @cached_property
     def content_type_preference(self) -> tuple[str, ...]:
@@ -174,13 +183,8 @@ class EmailPartitioningContext:
     @cached_property
     def from_address(self) -> str | None:
         """The address of the message sender."""
-        froms = self.msg.get_all("From")
-        if not froms:
-            # -- this should never occur because the From: header is mandatory per RFC 5322 --
-            return None
-        addrs = email.utils.getaddresses(froms)
-        formatted_addrs = [email.utils.formataddr(addr) for addr in addrs]
-        return formatted_addrs[0]
+        addrs = self._addresses("From")
+        return addrs[0] if addrs else None
 
     @cached_property
     def message_id(self) -> str | None:
@@ -222,19 +226,20 @@ class EmailPartitioningContext:
         return self._metadata_last_modified or self._sent_date or self._filesystem_last_modified
 
     @cached_property
-    def msg(self) -> EmailMessage:
-        """The Python stdlib `email.message.EmailMessage` object parsed from the EML file."""
+    def _source_bytes(self) -> bytes:
+        """Raw bytes of the EML, read once and reused for the lenient address re-parse."""
         if self._file_path is not None:
             with open(self._file_path, "rb") as f:
-                return cast(
-                    EmailMessage, email.message_from_binary_file(f, policy=email.policy.default)
-                )
-
+                return f.read()
         assert self._file is not None
+        return self._file.read()
 
-        file_bytes = self._file.read()
-
-        return cast(EmailMessage, email.message_from_bytes(file_bytes, policy=email.policy.default))
+    @cached_property
+    def msg(self) -> EmailMessage:
+        """The Python stdlib `email.message.EmailMessage` object parsed from the EML file."""
+        return cast(
+            EmailMessage, email.message_from_bytes(self._source_bytes, policy=email.policy.default)
+        )
 
     @cached_property
     def partitioning_kwargs(self) -> dict[str, Any]:
@@ -265,11 +270,7 @@ class EmailPartitioningContext:
     @cached_property
     def to_addresses(self) -> list[str] | None:
         """The To: addresses of the message."""
-        tos = self.msg.get_all("To")
-        if not tos:
-            return None
-        addrs = email.utils.getaddresses(tos)
-        return [email.utils.formataddr(addr) for addr in addrs]
+        return self._addresses("To")
 
     @cached_property
     def _filesystem_last_modified(self) -> str | None:


### PR DESCRIPTION
`partition_email` raises an uncaught `IndexError` on a valid `.eml` whose `To`/`From`/`Cc`/`Bcc` header contains a malformed address such as an unterminated quoted string. The message is parsed with `policy.default`, whose structured address parser runs eagerly on `get_all("To")`, and since `email_metadata` is computed for every element, one corrupt header aborts the whole partition. Reproduces on Python 3.11 and 3.12:

```python
import io
from unstructured.partition.email import partition_email
partition_email(file=io.BytesIO(b'To: "\r\nFrom: a@b.com\r\n\r\nbody\r\n'))
# IndexError: list index out of range  (email/_header_value_parser.py, local_part)
```

The fix routes the four address properties through one helper that keeps the `policy.default` parse (so encoded-word decoding for well-formed headers is unchanged) and falls back to a lenient compat32 re-parse only when it raises. Well-formed addresses in a mixed header are still recovered; a wholly malformed header degrades to `None`. Includes regression tests for each header and an end-to-end partition test.
