### PR TITLE
perf(nlp): run the spaCy pipeline once per distinct text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Enhancements
 
-- **Run the spaCy pipeline once per distinct text**: `_process()` in `unstructured.nlp.tokenize` was uncached while `word_tokenize()`, `pos_tag()` and `sent_tokenize()` each cached only their own extracted view, so every helper paid for its own identical pipeline run. Classifying one element via `is_possible_narrative_text()` reached all three and ran spaCy three times on the same string. The `Doc` is now memoized and shared, cutting `partition_html()` on a text-heavy document by ~2.8x (400 paragraphs: 1127ms -> 395ms). Texts above 8 KiB bypass the cache so a single very large element cannot pin an outsized `Doc` in memory.
+- **Run the spaCy pipeline once per distinct text**: `_process()` in `unstructured.nlp.tokenize` was uncached while `word_tokenize()`, `pos_tag()` and `sent_tokenize()` each cached only their own extracted view, so every helper paid for its own identical pipeline run. Classifying one element via `is_possible_narrative_text()` reached all three and ran spaCy three times on the same string. The `Doc` is now memoized and shared, cutting `partition_html()` on a text-heavy document by ~2.8x (400 paragraphs: 1127ms -> 395ms). Texts longer than 8,192 characters bypass the cache so a single very large element cannot pin an outsized `Doc` in memory.
 
 ## 0.26.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 - **Add privacy-bounded partition runtime telemetry**: Each top-level public partition call now makes one best-effort local attempt to send an event with fixed-enum runtime characteristics and aggregate final-element counts. Nested dispatch is suppressed. Delivery uses one non-queued daemon worker with tight connect/read timeouts; it disables redirects, retries, response-body downloads, proxy settings, and netrc credentials. A stuck transport cannot block document processing or process exit, at most one daemon can remain stranded, and later events drop while that slot is occupied. The event contains no document content, filenames, paths, URLs, caller MIME strings, exception details, credentials, or persistent identifiers. Set either `DO_NOT_TRACK` or `SCARF_NO_ANALYTICS` to any non-empty value after trimming to disable both startup and runtime telemetry before any runtime telemetry collection or delivery work.
 
+## 0.27.2
+
+### Enhancements
+
+- **Run the spaCy pipeline once per distinct text**: `_process()` in `unstructured.nlp.tokenize` was uncached while `word_tokenize()`, `pos_tag()` and `sent_tokenize()` each cached only their own extracted view, so every helper paid for its own identical pipeline run. Classifying one element via `is_possible_narrative_text()` reached all three and ran spaCy three times on the same string. The `Doc` is now memoized and shared, cutting `partition_html()` on a text-heavy document by ~2.8x (400 paragraphs: 1127ms -> 395ms). Texts above 8 KiB bypass the cache so a single very large element cannot pin an outsized `Doc` in memory.
+
 ## 0.26.3
 
 ### Fixes

--- a/test_unstructured/nlp/test_tokenize.py
+++ b/test_unstructured/nlp/test_tokenize.py
@@ -64,3 +64,92 @@ def test_process_does_not_truncate_text_within_limit():
     doc = tokenize._process(text)
     # When no truncation occurs the full text round-trips through spaCy.
     assert doc.text == text
