### PR TITLE
chore: restore telemetry by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   setup:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.26.0-dev0
+
+### Fixes
+
+- **Restore default-on library-load telemetry**: The lightweight library-load ping once again runs by default when `unstructured` is imported. Set either `DO_NOT_TRACK` or `SCARF_NO_ANALYTICS` to any non-empty value (after trimming whitespace) before import to disable it; empty and whitespace-only values retain the default behavior. This removes the `UNSTRUCTURED_TELEMETRY_ENABLED` explicit opt-in gate introduced by #4281 without changing the existing endpoint, payload, timeout, GPU probing, or failure-suppression behavior.
+
 ## 0.25.3-dev0
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
-## 0.26.0-dev0
+## 0.26.0
 
 ### Fixes
 
 - **Restore default-on library-load telemetry**: The lightweight library-load ping once again runs by default when `unstructured` is imported. Set either `DO_NOT_TRACK` or `SCARF_NO_ANALYTICS` to any non-empty value (after trimming whitespace) before import to disable it; empty and whitespace-only values retain the default behavior. This removes the `UNSTRUCTURED_TELEMETRY_ENABLED` explicit opt-in gate introduced by #4281 without changing the existing endpoint, payload, timeout, GPU probing, or failure-suppression behavior.
-
-## 0.25.3-dev0
-
-### Fixes
 
 - **Stop the `GLOBAL_WORKING_DIR` tests from disturbing other pytest-xdist workers**: test-only change, no library behavior changes. The two tests exercising `GLOBAL_WORKING_DIR_ENABLED` now redirect the working dir to a private `tmp_path` and restore `tempfile.tempdir` unconditionally, rather than moving the shared pgid-keyed directory aside mid-run and leaving the worker's `tempfile.tempdir` pointed at it. That shared path made `test_dockerfile` fail intermittently, with an unrelated test dying inside `tempfile`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **Restore default-on library-load telemetry**: The lightweight library-load ping once again runs by default when `unstructured` is imported. Set either `DO_NOT_TRACK` or `SCARF_NO_ANALYTICS` to any non-empty value (after trimming whitespace) before import to disable it; empty and whitespace-only values retain the default behavior. This removes the `UNSTRUCTURED_TELEMETRY_ENABLED` explicit opt-in gate introduced by #4281 without changing the existing endpoint, payload, timeout, GPU probing, or failure-suppression behavior.
+- **Restore default-on library-load telemetry**: The lightweight library-load ping once again runs by default when `unstructured` is imported. Set either `DO_NOT_TRACK` or `SCARF_NO_ANALYTICS` to any non-empty value (after trimming whitespace) before import to disable it; empty and whitespace-only values retain the default behavior. This removes the `UNSTRUCTURED_TELEMETRY_ENABLED` explicit opt-in gate introduced by #4281 while preserving the existing endpoint and payload. The best-effort `nvidia-smi` GPU probe now has a one-second timeout, and GPU-probe and request failures remain non-fatal.
 
 - **Stop the `GLOBAL_WORKING_DIR` tests from disturbing other pytest-xdist workers**: test-only change, no library behavior changes. The two tests exercising `GLOBAL_WORKING_DIR_ENABLED` now redirect the working dir to a private `tmp_path` and restore `tempfile.tempdir` unconditionally, rather than moving the shared pgid-keyed directory aside mid-run and leaving the worker's `tempfile.tempdir` pointed at it. That shared path made `test_dockerfile` fail intermittently, with an unrelated test dying inside `tempfile`.
 

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ docker-test:
 	-v ${CURRENT_DIR}/test_unstructured:/home/notebook-user/test_unstructured \
 	-v ${CURRENT_DIR}/test_unstructured_ingest:/home/notebook-user/test_unstructured_ingest \
 	$(if $(wildcard uns_test_env_file),--env-file uns_test_env_file,) \
+	--env DO_NOT_TRACK=1 \
 	$(DOCKER_IMAGE) \
 	bash -c "uv sync --locked --all-extras --group test --no-install-project && \
 	CI=$(CI) \

