### PR TITLE
feat: remove poppler-utils dependency by using pypdf for page counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           done
         }
         retry sudo apt-get update
-        retry sudo apt-get install -y libmagic-dev poppler-utils libreoffice
+        retry sudo apt-get install -y libmagic-dev libreoffice
         retry sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
         retry sudo apt-get update -o "APT::Update::Error-Mode=any"
         retry sudo apt-get install -y tesseract-ocr tesseract-ocr-kor
@@ -188,7 +188,7 @@ jobs:
           done
         }
         retry sudo apt-get update
-        retry sudo apt-get install -y libmagic-dev poppler-utils libreoffice
+        retry sudo apt-get install -y libmagic-dev libreoffice
         retry sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
         retry sudo apt-get update -o "APT::Update::Error-Mode=any"
         retry sudo apt-get install -y tesseract-ocr tesseract-ocr-kor
@@ -277,7 +277,7 @@ jobs:
           done
         }
         retry sudo apt-get update
-        retry sudo apt-get install -y libmagic-dev poppler-utils libreoffice
+        retry sudo apt-get install -y libmagic-dev libreoffice
         retry sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
         retry sudo apt-get update -o "APT::Update::Error-Mode=any"
         retry sudo apt-get install -y tesseract-ocr

--- a/.github/workflows/codeflash.yml
+++ b/.github/workflows/codeflash.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmagic-dev poppler-utils libreoffice
+          sudo apt-get install -y libmagic-dev libreoffice
           sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
           sudo apt-get update
           sudo apt-get install -y tesseract-ocr tesseract-ocr-kor

--- a/.github/workflows/ingest-test-fixtures-update-pr.yml
+++ b/.github/workflows/ingest-test-fixtures-update-pr.yml
@@ -79,7 +79,7 @@ jobs:
           CI: "true"
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmagic-dev poppler-utils libreoffice
+          sudo apt-get install -y libmagic-dev libreoffice
           sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
           sudo apt-get update
           sudo apt-get install -y tesseract-ocr

--- a/.github/workflows/partition-benchmark.yaml
+++ b/.github/workflows/partition-benchmark.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmagic-dev poppler-utils libreoffice
+          sudo apt-get install -y libmagic-dev libreoffice
           sudo add-apt-repository -y ppa:alex-p/tesseract-ocr5
           sudo apt-get update
           sudo apt-get install -y tesseract-ocr tesseract-ocr-kor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.25.3-dev0
 
+### Enhancements
+
+- **Remove poppler / pdf2image dependency**: PDF page counting for chunked rendering now uses `pypdf` instead of `pdf2image`, so the system `poppler` package is no longer required. PDF rendering continues to use PyPDFium2 via `unstructured-inference`.
+
 ### Fixes
 
 - **Stop the `GLOBAL_WORKING_DIR` tests from disturbing other pytest-xdist workers**: test-only change, no library behavior changes. The two tests exercising `GLOBAL_WORKING_DIR_ENABLED` now redirect the working dir to a private `tmp_path` and restore `tempfile.tempdir` unconditionally, rather than moving the shared pgid-keyed directory aside mid-run and leaving the worker's `tempfile.tempdir` pointed at it. That shared path made `test_dockerfile` fail intermittently, with an unrelated test dying inside `tempfile`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk_ok=false; \
       apk update && \
       apk add libxml2 python-3.12 python-3.12-base glib \
         mesa-gl mesa-libgallium cmake bash libmagic wget git openjpeg \
-        poppler poppler-utils poppler-glib libreoffice tesseract && \
+        libreoffice tesseract && \
       apk_ok=true && break; \
       echo "apk install failed (attempt $attempt/3), retrying in 5s..."; sleep 5; \
     done; $apk_ok && \

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ installation.
 - Install the following system dependencies if they are not already available on your system.
   Depending on what document types you're parsing, you may not need all of these.
     - `libmagic-dev` (filetype detection)
-    - `poppler-utils` (images and PDFs)
     - `tesseract-ocr` (images and PDFs, install `tesseract-lang` for additional language support)
     - `libreoffice` (MS Office docs)
     - `pandoc` is bundled automatically via the `pypandoc-binary` Python package (no system install needed)
@@ -187,8 +186,7 @@ make lock
 
 * Optional:
   * To install extras for processing images and PDFs locally, run `uv sync --extra pdf --extra image`.
