### PR TITLE
fix: stop encoding detection from returning mojibake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.27.6
+
+### Fixes
+
+- **Stop encoding detection from returning mojibake for shift_jis and iso_8859_1 text**: `detect_file_encoding()` no longer accepts a high-confidence `charset_normalizer` result outside `COMMON_ENCODINGS` (johab, windows-1250), which decoded cleanly as garbage. When detection is inconclusive or out of set, candidates are ranked inside `COMMON_ENCODINGS` instead of taking the first codec that decodes, so `iso_8859_1` no longer shadows later CJK codecs.
+
 ## 0.27.5
 
 ### Fixes

--- a/test_unstructured/file_utils/test_encoding.py
+++ b/test_unstructured/file_utils/test_encoding.py
@@ -11,6 +11,15 @@ import pytest
 from unstructured.errors import UnprocessableEntityError
 from unstructured.file_utils.encoding import detect_file_encoding
 
+# Samples from Unstructured-IO/unstructured#4466. charset_normalizer.detect() reports
+# johab / windows-1250 for these (outside COMMON_ENCODINGS); both still decode, so the
+# UnprocessableEntityError guard never fires and the mojibake becomes the element text.
+_OUT_OF_SET_DETECT_CASES = [
+    ("会議室予約", "shift_jis"),
+    ("café très à Paris", "iso_8859_1"),
+    ("Bonjour, ça va très bien. Le café est déjà prêt.", "iso_8859_1"),
+]
+
 
 def test_charset_detection_failure():
     """Test encoding detection failure with memory safety checks."""
@@ -69,3 +78,35 @@ def test_decode_failure():
 
         assert exception_memory < 10_000  # Small in-memory footprint
         assert serialized_size < 10_000  # Small serialization footprint
+
+
+@pytest.mark.parametrize(("text", "encoding"), _OUT_OF_SET_DETECT_CASES)
+@pytest.mark.parametrize("via", ["filename", "file"])
+def test_detect_file_encoding_recovers_text_when_detect_returns_out_of_set_codec(
+    text: str, encoding: str, via: str, tmp_path
+):
+    payload = text.encode(encoding)
+    if via == "filename":
+        path = tmp_path / "sample.txt"
+        path.write_bytes(payload)
+        detected, file_text = detect_file_encoding(filename=str(path))
+    else:
+        detected, file_text = detect_file_encoding(file=payload)
+
+    assert file_text == text
+    assert detected not in {"johab", "windows-1250"}
+
+
+def test_detect_file_encoding_fallback_reaches_cjk_instead_of_stopping_at_latin1(tmp_path):
+    """COMMON_ENCODINGS fallback must not take iso_8859_1 just because it never raises."""
+    text = "会議室予約"
+    encoding = "shift_jis"
+    path = tmp_path / "sample.txt"
+    path.write_bytes(text.encode(encoding))
+    detect_result = {"encoding": None, "confidence": None}
+    with patch("unstructured.file_utils.encoding.detect", return_value=detect_result):
+        detected, file_text = detect_file_encoding(filename=str(path))
+
+    assert file_text == text
+    assert file_text != text.encode(encoding).decode("iso_8859_1")
+    assert detected not in {"iso-8859-1", "latin-1"}

--- a/test_unstructured/partition/test_text.py
+++ b/test_unstructured/partition/test_text.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from pathlib import Path
 from typing import Optional, Type
 
 import pytest