--- a/README.md
+++ b/README.md
@@ -290,4 +290,4 @@ Encountered a bug? Please create a new [GitHub issue](https://github.com/Unstruc
 
 ## :chart_with_upwards_trend: Analytics
 
-Telemetry is **off by default**. To opt in, set `UNSTRUCTURED_TELEMETRY_ENABLED=true` (or `=1`) before importing `unstructured`. To opt out, set `DO_NOT_TRACK` or `SCARF_NO_ANALYTICS` to any non-empty value (e.g. `true`, `1`, `yes`, `false`, `0`—any non-empty string opts out); opt-out takes precedence. Unset the variable or leave it empty if you do not want to opt out. See our [Privacy Policy](https://unstructured.io/privacy-policy).
+Unstructured sends a lightweight library-load analytics ping by default when it is imported. To opt out before importing `unstructured`, set either `DO_NOT_TRACK` or `SCARF_NO_ANALYTICS` to any non-empty value after trimming whitespace (for example, `true`, `1`, `yes`, `false`, or `0`); either variable disables the ping. Unset the variables or leave them empty or whitespace-only to retain the default behavior. See our [Privacy Policy](https://unstructured.io/privacy-policy).

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+"""Global test configuration."""
+
+import os
+
+# Package import telemetry is default-on; keep ordinary test collection hermetic.
+os.environ.setdefault("DO_NOT_TRACK", "1")

--- a/conftest.py
+++ b/conftest.py
@@ -2,5 +2,5 @@
 
 import os
 
-# Package import telemetry is default-on; keep ordinary test collection hermetic.
-os.environ.setdefault("DO_NOT_TRACK", "1")
+# Package import telemetry is default-on; force ordinary test collection to opt out.
+os.environ["DO_NOT_TRACK"] = "1"

--- a/scripts/image/test-outbound-connectivity.sh
+++ b/scripts/image/test-outbound-connectivity.sh
@@ -61,14 +61,12 @@ fi
 
 # ---------- scenario‑specific settings --------------------------------
 DO_NOT_TRACK=""
-UNSTRUCTURED_TELEMETRY_ENABLED=""
 HF_HUB_OFFLINE=""
 REMOVE_CACHE=0
 case "$SCENARIO" in
 baseline) ;;
 missing-models) REMOVE_CACHE=1 ;;
 analytics-online-only)
-  UNSTRUCTURED_TELEMETRY_ENABLED=1
   HF_HUB_OFFLINE=1
   ;;
 offline)
@@ -93,7 +91,6 @@ CID=$(docker run -d --rm --name "sut_${SCENARIO}" \
   --network "$NET" \
   --cap-add NET_RAW --cap-add NET_ADMIN \
   -e DO_NOT_TRACK="$DO_NOT_TRACK" \
-  -e UNSTRUCTURED_TELEMETRY_ENABLED="$UNSTRUCTURED_TELEMETRY_ENABLED" \
   -e HF_HUB_OFFLINE="$HF_HUB_OFFLINE" \
   --entrypoint /bin/sh "$IMAGE" -c "sleep infinity")
 echo "Container: $CID  (scenario $SCENARIO)"
@@ -132,7 +129,7 @@ fi
 
 docker exec -i -e PYTHONUNBUFFERED=1 "$CID" python - <<PY |& tee "${PY_LOG_DIR}/${SCENARIO}.log"
 import logging
-# Telemetry runs at package init when UNSTRUCTURED_TELEMETRY_ENABLED is set (see analytics-online-only scenario).
+# Telemetry runs at package init unless the scenario sets DO_NOT_TRACK.
 from unstructured.partition.auto import partition
 import urllib.request, time, os, sys
 

--- a/test_unstructured/test_telemetry.py
+++ b/test_unstructured/test_telemetry.py
@@ -310,8 +310,12 @@ class DescribeTelemetryTestHermeticity:
         inherited_value,
     ):
         project_root = Path(__file__).resolve().parent.parent
+        conftest_path = project_root / "conftest.py"
+        if not conftest_path.is_file():
+            pytest.skip("root conftest is not included in this test distribution")
+
         monkeypatch.setenv("DO_NOT_TRACK", inherited_value)
 
-        runpy.run_path(str(project_root / "conftest.py"))
+        runpy.run_path(str(conftest_path))
 
         assert os.environ["DO_NOT_TRACK"] == "1"

--- a/test_unstructured/test_telemetry.py
+++ b/test_unstructured/test_telemetry.py
@@ -1,17 +1,16 @@
-"""Hermetic telemetry tests: env is set to opt-out before importing unstructured.
+"""Hermetic tests for the default-on library-load telemetry ping.
 
