### PR TITLE
fix(pdf): raise clear error when fast strategy can't handle complex PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+- **Raise a clear error instead of silently returning no elements when `strategy="fast"` can't be honored**: `partition_pdf()` skips pdfminer text extraction for PDFs flagged by `is_pdf_too_complex()` as mostly vector graphics, since pdfminer is slow and unreliable on them. For `strategy="auto"` this correctly falls back to another strategy, but an explicitly-requested `strategy="fast"` had no fallback available and silently returned `[]` with no indication anything went wrong. It now raises a `ValueError` explaining why and suggesting `"hi_res"` or `"auto"` instead. `strategy="auto"` is unaffected and continues to fall back gracefully.
+
 - **Stop the `GLOBAL_WORKING_DIR` tests from disturbing other pytest-xdist workers**: test-only change, no library behavior changes. The two tests exercising `GLOBAL_WORKING_DIR_ENABLED` now redirect the working dir to a private `tmp_path` and restore `tempfile.tempdir` unconditionally, rather than moving the shared pgid-keyed directory aside mid-run and leaving the worker's `tempfile.tempdir` pointed at it. That shared path made `test_dockerfile` fail intermittently, with an unrelated test dying inside `tempfile`.
 
 ## 0.25.2

--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -1767,6 +1767,28 @@ def test_is_pdf_too_complex_returns_false_for_normal_pdf():
     assert not pdf.is_pdf_too_complex(filename=example_doc_path("pdf/layout-parser-paper.pdf"))
 
 
+def test_partition_pdf_raises_for_explicit_fast_strategy_on_complex_pdf():
+    """strategy="fast" cannot honor a PDF flagged as too complex for pdfminer text
+    extraction (see is_pdf_too_complex). Previously this silently returned an empty
+    element list; it should now raise a clear, actionable error instead. See #4260."""
+    filename = example_doc_path("pdf/layout-parser-paper.pdf")
+
+    with mock.patch.object(pdf, "is_pdf_too_complex", return_value=True):
+        with pytest.raises(ValueError, match="too complex"):
+            pdf.partition_pdf(filename=filename, strategy=PartitionStrategy.FAST)
+
+
+def test_partition_pdf_auto_strategy_still_falls_back_on_complex_pdf():
+    """strategy="auto" should keep degrading gracefully (no exception) when a PDF is
+    flagged as too complex -- only an explicitly-requested "fast" strategy should raise."""
+    filename = example_doc_path("pdf/layout-parser-paper.pdf")
+
+    with mock.patch.object(pdf, "is_pdf_too_complex", return_value=True):
+        elements = pdf.partition_pdf(filename=filename, strategy=PartitionStrategy.AUTO)
+
+    assert len(elements) > 0
+
+
 def test_document_to_element_list_omits_coord_system_when_coord_points_absent():
     # TODO (yao): investigate why we need this test. The LayoutElement definition suggests bbox
     # can't be None and it has to be a Rectangle object that has x1, y1, x2, y2 attributes.

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -300,14 +300,21 @@ def partition_pdf_or_image(
     pdf_text_extractable = False
 
     if not is_image:
-        try:
-            if is_pdf_too_complex(filename=filename, file=file):
-                logger.info(
-                    "PDF is too complex for text extraction based on heuristic checks. "
-                    "Falling back to hi_res strategy without text extraction."
+        if is_pdf_too_complex(filename=filename, file=file):
+            if strategy == PartitionStrategy.FAST:
+                raise ValueError(
+                    "PDF is too complex for text extraction based on heuristic checks "
+                    "(high ratio of vector graphics to text), so the fast strategy "
+                    "cannot reliably extract text from it. Use strategy='hi_res' or "
+                    "strategy='auto' instead."
                 )
+            logger.info(
+                "PDF is too complex for text extraction based on heuristic checks. "
+                "Falling back to hi_res strategy without text extraction."
+            )
 
-            else:
+        else:
+            try:
                 extracted_elements = extractable_elements(
                     filename=filename,
                     file=spooled_to_bytes_io_if_needed(file),
@@ -323,9 +330,9 @@ def partition_pdf_or_image(
                     for page_elements in extracted_elements
                     for el in page_elements
                 )
-        except Exception as e:
-            logger.debug(e)
-            logger.info("PDF text extraction failed, skip text extraction...")
+            except Exception as e:
+                logger.debug(e)
+                logger.info("PDF text extraction failed, skip text extraction...")
 
     strategy = determine_pdf_or_image_strategy(
         strategy,


### PR DESCRIPTION
## Summary

`partition_pdf(..., strategy="fast")` silently returns an empty element list — no exception, no warning — when the PDF trips the internal `is_pdf_too_complex()` heuristic.

This change raises a clear `ValueError` instead.

Fixes #4260

## Problem

`is_pdf_too_complex()` exists to prevent pdfminer from running on documents where it performs poorly.

When the check fires, extraction is skipped and `extracted_elements` remains empty.

For `strategy="auto"`, the existing strategy-selection logic can fall back to another strategy. However, when the user explicitly requests `strategy="fast"`, the strategy remains `fast`, and the function eventually returns an empty list.

This results in a silent failure where the caller receives no elements and no explanation.

## Solution

When `is_pdf_too_complex()` returns `True` and `strategy="fast"` was explicitly requested, raise a clear `ValueError` suggesting `strategy="hi_res"` or `strategy="auto"`.

This preserves the existing complexity protection instead of bypassing it.

Normal `fast` PDFs and the existing `auto` behavior remain unchanged.

## Tests

Added a regression test covering explicit `fast` strategy on a complex PDF.

The regression test fails with the previous behavior and passes with the fix.

Also verified the relevant PDF and strategy tests, along with Ruff formatting and lint checks.

## Related Issue

Fixes #4260

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

