### PR TITLE
fix(html): handle declaration-only documents without TypeError

### DIFF
--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -717,6 +717,19 @@ def test_partition_html_from_text_works_with_empty_string():
     assert partition_html(text="") == []
 
 
+@pytest.mark.parametrize(
+    "html_text",
+    [
+        "<?xml version=\"1.0\"?>",
+        "<!DOCTYPE html>",
+        "<?xml",
+    ],
+)
+def test_partition_html_declaration_only_document_returns_empty(html_text: str):
+    # HTMLParser returns None for these; must not TypeError in strip_elements.
+    assert partition_html(text=html_text) == []
+
+
 def test_partition_html_accommodates_block_item_nested_inside_phrasing_element():
     html_text = """
     <div>

--- a/unstructured/partition/html/partition.py
+++ b/unstructured/partition/html/partition.py
@@ -259,6 +259,10 @@ class _HtmlPartitioner:
         except ValueError:
             root = etree.fromstring(html_text.encode("utf-8"), html_parser)
 
+        # HTMLParser returns None for declaration-only docs (e.g. "<!DOCTYPE html>")
+        if root is None:
+            root = etree.fromstring("<html></html>", html_parser)
+
         # -- remove a variety of HTML element types like <script> and <style> that we prefer not
         # -- to encounter while parsing.
         etree.strip_elements(


### PR DESCRIPTION
lxml HTMLParser returns None for declaration-only input such as <!DOCTYPE html> or <?xml ...?>, and strip_elements then TypeErrors. Re-parse a minimal <html></html> so partition_html returns [].

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

