### PR TITLE
Fix example document paths in README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Once in the running container, you can try things directly in Python interpreter
 python3
 
 >>> from unstructured.partition.pdf import partition_pdf
->>> elements = partition_pdf(filename="example-docs/layout-parser-paper-fast.pdf")
+>>> elements = partition_pdf(filename="example-docs/pdf/layout-parser-paper-fast.pdf")
 
 >>> from unstructured.partition.text import partition_text
 >>> elements = partition_text(filename="example-docs/fake-text.txt")
@@ -231,7 +231,7 @@ See our  [installation guide](https://docs.unstructured.io/open-source/installat
 ```python
 from unstructured.partition.auto import partition
 
-elements = partition("example-docs/layout-parser-paper.pdf")
+elements = partition("example-docs/pdf/layout-parser-paper.pdf")
 ```
 
 Run `print("\n\n".join([str(el) for el in elements]))` to get a string representation of the


### PR DESCRIPTION
The two quickstart snippets in the README point at example documents that have moved.

- `example-docs/layout-parser-paper-fast.pdf` (README line 121)
- `example-docs/layout-parser-paper.pdf` (README line 234)

Both files live under `example-docs/pdf/` since 0eb461ac ("refactor: restructure PDF/Image example document organization", 2024-07-18). The top-level paths no longer exist, so copying either snippet as written raises `FileNotFoundError`. One of them is in the Docker quickstart, which is a first-run experience for new users.

This just adds the `pdf/` segment to both. Verified the targets exist at `example-docs/pdf/layout-parser-paper.pdf` and `example-docs/pdf/layout-parser-paper-fast.pdf` on main.

Found by [docproof](https://github.com/melbinjp/docproof), a documentation checker that verifies claims in docs against the repository and its git history. Hand-checked against the current tree before opening the PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
