### PR TITLE
fix: keep overlap labels aligned with boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.26.4
+
+### Fixes
+
+- **Keep overlap labels aligned with coordinate-bearing elements**: `catch_overlapping_and_nested_bboxes()` now excludes elements without coordinates from the parallel label and text collections, matching the existing bounding-box filtering. Previously, a coordinate-less element before an overlapping pair shifted those collections and caused the report to name the wrong elements, texts, and parent-child relationship.
+
 ## 0.26.3
 
 ### Fixes

--- a/test_unstructured/test_utils.py
+++ b/test_unstructured/test_utils.py
@@ -312,6 +312,41 @@ def test_catch_overlapping_and_nested_bboxes_non_overlapping_case():
     assert overlapping_cases == []
 
 
+def test_catch_overlapping_and_nested_bboxes_ignores_elements_without_coordinates():
+    coordinate_system = PixelSpace(width=20, height=20)
+    elements = [
+        Title(
+            text="No coordinates",
+            metadata=ElementMetadata(page_number=1),
+        ),
+        Title(
+            text="Parent",
+            coordinates=((1, 1), (1, 10), (10, 10), (10, 1)),
+            coordinate_system=coordinate_system,
+            metadata=ElementMetadata(page_number=1),
+        ),
+        NarrativeText(
+            text="Child",
+            coordinates=((3, 3), (3, 5), (5, 5), (5, 3)),
+            coordinate_system=coordinate_system,
+            metadata=ElementMetadata(page_number=1),
+        ),
+    ]
+
+    overlapping_flag, overlapping_cases = utils.catch_overlapping_and_nested_bboxes(
+        elements,
+        nested_error_tolerance_px=1,
+    )
+
+    assert overlapping_flag is True
+    assert overlapping_cases[0]["overlapping_elements"] == [
+        "Title(ix=1)",
+        "NarrativeText(ix=2)",
+    ]
+    assert overlapping_cases[0]["parent_element"] == "Title(ix=1)"
+    assert overlapping_cases[0]["overlapping_case"] == "nested NarrativeText in Title"
+
+
 def test_only_returns_singleton_iterable():
     singleton_iterable = [42]
     result = utils.only(singleton_iterable)

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.26.3"  # pragma: no cover
+__version__ = "0.26.4"  # pragma: no cover

--- a/unstructured/utils.py
+++ b/unstructured/utils.py
@@ -604,8 +604,8 @@ def catch_overlapping_and_nested_bboxes(
         if element.metadata.coordinates:
             box = cast(Points, element.metadata.coordinates.to_dict()["points"])
             pages_of_bboxes[n_page_to_ix].append(box)
-        text_labels[n_page_to_ix].append(f"{ix}. {element.category}")
-        text_content[n_page_to_ix].append(element.text)
+            text_labels[n_page_to_ix].append(f"{ix}. {element.category}")
+            text_content[n_page_to_ix].append(element.text)
 
     document_with_overlapping_flag = False
     overlapping_cases: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary

- keep bounding boxes, element labels, and text content aligned when an element has no coordinates
- preserve original element indexes in overlap reports
- add a regression test covering a coordinate-less element before a nested pair

## Problem

`catch_overlapping_and_nested_bboxes()` already excludes elements without coordinates from its bounding-box collection, but it still appended their labels and text to the parallel collections. A coordinate-less element therefore shifted those collections, causing later overlap and parent-child reports to name the wrong elements and content.

The fix appends all three values only for coordinate-bearing elements, so every index used by the overlap detector refers to the same source element.

## Tests

- `python3 -m pytest test_unstructured/test_utils.py -q` — 38 passed
- `python3 -m ruff check unstructured/utils.py test_unstructured/test_utils.py`
- `python3 -m ruff format --check unstructured/utils.py test_unstructured/test_utils.py`
- `git diff --check`

AI assistance was used to help identify the edge case and prepare the focused patch. The behavior and test results were verified locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

