### PR TITLE
fix(cleaners): prevent UnboundLocalError in _get_indexed_match when pattern is absent

### DIFF
--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -15,8 +15,21 @@ def test_get_indexed_match_raises_with_bad_index():
 
 
 def test_get_indexed_match_raises_with_index_too_high():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="The largest index was 2"):
         extract._get_indexed_match("BLAH BLAH BLAH", "BLAH", 4)
+
+
+def test_get_indexed_match_raises_with_no_matches():
+    with pytest.raises(ValueError, match="No matches were found"):
+        extract._get_indexed_match("BLAH BLAH BLAH", "XYZ", 0)
+
+
+def test_extract_text_before_and_after_with_absent_pattern():
+    with pytest.raises(ValueError, match="No matches were found"):
+        extract.extract_text_before("hello world", "xyz")
+
+    with pytest.raises(ValueError, match="No matches were found"):
+        extract.extract_text_after("hello world", "xyz")
 
 
 def test_extract_text_before():

--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -18,11 +18,14 @@ def _get_indexed_match(text: str, pattern: str, index: int = 0) -> re.Match:
         raise ValueError(f"The index is {index}. Index must be a non-negative integer.")
 
     regex_match = None
+    i = -1
     for i, result in enumerate(re.finditer(pattern, text)):
         if i == index:
             regex_match = result
 
     if regex_match is None:
+        if i < 0:
+            raise ValueError(f"Result with index {index} was not found. No matches were found.")
         raise ValueError(f"Result with index {index} was not found. The largest index was {i}.")
 
     return regex_match


### PR DESCRIPTION
### Summary

Closes #4427

`extract_text_before()` and `extract_text_after()` raised an `UnboundLocalError` instead of a `ValueError` when the target pattern was not present in the input text. The helper `_get_indexed_match()` referenced loop counter `i` in its formatted error message, which remained unassigned when `re.finditer` produced 0 matches.

### Solution
- Initialized `i = -1` before the match iteration loop.
- Added a clear error message `Result with index {index} was not found. No matches were found.` when no matches are detected.
- Added unit regression tests in `test_unstructured/cleaners/test_extract.py`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

