### PR TITLE
fix: index_adjustment_after_clean_extra_whitespace maps cleaned index to the wrong original offset

### DIFF
--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -303,3 +303,13 @@ def test_clean(text, extra_whitespace, dashes, bullets, lowercase, trailing_punc
 def test_bytes_string_to_string():
     text = "\xe6\xaf\x8f\xe6\x97\xa5\xe6\x96\xb0\xe9\x97\xbb"
     assert core.bytes_string_to_string(text, "utf-8") == "每日新闻"
+
+
+def test_index_adjustment_maps_cleaned_index_back_to_original():
+    text = "ITEM 1.     BUSINESS"
+    cleaned, moved_indices = core.clean_extra_whitespace_with_index_run(text)
+    assert cleaned == "ITEM 1. BUSINESS"
+    cleaned_index = cleaned.index("B")
+    original_index = core.index_adjustment_after_clean_extra_whitespace(cleaned_index, moved_indices)
+    assert text[original_index] == cleaned[cleaned_index] == "B"
+    assert original_index == 12

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -487,4 +487,4 @@ def clean_extra_whitespace_with_index_run(text: str) -> Tuple[str, np.ndarray]:
 
 
 def index_adjustment_after_clean_extra_whitespace(index, moved_indices) -> int:
-    return int(index - moved_indices[index])
+    return int(index + moved_indices[index])


### PR DESCRIPTION
### What's broken

`index_adjustment_after_clean_extra_whitespace` **subtracts** the moved distance when it must **add** it:

```python
def index_adjustment_after_clean_extra_whitespace(index, moved_indices) -> int:
    return int(index - moved_indices[index])
```

`clean_extra_whitespace_with_index_run` returns `moved_indices` where `moved_indices[i]` is the number of characters removed before cleaned index `i` (per its docstring), so the original position of a cleaned character is `index + moved_indices[index]`. Subtracting maps every character following a collapsed whitespace run to the wrong — or a negative — original offset:

```python
text = "ITEM 1.     BUSINESS"
cleaned, moved = clean_extra_whitespace_with_index_run(text)   # 'ITEM 1. BUSINESS'
i = cleaned.index("B")                                          # 8
index_adjustment_after_clean_extra_whitespace(i, moved)        # 4  (a space) -- should be 12
```

Only `+` round-trips (`text[i + moved[i]] == cleaned[i]`) for every kept character, including multi-run cases like `"a  b  c"`.

### Fix

Change the operator to `+` and add a round-trip regression test. (Distinct from #4166, which optimized the producer `clean_extra_whitespace_with_index_run` and left this sign bug untouched.)

### Tests

Adds `test_index_adjustment_maps_cleaned_index_back_to_original`. Full `test_unstructured/cleaners/test_core.py` passes (89).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

