### PR TITLE
fix(cleaners): avoid UnboundLocalError in _get_indexed_match when the pattern is absent

### DIFF
--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -18,12 +18,16 @@ def _get_indexed_match(text: str, pattern: str, index: int = 0) -> re.Match:
         raise ValueError(f"The index is {index}. Index must be a non-negative integer.")
 
     regex_match = None
+    i = -1
     for i, result in enumerate(re.finditer(pattern, text)):
         if i == index:
             regex_match = result
 
     if regex_match is None:
-        raise ValueError(f"Result with index {index} was not found. The largest index was {i}.")
+        message = f"Result with index {index} was not found."
+        if i >= 0:
+            message += f" The largest index was {i}."
+        raise ValueError(message)
 
     return regex_match
 


### PR DESCRIPTION
Fixes #4427.

### Problem

`_get_indexed_match` (used by `extract_text_before` / `extract_text_after`) raises `UnboundLocalError` instead of a clear error when the pattern does not occur in the text:

```python
extract_text_before("hello world", "xyz")  # UnboundLocalError: cannot access local variable 'i'
```

When `re.finditer(pattern, text)` yields no matches, the `for i, result in ...` loop never runs, so `i` is never bound. The `regex_match is None` branch then builds the message with `{i}`, raising `UnboundLocalError` before the intended `ValueError`. This is the normal "pattern absent" path, so any caller of `extract_text_before` / `extract_text_after` with a pattern that is not present hits it.

### Fix

Initialize `i = -1` before the loop and only include the "largest index" detail when there was at least one match, so the pattern-absent case raises the intended `ValueError`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

