### PR TITLE
fix: switch `skip_infer_table_types` default to `None`

### DIFF
--- a/unstructured/partition/auto.py
+++ b/unstructured/partition/auto.py
@@ -37,7 +37,7 @@ def partition(
     ssl_verify: bool = True,
     request_timeout: Optional[int] = None,
     strategy: str = PartitionStrategy.AUTO,
-    skip_infer_table_types: list[str] = ["pdf", "jpg", "png", "heic"],
+    skip_infer_table_types: Optional[list[str]] = None,
     ocr_languages: Optional[str] = None,  # changing to optional for deprecation
     languages: Optional[list[str]] = None,
     detect_language_per_element: bool = False,
@@ -175,6 +175,11 @@ def partition(
         )
 
     set_partition_document_type(file_type)
+
+    # -- `None` is the documented default; set the actual default here so callers
+    # -- can tell an explicit value from the default (https://github.com/Unstructured-IO/unstructured/issues/3063)
+    if skip_infer_table_types is None:
+        skip_infer_table_types = ["pdf", "jpg", "png", "heic"]
 
     if file is not None:
         file.seek(0)


### PR DESCRIPTION
## Summary

Closes #3063: switch the `skip_infer_table_types` default from a hard-coded list to `None`, and set the actual default inside `partition()`.

## Changes

- `unstructured/partition/auto.py`:
  - `partition()` signature: `skip_infer_table_types: Optional[list[str]] = None` (was `["pdf", "jpg", "png", "heic"]`)
  - Inside `partition()`: normalize `None` → `["pdf", "jpg", "png", "heic"]` before it reaches `decide_table_extraction()`, so callers can distinguish an explicit value from the default

## Verification

- `ast.parse` passes
- Local assertions cover 3 scenarios:
  - Default (`None`): pdf skipped for table inference, docx inferred (unchanged behavior)
  - Explicit `[]`: pdf inferred too (no types skipped)
  - Custom `["docx"]`: docx skipped, pdf inferred
- Behavior for callers that pass an explicit list is byte-for-byte unchanged

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

