### PR TITLE
perf: bound separator runs in US_PHONE_NUMBERS_PATTERN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **Improve `US_PHONE_NUMBERS_PATTERN` matching performance.** Each separator run between digit groups in the US phone-number regex is now bounded to three characters, keeping match time linear on long sequences of separator characters. Phone formats using ordinary separators are unaffected. **Behavior change:** where a separator run exceeds the bound, it is no longer absorbed into the match — the result may cover a shorter span than before, or, for a long run between the last two digit groups, may not match at all.
+- **Improve `US_PHONE_NUMBERS_PATTERN` matching performance.** The US phone-number regex now accepts at most three separator characters between digit groups, keeping match time linear on long sequences of separator characters. Phone formats using ordinary separators are unaffected. **Behavior change:** a longer separator run is no longer absorbed into the match — the result may cover a shorter span than before, or, for a long run between the last two digit groups, may not match at all.
 
 ## 0.27.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- **Improve `US_PHONE_NUMBERS_PATTERN` matching performance.** The separator runs in the US phone-number regex are now bounded, keeping match time linear on long sequences of separator characters. Every phone format the previous pattern accepted is still accepted. **Behavior change:** a "phone number" separated by four or more consecutive separator characters is no longer matched.
+- **Improve `US_PHONE_NUMBERS_PATTERN` matching performance.** Each separator run between digit groups in the US phone-number regex is now bounded to three characters, keeping match time linear on long sequences of separator characters. Phone formats using ordinary separators are unaffected. **Behavior change:** where a separator run exceeds the bound, it is no longer absorbed into the match — the result may cover a shorter span than before, or, for a long run between the last two digit groups, may not match at all.
 
 ## 0.27.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.27.6
+
+### Fixes
+
+- **Improve `US_PHONE_NUMBERS_PATTERN` matching performance.** The separator runs in the US phone-number regex are now bounded, keeping match time linear on long sequences of separator characters. Every phone format the previous pattern accepted is still accepted. **Behavior change:** a "phone number" separated by four or more consecutive separator characters is no longer matched.
+
 ## 0.27.5
 
 ### Fixes

--- a/test_unstructured/nlp/test_patterns.py
+++ b/test_unstructured/nlp/test_patterns.py
@@ -1,6 +1,7 @@
 """Tests for the regex constants in `unstructured.nlp.patterns`."""
 
-import time
+import subprocess
+import sys
 
 import pytest
 
@@ -8,19 +9,43 @@ from unstructured.nlp.patterns import US_PHONE_NUMBERS_RE
 
 SEPARATOR_CHARS = ["-", ".", " ", "(", ")"]
 
-# Sized so that a regression to unbounded separator runs is unambiguous while the test
-# still finishes promptly: the current pattern matches this payload in ~0.3ms, the
-# unbounded form took ~940ms. Keeping the payload small bounds how long a regressed
-# pattern can occupy a test worker before the assertion is reached.
-PAYLOAD_LENGTH = 800
+PAYLOAD_LENGTH = 2000
 
