### PR TITLE
feat: add OrcaRouter embedding encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.27.3
+
+### Enhancements
+
+- **Add OrcaRouter embedding encoder**: Adds an OpenAI-compatible embedder backed by [OrcaRouter](https://www.orcarouter.ai). Like the existing OctoAI embedder it talks to the OpenAI embeddings API through the OpenAI SDK against a custom base URL (`https://api.orcarouter.ai/v1`), registered as the `orcarouter` embedding provider. OrcaRouter exposes a provider/model namespace across many models on one endpoint, and its gateway also provides zero-trust security controls for AI agents on the same endpoint.
+
 ## 0.27.2
 
 ### Fixes

--- a/test_unstructured/embed/test_orcarouter.py
+++ b/test_unstructured/embed/test_orcarouter.py
@@ -1,0 +1,39 @@
+from unstructured.documents.elements import Text
+from unstructured.embed.orcarouter import OrcaRouterEmbeddingConfig, OrcaRouterEmbeddingEncoder
+
+
+def test_embed_documents_does_not_break_element_to_dict(mocker):
+    # Mocked client with the desired behavior for embed_documents
+    mock_client = mocker.MagicMock()
+    mock_client.embed_documents.return_value = [1, 2]
+
+    # Mock get_client to return our mock_client
+    mocker.patch.object(OrcaRouterEmbeddingConfig, "get_client", return_value=mock_client)
+
+    encoder = OrcaRouterEmbeddingEncoder(config=OrcaRouterEmbeddingConfig(api_key="api_key"))
+    elements = encoder.embed_documents(
+        elements=[Text("This is sentence 1"), Text("This is sentence 2")],
+    )
+    assert len(elements) == 2
+    assert elements[0].to_dict()["text"] == "This is sentence 1"
+    assert elements[1].to_dict()["text"] == "This is sentence 2"
+
+
+def test_embed_query(mocker):
+    # Mocked client whose embeddings.create returns an object with the expected shape
+    mock_data_item = mocker.MagicMock()
+    mock_data_item.embedding = [0.1, 0.2, 0.3]
+    mock_response = mocker.MagicMock()
+    mock_response.data = [mock_data_item]
+    mock_client = mocker.MagicMock()
+    mock_client.embeddings.create.return_value = mock_response
+
+    mocker.patch.object(OrcaRouterEmbeddingConfig, "get_client", return_value=mock_client)
+
+    encoder = OrcaRouterEmbeddingEncoder(config=OrcaRouterEmbeddingConfig(api_key="api_key"))
+    embedding = encoder.embed_query("A sample query.")
+    assert embedding == [0.1, 0.2, 0.3]
+    mock_client.embeddings.create.assert_called_once_with(
+        input="A sample query.",
+        model="openai/text-embedding-3-small",
+    )

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.2"  # pragma: no cover
+__version__ = "0.27.3"  # pragma: no cover

--- a/unstructured/embed/__init__.py
+++ b/unstructured/embed/__init__.py
@@ -5,6 +5,7 @@ from unstructured.embed.huggingface import HuggingFaceEmbeddingEncoder
 from unstructured.embed.mixedbreadai import MixedbreadAIEmbeddingEncoder
 from unstructured.embed.octoai import OctoAIEmbeddingEncoder
 from unstructured.embed.openai import OpenAIEmbeddingEncoder
+from unstructured.embed.orcarouter import OrcaRouterEmbeddingEncoder
 from unstructured.embed.vertexai import VertexAIEmbeddingEncoder
 from unstructured.embed.voyageai import VoyageAIEmbeddingEncoder
 
@@ -16,6 +17,7 @@ EMBEDDING_PROVIDER_TO_CLASS_MAP = {
     "voyageai": VoyageAIEmbeddingEncoder,
     "mixedbread-ai": MixedbreadAIEmbeddingEncoder,
     "octoai": OctoAIEmbeddingEncoder,
+    "orcarouter": OrcaRouterEmbeddingEncoder,
 }
 
 

--- a/unstructured/embed/orcarouter.py
+++ b/unstructured/embed/orcarouter.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional
+
+import numpy as np
+from pydantic import Field, SecretStr
+
+from unstructured.documents.elements import (
+    Element,
+)
+from unstructured.embed.interfaces import BaseEmbeddingEncoder, EmbeddingConfig
+from unstructured.utils import requires_dependencies
+
+if TYPE_CHECKING:
+    from openai import OpenAI
+
+
+class OrcaRouterEmbeddingConfig(EmbeddingConfig):
+    """Configuration for the OrcaRouter embedding encoder.
+
+    OrcaRouter is an OpenAI-compatible AI gateway. It exposes the OpenAI embeddings
+    API on the same base URL, so the OpenAI SDK is used directly with an alternate
+    ``base_url`` and API key.
+    """
+
+    api_key: SecretStr
+    model_name: str = Field(default="openai/text-embedding-3-small")
+    base_url: str = Field(default="https://api.orcarouter.ai/v1")
+
+    @requires_dependencies(
+        ["openai"],
+        extras="embed-orcarouter",
+    )
+    def get_client(self) -> "OpenAI":
+        """Creates an OpenAI python client to embed elements. Uses the OpenAI SDK."""
+        from openai import OpenAI
+
+        return OpenAI(api_key=self.api_key.get_secret_value(), base_url=self.base_url)
+
+
+@dataclass
+class OrcaRouterEmbeddingEncoder(BaseEmbeddingEncoder):
+    config: OrcaRouterEmbeddingConfig
+    # Uses the OpenAI SDK
+    _exemplary_embedding: Optional[List[float]] = field(init=False, default=None)
+
+    def get_exemplary_embedding(self) -> List[float]:
+        return self.embed_query("Q")
+
+    def initialize(self):
+        pass
+
+    def num_of_dimensions(self):
+        exemplary_embedding = self.get_exemplary_embedding()
+        return np.shape(exemplary_embedding)
+
+    def is_unit_vector(self):
+        exemplary_embedding = self.get_exemplary_embedding()
+        return np.isclose(np.linalg.norm(exemplary_embedding), 1.0)
+
+    def embed_query(self, query):
+        client = self.config.get_client()
+        response = client.embeddings.create(input=str(query), model=self.config.model_name)
+        return response.data[0].embedding
+
+    def embed_documents(self, elements: List[Element]) -> List[Element]:
+        embeddings = [self.embed_query(e) for e in elements]
+        elements_with_embeddings = self._add_embeddings_to_elements(elements, embeddings)
+        return elements_with_embeddings
+
+    def _add_embeddings_to_elements(self, elements, embeddings) -> List[Element]:
+        assert len(elements) == len(embeddings)
+        elements_w_embedding = []
+        for i, element in enumerate(elements):
+            element.embeddings = embeddings[i]
+            elements_w_embedding.append(element)
+        return elements


### PR DESCRIPTION
## Summary

The `unstructured` library pre-processes documents for downstream LLM workflows, and its `unstructured.embed` module exposes embedding encoders so those pipelines can attach vector embeddings to partitioned elements. This PR adds OrcaRouter as a first-class embedding provider, mirroring the existing OctoAI embedder.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`unstructured/embed/orcarouter.py`** — new `OrcaRouterEmbeddingConfig` + `OrcaRouterEmbeddingEncoder`. It uses the OpenAI SDK directly against `https://api.orcarouter.ai/v1` (same pattern as the existing OctoAI embedder), with a default model of `openai/text-embedding-3-small`.
- **`unstructured/embed/__init__.py`** — register `orcarouter` in `EMBEDDING_PROVIDER_TO_CLASS_MAP`, next to `octoai`.
- **`test_unstructured/embed/test_orcarouter.py`** — unit tests for `embed_documents` and `embed_query`, following the existing `test_octoai.py` shape.
- **`CHANGELOG.md`** / **`unstructured/__version__.py`** — bumped to `0.27.3`.

## Testing

- `python3 -m pytest test_unstructured/embed/` — 18 passed (including the 2 new tests).
- `ruff check` and `ruff format --check` on all changed files — clean.
- Live check against the OrcaRouter embeddings endpoint through the new encoder: `embed_query` returned a 1536-dim vector and `embed_documents` embedded 2 elements, both via `https://api.orcarouter.ai/v1/embeddings`.

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

