### PR TITLE
fix(chunking): measure inter-chunk overlap in tokens under token chunking

### DIFF
--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -876,6 +876,50 @@ class DescribePreChunk:
         )
         assert pre_chunk.overlap_tail == expected_value
 
+    def it_measures_its_overlap_tail_in_tokens_under_token_chunking(self):
+        """Under token chunking `overlap` is a token count, so the tail is too.
+
+        A character slice would carry far fewer tokens than requested.
+        """
+        pytest.importorskip("tiktoken")
+        import tiktoken
+
+        enc = tiktoken.get_encoding("cl100k_base")
+        text = (
+            "In rhoncus ipsum sed lectus porta volutpat morbi tincidunt augue"
+            " interdum velit euismod in pellentesque massa placerat."
+        )
+        pre_chunk = PreChunk(
+            [Text(text)],
+            overlap_prefix="",
+            opts=ChunkingOptions(
+                max_tokens=100, tokenizer="cl100k_base", overlap=10, overlap_all=True
+            ),
+        )
+
+        tail = pre_chunk.overlap_tail
+
+        # -- the tail is a real suffix of the chunk text --
+        assert text.endswith(tail)
+        tail_tokens = len(enc.encode(tail))
+        # -- it carries ~10 tokens (never more), not the ~3 that a 10-character slice
+        # -- of this text would yield --
+        assert 8 <= tail_tokens <= 10
+
+    def it_returns_the_whole_text_when_shorter_than_the_token_overlap(self):
+        """When the chunk has fewer tokens than the overlap, the tail is the whole text."""
+        pytest.importorskip("tiktoken")
+
+        pre_chunk = PreChunk(
+            [Text("Hello world")],
+            overlap_prefix="",
+            opts=ChunkingOptions(
+                max_tokens=100, tokenizer="cl100k_base", overlap=50, overlap_all=True
+            ),
+        )
+
+        assert pre_chunk.overlap_tail == "Hello world"
+
     @pytest.mark.parametrize(
         ("elements", "overlap_prefix", "expected_value"),
         [

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -729,7 +729,16 @@ class PreChunk:
         trailing whitespace.
         """
         overlap = self._opts.inter_chunk_overlap
-        return self._text[-overlap:].strip() if overlap else ""
+        if not overlap:
+            return ""
+        # -- Under token chunking, `overlap` is a token count like every other size
+        # -- option, and the text-splitter already measures its split-boundary overlap in
+        # -- tokens. A raw character slice here would make the same `overlap` value mean
+        # -- tokens at a split boundary but characters at a chunk boundary, silently
+        # -- shrinking inter-chunk overlap to a fraction of what was requested.
+        if self._opts.use_token_counting:
+            return _token_overlap_tail(self._text, overlap, self._opts.measure).strip()
+        return self._text[-overlap:].strip()
 
     def _iter_text_segments(self) -> Iterator[str]:
         """Generate overlap text and each element text segment in order.
@@ -1393,6 +1402,44 @@ class _HtmlTableSplitter:
         return rows[0] if rows else None
 
 
+def _token_overlap_tail(text: str, target_tokens: int, measure: Callable[[str], int]) -> str:
+    """Return the tail of `text` holding approximately `target_tokens` tokens.
+
+    Uses binary search to find the character position from which the tail contains
+    approximately `target_tokens` tokens, then adjusts forward to a word boundary so a
+    word is not split. `measure` counts tokens for a string. The tail is approximate: it
+    rounds to a word boundary and so may carry slightly fewer tokens than requested.
+    """
+    # -- if the entire text has fewer tokens than target, return all of it --
+    if measure(text) <= target_tokens:
+        return text.strip()
+
+    # -- binary search to find the character position that yields ~target_tokens --
+    low, high = 0, len(text)
+
+    while low < high:
+        mid = (low + high) // 2
+        tail = text[mid:]
+        token_count = measure(tail)
+        if token_count > target_tokens:
+            low = mid + 1
+        else:
+            high = mid
+
+    # -- adjust to word boundary: search forward for whitespace then skip it --
+    pos = low
+    while pos < len(text) and not text[pos].isspace():
+        pos += 1
+    while pos < len(text) and text[pos].isspace():
+        pos += 1
+
+    # -- if we've moved too far, fall back to just stripping leading whitespace --
+    if pos >= len(text):
+        return text[low:].lstrip()
+
+    return text[pos:]
+
+
 class _TextSplitter:
     """Provides a text-splitting function configured on construction.
 
@@ -1532,40 +1579,10 @@ class _TextSplitter:
     def _get_token_overlap_tail(self, text: str, target_tokens: int) -> str:
         """Extract tail of text containing approximately `target_tokens` tokens.
 
-        Uses binary search to find the character position from which the tail contains
-        approximately the specified number of tokens. Adjusts to word boundaries to avoid
-        splitting words.
+        Delegates to the module-level `_token_overlap_tail` so the same token-tail logic
+        is shared with `PreChunk.overlap_tail`.
         """
-        measure = self._opts.measure
-
-        # -- if the entire text has fewer tokens than target, return all of it --
-        if measure(text) <= target_tokens:
-            return text.strip()
-
-        # -- binary search to find the character position that yields ~target_tokens --
-        low, high = 0, len(text)
-
-        while low < high:
-            mid = (low + high) // 2
-            tail = text[mid:]
-            token_count = measure(tail)
-            if token_count > target_tokens:
-                low = mid + 1
-            else:
-                high = mid
-
-        # -- adjust to word boundary: search forward for whitespace then skip it --
-        pos = low
-        while pos < len(text) and not text[pos].isspace():
-            pos += 1
-        while pos < len(text) and text[pos].isspace():
-            pos += 1
-
-        # -- if we've moved too far, fall back to just stripping leading whitespace --
-        if pos >= len(text):
-            return text[low:].lstrip()
-
-        return text[pos:]
+        return _token_overlap_tail(text, target_tokens, self._opts.measure)
 
     @cached_property
     def _patterns(self) -> tuple[tuple[regex.Pattern[str], int], ...]:


### PR DESCRIPTION
`overlap` is documented as a size in the chunking window's units, and under `max_tokens` chunking every other size (`max_tokens`, `new_after_n_tokens`, `hard_max`, `soft_max`) is measured in tokens via `ChunkingOptions.measure`. The text splitter follows that: when it splits an oversized element it calls `_get_token_overlap_tail(fragment, overlap)` and hands the next fragment approximately `overlap` **tokens**.

`PreChunk.overlap_tail`, which produces the overlap between two whole chunks, did not:

```python
overlap = self._opts.inter_chunk_overlap
return self._text[-overlap:].strip() if overlap else ""
```

That is a character slice regardless of mode, so the same `overlap` value means two different things depending on which boundary it lands on.

With `max_tokens=100, tokenizer="cl100k_base", overlap=50, overlap_all=True` over a long paragraph:

```
split boundary  -> 50 tokens   (as requested)
chunk boundary  -> 50 chars = 13 tokens
```

So inter-chunk overlap is silently about a quarter of what was asked for, and it varies with the text, since characters-per-token is not constant. Overlap exists to keep context across a boundary for retrieval, so quietly shrinking it degrades results without any error.

The fix pulls the existing binary-search tail lookup out of `_TextSplitter` into a module-level `_token_overlap_tail(text, target_tokens, measure)` and calls it from both places. `_TextSplitter._get_token_overlap_tail` now delegates to it, so the splitter's behaviour is byte-for-byte the same. Character-based chunking still takes the character slice and is untouched.

After the change the chunk boundary carries approximately 50 tokens, matching the split boundary.

Added two cases to `DescribePreChunk` in `test_unstructured/chunking/test_base.py`: one asserting the tail measures the requested token count (and is a real suffix of the text), one covering text shorter than the overlap. Verified with `pytest test_unstructured/chunking/test_base.py`: the token case fails against the current code, and all 226 pass with the fix. The existing character-mode `overlap_tail` cases pass unchanged either way.

I kept the approximate semantics rather than making the tail exact, since `_get_token_overlap_tail` already rounds to a word boundary and the docstring says the overlap "will not exceed this number ... but may be less as required to respect splitting-character boundaries".


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