-# ~900x above the expected match time and ~4x below a regression, so the test is stable
-# on a slow or loaded runner without losing its signal.
-TIME_BUDGET_SECONDS = 0.25
+# The current pattern matches these payloads in under a millisecond, so this is orders of
+# magnitude of headroom on a slow or loaded runner while still bounding a regression.
+TIME_BUDGET_SECONDS = 5.0
+
+_MATCH_SCRIPT = "import re, sys; re.search(sys.argv[1], sys.argv[2])"
+
+
+def _search_completes_within(payload: str, timeout: float) -> bool:
+    """Run the pattern against `payload` in a subprocess, bounded by `timeout`.
+
+    CPython does not check for signals while a regex match is in progress, so an
+    in-process alarm cannot interrupt one and a wall-clock assertion after the call
+    cannot bound it. A separate process is what makes the budget enforceable.
+
+    Args:
+        payload (str): The text to match against.
+        timeout (float): Seconds to allow before killing the subprocess.
+
+    Returns:
+        bool: True if the match completed within the timeout.
+    """
+    try:
+        subprocess.run(
+            [sys.executable, "-c", _MATCH_SCRIPT, US_PHONE_NUMBERS_RE.pattern, payload],
+            timeout=timeout,
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.TimeoutExpired:
+        return False
+    return True
 
 
 @pytest.mark.parametrize("char", SEPARATOR_CHARS)
-def test_us_phone_numbers_pattern_matches_long_separator_runs_quickly(char: str):
+def test_us_phone_numbers_pattern_matches_long_separator_runs_within_budget(char: str):
     """A long run of separator characters must match in linear time.
 
     Such runs are common in extracted document text -- table borders, Markdown
@@ -29,39 +54,60 @@ def test_us_phone_numbers_pattern_matches_long_separator_runs_quickly(char: str)
     Args:
         char (str): A single character drawn from the pattern's separator classes.
     """
-    payload = char * PAYLOAD_LENGTH
-
-    start = time.perf_counter()
-    match = US_PHONE_NUMBERS_RE.search(payload)
-    elapsed = time.perf_counter() - start
-
-    assert match is None, "separator-only input should not be read as a phone number"
-    assert elapsed < TIME_BUDGET_SECONDS, (
-        f"matching {PAYLOAD_LENGTH} {char!r} characters took {elapsed:.3f}s "
-        f"(budget {TIME_BUDGET_SECONDS}s) -- the separator runs are likely unbounded again"
+    assert _search_completes_within(char * PAYLOAD_LENGTH, TIME_BUDGET_SECONDS), (
+        f"matching {PAYLOAD_LENGTH} {char!r} characters exceeded {TIME_BUDGET_SECONDS}s "
+        f"-- the separator runs are likely unbounded again"
     )
 
 
-def test_us_phone_numbers_pattern_matches_separator_run_with_digit_tail_quickly():
+def test_us_phone_numbers_pattern_matches_separator_run_with_digit_tail_within_budget():
     """A separator run followed by digits must also match in linear time."""
     payload = " " * PAYLOAD_LENGTH + "1234"
 
-    start = time.perf_counter()
-    US_PHONE_NUMBERS_RE.search(payload)
-    elapsed = time.perf_counter() - start
-
-    assert elapsed < TIME_BUDGET_SECONDS, (
-        f"matching a {PAYLOAD_LENGTH}-space run followed by digits took {elapsed:.3f}s "
-        f"(budget {TIME_BUDGET_SECONDS}s) -- the separator runs are likely unbounded again"
+    assert _search_completes_within(payload, TIME_BUDGET_SECONDS), (
+        f"matching a {PAYLOAD_LENGTH}-space run followed by digits exceeded "
+        f"{TIME_BUDGET_SECONDS}s -- the separator runs are likely unbounded again"
     )
+
+
+@pytest.mark.parametrize("char", SEPARATOR_CHARS)
+def test_us_phone_numbers_pattern_does_not_read_separators_as_a_phone_number(char: str):
+    """Separator-only text contains no phone number.
+
+    Args:
+        char (str): A single character drawn from the pattern's separator classes.
+    """
+    assert US_PHONE_NUMBERS_RE.search(char * 40) is None
+
+
+@pytest.mark.parametrize(
+    ("run_length", "is_matched"),
+    [(0, True), (1, True), (2, True), (3, True), (4, False), (5, False), (10, False)],
+)
+def test_us_phone_numbers_pattern_bounds_the_run_between_final_digit_groups(
+    run_length: int, is_matched: bool
+):
+    """Pin the bound at three characters where no adjacent class can absorb the overflow.
+
+    Between the last two digit groups a single separator class applies, so this is the
+    position that distinguishes `{0,3}` from a looser bound: a four-character run must
+    not match.
+
+    Args:
+        run_length (int): Number of separator characters between the digit groups.
+        is_matched (bool): Whether the pattern is expected to match.
+    """
+    text = "867" + ("-" * run_length) + "5309"
+
+    assert (US_PHONE_NUMBERS_RE.search(text) is not None) is is_matched
 
 
 @pytest.mark.parametrize("char", ["-", ".", " "])
 def test_us_phone_numbers_pattern_does_not_absorb_long_separator_runs(char: str):
     """A separator run past the bound is excluded from the match rather than absorbed.
 
-    The leading digit group is dropped and a shorter trailing span matches instead, so
-    the run itself never appears in full inside the result.
+    Earlier in the string the leading digit group is dropped and a shorter trailing span
+    matches instead, so the run itself never appears in full inside the result.
 
     Args:
         char (str): A separator character to repeat between the digit groups.
@@ -73,15 +119,6 @@ def test_us_phone_numbers_pattern_does_not_absorb_long_separator_runs(char: str)
     assert match is not None
     assert match.group() != text
     assert len(match.group()) < len(text)
-
-
-def test_us_phone_numbers_pattern_rejects_long_run_between_final_digit_groups():
-    """A run past the bound between the last two digit groups leaves nothing to match.
-
-    Unlike a run earlier in the string, there is no shorter trailing span that satisfies
-    the pattern, so the input is not matched at all.
-    """
-    assert US_PHONE_NUMBERS_RE.search("867" + ("-" * 10) + "5309") is None
 
 
 @pytest.mark.parametrize(

--- a/test_unstructured/nlp/test_patterns.py
+++ b/test_unstructured/nlp/test_patterns.py
@@ -102,6 +102,31 @@ def test_us_phone_numbers_pattern_bounds_the_run_between_final_digit_groups(
     assert (US_PHONE_NUMBERS_RE.search(text) is not None) is is_matched
 
 
+@pytest.mark.parametrize(
+    ("run_length", "is_full_match"),
+    [(1, True), (2, True), (3, True), (4, False), (6, False), (10, False)],
+)
+def test_us_phone_numbers_pattern_bounds_the_combined_separator_run(
+    run_length: int, is_full_match: bool
+):
+    """The bound holds across adjacent separator classes, not only within one.
+
+    Between the country code and the prefix two separator runs sit either side of an
+    optional area-code group. The area code's trailing run is nested inside that optional
+    group, so when no area code is present the two runs cannot combine to accept more
+    than three characters.
+
+    Args:
+        run_length (int): Number of separator characters between the digit groups.
+        is_full_match (bool): Whether the whole string is expected to match.
+    """
+    text = "215" + ("-" * run_length) + "867-5309"
+
+    match = US_PHONE_NUMBERS_RE.search(text)
+
+    assert (match is not None and match.group() == text) is is_full_match
+
+
 @pytest.mark.parametrize("char", ["-", ".", " "])
 def test_us_phone_numbers_pattern_does_not_absorb_long_separator_runs(char: str):
     """A separator run past the bound is excluded from the match rather than absorbed.

--- a/test_unstructured/nlp/test_patterns.py
+++ b/test_unstructured/nlp/test_patterns.py
@@ -1,0 +1,78 @@
+"""Tests for the regex constants in `unstructured.nlp.patterns`."""
+
+import time
+
+import pytest
+
+from unstructured.nlp.patterns import US_PHONE_NUMBERS_RE
+
+SEPARATOR_CHARS = ["-", ".", " ", "(", ")"]
+
+PAYLOAD_LENGTH = 2000
+
+# Generous relative to the expected sub-millisecond match time, so the test stays stable
+# on a slow or loaded CI runner.
+TIME_BUDGET_SECONDS = 2.0
+
+
+@pytest.mark.parametrize("char", SEPARATOR_CHARS)
+def test_us_phone_numbers_pattern_matches_long_separator_runs_quickly(char: str):
+    """A long run of separator characters must match in linear time.
+
+    Such runs are common in extracted document text -- table borders, Markdown
+    horizontal rules, email signature dividers.
+
+    Args:
+        char (str): A single character drawn from the pattern's separator classes.
+    """
+    payload = char * PAYLOAD_LENGTH
+
+    start = time.perf_counter()
+    match = US_PHONE_NUMBERS_RE.search(payload)
+    elapsed = time.perf_counter() - start
+
+    assert match is None, "separator-only input should not be read as a phone number"
+    assert elapsed < TIME_BUDGET_SECONDS, (
+        f"matching {PAYLOAD_LENGTH} {char!r} characters took {elapsed:.2f}s "
+        f"(budget {TIME_BUDGET_SECONDS}s) -- the separator runs are likely unbounded again"
+    )
+
+
+def test_us_phone_numbers_pattern_matches_separator_run_with_digit_tail_quickly():
+    """A separator run followed by digits must also match in linear time."""
+    payload = " " * PAYLOAD_LENGTH + "1234"
+
+    start = time.perf_counter()
+    US_PHONE_NUMBERS_RE.search(payload)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < TIME_BUDGET_SECONDS, (
+        f"matching a {PAYLOAD_LENGTH}-space run followed by digits took {elapsed:.2f}s "
+        f"(budget {TIME_BUDGET_SECONDS}s) -- the separator runs are likely unbounded again"
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "215-867-5309",
+        "+1 215.867.5309",
+        "8675309",
+        "2158675309",
+        "+12158675309",
+        "867.5309",
+        "1-800-867-5309",
+        "1(800)-867-5309",
+        "(215) 867-5309",
+        "215 . 867 . 5309",
+        "Tel: 1(800)-867-5309",
+        "Phone Number: 215-867-5309 x1234",
+    ],
+)
+def test_us_phone_numbers_pattern_still_matches_real_numbers(text: str):
+    """Bounding the separator runs must not narrow the set of accepted phone formats.
+
+    Args:
+        text (str): A string containing a US phone number in a supported format.
+    """
+    assert US_PHONE_NUMBERS_RE.search(text) is not None

--- a/test_unstructured/nlp/test_patterns.py
+++ b/test_unstructured/nlp/test_patterns.py
@@ -106,21 +106,43 @@ def test_us_phone_numbers_pattern_bounds_the_run_between_final_digit_groups(
     ("run_length", "is_full_match"),
     [(1, True), (2, True), (3, True), (4, False), (6, False), (10, False)],
 )
-def test_us_phone_numbers_pattern_bounds_the_combined_separator_run(
+def test_us_phone_numbers_pattern_bounds_the_run_before_the_prefix(
     run_length: int, is_full_match: bool
 ):
-    """The bound holds across adjacent separator classes, not only within one.
+    """With no area code present, the runs either side of it cannot merge.
 
-    Between the country code and the prefix two separator runs sit either side of an
-    optional area-code group. The area code's trailing run is nested inside that optional
-    group, so when no area code is present the two runs cannot combine to accept more
-    than three characters.
+    The area code's trailing separator run is nested inside the optional area-code group,
+    so when that group does not participate only the leading run applies. Without the
+    nesting these two runs are adjacent and accept six characters between them.
 
     Args:
-        run_length (int): Number of separator characters between the digit groups.
+        run_length (int): Number of separator characters before the prefix.
         is_full_match (bool): Whether the whole string is expected to match.
     """
     text = "215" + ("-" * run_length) + "867-5309"
+
+    match = US_PHONE_NUMBERS_RE.search(text)
+
+    assert (match is not None and match.group() == text) is is_full_match
+
+
+@pytest.mark.parametrize(
+    ("run_length", "is_full_match"),
+    [(0, True), (1, True), (3, True), (4, False), (5, False)],
+)
+def test_us_phone_numbers_pattern_bounds_the_run_after_the_area_code(
+    run_length: int, is_full_match: bool
+):
+    """The area code's own trailing run is bounded when that group does participate.
+
+    Covers the other separator branch: here the optional area-code group matches, so the
+    run being bounded is the one nested inside it rather than the leading run.
+
+    Args:
+        run_length (int): Number of separator characters after the area code.
+        is_full_match (bool): Whether the whole string is expected to match.
+    """
+    text = "1-800" + ("-" * run_length) + "867-5309"
 
     match = US_PHONE_NUMBERS_RE.search(text)
 

--- a/test_unstructured/nlp/test_patterns.py
+++ b/test_unstructured/nlp/test_patterns.py
@@ -8,11 +8,15 @@ from unstructured.nlp.patterns import US_PHONE_NUMBERS_RE
 
 SEPARATOR_CHARS = ["-", ".", " ", "(", ")"]
 
-PAYLOAD_LENGTH = 2000
+# Sized so that a regression to unbounded separator runs is unambiguous while the test
+# still finishes promptly: the current pattern matches this payload in ~0.3ms, the
+# unbounded form took ~940ms. Keeping the payload small bounds how long a regressed
+# pattern can occupy a test worker before the assertion is reached.
+PAYLOAD_LENGTH = 800
 
-# Generous relative to the expected sub-millisecond match time, so the test stays stable
-# on a slow or loaded CI runner.
-TIME_BUDGET_SECONDS = 2.0
+# ~900x above the expected match time and ~4x below a regression, so the test is stable
+# on a slow or loaded runner without losing its signal.
+TIME_BUDGET_SECONDS = 0.25
 
 
 @pytest.mark.parametrize("char", SEPARATOR_CHARS)
@@ -33,7 +37,7 @@ def test_us_phone_numbers_pattern_matches_long_separator_runs_quickly(char: str)
 
     assert match is None, "separator-only input should not be read as a phone number"
     assert elapsed < TIME_BUDGET_SECONDS, (
-        f"matching {PAYLOAD_LENGTH} {char!r} characters took {elapsed:.2f}s "
+        f"matching {PAYLOAD_LENGTH} {char!r} characters took {elapsed:.3f}s "
         f"(budget {TIME_BUDGET_SECONDS}s) -- the separator runs are likely unbounded again"
     )
 
@@ -47,9 +51,37 @@ def test_us_phone_numbers_pattern_matches_separator_run_with_digit_tail_quickly(
     elapsed = time.perf_counter() - start
 
     assert elapsed < TIME_BUDGET_SECONDS, (
-        f"matching a {PAYLOAD_LENGTH}-space run followed by digits took {elapsed:.2f}s "
+        f"matching a {PAYLOAD_LENGTH}-space run followed by digits took {elapsed:.3f}s "
         f"(budget {TIME_BUDGET_SECONDS}s) -- the separator runs are likely unbounded again"
     )
+
+
+@pytest.mark.parametrize("char", ["-", ".", " "])
+def test_us_phone_numbers_pattern_does_not_absorb_long_separator_runs(char: str):
+    """A separator run past the bound is excluded from the match rather than absorbed.
+
+    The leading digit group is dropped and a shorter trailing span matches instead, so
+    the run itself never appears in full inside the result.
+
+    Args:
+        char (str): A separator character to repeat between the digit groups.
+    """
+    text = "215" + (char * 20) + "867-5309"
+
+    match = US_PHONE_NUMBERS_RE.search(text)
+
+    assert match is not None
+    assert match.group() != text
+    assert len(match.group()) < len(text)
+
+
+def test_us_phone_numbers_pattern_rejects_long_run_between_final_digit_groups():
+    """A run past the bound between the last two digit groups leaves nothing to match.
+
+    Unlike a run earlier in the string, there is no shorter trailing span that satisfies
+    the pattern, so the input is not matched at all.
+    """
+    assert US_PHONE_NUMBERS_RE.search("867" + ("-" * 10) + "5309") is None
 
 
 @pytest.mark.parametrize(

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.5"  # pragma: no cover
+__version__ = "0.27.6"  # pragma: no cover

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -5,7 +5,7 @@ from typing import Final, List
 # ref: https://stackoverflow.com/questions/16699007/
 # regular-expression-to-match-standard-10-digit-phone-number
 US_PHONE_NUMBERS_PATTERN = (
-    r"(?:\+?(\d{1,3}))?[-. (]{0,3}(\d{3})?[-. )]{0,3}(\d{3})[-. ]{0,3}(\d{4})(?: *x(\d+))?\s*$"
+    r"(?:\+?(\d{1,3}))?[-. (]{0,3}(?:(\d{3})[-. )]{0,3})?(\d{3})[-. ]{0,3}(\d{4})(?: *x(\d+))?\s*$"
 )
 US_PHONE_NUMBERS_RE = re.compile(US_PHONE_NUMBERS_PATTERN)
 

--- a/unstructured/nlp/patterns.py
+++ b/unstructured/nlp/patterns.py
@@ -5,7 +5,7 @@ from typing import Final, List
 # ref: https://stackoverflow.com/questions/16699007/
 # regular-expression-to-match-standard-10-digit-phone-number
 US_PHONE_NUMBERS_PATTERN = (
-    r"(?:\+?(\d{1,3}))?[-. (]*(\d{3})?[-. )]*(\d{3})[-. ]*(\d{4})(?: *x(\d+))?\s*$"
+    r"(?:\+?(\d{1,3}))?[-. (]{0,3}(\d{3})?[-. )]{0,3}(\d{3})[-. ]{0,3}(\d{4})(?: *x(\d+))?\s*$"
 )
 US_PHONE_NUMBERS_RE = re.compile(US_PHONE_NUMBERS_PATTERN)
 


### PR DESCRIPTION
## Summary

The separator runs in the US phone-number regex were unbounded (`[-. (]*`,
`[-. )]*`, `[-. ]*`), which made match time grow non-linearly on long sequences
of separator characters. Bounding each run at `{0,3}` keeps matching linear.

Real separators are at most three characters — `)-`, ` (`, and ` . ` as in
`215 . 867 . 5309` — so every phone format the previous pattern accepted is
still accepted.

## Changes

| File | Change |
|---|---|
| `unstructured/nlp/patterns.py` | Bound the three separator runs at `{0,3}` |
| `test_unstructured/nlp/test_patterns.py` | New — the pattern module had no direct test coverage |
| `CHANGELOG.md`, `unstructured/__version__.py` | 0.27.6 |

## Behavior change

A "phone number" separated by four or more consecutive separator characters is
no longer matched. Nothing in the existing test suite relies on that.

## Testing

- New `test_patterns.py` covers match time on long separator runs and the set of
  accepted phone formats — including `215 . 867 . 5309`, the three-character
  separator that makes `{0,3}` the correct bound rather than `{0,2}`.
- Existing `test_extract.py::test_extract_us_phone_number` and
  `test_text_type.py::test_contains_us_phone_number` cases are unaffected.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