-  * For processing image files, `tesseract` is required. See [here](https://tesseract-ocr.github.io/tessdoc/Installation.html) for installation instructions.
-  * For processing PDF files, `tesseract` and `poppler` are required. The [pdf2image docs](https://pdf2image.readthedocs.io/en/latest/installation.html) have instructions on installing `poppler` across various platforms.
+  * For processing image and PDF files, `tesseract` is required. See [here](https://tesseract-ocr.github.io/tessdoc/Installation.html) for installation instructions.
 
 Additionally, if you're planning to contribute to `unstructured`, we provide you an optional `pre-commit` configuration
 file to ensure your code matches the formatting and linting standards used in `unstructured`.

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - python=3.10
   - pytorch=2.1.2
   - pywin32
-  - poppler
   - torchvision
   - pip
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ epub = [
 ]
 image = [
     "google-cloud-vision>=3.12.1, <4.0.0",
-    "pdf2image>=1.17.0, <2.0.0",
     "pdfminer.six>=20251230, <20270000",
     "pi-heif>=1.2.0, <2.0.0",
     "pikepdf>=10.3.0, <11.0.0",

--- a/scripts/setup_al2.sh
+++ b/scripts/setup_al2.sh
@@ -77,10 +77,6 @@ EOF
 #### OpenCV dependencies
 $sudo $pac install -y mesa-libGL
 
-#### Poppler
-# Install poppler
-$sudo $pac install -y poppler-utils
-
 #### Tesseract
 # Install dependencies for image and pdf manipulation
 $sudo $pac install -y opencv opencv-devel opencv-python perl-core clang libpng-devel libtiff-devel libwebp-devel libjpeg-turbo-devel git-core libtool pkgconfig xz

--- a/scripts/setup_ubuntu.sh
+++ b/scripts/setup_ubuntu.sh
@@ -79,10 +79,6 @@ EOF
 #### OpenCV dependencies
 $sudo $pac install -y libgl1
 
-#### Poppler
-# Install poppler
-$sudo $pac install -y poppler-utils
-
 #### OpenOffice / MSOffice doc conversion capabilities
 $sudo $pac install -y libreoffice pandoc
 

--- a/test_unstructured/file_utils/test_model.py
+++ b/test_unstructured/file_utils/test_model.py
@@ -96,7 +96,7 @@ class DescribeFileType:
             (FileType.EMPTY, ()),
             (FileType.HTML, ()),
             (FileType.ODT, ("docx", "pypandoc")),
-            (FileType.PDF, ("pdf2image", "pdfminer", "PIL")),
+            (FileType.PDF, ("pypdf", "pdfminer", "PIL")),
             (FileType.UNK, ()),
             (FileType.WAV, ()),  # STT agent deps validated at runtime
             (FileType.ZIP, ()),

--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -14,9 +14,9 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
-from pdf2image.exceptions import PDFPageCountError
 from PIL import Image
 from pytest_mock import MockFixture
+from pypdfium2 import PdfiumError
 from unstructured_inference.inference import layout, pdf_image
 from unstructured_inference.inference.elements import Rectangle
 from unstructured_inference.inference.layout import DocumentLayout, PageLayout
@@ -208,7 +208,7 @@ def test_partition_pdf_local(monkeypatch, filename, file):
 
 
 def test_partition_pdf_local_raises_with_no_filename():
-    with pytest.raises((FileNotFoundError, PDFPageCountError, TypeError)):
+    with pytest.raises((FileNotFoundError, PdfiumError, TypeError)):
         pdf._partition_pdf_or_image_local(filename="", file=None, is_image=False)
 
 

--- a/test_unstructured/partition/pdf_image/test_pdf.py
+++ b/test_unstructured/partition/pdf_image/test_pdf.py
@@ -15,8 +15,8 @@ from unittest import mock
 
 import pytest
 from PIL import Image
-from pytest_mock import MockFixture
 from pypdfium2 import PdfiumError
+from pytest_mock import MockFixture
 from unstructured_inference.inference import layout, pdf_image
 from unstructured_inference.inference.elements import Rectangle
 from unstructured_inference.inference.layout import DocumentLayout, PageLayout

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -76,7 +76,8 @@ def test_convert_pdf_to_image_raises_unprocessable_when_render_too_large():
 
 def test_convert_pdf_to_images_raises_unprocessable_when_render_too_large():
     with (
-        patch.object(pdf_image_utils, "PdfReader", return_value=MagicMock(get_num_pages=lambda: 1)),
+        patch.object(pdf_image_utils, "PdfReader"),
+        patch.object(pdf_image_utils, "_pdf_page_count", return_value=1),
         patch.object(
             pdf_image_utils,
             "render_pdf_to_image",

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -84,15 +84,6 @@ def test_pdf_page_count_reads_catalog_count():
         assert pdf_page_count(PdfReader(f)) == 2
 
 
-def test_pdf_page_count_does_not_flatten_page_tree():
-    from unstructured.partition.pdf_image.pypdf_utils import pdf_page_count
-
-    reader = MagicMock()
-    reader.root_object = {"/Pages": {"/Count": 3}}
-    assert pdf_page_count(reader) == 3
-    reader.get_num_pages.assert_not_called()
-
-
 def test_convert_pdf_to_images_raises_unprocessable_when_render_too_large():
     filename = example_doc_path("pdf/layout-parser-paper-fast.pdf")
     with patch.object(

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -75,8 +75,8 @@ def test_convert_pdf_to_image_raises_unprocessable_when_render_too_large():
 
 
 def test_convert_pdf_to_images_raises_unprocessable_when_render_too_large():
+    filename = example_doc_path("pdf/layout-parser-paper-fast.pdf")
     with (
-        patch.object(pdf_image_utils, "PdfReader"),
         patch.object(pdf_image_utils, "_pdf_page_count", return_value=1),
         patch.object(
             pdf_image_utils,
@@ -85,7 +85,7 @@ def test_convert_pdf_to_images_raises_unprocessable_when_render_too_large():
         ),
     ):
         with pytest.raises(UnprocessableEntityError, match="too many pixels"):
-            list(pdf_image_utils.convert_pdf_to_images(filename="example.pdf"))
+            list(pdf_image_utils.convert_pdf_to_images(filename=filename))
 
 
 @pytest.mark.parametrize("file_mode", ["filename", "rb"])

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -76,7 +76,7 @@ def test_convert_pdf_to_image_raises_unprocessable_when_render_too_large():
 
 def test_convert_pdf_to_images_raises_unprocessable_when_render_too_large():
     with (
-        patch.object(pdf_image_utils.pdf2image, "pdfinfo_from_path", return_value={"Pages": 1}),
+        patch.object(pdf_image_utils, "PdfReader", return_value=MagicMock(get_num_pages=lambda: 1)),
         patch.object(
             pdf_image_utils,
             "render_pdf_to_image",
@@ -425,7 +425,7 @@ def test_annotate_layout_elements(filename, is_image):
         patch(
             "unstructured.partition.pdf_image.pdf_image_utils.convert_pdf_to_image",
             return_value=["/path/to/image1.jpg", "/path/to/image2.jpg"],
-        ) as mock_pdf2image,
+        ) as mock_convert_pdf_to_image,
         patch(
             "unstructured.partition.pdf_image.pdf_image_utils.annotate_layout_elements_with_image"
         ) as mock_annotate_layout_elements_with_image,
@@ -442,7 +442,7 @@ def test_annotate_layout_elements(filename, is_image):
             mock_annotate_layout_elements_with_image.assert_called_once()
         else:
             assert mock_annotate_layout_elements_with_image.call_count == len(
-                mock_pdf2image.return_value
+                mock_convert_pdf_to_image.return_value
             )
 
 

--- a/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
+++ b/test_unstructured/partition/pdf_image/test_pdf_image_utils.py
@@ -74,15 +74,31 @@ def test_convert_pdf_to_image_raises_unprocessable_when_render_too_large():
             pdf_image_utils.convert_pdf_to_image(filename="example.pdf")
 
 
+def test_pdf_page_count_reads_catalog_count():
+    from pypdf import PdfReader
+
+    from unstructured.partition.pdf_image.pypdf_utils import pdf_page_count
+
+    filename = example_doc_path("pdf/layout-parser-paper-fast.pdf")
+    with open(filename, "rb") as f:
+        assert pdf_page_count(PdfReader(f)) == 2
+
+
+def test_pdf_page_count_does_not_flatten_page_tree():
+    from unstructured.partition.pdf_image.pypdf_utils import pdf_page_count
+
+    reader = MagicMock()
+    reader.root_object = {"/Pages": {"/Count": 3}}
+    assert pdf_page_count(reader) == 3
+    reader.get_num_pages.assert_not_called()
+
+
 def test_convert_pdf_to_images_raises_unprocessable_when_render_too_large():
     filename = example_doc_path("pdf/layout-parser-paper-fast.pdf")
-    with (
-        patch.object(pdf_image_utils, "_pdf_page_count", return_value=1),
-        patch.object(
-            pdf_image_utils,
-            "render_pdf_to_image",
-            side_effect=pdf_image.PdfRenderTooLargeError("too many pixels"),
-        ),
+    with patch.object(
+        pdf_image_utils,
+        "render_pdf_to_image",
+        side_effect=pdf_image.PdfRenderTooLargeError("too many pixels"),
     ):
         with pytest.raises(UnprocessableEntityError, match="too many pixels"):
             list(pdf_image_utils.convert_pdf_to_images(filename=filename))

--- a/test_unstructured/partition/test_auto.py
+++ b/test_unstructured/partition/test_auto.py
@@ -1527,7 +1527,7 @@ def test_auto_partition_that_requires_extras_raises_when_dependencies_are_not_in
     with pytest.raises(ImportError, match=match):
         partition(example_doc_path("pdf/layout-parser-paper-fast.pdf"))
 
-    dependency_exists_.assert_called_once_with("pdf2image")
+    dependency_exists_.assert_called_once_with("pypdf")
 
 
 # ================================================================================================

--- a/unstructured/file_utils/model.py
+++ b/unstructured/file_utils/model.py
@@ -406,7 +406,7 @@ class FileType(enum.Enum):
     PDF = (
         "pdf",
         "pdf",
-        ["pdf2image", "pdfminer", "PIL"],
+        ["pypdf", "pdfminer", "PIL"],
         "pdf",
         [".pdf"],
         "application/pdf",

--- a/unstructured/partition/pdf.py
+++ b/unstructured/partition/pdf.py
@@ -65,6 +65,7 @@ from unstructured.partition.pdf_image.pdfminer_utils import (
     open_pdfminer_pages_generator,
     rect_to_bbox,
 )
+from unstructured.partition.pdf_image.pypdf_utils import pdf_page_count
 from unstructured.partition.strategies import determine_pdf_or_image_strategy, validate_strategy
 from unstructured.partition.text import element_from_text
 from unstructured.partition.utils.config import env_config
@@ -591,14 +592,16 @@ def _get_pdf_page_number(
     filename: str = "",
     file: Optional[bytes | IO[bytes]] = None,
 ) -> int:
-    if file:
-        number_of_pages = PdfReader(file).get_num_pages()
+    if file is not None:
+        if isinstance(file, (bytes, bytearray)):
+            return pdf_page_count(PdfReader(io.BytesIO(file)))
+        number_of_pages = pdf_page_count(PdfReader(file))
         file.seek(0)
-    elif filename:
-        number_of_pages = PdfReader(filename).get_num_pages()
-    else:
-        raise ValueError("Either 'file' or 'filename' must be provided.")
-    return number_of_pages
+        return number_of_pages
+    if filename:
+        with open(filename, "rb") as f:
+            return pdf_page_count(PdfReader(f))
+    raise ValueError("Either 'file' or 'filename' must be provided.")
 
 
 def check_pdf_hi_res_max_pages_exceeded(

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -414,7 +414,8 @@ def convert_pdf_to_images(
         total_pages = _pdf_page_count(PdfReader(BytesIO(f_bytes), password=password))
     else:
         f_bytes = None
-        total_pages = _pdf_page_count(PdfReader(filename, password=password))
+        with open(filename, "rb") as f:
+            total_pages = _pdf_page_count(PdfReader(f, password=password))
 
     for start_page in range(1, total_pages + 1, chunk_size):
         end_page = min(start_page + chunk_size - 1, total_pages)

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -12,8 +12,8 @@ from typing import IO, TYPE_CHECKING, BinaryIO, Iterator, List, Optional, Tuple,
 
 import cv2
 import numpy as np
-import pdf2image
 from PIL import Image
+from pypdf import PdfReader
 from unstructured_inference.inference.layout import convert_pdf_to_image as render_pdf_to_image
 from unstructured_inference.inference.pdf_image import PdfRenderTooLargeError
 
@@ -403,12 +403,11 @@ def convert_pdf_to_images(
     exactly_one(filename=filename, file=file)
     if file is not None:
         f_bytes = convert_to_bytes(file)
-        info = pdf2image.pdfinfo_from_bytes(f_bytes, userpw=password)
+        total_pages = PdfReader(BytesIO(f_bytes), password=password).get_num_pages()
     else:
         f_bytes = None
-        info = pdf2image.pdfinfo_from_path(filename, userpw=password)
+        total_pages = PdfReader(filename, password=password).get_num_pages()
 
-    total_pages = info["Pages"]
     for start_page in range(1, total_pages + 1, chunk_size):
         end_page = min(start_page + chunk_size - 1, total_pages)
         try:

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -393,6 +393,14 @@ def annotate_layout_elements(
             raise FileNotFoundError(f'File "{filename}" not found!') from e
 
 
+def _pdf_page_count(reader: PdfReader) -> int:
+    """Return the catalog page count without flattening the page tree.
+
+    Matches poppler ``pdfinfo`` / former ``pdf2image.pdfinfo_*`` ``Pages`` behavior.
+    """
+    return int(reader.root_object["/Pages"]["/Count"])
+
+
 def convert_pdf_to_images(
     filename: str = "",
     file: Optional[bytes | IO[bytes]] = None,
@@ -403,10 +411,10 @@ def convert_pdf_to_images(
     exactly_one(filename=filename, file=file)
     if file is not None:
         f_bytes = convert_to_bytes(file)
-        total_pages = PdfReader(BytesIO(f_bytes), password=password).get_num_pages()
+        total_pages = _pdf_page_count(PdfReader(BytesIO(f_bytes), password=password))
     else:
         f_bytes = None
-        total_pages = PdfReader(filename, password=password).get_num_pages()
+        total_pages = _pdf_page_count(PdfReader(filename, password=password))
 
     for start_page in range(1, total_pages + 1, chunk_size):
         end_page = min(start_page + chunk_size - 1, total_pages)

--- a/unstructured/partition/pdf_image/pdf_image_utils.py
+++ b/unstructured/partition/pdf_image/pdf_image_utils.py
@@ -21,6 +21,7 @@ from unstructured.documents.elements import ElementType
 from unstructured.errors import UnprocessableEntityError
 from unstructured.logger import logger
 from unstructured.partition.common.common import convert_to_bytes, exactly_one
+from unstructured.partition.pdf_image.pypdf_utils import pdf_page_count
 from unstructured.partition.utils.config import env_config
 
 if TYPE_CHECKING:
@@ -393,14 +394,6 @@ def annotate_layout_elements(
             raise FileNotFoundError(f'File "{filename}" not found!') from e
 
 
-def _pdf_page_count(reader: PdfReader) -> int:
-    """Return the catalog page count without flattening the page tree.
-
-    Matches poppler ``pdfinfo`` / former ``pdf2image.pdfinfo_*`` ``Pages`` behavior.
-    """
-    return int(reader.root_object["/Pages"]["/Count"])
-
-
 def convert_pdf_to_images(
     filename: str = "",
     file: Optional[bytes | IO[bytes]] = None,
@@ -411,11 +404,11 @@ def convert_pdf_to_images(
     exactly_one(filename=filename, file=file)
     if file is not None:
         f_bytes = convert_to_bytes(file)
-        total_pages = _pdf_page_count(PdfReader(BytesIO(f_bytes), password=password))
+        total_pages = pdf_page_count(PdfReader(BytesIO(f_bytes), password=password))
     else:
         f_bytes = None
         with open(filename, "rb") as f:
-            total_pages = _pdf_page_count(PdfReader(f, password=password))
+            total_pages = pdf_page_count(PdfReader(f, password=password))
 
     for start_page in range(1, total_pages + 1, chunk_size):
         end_page = min(start_page + chunk_size - 1, total_pages)

--- a/unstructured/partition/pdf_image/pdfminer_processing.py
+++ b/unstructured/partition/pdf_image/pdfminer_processing.py
@@ -573,7 +573,7 @@ def process_data_with_pdfminer(
     rotation_corrections: Optional[List[int]] = None,
 ) -> tuple[List[LayoutElements], List[List]]:
     """Loads the image and word objects from a pdf using pdfplumber and the image renderings of the
-    pdf pages using pdf2image
+    pdf pages using PyPDFium2
 
     ``rotation_corrections`` is an optional per-page list of extra rotations (degrees,
     counter-clockwise) that unstructured-inference applied to the rendered page images to

--- a/unstructured/partition/pdf_image/pypdf_utils.py
+++ b/unstructured/partition/pdf_image/pypdf_utils.py
@@ -2,6 +2,15 @@ import io
 from typing import BinaryIO
 
 import pypdf
+from pypdf import PdfReader
+
+
+def pdf_page_count(reader: PdfReader) -> int:
+    """Return the catalog page count without flattening the page tree.
+
+    Matches poppler ``pdfinfo`` ``Pages`` (PDF catalog ``/Pages`` ``/Count``).
+    """
+    return int(reader.root_object["/Pages"]["/Count"])
 
 
 def get_page_data(fp: BinaryIO, page_number: int):

--- a/uv.lock
+++ b/uv.lock
@@ -4316,18 +4316,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pdf2image"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pillow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/d8/b280f01045555dc257b8153c00dee3bc75830f91a744cd5f84ef3a0a64b1/pdf2image-1.17.0.tar.gz", hash = "sha256:eaa959bc116b420dd7ec415fcae49b98100dda3dd18cd2fdfa86d09f112f6d57", size = 12811, upload-time = "2024-01-07T20:33:01.965Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/33/61766ae033518957f877ab246f87ca30a85b778ebaad65b7f74fa7e52988/pdf2image-1.17.0-py3-none-any.whl", hash = "sha256:ecdd58d7afb810dffe21ef2b1bbc057ef434dabbac6c33778a38a3f7744a27e2", size = 11618, upload-time = "2024-01-07T20:32:59.957Z" },
-]
-
-[[package]]
 name = "pdfminer-six"
 version = "20260107"
 source = { registry = "https://pypi.org/simple" }
@@ -7252,7 +7240,6 @@ all-docs = [
     { name = "openai-whisper" },
     { name = "openpyxl" },
     { name = "pandas" },
-    { name = "pdf2image" },
     { name = "pdfminer-six" },
     { name = "pi-heif" },
     { name = "pikepdf" },
@@ -7289,7 +7276,6 @@ huggingface = [
 ]
 image = [
     { name = "google-cloud-vision" },
-    { name = "pdf2image" },
     { name = "pdfminer-six" },
     { name = "pi-heif" },
     { name = "pikepdf" },
@@ -7308,7 +7294,6 @@ local-inference = [
     { name = "openai-whisper" },
     { name = "openpyxl" },
     { name = "pandas" },
-    { name = "pdf2image" },
     { name = "pdfminer-six" },
     { name = "pi-heif" },
     { name = "pikepdf" },
@@ -7336,7 +7321,6 @@ paddleocr = [
 ]
 pdf = [
     { name = "google-cloud-vision" },
-    { name = "pdf2image" },
     { name = "pdfminer-six" },
     { name = "pi-heif" },
     { name = "pikepdf" },
@@ -7437,10 +7421,6 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'local-inference'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pandas", marker = "extra == 'tsv'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pandas", marker = "extra == 'xlsx'", specifier = ">=2.0.0,<3.0.0" },
-    { name = "pdf2image", marker = "extra == 'all-docs'", specifier = ">=1.17.0,<2.0.0" },
-    { name = "pdf2image", marker = "extra == 'image'", specifier = ">=1.17.0,<2.0.0" },
-    { name = "pdf2image", marker = "extra == 'local-inference'", specifier = ">=1.17.0,<2.0.0" },
-    { name = "pdf2image", marker = "extra == 'pdf'", specifier = ">=1.17.0,<2.0.0" },
     { name = "pdfminer-six", marker = "extra == 'all-docs'", specifier = ">=20251230,<20270000" },
     { name = "pdfminer-six", marker = "extra == 'image'", specifier = ">=20251230,<20270000" },
     { name = "pdfminer-six", marker = "extra == 'local-inference'", specifier = ">=20251230,<20270000" },


### PR DESCRIPTION
To make our containers smaller and have fewer CVEs detected - I've been removing dependencies we don't use from our unstructured deployment. poppler-utils on debian trixie for instance has some CVEs associated with it.

Once I realised this project has almost entirely moved away from pdf2image in https://github.com/Unstructured-IO/unstructured/pull/4185 I thought I might as-well contribute finishing the job.

I have made some effort to ensure this is not a regression in performance or behaviour. From limited testing I think this is faster for small PDFs (probably due to no sub-process startup) and on-par for larger PDFs (thanks to opening the file and only reading the amount we need).

This code in this PR is written by Cursor with my supervision - I am heavily relying on the test suite to validate behaviour. If you are aware of any corner cases that aren't captured by the existing suite in terms of the sorts of weird PDFs that this PR might trip up on lmk and I can try and expand it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

