### PR TITLE
fix(html): extract <details>/<summary> content instead of discarding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 - **Add privacy-bounded partition runtime telemetry**: Each top-level public partition call now makes one best-effort local attempt to send an event with fixed-enum runtime characteristics and aggregate final-element counts. Nested dispatch is suppressed. Delivery uses one non-queued daemon worker with tight connect/read timeouts; it disables redirects, retries, response-body downloads, proxy settings, and netrc credentials. A stuck transport cannot block document processing or process exit, at most one daemon can remain stranded, and later events drop while that slot is occupied. The event contains no document content, filenames, paths, URLs, caller MIME strings, exception details, credentials, or persistent identifiers. Set either `DO_NOT_TRACK` or `SCARF_NO_ANALYTICS` to any non-empty value after trimming to disable both startup and runtime telemetry before any runtime telemetry collection or delivery work.
 
+## 0.27.2
+
+### Fixes
+
+- **Extract `<details>`/`<summary>` content instead of discarding it**: both tags were mapped to `RemovedBlock`, so `partition_html()` silently dropped every disclosure widget and everything inside it. FAQ and documentation pages built from accordions lost all of their questions and answers, and the caller saw a shorter element list rather than an error. `<details>` is now `Flow` (an ordinary block container) and `<summary>` is `Heading`, which emits a `Title` -- so `chunk_by_title()` opens a new section per entry and a question stays attached to its own answer. Resolves #3919.
+
 ## 0.26.3
 
 ### Fixes

--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -1551,3 +1551,77 @@ def test_partition_html_leaves_page_number_None_when_not_present():
     html_text = "<html><body><p>No page markup.</p></body></html>"
     elements = partition_html(text=html_text)
     assert all(e.metadata.page_number is None for e in elements)
+
+
+# -- disclosure widgets (`<details>`/`<summary>`) -------------------------------------------------
+
+
+def test_partition_html_extracts_details_and_summary_content():
+    """`<details>` and `<summary>` were mapped to `RemovedBlock`, so an accordion vanished.
+
+    FAQ pages are commonly built this way, and every question and answer was dropped silently --
+    the caller got a shorter element list, not an error. See #3919.
+    """
+    html_text = (
+        "<html><body>"
+        "<h1>Support FAQ</h1>"
+        "<details><summary>Which Bluetooth profiles are supported?</summary>"
+        "<p>Your device supports A2DP and HFP profiles.</p></details>"
+        "<details open><summary>How do I pair my hearing aid?</summary>"
+        "<p>Open settings and select Bluetooth.</p></details>"
+        "</body></html>"
+    )
+
+    elements = partition_html(text=html_text)
+
+    assert [(type(e).__name__, e.text) for e in elements] == [
+        ("Title", "Support FAQ"),
+        ("Title", "Which Bluetooth profiles are supported?"),
+        ("NarrativeText", "Your device supports A2DP and HFP profiles."),
+        ("Title", "How do I pair my hearing aid?"),
+        ("NarrativeText", "Open settings and select Bluetooth."),
+    ]
+
+
+def test_partition_html_makes_a_summary_start_its_own_chunk_section():
+    """The reason the element type matters: `chunk_by_title` opens a new section at a `Title`.
+
+    Two unrelated Q&A pairs land in separate chunks instead of one blended chunk. Small sections
+    are still merged under the default `combine_text_under_n_chars`, so that is disabled here to
+    isolate the sectioning behaviour rather than the merging.
+    """
+    html_text = (
+        "<html><body>"
+        "<details><summary>First question?</summary><p>First answer.</p></details>"
+        "<details><summary>Second question?</summary><p>Second answer.</p></details>"
+        "</body></html>"
+    )
+
+    chunks = chunk_by_title(
+        partition_html(text=html_text), max_characters=200, combine_text_under_n_chars=0
+    )
+
+    assert [c.text for c in chunks] == [
+        "First question?\n\nFirst answer.",
+        "Second question?\n\nSecond answer.",
+    ]
+
+
+def test_partition_html_extracts_a_details_block_that_has_no_summary():
+    html_text = "<html><body><details><p>Just the body.</p></details></body></html>"
+
+    assert [e.text for e in partition_html(text=html_text)] == ["Just the body."]
+
+
+def test_partition_html_extracts_nested_details_blocks():
+    html_text = (
+        "<html><body><details><summary>Outer</summary>"
+        "<details><summary>Inner</summary><p>Innermost body.</p></details>"
+        "</details></body></html>"
+    )
+
+    assert [(type(e).__name__, e.text) for e in partition_html(text=html_text)] == [
+        ("Title", "Outer"),
+        ("Title", "Inner"),
+        ("Text", "Innermost body."),
+    ]

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.1"  # pragma: no cover
+__version__ = "0.27.2"  # pragma: no cover