-This module must set DO_NOT_TRACK (or equivalent) before any import of unstructured
-so that init_telemetry() runs with opt-out at import time and no real network/subprocess
-occurs. Tests then use monkeypatch and mocks to assert behavior.
+This module sets an opt-out before importing unstructured so the package initializer cannot
+perform real network or subprocess work. Individual tests clear that opt-out and mock the
+telemetry side effects before exercising the behavior under test.
 """
 
 from __future__ import annotations
 
-# Set opt-out before any unstructured import so package init does not run telemetry.
 import os
 
+# Set an opt-out before importing unstructured so package initialization is hermetic.
 os.environ["DO_NOT_TRACK"] = "1"
-os.environ.pop("UNSTRUCTURED_TELEMETRY_ENABLED", None)
 os.environ.pop("SCARF_NO_ANALYTICS", None)
 
 import platform
@@ -28,12 +27,7 @@ from unstructured import utils
 
 @pytest.fixture
 def telemetry_mocks(monkeypatch):
-    """Clear telemetry env and patch requests.get + subprocess.check_output.
-
-    Returns (mock_get, mock_subprocess). Use for both send and no-send tests so
-    we can assert network and subprocess side effects.
-    """
-    monkeypatch.delenv("UNSTRUCTURED_TELEMETRY_ENABLED", raising=False)
+    """Clear opt-outs and patch telemetry's network and GPU-probe side effects."""
     monkeypatch.delenv("SCARF_NO_ANALYTICS", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
     mock_get = Mock()
@@ -44,7 +38,7 @@ def telemetry_mocks(monkeypatch):
 
 
 def _apply_telemetry_env(monkeypatch, env_overrides):
-    """Set env vars from dict; keys are env var names, values are str or None (delenv)."""
+    """Set env vars from a mapping whose values are strings or None to remove a variable."""
     for key, value in env_overrides.items():
         if value is None:
             monkeypatch.delenv(key, raising=False)
@@ -53,92 +47,13 @@ def _apply_telemetry_env(monkeypatch, env_overrides):
 
 
 class DescribeScarfAnalytics:
-    """Tests for scarf_analytics (telemetry off by default, opt-in only)."""
+    """Tests for the default-on library-load analytics ping."""
 
-    def it_telemetry_opt_out_any_non_empty_for_both_vars(self, monkeypatch):
-        """Contract: DO_NOT_TRACK and SCARF_NO_ANALYTICS both opt out on any non-empty value."""
-        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-        monkeypatch.delenv("SCARF_NO_ANALYTICS", raising=False)
-        assert utils._telemetry_opt_out() is False
-        monkeypatch.setenv("DO_NOT_TRACK", "yes")
-        assert utils._telemetry_opt_out() is True
-        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
-        monkeypatch.setenv("SCARF_NO_ANALYTICS", "on")
-        assert utils._telemetry_opt_out() is True
-
-    def it_telemetry_opt_in_only_true_or_1(self, monkeypatch):
-        """Contract: only UNSTRUCTURED_TELEMETRY_ENABLED in ('true','1') opts in."""
-        monkeypatch.delenv("UNSTRUCTURED_TELEMETRY_ENABLED", raising=False)
-        assert utils._telemetry_opt_in() is False
-        for val in ("true", "1", "True", "TRUE"):
-            monkeypatch.setenv("UNSTRUCTURED_TELEMETRY_ENABLED", val)
-            assert utils._telemetry_opt_in() is True
-        for val in ("false", "0", "yes", ""):
-            monkeypatch.setenv("UNSTRUCTURED_TELEMETRY_ENABLED", val)
-            assert utils._telemetry_opt_in() is False
-
-    @pytest.mark.parametrize(
-        "env_overrides",
-        [
-            {},
-            {"DO_NOT_TRACK": "true"},
-            {"DO_NOT_TRACK": "1"},
-            {"DO_NOT_TRACK": "TRUE"},
-            {"DO_NOT_TRACK": "false"},
-            {"DO_NOT_TRACK": "0"},
-            {"SCARF_NO_ANALYTICS": "true"},
-            {"SCARF_NO_ANALYTICS": "yes"},
-            {"SCARF_NO_ANALYTICS": "on"},
-            {"SCARF_NO_ANALYTICS": "1"},
-            {"SCARF_NO_ANALYTICS": "TRUE"},
-            {"SCARF_NO_ANALYTICS": "false"},
-            {"SCARF_NO_ANALYTICS": "0"},
-            {"SCARF_NO_ANALYTICS": "  true  "},
-            {"UNSTRUCTURED_TELEMETRY_ENABLED": "false"},
-            {"UNSTRUCTURED_TELEMETRY_ENABLED": "0"},
-            {"UNSTRUCTURED_TELEMETRY_ENABLED": "yes"},
-            {"UNSTRUCTURED_TELEMETRY_ENABLED": "FALSE"},
-            {"UNSTRUCTURED_TELEMETRY_ENABLED": "true", "DO_NOT_TRACK": "true"},
-            {"UNSTRUCTURED_TELEMETRY_ENABLED": "true", "SCARF_NO_ANALYTICS": "on"},
-        ],
-        ids=[
-            "default_no_opt_in",
-            "DO_NOT_TRACK=true",
-            "DO_NOT_TRACK=1",
-            "DO_NOT_TRACK=TRUE",
-            "DO_NOT_TRACK=false",
-            "DO_NOT_TRACK=0",
-            "SCARF_NO_ANALYTICS=true",
-            "SCARF_NO_ANALYTICS=yes",
-            "SCARF_NO_ANALYTICS=on",
-            "SCARF_NO_ANALYTICS=1",
-            "SCARF_NO_ANALYTICS=TRUE",
-            "SCARF_NO_ANALYTICS=false",
-            "SCARF_NO_ANALYTICS=0",
-            "SCARF_NO_ANALYTICS=whitespace",
-            "opt_in=false",
-            "opt_in=0",
-            "opt_in=yes",
-            "opt_in=FALSE",
-            "opt_in_true_but_DO_NOT_TRACK",
-            "opt_in_true_but_SCARF_NO_ANALYTICS",
-        ],
-    )
-    def it_does_not_send_telemetry_when_disabled_or_opted_out(
-        self, monkeypatch, telemetry_mocks, env_overrides
-    ):
-        """No network or subprocess when telemetry disabled or opt-out set."""
+    def it_sends_telemetry_by_default(self, telemetry_mocks):
         mock_get, mock_subprocess = telemetry_mocks
-        _apply_telemetry_env(monkeypatch, env_overrides)
-        utils.scarf_analytics()
-        mock_get.assert_not_called()
-        mock_subprocess.assert_not_called()
 
-    @pytest.mark.parametrize("opt_in_value", ["true", "True", "TRUE", "1"])
-    def it_sends_telemetry_when_opt_in_is_set(self, monkeypatch, telemetry_mocks, opt_in_value):
-        mock_get, mock_subprocess = telemetry_mocks
-        _apply_telemetry_env(monkeypatch, {"UNSTRUCTURED_TELEMETRY_ENABLED": opt_in_value})
         utils.scarf_analytics()
+
         mock_get.assert_called_once()
         mock_subprocess.assert_called_once_with(["nvidia-smi"], stderr=subprocess.DEVNULL)
         call_args = mock_get.call_args
@@ -148,17 +63,62 @@ class DescribeScarfAnalytics:
         assert call_args[1]["timeout"] == 10
 
     @pytest.mark.parametrize(
+        ("env_name", "value"),
+        [
+            ("DO_NOT_TRACK", "true"),
+            ("DO_NOT_TRACK", "false"),
+            ("SCARF_NO_ANALYTICS", "yes"),
+            ("SCARF_NO_ANALYTICS", "0"),
+        ],
+        ids=["do-not-track-true", "do-not-track-false", "scarf-yes", "scarf-zero"],
+    )
+    def it_does_not_probe_or_send_when_either_opt_out_is_non_empty(
+        self, monkeypatch, telemetry_mocks, env_name, value
+    ):
+        mock_get, mock_subprocess = telemetry_mocks
+        _apply_telemetry_env(monkeypatch, {env_name: value})
+
+        assert utils._telemetry_opt_out() is True
+        utils.scarf_analytics()
+
+        mock_get.assert_not_called()
+        mock_subprocess.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("env_name", "value"),
+        [
+            ("DO_NOT_TRACK", ""),
+            ("DO_NOT_TRACK", " \t "),
+            ("SCARF_NO_ANALYTICS", ""),
+            ("SCARF_NO_ANALYTICS", " \t "),
+        ],
+        ids=["do-not-track-empty", "do-not-track-whitespace", "scarf-empty", "scarf-whitespace"],
+    )
+    def it_sends_when_opt_out_is_empty_or_whitespace_only(
+        self, monkeypatch, telemetry_mocks, env_name, value
+    ):
+        mock_get, mock_subprocess = telemetry_mocks
+        _apply_telemetry_env(monkeypatch, {env_name: value})
+
+        assert utils._telemetry_opt_out() is False
+        utils.scarf_analytics()
+
+        mock_get.assert_called_once()
+        mock_subprocess.assert_called_once_with(["nvidia-smi"], stderr=subprocess.DEVNULL)
+
+    @pytest.mark.parametrize(
         ("version_val", "expected_dev"),
         [("1.2.3.dev0", "true"), ("1.2.3", "false")],
-        ids=["dev_version", "release_version"],
+        ids=["dev-version", "release-version"],
     )
     def it_sends_telemetry_with_correct_dev_param(
         self, monkeypatch, telemetry_mocks, version_val, expected_dev
     ):
         mock_get, mock_subprocess = telemetry_mocks
