### PR TITLE
fix: partition multi-section DOCX files in linear time

### DIFF
--- a/.github/workflows/release-version-alert.yml
+++ b/.github/workflows/release-version-alert.yml
@@ -10,11 +10,9 @@ on:
 jobs:
   check-version:  
     runs-on: ubuntu-latest
-    env:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
       - name: Checkout codes
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4 
       - name: Get PR information
         id: pr-info
         run: |
@@ -51,7 +49,7 @@ jobs:
       - name: Restore Message from Cache
         if: env.SKIP_STEPS != 'true'
         id: restore-cache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@v4
         with: 
           path: message_cache.txt
           key: message-cache-${{ env.MESSAGE_HASH  }}
@@ -71,16 +69,15 @@ jobs:
           cat message_cache.txt
       - name: Store Message in Cache
         if: env.SKIP_STEPS != 'true'
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@v4
         with:
           path: message_cache.txt
           key: message-cache-${{ env.MESSAGE_HASH }}
       - name: Slack Notification
-        if: env.SKIP_STEPS != 'true' && env.SLACK_BOT_TOKEN != ''
-        uses: slackapi/slack-github-action@v4
+        if: env.SKIP_STEPS != 'true'
+        uses: slackapi/slack-github-action@v1.24.0
         with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: C05S1QMKL5D
