### PR TITLE
fix: normalize `None` text to empty string in `Text` elements

### DIFF
--- a/test_unstructured/documents/test_elements.py
+++ b/test_unstructured/documents/test_elements.py
@@ -26,6 +26,7 @@ from unstructured.documents.elements import (
     DataSourceMetadata,
     Element,
     ElementMetadata,
+    Image,
     Points,
     Text,
     Title,
@@ -57,6 +58,15 @@ def test_Element_autoassigns_a_UUID_then_becomes_an_idempotent_and_deterministic
 def test_Text_is_JSON_serializable():
     # -- This shold run without an error --
     json.dumps(Text(text="hello there!", element_id=None).to_dict())
+
+
+def test_Image_text_none_str_returns_empty_string():
+    # https://github.com/Unstructured-IO/unstructured/issues/4084
+    # -- `Image` elements whose `text` was normalized to `None` should still
+    # -- render as a string when `__str__` is called.
+    image = Image(text=None)
+    assert image.text == ""
+    assert str(image) == ""
 
 
 @pytest.mark.parametrize(

--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -874,7 +874,7 @@ class Text(Element):
         embeddings: Optional[list[float]] = None,
     ):
         metadata = metadata if metadata else ElementMetadata()
-        self.text: str = text
+        self.text: str = "" if text is None else text
         self.embeddings: Optional[list[float]] = embeddings
 
         super().__init__(
@@ -898,7 +898,7 @@ class Text(Element):
         )
 
     def __str__(self):
-        return self.text
+        return "" if self.text is None else self.text
 
     def apply(self, *cleaners: Callable[[str], str]):
         """Applies a cleaning brick to the text element.


### PR DESCRIPTION
## Summary

Fixes #4084: when an `Image` element is created with `text=None` (e.g. yolox hi-res model detects a bbox with missing text), `str(element)` returned a non-string, breaking printing/accessing the element.

## Changes

- `unstructured/documents/elements.py`:
  - `Text.__init__`: normalize `None` text to `""` so `self.text` is always a `str`
  - `Text.__str__`: fall back to `""` when `self.text` is `None` (defensive, e.g. deserialized elements)
- `test_unstructured/documents/test_elements.py`: add `test_Image_text_none_str_returns_empty_string` covering both `image.text == ""` and `str(image) == ""`

## Verification

- `ast.parse` passes on both files
- Local assertions: `Image(text=None)` → `text=''` and `str=''`; `Image(text='hello')` unchanged → `text='hello'`, `str='hello'`
- Docs-only class hierarchy: `Image(Text)`, no other behavior changed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