-        _apply_telemetry_env(monkeypatch, {"UNSTRUCTURED_TELEMETRY_ENABLED": "true"})
         monkeypatch.setattr("unstructured.utils.__version__", version_val)
+
         utils.scarf_analytics()
+
         mock_get.assert_called_once()
         mock_subprocess.assert_called_once()
         params = mock_get.call_args[1]["params"]
@@ -168,11 +128,12 @@ class DescribeScarfAnalytics:
         assert params["arch"] == platform.machine()
         assert mock_get.call_args[1]["timeout"] == 10
 
-    def it_handles_requests_exception_gracefully(self, monkeypatch, telemetry_mocks):
+    def it_suppresses_requests_exceptions(self, telemetry_mocks):
         mock_get, mock_subprocess = telemetry_mocks
         mock_get.side_effect = requests.RequestException("network error")
-        _apply_telemetry_env(monkeypatch, {"UNSTRUCTURED_TELEMETRY_ENABLED": "true"})
+
         utils.scarf_analytics()  # does not raise
+
         mock_get.assert_called_once()
         mock_subprocess.assert_called_once()
         assert mock_get.call_args[0][0] == "https://packages.unstructured.io/python-telemetry"
@@ -187,25 +148,27 @@ class DescribeScarfAnalytics:
         ],
         ids=["OSError", "PermissionError", "CalledProcessError"],
     )
