### PR TITLE
fix: file-type detection crash on non-UTF-8 text starting with "{" or "["

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.27.3
+
+### Fixes
+
+- **File-type detection no longer crashes on non-UTF-8 text starting with `{` or `[`**: `_TextFileDifferentiator._is_json` parsed the raw bytes with `json.load()`, which only auto-detects the UTF-8/16/32 family, and caught only `json.JSONDecodeError`. A plain-text file in any other character set (e.g. cp1252/latin-1) whose first non-whitespace character is `{` or `[` — a log file or INI-style config — raised `UnicodeDecodeError` from `detect_filetype()` and `partition()` instead of classifying as TXT. The check now treats an undecodable payload as not-JSON after retrying with the declared `encoding`, so an explicitly-declared legacy-encoded JSON file still classifies as JSON. Regression of the encoding-aware detection fixed in #707 (issue #705), reintroduced when detection was rewritten.
+
 ## 0.27.2
 
 ### Fixes

--- a/test_unstructured/file_utils/test_filetype.py
+++ b/test_unstructured/file_utils/test_filetype.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import pathlib
 
 import pytest
 
@@ -1298,6 +1299,10 @@ class Describe_TextFileDifferentiator:
             (b"", False),
             # -- valid JSON, but not for our purposes --
             (b'"This is not a JSON"', False),
+            # -- starts with "{"/"[" but is non-UTF text (cp1252), not JSON; previously raised
+            # -- UnicodeDecodeError instead of returning False --
+            ('{"name": "café", "city": "münchen"}'.encode("cp1252"), False),
+            ("[config]\nname=caf\xe9\nport=8080\n".encode("cp1252"), False),
         ],
     )
     def it_distinguishes_a_JSON_file_from_other_text_files(
@@ -1307,6 +1312,24 @@ class Describe_TextFileDifferentiator:
         differentiator = _TextFileDifferentiator(ctx)
 
         assert differentiator._is_json is expected_value
+
+    def and_it_does_not_raise_on_a_non_UTF_text_file_path_that_starts_with_a_brace(
+        self, tmp_path: pathlib.Path
+    ):
+        """A cp1252/latin-1 text file starting with "[" or "{" is not-JSON, not an error."""
+        file_path = tmp_path / "notes.txt"
+        file_path.write_bytes("[2026-08-19] M\xfcnchen report\n".encode("cp1252"))
+
+        ctx = _FileTypeDetectionContext(str(file_path))
+
+        assert _TextFileDifferentiator(ctx)._is_json is False
+
+    def and_it_classifies_JSON_in_a_declared_non_UTF_encoding_as_JSON(self):
+        content = '{"name": "café", "city": "münchen"}'.encode("cp1252")
+
+        ctx = _FileTypeDetectionContext(file=io.BytesIO(content), encoding="cp1252")
+
+        assert _TextFileDifferentiator(ctx)._is_json is True
 
 
 class Describe_ZipFileDetector:

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.2"  # pragma: no cover
+__version__ = "0.27.3"  # pragma: no cover

--- a/unstructured/file_utils/filetype.py
+++ b/unstructured/file_utils/filetype.py
@@ -984,6 +984,21 @@ class _TextFileDifferentiator:
             return True
         except json.JSONDecodeError:
             return False
+        except (UnicodeDecodeError, UnicodeError):
+            # -- `json.load()` reads the raw bytes and auto-detects only the UTF-8/16/32
+            # -- family (the encodings valid for JSON interchange, RFC 8259). A text file in
+            # -- any other character set whose first non-whitespace character is "{" or "["
+            # -- (e.g. a cp1252 log or INI file) lands here. Retry with the declared encoding
+            # -- so an explicitly-declared legacy-encoded JSON still classifies as JSON;
+            # -- otherwise the file is not (interchangeable) JSON, not an error --
+            try:
+                with self._ctx.open() as file:
+                    content = file.read()
+                text = content.decode(self._ctx.encoding) if isinstance(content, bytes) else content
+                json.loads(text)
+                return True
+            except (json.JSONDecodeError, UnicodeDecodeError, UnicodeError):
+                return False
 
 
 class _ZipFileDetector:


### PR DESCRIPTION
Fixes #4446

## Summary

`detect_filetype()` and `partition()` raised `UnicodeDecodeError` on any non-UTF-8 plain-text file (cp1252, latin-1, …) whose first non-whitespace character is `{` or `[` — log files with `[timestamp]` lines, INI-style configs, or legacy-encoded JSON on systems where libmagic reports it as `text/plain`. `_TextFileDifferentiator._is_json` parses the raw byte stream with `json.load()`, which auto-detects only the UTF-8/16/32 family (the JSON interchange encodings, RFC 8259), and caught only `json.JSONDecodeError`.

## Fix

Keep the `json.load()` raw-stream parse first (preserving JSON-spec UTF-16/32 auto-detection exactly), and on `UnicodeDecodeError`/`UnicodeError` retry once decoding with the declared `encoding` — so an explicitly-declared legacy-encoded JSON file still classifies as JSON — otherwise classify as not-JSON instead of raising. This is a regression of the encoding-aware detection from #707 (issue #705), reintroduced when detection was rewritten into the `_TextFileDifferentiator` architecture.

## Testing

Two new parametrized `_is_json` cases (cp1252 JSON-lookalike, latin-1 INI) plus a file-path test and a declared-encoding-JSON test — all four fail with the exact `UnicodeDecodeError` without the fix and pass with it. Full `test_filetype.py`: 277 passed. `ruff check` + `ruff format --check` clean on touched files. CHANGELOG entry and version bump (0.26.5 — note: open PR #4444 claims 0.26.4; whichever merges second has a trivial adjacent-line CHANGELOG/version conflict, happy to renumber) included per repo convention.

Disclosure: prepared with AI assistance (Claude Code); I reviewed the change and take responsibility for it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

