### PR TITLE
feat: add `clean_newline` to concatenate words wrapped across lines

### DIFF
--- a/test_unstructured/cleaners/test_core.py
+++ b/test_unstructured/cleaners/test_core.py
@@ -411,3 +411,17 @@ def test_clean(text, extra_whitespace, dashes, bullets, lowercase, trailing_punc
 def test_bytes_string_to_string():
     text = "\xe6\xaf\x8f\xe6\x97\xa5\xe6\x96\xb0\xe9\x97\xbb"
     assert core.bytes_string_to_string(text, "utf-8") == "每日新闻"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("docu-\nment", "document"),
+        ("docu- \nment", "document"),
+        ("hello-\nworld", "helloworld"),
+        ("no-hyphen text", "no-hyphen text"),
+        ("word-\n word", "wordword"),
+    ],
+)
+def test_clean_newline(text, expected):
+    assert core.clean_newline(text) == expected

--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -355,6 +355,21 @@ def clean_trailing_punctuation(text: str) -> str:
     return text.strip().rstrip(".,:;")
 
 
+def clean_newline(text: str, pattern: str = r"(\w+)-\s+(\w+)") -> str:
+    """Concatenate words broken across a newline by a hyphen and whitespace.
+
+    When text is wrapped, a word that continues on the following line is
+    often written as a character followed by a dash and whitespace. This
+    function removes the hyphen and the whitespace between the two parts so
+    the word is joined again.
+
+    Example
+    -------
+    "docu-\\nment" -> "document"
+    """
+    return re.sub(pattern, r"\1\2", text)
+
+
 def replace_mime_encodings(text: str, encoding: str = "utf-8") -> str:
     """Replaces MIME encodings with their equivalent characters in the specified encoding.
 


### PR DESCRIPTION
## Summary

Per #2513: when text is wrapped, a word that continues on the following line is often written as a character followed by a dash and whitespace. Adds a `clean_newline` function that removes the hyphen and whitespace and joins the two parts.

## Changes

- `unstructured/cleaners/core.py`: new `clean_newline(text, pattern=r"(\w+)-\s+(\w+)")` using `re.sub(pattern, r"", text)`, exactly as proposed in the issue
- `test_unstructured/cleaners/test_core.py`: parametrized tests covering hyphen+newline, hyphen+space+newline, plain text passthrough

## Verification

- All 5 parametrized cases pass locally (docu-
ment → document, docu- 
ment → document, hello-
world → helloworld, no-hyphen text unchanged, word-
 word → wordword)
- `ast.parse` passes on both files
- Implementation matches the issue's proposed signature/docstring intent

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