-    def it_handles_nvidia_smi_failure_gracefully(self, monkeypatch, telemetry_mocks, exc):
-        """nvidia-smi probe failures must not propagate; telemetry still sends with gpu=False."""
+    def it_sends_with_gpu_false_when_the_probe_fails(self, telemetry_mocks, exc):
         mock_get, mock_subprocess = telemetry_mocks
         mock_subprocess.side_effect = exc
-        _apply_telemetry_env(monkeypatch, {"UNSTRUCTURED_TELEMETRY_ENABLED": "true"})
+
         utils.scarf_analytics()  # does not raise
+
         mock_get.assert_called_once()
         assert mock_get.call_args[1]["params"]["gpu"] == "False"
         mock_subprocess.assert_called_once_with(["nvidia-smi"], stderr=subprocess.DEVNULL)
 
-    def it_import_unstructured_succeeds_with_opt_out(self):
-        """Import path with opt-out env does not crash (integration-style)."""
+    def it_import_unstructured_succeeds_when_opted_out(self):
+        """Importing while opted out remains non-fatal."""
         project_root = Path(__file__).resolve().parent.parent
-        env = {k: v for k, v in os.environ.items() if k != "UNSTRUCTURED_TELEMETRY_ENABLED"}
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("DO_NOT_TRACK", "SCARF_NO_ANALYTICS")
+        }
         env.update(
             {
-                "DO_NOT_TRACK": "1",
-                "SCARF_NO_ANALYTICS": "1",
-                "UNSTRUCTURED_TELEMETRY_ENABLED": "",
+                "DO_NOT_TRACK": "false",
                 "PYTHONPATH": str(project_root),
             }
         )
@@ -220,20 +183,15 @@ class DescribeScarfAnalytics:
         assert result.returncode == 0, result.stderr or result.stdout
         assert "ok" in result.stdout
 
-    def it_import_unstructured_runs_telemetry_once_when_opt_in(self):
-        """Import path with opt-in runs init_telemetry exactly once (patch then import)."""
+    def it_import_unstructured_runs_telemetry_once_by_default(self):
+        """The package initializer sends exactly one ping when no opt-out is set."""
         project_root = Path(__file__).resolve().parent.parent
         env = {
-            k: v
-            for k, v in os.environ.items()
-            if k not in ("DO_NOT_TRACK", "SCARF_NO_ANALYTICS", "UNSTRUCTURED_TELEMETRY_ENABLED")
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("DO_NOT_TRACK", "SCARF_NO_ANALYTICS")
         }
