### PR TITLE
docs: name the metric args the docstrings describe

### DIFF
--- a/unstructured/metrics/evaluate.py
+++ b/unstructured/metrics/evaluate.py
@@ -517,7 +517,7 @@ def get_mean_grouping(
 ) -> None:
     """Aggregates accuracy and missing metrics by column name 'doctype' or 'connector',
     or 'all' for all rows. Export to TSV.
-    If `all`, passing export_name is recommended.
+    If `all`, passing export_filename is recommended.
 
     Args:
         group_by (str): Grouping category ('doctype' or 'connector' or 'all').
@@ -526,7 +526,7 @@ def get_mean_grouping(
         eval_name (str): Evaluated metric ('text_extraction' or 'element_type').
         agg_name (str, optional): String to use with export filename. Default is `cct` for
             group_by `text_extraction` and `element-type` for `element_type`
-        export_name (str, optional): Export filename.
+        export_filename (str, optional): Export filename.
     """
     if group_by not in ("doctype", "connector") and group_by != "all":
         raise ValueError("Invalid grouping category. Returning a non-group evaluation.")

--- a/unstructured/metrics/object_detection.py
+++ b/unstructured/metrics/object_detection.py
@@ -298,7 +298,7 @@ class ObjectDetectionEvalProcessor:
         Clips bboxes to image boundaries.
 
         Args:
-            bboxes:         Input bounding boxes in XYXY format of [..., 4] shape
+            boxes:          Input bounding boxes in XYXY format of [..., 4] shape
             img_shape:      Image shape (height, width).
         Returns:
             clipped_boxes:  Clipped bboxes in XYXY format of [..., 4] shape


### PR DESCRIPTION
`get_mean_grouping` is public and takes `export_filename`, but the docstring calls it `export_name` in both the Args block and the line above it, so anyone following the docs passes a kwarg that does not exist. The other one is in `_change_bbox_bounds_for_image_size`, which came over from super-gradients: the arg was renamed to `boxes` on the way in and the docstring kept `bboxes`.

No CHANGELOG entry or version bump, since this does not touch core code. Say the word if you want one anyway.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