+
+
+def test_the_spacy_pipeline_runs_once_per_distinct_text(monkeypatch):
+    """`_process` is the only expensive call in this module and every public helper needs it.
+
+    `is_possible_narrative_text` reaches it three times for one string -- via `sent_tokenize`,
+    `word_tokenize` and `pos_tag` -- and each produced an identical `Doc`. The per-helper caches
+    hide the repetition from their own callers but not from spaCy.
+    """
+    from unstructured.partition.text_type import is_possible_narrative_text
+
+    _clear_tokenize_caches()
+    runs = _count_pipeline_runs(monkeypatch)
+
+    is_possible_narrative_text("Paragraph number 7 with some filler text in it.")
+
+    assert runs["n"] == 1, f"spaCy pipeline ran {runs['n']} times for one string"
+
+
+def test_repeated_text_does_not_re_run_the_pipeline(monkeypatch):
+    """Headers, footers and boilerplate repeat across a document."""
+    _clear_tokenize_caches()
+    runs = _count_pipeline_runs(monkeypatch)
+
+    for _ in range(5):
+        tokenize.word_tokenize("Confidential -- internal use only.")
+        tokenize.pos_tag("Confidential -- internal use only.")
+
+    assert runs["n"] == 1
+
+
+def test_oversized_text_bypasses_the_doc_cache(monkeypatch):
+    """A `Doc` is much heavier than the token lists the other caches hold.
+
+    Caching one built from a multi-megabyte element would pin that cost for the life of the
+    process, so past the threshold the pipeline is run without memoizing the result.
+    """
+    _clear_tokenize_caches()
+    runs = _count_pipeline_runs(monkeypatch)
+    oversized = "word " * ((tokenize.MAX_CACHEABLE_CHARS // 5) + 1)
+    assert len(oversized) > tokenize.MAX_CACHEABLE_CHARS
+
+    tokenize._process(oversized)
+    tokenize._process(oversized)
+
+    assert runs["n"] == 2, "oversized text should not be memoized"
+    assert tokenize._process_cached.cache_info().currsize == 0
+
+
+def test_text_at_the_threshold_is_still_cached(monkeypatch):
+    _clear_tokenize_caches()
+    runs = _count_pipeline_runs(monkeypatch)
+    sized = "a" * tokenize.MAX_CACHEABLE_CHARS
+
+    tokenize._process(sized)
+    tokenize._process(sized)
+
+    assert runs["n"] == 1
+
+
+def _clear_tokenize_caches() -> None:
+    for cached in (
+        tokenize.word_tokenize,
+        tokenize.pos_tag,
+        tokenize._tokenize_for_cache,
+        tokenize._process_cached,
+    ):
+        cached.cache_clear()
+
+
+def _count_pipeline_runs(monkeypatch) -> dict[str, int]:
+    """Count trips into spaCy itself, below every cache in this module.
+
+    The counter wraps the `Language` object rather than `_process`, so it still measures real
+    pipeline work once `_process` is itself cached. Patching `nlp.__call__` on the instance does
+    not work -- Python resolves dunders on the type.
+    """
+    runs = {"n": 0}
+    real_nlp = tokenize._get_nlp()
+
+    class CountingNlp:
+        max_length = real_nlp.max_length
+
+        def __call__(self, text, *args, **kwargs):
+            runs["n"] += 1
+            return real_nlp(text, *args, **kwargs)
+
+    monkeypatch.setattr(tokenize, "_get_nlp", lambda: CountingNlp())
+    return runs

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.1"  # pragma: no cover
+__version__ = "0.27.2"  # pragma: no cover

--- a/unstructured/nlp/tokenize.py
+++ b/unstructured/nlp/tokenize.py
@@ -19,6 +19,8 @@ from filelock import FileLock
 logger = logging.getLogger(__name__)
 
 CACHE_MAX_SIZE: Final[int] = 128
+# -- Element text is a paragraph or a table cell; 8 KiB covers that with room to spare. --
+MAX_CACHEABLE_CHARS: Final[int] = 8192
 
 _SPACY_MODEL_NAME: Final[str] = "en_core_web_sm"
 _SPACY_MODEL_VERSION: Final[str] = "3.8.0"
@@ -148,10 +150,31 @@ def _get_nlp() -> spacy.language.Language:
     return _load_spacy_model()
 
 
+@lru_cache(maxsize=CACHE_MAX_SIZE)
+def _process_cached(text: str) -> spacy.tokens.Doc:
+    """Memoized `_run_pipeline`, keyed on the text.
+
+    `word_tokenize`, `pos_tag` and `sent_tokenize` each cache their own extracted view, so a
+    caller that needs two of them for the same string previously paid for two identical pipeline
+    runs. Classifying one element in `is_possible_narrative_text` reaches all three.
+    """
+    return _run_pipeline(text)
+
+
 def _process(text: str) -> spacy.tokens.Doc:
     """Run the spaCy pipeline once. All public functions extract what they need from the Doc."""
     # -- str() handles numpy.str_ from OCR pipelines --
     text = str(text)
+    # -- Docs are far heavier than the token lists the other caches hold, and this accepts text
+    # -- up to spaCy's 1M-char limit. Cache the element-sized strings this is actually called
+    # -- with; stream anything larger, where a repeat hit is unlikely to pay for the residency.
+    if len(text) > MAX_CACHEABLE_CHARS:
+        return _run_pipeline(text)
+    return _process_cached(text)
+
+
+def _run_pipeline(text: str) -> spacy.tokens.Doc:
+    """Feed `text` through spaCy, truncating to the model's limit if needed."""
     nlp = _get_nlp()
     if len(text) > nlp.max_length:
         logger.warning(

--- a/unstructured/nlp/tokenize.py
+++ b/unstructured/nlp/tokenize.py
@@ -19,7 +19,8 @@ from filelock import FileLock
 logger = logging.getLogger(__name__)
 
 CACHE_MAX_SIZE: Final[int] = 128
-# -- Element text is a paragraph or a table cell; 8 KiB covers that with room to spare. --
+# -- Characters, not bytes: `Doc` size tracks token count, which tracks characters rather
+# -- than UTF-8 width. Element text is a paragraph or a table cell, so 8,192 covers it. --
 MAX_CACHEABLE_CHARS: Final[int] = 8192
 
 _SPACY_MODEL_NAME: Final[str] = "en_core_web_sm"
@@ -166,8 +167,9 @@ def _process(text: str) -> spacy.tokens.Doc:
     # -- str() handles numpy.str_ from OCR pipelines --
     text = str(text)
     # -- Docs are far heavier than the token lists the other caches hold, and this accepts text
-    # -- up to spaCy's 1M-char limit. Cache the element-sized strings this is actually called
-    # -- with; stream anything larger, where a repeat hit is unlikely to pay for the residency.
+    # -- up to spaCy's 1M-character limit. Cache the element-sized strings this is actually
+    # -- called with; stream anything longer, where a repeat hit is unlikely to pay for the
+    # -- residency.
     if len(text) > MAX_CACHEABLE_CHARS:
         return _run_pipeline(text)
     return _process_cached(text)


### PR DESCRIPTION
## Problem

`_process()` is the only expensive call in `unstructured/nlp/tokenize.py` and the only one without a cache. `word_tokenize()`, `pos_tag()` and `sent_tokenize()` each memoize their own extracted view, which hides the repetition from their callers but not from spaCy.

`is_possible_narrative_text()` reaches all three while classifying a single element:

```
_tokenize_for_cache <- sent_tokenize <- sentence_count <- exceeds_cap_ratio <- is_possible_narrative_text
word_tokenize <- exceeds_cap_ratio <- is_possible_narrative_text
pos_tag <- is_possible_narrative_text
```

Three identical `Doc`s per element. On a 400-paragraph document that is 88% of `partition_html()` (`is_possible_narrative_text` 1.60s of 1.81s in cProfile).

## Fix

Memoize the `Doc` so the three extractors share one pipeline run.

Texts over 8 KiB bypass the cache. A `Doc` is much heavier than the token lists the existing caches hold (~8 KB serialised for a 68-char paragraph) and `_process()` accepts input up to spaCy's 1M-char limit, so one oversized element could otherwise pin an outsized object for the life of the process.

All three consumers only read from the `Doc` and each returns a fresh list/tuple, so sharing is safe. `_process()` has no callers outside this module.

## Numbers

| | before | after |
|---|---|---|
| `partition_html`, 400 `<p>` | 1127 ms | 395 ms |
| `partition_text`, 400 paragraphs | 1129 ms | 403 ms |

Same shared classification path, so this is not HTML-specific. Scaling was already linear and stays linear — this is a constant-factor change. The test suite itself drops 38.2s to 33.0s.

## Tests

Four tests in `test_unstructured/nlp/test_tokenize.py`, counting entries into spaCy below every cache in the module rather than timing anything. With the source change reverted on this branch:

```
FAILED test_the_spacy_pipeline_runs_once_per_distinct_text - assert 3 == 1
FAILED test_repeated_text_does_not_re_run_the_pipeline     - assert 2 == 1
FAILED test_oversized_text_bypasses_the_doc_cache
FAILED test_text_at_the_threshold_is_still_cached
```

Suite before 146 failed / 2531 passed, after 146 failed / 2533 passed — the same 146 IDs, all pre-existing here (pandoc and the ML extras aren't installed locally). 14 modules that can't be collected without those extras were excluded from both runs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