-        env.update(
-            {
-                "UNSTRUCTURED_TELEMETRY_ENABLED": "true",
-                "PYTHONPATH": str(project_root),
-            }
-        )
+        env["PYTHONPATH"] = str(project_root)
         script = """
 from unittest.mock import Mock, patch
 m_get = Mock()
@@ -251,7 +209,7 @@ exit(0 if (m_get.call_count == 1 and m_subprocess.call_count == 1) else 1)
             timeout=30,
         )
         assert result.returncode == 0, (
-            "Import with opt-in should run telemetry exactly once (requests.get and "
+            "Import without an opt-out should run telemetry exactly once (requests.get and "
             "subprocess.check_output each called once). "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )

--- a/test_unstructured/test_telemetry.py
+++ b/test_unstructured/test_telemetry.py
@@ -14,6 +14,7 @@ os.environ["DO_NOT_TRACK"] = "1"
 os.environ.pop("SCARF_NO_ANALYTICS", None)
 
 import platform
+import runpy
 import subprocess
 import sys
 from pathlib import Path
@@ -31,10 +32,21 @@ def telemetry_mocks(monkeypatch):
     monkeypatch.delenv("SCARF_NO_ANALYTICS", raising=False)
     monkeypatch.delenv("DO_NOT_TRACK", raising=False)
     mock_get = Mock()
-    mock_subprocess = Mock()
+    mock_run = Mock()
     monkeypatch.setattr("unstructured.utils.requests.get", mock_get)
-    monkeypatch.setattr("unstructured.utils.subprocess.check_output", mock_subprocess)
-    return mock_get, mock_subprocess
+    monkeypatch.setattr("unstructured.utils.subprocess.run", mock_run)
+    return mock_get, mock_run
+
+
+def _assert_gpu_probe_called_once(mock_run):
+    mock_run.assert_called_once_with(
+        ["nvidia-smi"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+        timeout=1.0,
+    )
 
 
 def _apply_telemetry_env(monkeypatch, env_overrides):
@@ -50,12 +62,12 @@ class DescribeScarfAnalytics:
     """Tests for the default-on library-load analytics ping."""
 
     def it_sends_telemetry_by_default(self, telemetry_mocks):
-        mock_get, mock_subprocess = telemetry_mocks
+        mock_get, mock_run = telemetry_mocks
 
         utils.scarf_analytics()
 
         mock_get.assert_called_once()
-        mock_subprocess.assert_called_once_with(["nvidia-smi"], stderr=subprocess.DEVNULL)
+        _assert_gpu_probe_called_once(mock_run)
         call_args = mock_get.call_args
         assert call_args[0][0] == "https://packages.unstructured.io/python-telemetry"
         params = call_args[1]["params"]
@@ -75,14 +87,14 @@ class DescribeScarfAnalytics:
     def it_does_not_probe_or_send_when_either_opt_out_is_non_empty(
         self, monkeypatch, telemetry_mocks, env_name, value
     ):
-        mock_get, mock_subprocess = telemetry_mocks
+        mock_get, mock_run = telemetry_mocks
         _apply_telemetry_env(monkeypatch, {env_name: value})
 
         assert utils._telemetry_opt_out() is True
         utils.scarf_analytics()
 
         mock_get.assert_not_called()
-        mock_subprocess.assert_not_called()
+        mock_run.assert_not_called()
 
     @pytest.mark.parametrize(
         ("env_name", "value"),
@@ -97,14 +109,14 @@ class DescribeScarfAnalytics:
     def it_sends_when_opt_out_is_empty_or_whitespace_only(
         self, monkeypatch, telemetry_mocks, env_name, value
     ):
-        mock_get, mock_subprocess = telemetry_mocks
+        mock_get, mock_run = telemetry_mocks
         _apply_telemetry_env(monkeypatch, {env_name: value})
 
         assert utils._telemetry_opt_out() is False
         utils.scarf_analytics()
 
         mock_get.assert_called_once()
-        mock_subprocess.assert_called_once_with(["nvidia-smi"], stderr=subprocess.DEVNULL)
+        _assert_gpu_probe_called_once(mock_run)
 
     @pytest.mark.parametrize(
         ("version_val", "expected_dev"),
@@ -114,13 +126,13 @@ class DescribeScarfAnalytics:
     def it_sends_telemetry_with_correct_dev_param(
         self, monkeypatch, telemetry_mocks, version_val, expected_dev
     ):
-        mock_get, mock_subprocess = telemetry_mocks
+        mock_get, mock_run = telemetry_mocks
         monkeypatch.setattr("unstructured.utils.__version__", version_val)
 
         utils.scarf_analytics()
 
         mock_get.assert_called_once()
-        mock_subprocess.assert_called_once()
+        mock_run.assert_called_once()
         params = mock_get.call_args[1]["params"]
         assert params["dev"] == expected_dev
         assert params["version"] == version_val
@@ -129,13 +141,13 @@ class DescribeScarfAnalytics:
         assert mock_get.call_args[1]["timeout"] == 10
 
     def it_suppresses_requests_exceptions(self, telemetry_mocks):
-        mock_get, mock_subprocess = telemetry_mocks
+        mock_get, mock_run = telemetry_mocks
         mock_get.side_effect = requests.RequestException("network error")
 
         utils.scarf_analytics()  # does not raise
 
         mock_get.assert_called_once()
-        mock_subprocess.assert_called_once()
+        mock_run.assert_called_once()
         assert mock_get.call_args[0][0] == "https://packages.unstructured.io/python-telemetry"
         assert "version" in mock_get.call_args[1]["params"]
 
@@ -145,18 +157,19 @@ class DescribeScarfAnalytics:
             OSError(),
             PermissionError("nvidia-smi denied"),
             subprocess.CalledProcessError(returncode=1, cmd=["nvidia-smi"]),
+            subprocess.TimeoutExpired(cmd=["nvidia-smi"], timeout=1.0),
         ],
-        ids=["OSError", "PermissionError", "CalledProcessError"],
+        ids=["OSError", "PermissionError", "CalledProcessError", "TimeoutExpired"],
     )
     def it_sends_with_gpu_false_when_the_probe_fails(self, telemetry_mocks, exc):
-        mock_get, mock_subprocess = telemetry_mocks
-        mock_subprocess.side_effect = exc
+        mock_get, mock_run = telemetry_mocks
+        mock_run.side_effect = exc
 
         utils.scarf_analytics()  # does not raise
 
         mock_get.assert_called_once()
         assert mock_get.call_args[1]["params"]["gpu"] == "False"
-        mock_subprocess.assert_called_once_with(["nvidia-smi"], stderr=subprocess.DEVNULL)
+        _assert_gpu_probe_called_once(mock_run)
 
     def it_import_unstructured_succeeds_when_opted_out(self):
         """Importing while opted out remains non-fatal."""
@@ -193,12 +206,23 @@ class DescribeScarfAnalytics:
         }
         env["PYTHONPATH"] = str(project_root)
         script = """
