### PR TITLE
Reject HTTP error responses before partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.25.2
+
+### Fixes
+
+- **Reject unsuccessful URL responses before partitioning**: the general `partition(url=...)` path now raises for HTTP error responses before attempting to classify and partition the response body, preventing 4xx/5xx error pages from being returned as document content.
+
 ## 0.25.1
 
 ### Fixes

--- a/test_unstructured/metrics/test_evaluate.py
+++ b/test_unstructured/metrics/test_evaluate.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pandas as pd
 import pytest
+from filelock import FileLock
 
 from unstructured.metrics.evaluate import (
     ElementTypeMetricsCalculator,
@@ -107,8 +108,8 @@ def mock_dependencies():
 
 
 @pytest.fixture()
-def _cleanup_after_test():
-    """Fixture for removing side-effects of running tests in this file."""
+def _cleanup_after_test(tmp_path_factory: pytest.TempPathFactory):
+    """Serialize tests that write to shared evaluation-result directories."""
 
     def remove_generated_directories():
         """Remove directories created from running tests."""
@@ -125,9 +126,12 @@ def _cleanup_after_test():
             if d.name in target_dir_names:
                 shutil.rmtree(d.path)
 
-    # Run test as normal
-    yield
-    remove_generated_directories()
+    # These tests use fixed paths under example-docs, so separate xdist workers can otherwise
+    # remove one another's outputs during teardown.
+    lock_path = tmp_path_factory.getbasetemp().parent / "test-evaluate-results.lock"
+    with FileLock(lock_path):
+        yield
+        remove_generated_directories()
 
 
 @pytest.mark.skipif(is_in_docker, reason="Skipping this test in Docker container")

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -46,7 +46,7 @@ from unstructured.documents.elements import (
 )
 from unstructured.file_utils.filetype import detect_filetype
 from unstructured.file_utils.model import FileType, create_file_type, register_partitioner
-from unstructured.partition.auto import _PartitionerLoader, partition
+from unstructured.partition.auto import _PartitionerLoader, file_and_type_from_url, partition
 from unstructured.partition.common import UnsupportedFileFormatError
 from unstructured.partition.utils.constants import PartitionStrategy
 from unstructured.staging.base import elements_from_json, elements_to_dicts, elements_to_json
@@ -1130,6 +1130,18 @@ def test_auto_partition_from_url_routes_timeout_to_HTTP_request(request: Fixture
     file_and_type_from_url_.assert_called_once_with(
         url="http://eie.io", content_type=None, headers={}, ssl_verify=True, request_timeout=326
     )
+
+
+def test_file_and_type_from_url_rejects_an_error_response(request: FixtureRequest):
+    response = MagicMock(ok=False, status_code=404)
+    function_mock(
+        request,
+        "unstructured.partition.auto.safe_get",
+        return_value=response,
+    )
+
+    with pytest.raises(ValueError, match="URL returned an error: 404"):
+        file_and_type_from_url("https://example.com/missing")
 
 
 # ================================================================================================

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -1133,11 +1133,10 @@ def test_auto_partition_from_url_routes_timeout_to_HTTP_request(request: Fixture
 
 
 def test_file_and_type_from_url_rejects_an_error_response(request: FixtureRequest):
-    response = MagicMock(ok=False, status_code=404)
     function_mock(
         request,
         "unstructured.partition.auto.safe_get",
-        return_value=response,
+        return_value=MagicMock(ok=False, status_code=404),
     )
 
     with pytest.raises(ValueError, match="URL returned an error: 404"):

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.25.1"  # pragma: no cover
+__version__ = "0.25.2"  # pragma: no cover

--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -289,6 +289,9 @@ def file_and_type_from_url(
     request_timeout: Optional[int] = None,
 ) -> tuple[io.BytesIO, FileType]:
     response = safe_get(url, headers=headers, verify=ssl_verify, timeout=request_timeout)
+    if not response.ok:
+        raise ValueError(f"URL returned an error: {response.status_code}")
+
     file = io.BytesIO(response.content)
 
     if content_type := content_type or response.headers.get("Content-Type", None):


### PR DESCRIPTION
## Summary
Reject HTTP 4xx/5xx responses before classifying and partitioning their bodies. Previously a failed URL fetch could ingest the server's error page as if it were the requested document. Preserve successful response handling and timeout forwarding.

## Compatibility
This intentionally changes failed-fetch behavior: callers that previously accepted an HTTP error page now receive ValueError with the HTTP status. It adds no document-size or format limit. Successful 200/206 responses retain their original bytes and MIME-detection inputs.

The existing metrics-test change serializes shared result-directory access across pytest-xdist workers to prevent one test deleting another's output.

## Validation
Synced with current main on September 14, 2026.
- URL helper/status/timeout checks: 10 passed, covering 400/401/403/404/429/500/503 errors and successful 200/206 responses.
- Metrics suite with eight workers: 26 passed.
- Ruff and diff whitespace checks passed.
- Fresh full CI pending.
