### PR TITLE
fix(staging): write LabelBox staging text files as UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.27.3
+
+### Fixes
+
+- **Write LabelBox staging text files as UTF-8**: `stage_for_label_box()` opened each `<external-id>.txt` file in text mode without an explicit encoding, so the element text was encoded with the platform's locale codec. Any element text outside that codec raised `UnicodeEncodeError` (Windows `cp1252`, or a POSIX/`C` locale in a container), and where it did not raise, the staged file was written in the locale encoding while LabelBox reads it as UTF-8. The other staging serializers in `unstructured.staging.base` already pass an explicit encoding.
+
 ## 0.27.2
 
 ### Fixes

--- a/test_unstructured/staging/test_label_box.py
+++ b/test_unstructured/staging/test_label_box.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 
 import pytest
@@ -139,5 +140,35 @@ def test_stage_for_label_box(
             assert element_config["data"].endswith(f"{element_config['externalId']}.txt")
 
             output_filepath = os.path.join(output_directory, f"{element_config['externalId']}.txt")
-            with open(output_filepath) as data_file:
+            with open(output_filepath, encoding="utf-8") as data_file:
                 assert data_file.read().strip() == element.text.strip()
+
+
+def test_stage_for_label_box_writes_text_files_as_utf8(output_directory, url_prefix, monkeypatch):
+    """Element text is staged as UTF-8 rather than in the platform's locale encoding.
+
+    LabelBox reads the staged files as UTF-8, and text outside the locale codec (for example
+    ``cp1252`` on Windows, or ASCII under a POSIX/``C`` locale) otherwise raises
+    ``UnicodeEncodeError``. Record the encoding each text-mode ``open()`` is given so the
+    assertion holds on a UTF-8 platform too.
+    """
+    text = "Sales figures — 第一季度 café"
+    text_mode_encodings = []
+    real_open = builtins.open
+
+    def recording_open(file, mode="r", buffering=-1, encoding=None, *args, **kwargs):
+        if "b" not in mode:
+            text_mode_encodings.append(encoding)
+        return real_open(file, mode, buffering, encoding, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", recording_open)
+    config = label_box.stage_for_label_box(
+        [NarrativeText(text=text)], output_directory, url_prefix, create_directory=True
+    )
+    monkeypatch.undo()
+
+    assert text_mode_encodings == ["utf-8"]
+
+    output_filepath = os.path.join(output_directory, f"{config[0]['externalId']}.txt")
+    with open(output_filepath, "rb") as data_file:
+        assert data_file.read().decode("utf-8") == text

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.2"  # pragma: no cover
+__version__ = "0.27.3"  # pragma: no cover

--- a/unstructured/staging/label_box.py
+++ b/unstructured/staging/label_box.py
@@ -82,7 +82,7 @@ def stage_for_label_box(
         output_filename = f"{element_id}.txt"
         data_url = "/".join([url_prefix.rstrip("/"), output_filename])
         output_filepath = os.path.join(output_directory, output_filename)
-        with open(output_filepath, "w+") as output_text_file:
+        with open(output_filepath, "w+", encoding="utf-8") as output_text_file:
             output_text_file.write(element.text)
 
         element_config: Dict[str, Any] = {


### PR DESCRIPTION
## Summary

`stage_for_label_box()` writes each element's text to `<external-id>.txt` in text mode with no explicit encoding, so the bytes are produced with the platform's *locale* codec:

https://github.com/Unstructured-IO/unstructured/blob/main/unstructured/staging/label_box.py#L85

```python
with open(output_filepath, "w+") as output_text_file:
    output_text_file.write(element.text)
```

Two consequences:

* **It raises** where the locale codec cannot represent the text — `cp1252` on Windows, or ASCII when the process runs under a `POSIX`/`C` locale (common in containers). Any non-Latin-1 document (CJK, Greek, an em dash) aborts staging.
* **Where it does not raise**, the staged file is written in the locale encoding while LabelBox reads the URL as UTF-8, so the labelling task silently shows mojibake.

Every other `open()` in `unstructured/staging/` already passes an explicit encoding — the six in `unstructured/staging/base.py` (`elements_from_json`, `elements_to_json`, `convert_to_csv`/`dataframe`, `elements_to_md`, …) all take an `encoding` argument and forward it. `label_box.py` is the only one that does not.

## Reproduction

On any interpreter whose `locale.getpreferredencoding(False)` is not UTF-8 (here Windows / `cp1252`, Python 3.12):

```python
from unstructured.documents.elements import NarrativeText
from unstructured.staging.label_box import stage_for_label_box

stage_for_label_box(
    [NarrativeText(text="第一段：表格中的中文内容。")],
    output_directory=out,
    url_prefix="https://example.com/docs",
    create_directory=True,
)
```

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-12: character maps to <undefined>
```

## Fix

One line — pass `encoding="utf-8"`, matching the sibling serializers and what LabelBox expects on the other end.

## Tests

`test_stage_for_label_box_writes_text_files_as_utf8` stages an element containing an em dash, CJK and an accented character, then asserts both that the staged bytes decode as UTF-8 and that the text-mode `open()` was given an explicit `utf-8`. The second assertion is what makes the test fail on a UTF-8 platform too, where the old code happens to produce the right bytes.

* before the fix: `1 failed, 13 passed` (fails at the write on `cp1252`; fails on the encoding assertion under a UTF-8 locale)
* after the fix: `14 passed`

The pre-existing `test_stage_for_label_box` read the staged file back with a bare `open()` as well; that read is now explicit too, so the assertion does not depend on the runner's locale.

`ruff check` / `ruff format --check` clean on both files, and `scripts/version-sync.sh -c` passes for the `0.27.3` bump.

## Not included

The remaining locale-dependent `open()` calls in the package live under `unstructured/metrics/` (evaluation tooling reading prediction/ground-truth JSON and `.txt` files). They are the same class of defect but a separate surface — happy to send a follow-up if you want them covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