+import subprocess
 from unittest.mock import Mock, patch
+
 m_get = Mock()
-m_subprocess = Mock()
-with patch('requests.get', m_get), patch('subprocess.check_output', m_subprocess):
+m_run = Mock()
+with patch("requests.get", m_get), patch("subprocess.run", m_run):
     import unstructured
-exit(0 if (m_get.call_count == 1 and m_subprocess.call_count == 1) else 1)
+
+m_run.assert_called_once_with(
+    ["nvidia-smi"],
+    stdin=subprocess.DEVNULL,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    check=True,
+    timeout=1.0,
+)
+assert m_get.call_count == 1
 """
         result = subprocess.run(
             [sys.executable, "-c", script],
@@ -210,6 +234,84 @@ exit(0 if (m_get.call_count == 1 and m_subprocess.call_count == 1) else 1)
         )
         assert result.returncode == 0, (
             "Import without an opt-out should run telemetry exactly once (requests.get and "
-            "subprocess.check_output each called once). "
+            "subprocess.run each called once). "
             f"stderr={result.stderr!r} stdout={result.stdout!r}"
         )
+
+    def it_import_unstructured_uses_a_bounded_gpu_probe(self):
+        """Import remains non-fatal when the bounded GPU probe times out."""
+        project_root = Path(__file__).resolve().parent.parent
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("DO_NOT_TRACK", "SCARF_NO_ANALYTICS")
+        }
+        env["PYTHONPATH"] = str(project_root)
+        script = """
+import subprocess
+from unittest.mock import Mock, patch
+
+real_run = subprocess.run
+real_check_output = subprocess.check_output
+m_get = Mock()
+
+def reject_legacy_probe(args, **kwargs):
+    if args == ["nvidia-smi"]:
+        raise AssertionError("legacy unbounded subprocess.check_output was called")
+    return real_check_output(args, **kwargs)
+
+def timeout_gpu_probe(args, **kwargs):
+    if args != ["nvidia-smi"]:
+        return real_run(args, **kwargs)
+
+    assert kwargs == {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "check": True,
+        "timeout": 1.0,
+    }
+    raise subprocess.TimeoutExpired(cmd=args, timeout=kwargs["timeout"])
+
+with (
+    patch("requests.get", m_get),
+    patch("subprocess.check_output", side_effect=reject_legacy_probe),
+    patch("subprocess.run", side_effect=timeout_gpu_probe) as m_run,
+):
+    import unstructured
+
+assert m_run.call_count == 1
+assert m_get.call_count == 1
+assert m_get.call_args.args[0] == "https://packages.unstructured.io/python-telemetry"
+assert m_get.call_args.kwargs["params"]["gpu"] == "False"
+assert m_get.call_args.kwargs["timeout"] == 10
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, result.stderr or result.stdout
+
+
+class DescribeTelemetryTestHermeticity:
+    @pytest.mark.parametrize(
+        "inherited_value",
+        ["", " \t "],
+        ids=["empty", "whitespace"],
+    )
+    def it_root_conftest_forces_do_not_track_for_empty_or_whitespace_inheritance(
+        self,
+        monkeypatch,
+        inherited_value,
+    ):
+        project_root = Path(__file__).resolve().parent.parent
+        monkeypatch.setenv("DO_NOT_TRACK", inherited_value)
+
+        runpy.run_path(str(project_root / "conftest.py"))
+
+        assert os.environ["DO_NOT_TRACK"] == "1"

--- a/unstructured/__init__.py
+++ b/unstructured/__init__.py
@@ -4,5 +4,5 @@ from .telemetry import init_telemetry
 # init env_config
 env_config
 
