### PR TITLE
fix: decode CSV delimiter-sniff sample as a single stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.27.3
+
+### Fixes
+
+- **`partition_csv()` no longer crashes on UTF-16-LE CSV files**: delimiter sniffing decoded its sample line-by-line, but `readlines()` splits the raw bytes on `0x0A`, which in multi-byte encodings like UTF-16 lands mid-code-unit, and only the first fragment carries the BOM. A UTF-16-LE file (what `str.encode("utf-16")` and Excel's "Unicode Text" export produce) raised `UnicodeDecodeError: truncated data` even when the correct `encoding` was passed; UTF-16-BE silently sniffed mojibake. The sample is now decoded as a single stream with an incremental decoder that tolerates a character split at the read boundary.
+
 ## 0.27.2
 
 ### Fixes

--- a/test_unstructured/partition/test_csv.py
+++ b/test_unstructured/partition/test_csv.py
@@ -86,6 +86,22 @@ def test_partition_csv_with_encoding():
     assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
 
 
+def test_partition_csv_with_utf_16_le_encoding():
+    """UTF-16-LE is what `str.encode("utf-16")` and Excel's "Unicode Text" export produce.
+
+    Delimiter-sniffing previously decoded its sample line-by-line, which raised
+    `UnicodeDecodeError: truncated data` for UTF-16-LE because `readlines()` splits on a 0x0A
+    byte that lands mid-code-unit and only the first fragment carries the BOM.
+    """
+    with open(example_doc_path("stanley-cups.csv")) as f:
+        utf_16_le_bytes = f.read().encode("utf-16")
+
+    elements = partition_csv(file=io.BytesIO(utf_16_le_bytes), encoding="utf-16")
+
+    assert clean_extra_whitespace(elements[0].text) == EXPECTED_TEXT
+    assert elements[0].metadata.text_as_html == EXPECTED_TABLE
+
+
 @pytest.mark.parametrize(
     ("filename", "expected_text", "expected_table"),
     [
@@ -259,6 +275,14 @@ class Describe_CsvPartitioningContext:
     def and_it_auto_detects_the_delimiter_for_a_semicolon_delimited_CSV_file(self):
         ctx = _CsvPartitioningContext(example_doc_path("semicolon-delimited.csv"))
         assert ctx.delimiter == ";"
+
+    def and_it_auto_detects_the_delimiter_for_a_UTF_16_encoded_CSV_file(self):
+        # -- previously raised `UnicodeDecodeError: truncated data`: the sniff sample was
+        # -- decoded line-by-line, but `readlines()` splits UTF-16-LE mid-code-unit and only
+        # -- the first fragment carries the BOM --
+        file = io.BytesIO("a,b,c\nd,e,f\ng,h,i\n".encode("utf-16"))
+        ctx = _CsvPartitioningContext(file=file, encoding="utf-16")
+        assert ctx.delimiter == ","
 
     def but_it_returns_None_as_the_delimiter_for_a_single_column_CSV_file(self):
         ctx = _CsvPartitioningContext(example_doc_path("single-column.csv"))

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.2"  # pragma: no cover
+__version__ = "0.27.3"  # pragma: no cover

--- a/unstructured/partition/csv.py
+++ b/unstructured/partition/csv.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import codecs
 import contextlib
 import csv
 from functools import cached_property
@@ -129,9 +130,16 @@ class _CsvPartitioningContext:
 
         with self.open() as file:
             # -- read whole lines, sniffer can be confused by a trailing partial line --
-            data = "\n".join(
-                ln.decode(self._encoding or "utf-8") for ln in file.readlines(num_bytes)
-            )
+            sample_bytes = b"".join(file.readlines(num_bytes))
+
+        # -- Decode the sample as a single stream, not line-by-line. `readlines()` splits on the
+        # -- 0x0A byte, which in a multi-byte encoding like UTF-16 can land mid-character, and a
+        # -- BOM appears only at the start of the stream. Decoding each fragment separately
+        # -- raised `UnicodeDecodeError: truncated data` for UTF-16-LE and silently produced
+        # -- mojibake for UTF-16-BE. `final=False` buffers a character split at the read
+        # -- boundary instead of raising on it.
+        decoder = codecs.getincrementaldecoder(self._encoding or "utf-8")()
+        data = decoder.decode(sample_bytes, final=False)
 
         try:
             return sniffer.sniff(data, delimiters=",;|").delimiter


### PR DESCRIPTION
Fixes #4443

## Summary

`partition_csv()` crashed with `UnicodeDecodeError: truncated data` on UTF-16-LE files even when the correct `encoding` was passed, because `_CsvPartitioningContext.delimiter` decoded its sniff sample line-by-line: `readlines()` splits raw bytes on `0x0A`, which lands mid-code-unit in UTF-16, and only the first fragment carries the BOM. UTF-16-BE didn't raise but silently fed the sniffer mojibake for every line after the first.

## Fix

Keep the whole-line read semantics from #2998, but join the line fragments back into one byte stream and decode once with `codecs.getincrementaldecoder(encoding)(...).decode(sample, final=False)` — a character split at the read boundary is buffered instead of raising. Wrong-encoding inputs (e.g. latin-1 bytes decoded as utf-8) still raise exactly as before.

## Testing

`test_partition_csv_with_utf_16_le_encoding` (end-to-end) and `and_it_auto_detects_the_delimiter_for_a_UTF_16_encoded_CSV_file` — both fail with the exact `UnicodeDecodeError` without the fix and pass with it. Full `test_csv.py`: 36 passed (includes the #2643 long-line regression, semicolon, single-column, and BE-utf-16 cases); `test_tsv.py` 15 passed; `test_text.py` 50 passed. `ruff check` + `ruff format --check` clean on touched files. CHANGELOG entry and version bump 0.26.3 → 0.26.4 included per repo convention.

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