-            text: ${{ toJSON(env.SLACK_MESSAGE) }}
+          channel-id: 'C05S1QMKL5D'
+          slack-message: ${{ env.SLACK_MESSAGE }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-version-alert.yml
+++ b/.github/workflows/release-version-alert.yml
@@ -10,9 +10,11 @@ on:
 jobs:
   check-version:  
     runs-on: ubuntu-latest
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
       - name: Checkout codes
-        uses: actions/checkout@v4 
+        uses: actions/checkout@v7
       - name: Get PR information
         id: pr-info
         run: |
@@ -49,7 +51,7 @@ jobs:
       - name: Restore Message from Cache
         if: env.SKIP_STEPS != 'true'
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with: 
           path: message_cache.txt
           key: message-cache-${{ env.MESSAGE_HASH  }}
@@ -69,15 +71,16 @@ jobs:
           cat message_cache.txt
       - name: Store Message in Cache
         if: env.SKIP_STEPS != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: message_cache.txt
           key: message-cache-${{ env.MESSAGE_HASH }}
       - name: Slack Notification
-        if: env.SKIP_STEPS != 'true'
-        uses: slackapi/slack-github-action@v1.24.0
+        if: env.SKIP_STEPS != 'true' && env.SLACK_BOT_TOKEN != ''
+        uses: slackapi/slack-github-action@v4
         with:
-          channel-id: 'C05S1QMKL5D'
-          slack-message: ${{ env.SLACK_MESSAGE }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.postMessage
+          token: ${{ env.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: C05S1QMKL5D
+            text: ${{ toJSON(env.SLACK_MESSAGE) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - **Stop duplicating merged-cell text in DOCX `text_as_html`.** A merged cell (`gridSpan`/`vMerge`) was repeated into every `<td>` its merge visually covered, with no `colspan`/`rowspan` attribute marking the merge; merged cells are now emitted once, with `colspan`/`rowspan` reflecting the true geometry. Since DOCX tables can now carry real spans, table chunking was also made rowspan-aware, so a chunk boundary can no longer split a table in a way that misattributes a spanned cell's rows to the wrong columns.
+- **Partition multi-section DOCX files in linear time**: DOCX partitioning now traverses body blocks once and switches section metadata at each section boundary instead of asking `python-docx` to rescan the document prefix for every section. This preserves header, body, footer, and page-break ordering while avoiding severe slowdowns on documents with hundreds of sections and thousands of paragraphs.
 
 ## 0.27.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+## 0.27.7
+
+### Fixes
+
+- **Partition multi-section DOCX files in linear time**: DOCX partitioning now traverses body blocks once and switches section metadata at each section boundary instead of asking `python-docx` to rescan the document prefix for every section. This preserves header, body, footer, and page-break ordering while avoiding severe slowdowns on documents with hundreds of sections and thousands of paragraphs.
+
 ## 0.27.6
 
 ### Fixes
 
 - **Stop duplicating merged-cell text in DOCX `text_as_html`.** A merged cell (`gridSpan`/`vMerge`) was repeated into every `<td>` its merge visually covered, with no `colspan`/`rowspan` attribute marking the merge; merged cells are now emitted once, with `colspan`/`rowspan` reflecting the true geometry. Since DOCX tables can now carry real spans, table chunking was also made rowspan-aware, so a chunk boundary can no longer split a table in a way that misattributes a spanned cell's rows to the wrong columns.
-- **Partition multi-section DOCX files in linear time**: DOCX partitioning now traverses body blocks once and switches section metadata at each section boundary instead of asking `python-docx` to rescan the document prefix for every section. This preserves header, body, footer, and page-break ordering while avoiding severe slowdowns on documents with hundreds of sections and thousands of paragraphs.
 
 ## 0.27.5
 

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -14,6 +14,8 @@ from typing import Any, Iterator
 import docx
 import pytest
 from docx.document import Document
+from docx.enum.section import WD_SECTION
+from docx.section import Section
 from docx.text.paragraph import Paragraph
 from pytest_mock import MockFixture
 
@@ -1430,6 +1432,35 @@ class Describe_DocxPartitioner:
 
         element = next(footer_iter)
         assert element.text == "para1\ncell1 a b c d e f\npara2"
+
+    def it_traverses_document_blocks_once_for_many_sections(
+        self, opts_args: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ):
+        """Partitioning avoids the per-section full-prefix scans in python-docx."""
+        document = docx.Document()
+        expected_texts: list[str] = []
+        for section_idx in range(25):
+            text = f"section-{section_idx}"
+            document.add_paragraph(text)
+            expected_texts.append(text)
+            if section_idx < 24:
+                document.add_section(WD_SECTION.CONTINUOUS)
+
+        file = io.BytesIO()
+        document.save(file)
+        file.seek(0)
+        opts_args["file"] = file
+
+        def fail_on_section_scan(_self: Section) -> Iterator[Paragraph]:
+            raise AssertionError("partitioner must not scan each section from document start")
+
+        monkeypatch.setattr(Section, "iter_inner_content", fail_on_section_scan)
+
+        elements = list(
+            _DocxPartitioner.iter_document_elements(DocxPartitionerOptions(**opts_args))
+        )
+
+        assert [element.text for element in elements] == expected_texts
 
 
 def test_partition_docx_skips_malformed_row_cells():

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -1462,6 +1462,25 @@ class Describe_DocxPartitioner:
 
         assert [element.text for element in elements] == expected_texts
 
+    def it_partitions_a_document_without_a_body_level_sectPr(self, opts_args: dict[str, Any]):
+        """A paragraph-level final section boundary does not require a body-level sentinel."""
+        document = docx.Document()
+        document.sections[0].header.paragraphs[0].text = "Header"
+        document.sections[0].footer.paragraphs[0].text = "Footer"
+        paragraph = document.add_paragraph("Body")
+        paragraph._p.get_or_add_pPr().append(document._element.body.sectPr)
+
+        file = io.BytesIO()
+        document.save(file)
+        file.seek(0)
+        opts_args["file"] = file
+
+        elements = list(
+            _DocxPartitioner.iter_document_elements(DocxPartitionerOptions(**opts_args))
+        )
+
+        assert [element.text for element in elements] == ["Header", "Body", "Footer"]
+
 
 def test_partition_docx_skips_malformed_row_cells():
     """Test that partition_docx does not crash on a DOCX with malformed/merged table rows."""

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.6"  # pragma: no cover
+__version__ = "0.27.7"  # pragma: no cover

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -425,7 +425,10 @@ class _DocxPartitioner:
                 and block_item._p.pPr.sectPr is section._sectPr
             ):
                 yield from self._iter_section_footers(section)
-                section_idx, section = next(sections)
+                next_section = next(sections, None)
+                if next_section is None:
+                    return
+                section_idx, section = next_section
                 yield from self._iter_section_page_breaks(section_idx, section)
                 yield from self._iter_section_headers(section)
 

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -397,32 +397,39 @@ class _DocxPartitioner:
 
     def _iter_document_elements(self) -> Iterator[Element]:
         """Generate each document-element in (docx) `document` in document order."""
-        # -- This implementation composes a collection of iterators into a "combined" iterator
-        # -- return value using `yield from`. You can think of the return value as an Element
-        # -- stream and each `yield from` as "add elements found by this function to the stream".
-        # -- This is functionally analogous to declaring `elements: list[Element] = []` at the top
-        # -- and using `elements.extend()` for the results of each of the function calls, but is
-        # -- more perfomant, uses less memory (avoids producing and then garbage-collecting all
-        # -- those small lists), is more flexible for later iterator operations like filter,
-        # -- chain, map, etc. and is perhaps more elegant and simpler to read once you have the
-        # -- concept of what it's doing. You can see the same pattern repeating in the "sub"
-        # -- functions like `._iter_paragraph_elements()` where the "just return when done"
-        # -- characteristic of a generator avoids repeated code to form interim results into lists.
-        for section_idx, section in enumerate(self._document.sections):
-            yield from self._iter_section_page_breaks(section_idx, section)
-            yield from self._iter_section_headers(section)
+        sections = iter(enumerate(self._document.sections))
+        section_idx, section = next(sections)
 
-            for block_item in section.iter_inner_content():
-                # -- a block-item can be a Paragraph or a Table, maybe others later so elif here.
-                # -- Paragraph is more common so check that first.
-                if isinstance(block_item, Paragraph):
-                    yield from self._iter_paragraph_elements(block_item)
-                elif isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
-                    block_item, DocxTable
-                ):
-                    yield from self._iter_table_element(block_item)
+        yield from self._iter_section_page_breaks(section_idx, section)
+        yield from self._iter_section_headers(section)
 
-            yield from self._iter_section_footers(section)
+        # -- Iterate document blocks only once. `Section.iter_inner_content()` scans from the start
+        # -- of the document to find each section's boundaries, which becomes prohibitively
+        # -- expensive for documents with many sections and paragraphs.
+        for block_item in self._document.iter_inner_content():
+            # -- a block-item can be a Paragraph or a Table, maybe others later so elif here.
+            # -- Paragraph is more common so check that first.
+            if isinstance(block_item, Paragraph):
+                yield from self._iter_paragraph_elements(block_item)
+            elif isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+                block_item, DocxTable
+            ):
+                yield from self._iter_table_element(block_item)
+
+            # -- A paragraph-level sectPr marks the final paragraph governed by the current
+            # -- section. The final section's sectPr lives directly under w:body, so it is handled
+            # -- after the loop.
+            if (
+                isinstance(block_item, Paragraph)
+                and block_item._p.pPr is not None
+                and block_item._p.pPr.sectPr is section._sectPr
+            ):
+                yield from self._iter_section_footers(section)
+                section_idx, section = next(sections)
+                yield from self._iter_section_page_breaks(section_idx, section)
+                yield from self._iter_section_headers(section)
+
+        yield from self._iter_section_footers(section)
 
     def _iter_sectionless_document_elements(self) -> Iterator[Element]:
         """Generate each document-element in a docx `document` that has no sections.


### PR DESCRIPTION
## Summary

This pull request fixes #3592 by replacing per-section `Section.iter_inner_content()` calls with a single document-body traversal. Section boundaries are detected at paragraph-level `sectPr` elements so page breaks, headers, body content, and footers retain their existing order.

On the current main branch with python-docx 1.2.0, traversing synthetic documents with 20 paragraphs per section took:

- 100 sections: 0.43s
- 200 sections: 3.61s
- 400 sections: 40.37s

With this change, the isolated traversal path took 0.008s, 0.010s, and 0.024s respectively. The full partition pipeline still includes text classification and metadata work; these numbers intentionally isolate the repeated section-prefix scan fixed here.

## Tests

- `uv run --no-sync pytest -q test_unstructured/partition/test_docx.py` (79 passed)
- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format --check .`
- `git diff --check`
- Regression test verified against the previous implementation: it fails because `Section.iter_inner_content()` is called.

`make test-extra-docx` additionally ran 96 tests successfully, while 6 legacy `.doc` conversion tests failed because the local LibreOffice process did not produce the requested `.docx` files. The complete DOCX test module passes independently.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

