### PR TITLE
perf(html): use indexed parent lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Enhancements
+
+- **Speed up HTML element hierarchy reconstruction**: `elements_to_html()` now indexes elements by ID before attaching children, avoiding repeated linear parent scans.
+
 ## 0.25.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.25.2-dev0
 
 ### Enhancements
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.25.1"  # pragma: no cover
+__version__ = "0.25.2-dev0"  # pragma: no cover

--- a/unstructured/partition/html/convert.py
+++ b/unstructured/partition/html/convert.py
@@ -262,12 +262,14 @@ def _group_element_children(children: list[ElementHtml]) -> list[ElementHtml]:
 
 def _elements_to_html_tags_by_parent(elements: list[ElementHtml]) -> list[ElementHtml]:
     parent_to_children_map: dict[str, list[ElementHtml]] = defaultdict(list)
+    elements_by_id: dict[str, ElementHtml] = {}
     for element in elements:
+        elements_by_id.setdefault(element.element.id, element)
         if element.element.metadata.parent_id is not None:
             parent_to_children_map[element.element.metadata.parent_id].append(element)
     for parent_id, children in parent_to_children_map.items():
         grouped_children = _group_element_children(children)
-        parent = next((el for el in elements if el.element.id == parent_id), None)
+        parent = elements_by_id.get(parent_id)
         if parent is None:
             logger.warning(f"Parent element with id {parent_id} not found. Skipping.")
             continue


### PR DESCRIPTION
## Summary

Replace repeated linear parent lookups during HTML element reconstruction with a precomputed element ID map.

## Performance

This changes parent lookup from O(elements × parents) to O(elements + parents), improving scalability for documents with many hierarchical HTML elements.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

