### PR TITLE
fix(cleaners): raise clear ValueError when extract pattern is absent

### DIFF
--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -19,6 +19,16 @@ def test_get_indexed_match_raises_with_index_too_high():
         extract._get_indexed_match("BLAH BLAH BLAH", "BLAH", 4)
 
 
+def test_get_indexed_match_no_match_raises_clear_error():
+    with pytest.raises(ValueError, match="not found"):
+        extract._get_indexed_match("BLAH BLAH BLAH", "XYZ")
+
+
+def test_extract_text_before_no_match_raises_clear_error():
+    with pytest.raises(ValueError, match="not found"):
+        extract.extract_text_before("BLAH BLAH BLAH", "XYZ")
+
+
 def test_extract_text_before():
     text = "Teacher: BLAH BLAH BLAH; Student: BLAH BLAH BLAH!"
     assert extract.extract_text_before(text, "BLAH", 1) == "Teacher: BLAH"

--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -18,12 +18,16 @@ def _get_indexed_match(text: str, pattern: str, index: int = 0) -> re.Match:
         raise ValueError(f"The index is {index}. Index must be a non-negative integer.")
 
     regex_match = None
+    largest_index = -1
     for i, result in enumerate(re.finditer(pattern, text)):
+        largest_index = i
         if i == index:
             regex_match = result
 
     if regex_match is None:
-        raise ValueError(f"Result with index {index} was not found. The largest index was {i}.")
+        raise ValueError(
+            f"Result with index {index} was not found. The largest index was {largest_index}."
+        )
 
     return regex_match
 


### PR DESCRIPTION
Fixes #4427

`_get_indexed_match` referenced the enumerate loop variable `i` inside the "not found" error message, but `i` is never bound when `re.finditer` yields zero matches. So `extract_text_before` / `extract_text_after` raised an `UnboundLocalError` (crash) instead of the intended `ValueError` when the pattern does not occur in the text.

Track the largest match index in a dedicated variable initialized to `-1`, so the no-match path always raises a clear message: "Result with index 0 was not found. The largest index was -1."

Tests added:
- `test_get_indexed_match_no_match_raises_clear_error`
- `test_extract_text_before_no_match_raises_clear_error`

Validation: `python3 -m pytest test_unstructured/cleaners/test_extract.py -q` (41 passed), `uv run ruff check` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