@@ -109,6 +110,25 @@ def test_partition_text_from_filename_raises_econding_error(
     with pytest.raises(error):
         filename = example_doc_path(filename)
         partition_text(filename=filename, encoding=encoding)
+
+
+@pytest.mark.parametrize(
+    ("text", "encoding"),
+    [
+        ("会議室予約", "shift_jis"),
+        ("café très à Paris", "iso_8859_1"),
+        ("Bonjour, ça va très bien. Le café est déjà prêt.", "iso_8859_1"),
+    ],
+)
+def test_partition_text_recovers_shift_jis_and_latin1_when_detect_picks_out_of_set_codec(
+    text: str, encoding: str, tmp_path: Path
+):
+    path = tmp_path / "sample.txt"
+    path.write_bytes(text.encode(encoding))
+
+    elements = partition_text(filename=str(path))
+
+    assert elements[0].text == text
 
 
 def test_partition_text_from_file():

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.5"  # pragma: no cover
+__version__ = "0.27.6"  # pragma: no cover

--- a/unstructured/file_utils/encoding.py
+++ b/unstructured/file_utils/encoding.py
@@ -1,6 +1,6 @@
 from typing import IO, Optional, Tuple, Union
 
-from charset_normalizer import detect
+from charset_normalizer import detect, from_bytes
 
 from unstructured.errors import UnprocessableEntityError
 from unstructured.partition.common.common import convert_to_bytes
@@ -75,20 +75,16 @@ def detect_file_encoding(
     encoding = result["encoding"]
     confidence = result["confidence"]
 
-    if encoding is None or confidence is None or confidence < ENCODE_REC_THRESHOLD:
-        # Encoding detection failed, fallback to predefined encodings
-        for enc in COMMON_ENCODINGS:
-            try:
-                if filename:
-                    with open(filename, encoding=enc) as f:
-                        file_text = f.read()
-                else:
-                    file_text = byte_data.decode(enc)
-                encoding = enc
-                break
-            except (UnicodeDecodeError, UnicodeError):
-                continue
-        else:
+    if (
+        encoding is None
+        or confidence is None
+        or confidence < ENCODE_REC_THRESHOLD
+        or not validate_encoding(encoding)
+    ):
+        # iso_8859_1 maps every byte, so first-success over COMMON_ENCODINGS never
+        # reaches later CJK codecs. Rank candidates inside the supported set instead.
+        best = from_bytes(byte_data, cp_isolation=COMMON_ENCODINGS).best()
+        if best is None:
             # NOTE: Use UnprocessableEntityError instead of UnicodeDecodeError to avoid
             # logging the entire file content. UnicodeDecodeError automatically stores
             # the complete input data, which can be problematic for large files.
@@ -96,19 +92,19 @@ def detect_file_encoding(
                 "Unable to determine file encoding after trying all common encodings. "
                 "File may be corrupted or in an unsupported format."
             ) from None
+        encoding = best.encoding
 
-    else:
-        # NOTE: Catch UnicodeDecodeError to avoid logging the entire file content.
-        # UnicodeDecodeError automatically stores the complete input data in its
-        # 'object' attribute, which can cause issues with large files in logging
-        # and error reporting systems.
-        try:
-            file_text = byte_data.decode(encoding)
-        except (UnicodeDecodeError, UnicodeError):
-            raise UnprocessableEntityError(
-                f"File encoding detection failed: detected '{encoding}' but decode failed. "
-                f"File may be corrupted or in an unsupported format."
-            ) from None
+    # NOTE: Catch UnicodeDecodeError to avoid logging the entire file content.
+    # UnicodeDecodeError automatically stores the complete input data in its
+    # 'object' attribute, which can cause issues with large files in logging
+    # and error reporting systems.
+    try:
+        file_text = byte_data.decode(encoding)
+    except (UnicodeDecodeError, UnicodeError):
+        raise UnprocessableEntityError(
+            f"File encoding detection failed: detected '{encoding}' but decode failed. "
+            f"File may be corrupted or in an unsupported format."
+        ) from None
 
     formatted_encoding = format_encoding_str(encoding)
 


### PR DESCRIPTION
## Summary

`detect_file_encoding()` accepted a high-confidence `charset_normalizer.detect()` result even when that codec was outside `COMMON_ENCODINGS`. Those guesses (`johab`, `windows-1250`) still decoded, so the `UnprocessableEntityError` guard never fired and the mojibake became element text. That hits everything that reads text through `read_txt_file()` (`partition_text`, `partition_md`, `partition_html`).

A second path in the same function walked `COMMON_ENCODINGS` and took the first codec that decoded. `iso_8859_1` maps every byte, so later CJK codecs on that list were unreachable.

## Fix

- Reject a detected codec that fails `validate_encoding()` (already present, previously unused).
- When detection is inconclusive or out of set, rank candidates with `from_bytes(..., cp_isolation=COMMON_ENCODINGS)` instead of first-success decode.

## Tests

- `detect_file_encoding` recovers the issue's `shift_jis` and `iso_8859_1` samples via filename and file.
- Fallback path with mocked inconclusive `detect()` reaches `shift_jis` instead of stopping at `iso_8859_1`.
- `partition_text` recovers the same three samples.

Fixes #4466

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