--- a/unstructured/partition/html/parser.py
+++ b/unstructured/partition/html/parser.py
@@ -1018,8 +1018,10 @@ element_class_lookup.get_namespace(None).update(
         # -- removed phrasing --
         "button": RemovedPhrasing,
         "label": RemovedPhrasing,
+        # -- disclosure widget: `<summary>` is its heading, the rest is ordinary flow content --
+        "details": Flow,
+        "summary": Heading,
         # -- removed block --
-        "details": RemovedBlock,  # -- likely boilerplate --
         "dl": RemovedBlock,
         "dd": RemovedBlock,
         "dt": RemovedBlock,
@@ -1030,6 +1032,5 @@ element_class_lookup.get_namespace(None).update(
         # -- removed form-related --
         "form": RemovedBlock,
         "input": RemovedBlock,
-        "summary": RemovedBlock,  # -- child of `details`
     }
 )


### PR DESCRIPTION
## Problem

`<details>` and `<summary>` were both mapped to `RemovedBlock`, so `partition_html()` discarded the whole subtree. On the FAQ page from the issue, every question and answer disappears and the caller gets a shorter element list rather than an error:

```python
>>> partition_html(text="<h1>Support FAQ</h1>"
...   "<details><summary>Which Bluetooth profiles are supported?</summary>"
...   "<p>Your device supports A2DP and HFP profiles.</p></details>")
[<Title 'Support FAQ'>]          # both the question and the answer are gone
```

## Fix

`<details>` is an ordinary block container, so it becomes `Flow`, like `<div>`.

`<summary>` becomes `Heading`. The spec calls it "a summary, caption, or legend for the rest of the contents", the issue asks for the questions as titles, and it is what makes the fix useful downstream — `chunk_by_title()` opens a new section at each `Title`, so a question stays attached to its own answer instead of blending into the next entry.

`<summary>` was also listed twice, under both phrasing and the removed-form group; there is now one mapping.

## Scope

Only these two tags. `<dl>`, `<figure>` and the form/nav tags stay in `RemovedBlock`:

- `<figure>`/`<figcaption>` removal is asserted by `DescribeRemovedBlock.it_is_skipped_during_parsing`, so it is a deliberate decision, not an oversight.
- `<dl>`/`<dt>`/`<dd>` also drop their content, and `ListBlock`'s docstring already says "maybe a `<dl>` element at some point". That looks worth doing, but reclassifying it changes the ancestor chain that `_category_depth` walks (there is a parametrised case at `test_parser.py:298` relying on `<dl><dd>` nesting), so it belongs in its own PR rather than riding along here.

## Tests

Four tests in `test_unstructured/partition/html/test_partition.py`. With the parser change reverted on this branch:

```
FAILED test_partition_html_extracts_details_and_summary_content        - assert [] == [(...5 elements)]
FAILED test_partition_html_makes_a_summary_start_its_own_chunk_section
FAILED test_partition_html_extracts_a_details_block_that_has_no_summary
FAILED test_partition_html_extracts_nested_details_blocks
```

Also checked by hand and behaving: unclosed `<details>`, `<summary>` not the first child, two `<summary>` siblings, empty `<summary>`, `<summary>` outside any `<details>`, attributes on `<details>`, inline markup inside `<summary>`, `<details>` inside a table cell and inside a list item, 20-deep nesting, and a JSON round-trip.

Suite before 146 failed / 2531 passed, after 146 failed / 2535 passed — the same 146 IDs, all pre-existing here (pandoc and the ML extras aren't installed locally). 14 modules that cannot be collected without those extras were excluded from both runs.

Note: this bumps to `0.26.4`, as does #4449 — whichever lands second needs the version and changelog re-pointed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

