### PR TITLE
docs: fix moved example PDF path in README quick tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Once in the running container, you can try things directly in Python interpreter
 python3
 
 >>> from unstructured.partition.pdf import partition_pdf
->>> elements = partition_pdf(filename="example-docs/layout-parser-paper-fast.pdf")
+>>> elements = partition_pdf(filename="example-docs/pdf/layout-parser-paper-fast.pdf")
 
 >>> from unstructured.partition.text import partition_text
 >>> elements = partition_text(filename="example-docs/fake-text.txt")


### PR DESCRIPTION
The Quick Tour `partition_pdf` snippet in the README references a PDF at a path that no longer exists:

```python
>>> elements = partition_pdf(filename="example-docs/layout-parser-paper-fast.pdf")
```

`example-docs/layout-parser-paper-fast.pdf` returns 404 — the example PDFs were reorganized into `example-docs/pdf/` (PR #3410), and the file now lives at `example-docs/pdf/layout-parser-paper-fast.pdf`. The sibling snippet just below (`example-docs/fake-text.txt`) still resolves, confirming the base directory is correct and isolating this to the moved PDF.

As written, the documented command raises `FileNotFoundError` (also inside the container, where the Dockerfile copies `example-docs` preserving the `pdf/` subdir).

Docs-only, no functional change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