-# Explicit startup boundary for telemetry (opt-in, best-effort)
+# Explicit startup boundary for the library-load telemetry ping (best-effort)
 init_telemetry()

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.25.3-dev0"  # pragma: no cover
+__version__ = "0.26.0-dev0"  # pragma: no cover

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.26.0-dev0"  # pragma: no cover
+__version__ = "0.26.0"  # pragma: no cover

--- a/unstructured/telemetry.py
+++ b/unstructured/telemetry.py
@@ -4,5 +4,5 @@ from unstructured.utils import scarf_analytics
 
 
 def init_telemetry() -> None:
-    """Run the analytics ping if enabled by env. Best-effort and non-fatal."""
+    """Run the library-load analytics ping unless opted out. Best-effort and non-fatal."""
     scarf_analytics()

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -188,21 +188,12 @@ def _telemetry_opt_out() -> bool:
     )
 
 
-def _telemetry_opt_in() -> bool:
-    """True if telemetry is explicitly enabled via env. Only 'true' and '1' opt in."""
-    return (os.getenv("UNSTRUCTURED_TELEMETRY_ENABLED") or "").strip().lower() in (
-        "true",
-        "1",
-    )
-
-
 def scarf_analytics():
-    """Send a lightweight analytics ping. Off by default.
+    """Send a lightweight library-load analytics ping unless it is opted out.
 
-    Set UNSTRUCTURED_TELEMETRY_ENABLED=true to opt in.
     Opt-out env vars (DO_NOT_TRACK, SCARF_NO_ANALYTICS): any non-empty value opts out.
     """
-    if _telemetry_opt_out() or not _telemetry_opt_in():
+    if _telemetry_opt_out():
         return
 
     try:

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -177,6 +177,9 @@ def only(it: Iterable[Any]) -> Any:
     return out
 
 
+_NVIDIA_SMI_TIMEOUT_SECONDS = 1.0
+
+
 def _telemetry_opt_out() -> bool:
     """True if telemetry should be disabled via env.
 
@@ -197,9 +200,16 @@ def scarf_analytics():
         return
 
     try:
-        subprocess.check_output(["nvidia-smi"], stderr=subprocess.DEVNULL)
+        subprocess.run(
+            ["nvidia-smi"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+            timeout=_NVIDIA_SMI_TIMEOUT_SECONDS,
+        )
         gpu_present = True
-    except (OSError, subprocess.CalledProcessError):
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         gpu_present = False
 
     python_version = ".".join(platform.python_version().split(".")[:2])


### PR DESCRIPTION
## Summary

PR #4281 accidentally changed the existing library-load telemetry ping from default-on/opt-out to explicit opt-in. This PR resumes the existing library-load telemetry by default when `unstructured` is imported.

## Changes

- Removes the explicit `UNSTRUCTURED_TELEMETRY_ENABLED` gate while preserving the telemetry endpoint, query payload keys and values, 10-second HTTP timeout, opt-out semantics, and best-effort failure suppression. The synchronous `nvidia-smi` GPU probe now uses `subprocess.run` with a 1.0-second timeout and stdin, stdout, and stderr directed to `DEVNULL`; launch, non-zero-exit, and timeout failures keep import non-fatal and send `gpu="False"`.
- Users can still turn telemetry off before import by setting either `DO_NOT_TRACK` or `SCARF_NO_ANALYTICS` to any non-empty value after trimming whitespace; either variable takes precedence.
- Updates the README disclosure, outbound-connectivity tooling, focused telemetry coverage, version (`0.26.0`), and changelog.
- Forces `DO_NOT_TRACK=1` in the root pytest `conftest.py` before ordinary collection, including when an inherited value is empty or whitespace-only; focused telemetry tests explicitly clear both opt-outs under mocks to prove default-on behavior.
- Passes `DO_NOT_TRACK=1` after any optional env file in `make docker-test`, ensuring the packaged Docker test layout opts out before pytest collection without changing the production image.

## Validation

- Dedicated regressions: 3 failures on the pre-fix implementation, then 3 passes after the bounded probe and forced test opt-out were applied.
- `/opt/homebrew/opt/uv-wrapper/bin/uv run --locked --group test pytest -q --tb=short test_unstructured/test_telemetry.py` — 21 passed
- `make check` — passed
- `make check-version` — passed
- `git diff --check` — passed
- `shellcheck scripts/image/test-outbound-connectivity.sh scripts/image/test-all-outbound-connectivity-scenarios.sh` — passed on the unchanged shell files earlier in this PR
- BCE Junior / Opus and GPT-5.6 Pro Oracle reviews completed; incorporated the bounded GPU-probe, inherited empty/whitespace, and packaged Docker test-hermeticity findings.

(authored by codex)

