### PR TITLE
fix(staging): report the value's type, not the key's, in Datasaur validation error

### DIFF
--- a/unstructured/staging/datasaur.py
+++ b/unstructured/staging/datasaur.py
@@ -32,4 +32,4 @@ def _validate_datasaur_entity(entity: Dict[str, Any]):
         if key not in entity:
             raise ValueError(f"Key '{key}' was expected but not present in the Datasaur entity.")
         if not isinstance(entity[key], _type):
-            raise ValueError(f"Expected type {_type} for {key}. Got {type(key)}.")
+            raise ValueError(f"Expected type {_type} for {key}. Got {type(entity[key])}.")


### PR DESCRIPTION
### Summary

In `stage_for_datasaur`, the validation error used `type(key)` — always `<class 'str'>` since `key` is the dict key name — producing self-contradictory messages like "Expected type <class 'str'> for start_idx. Got <class 'str'>" when a value has the wrong type (e.g. `start_idx=1.5`). Changed to `type(entity[key])`.

### Checklist

- [x] Conventional Commit title
- [x] Existing test (`test_unstructured/staging/test_datasaur.py`) asserts only `pytest.raises(ValueError)`, no message match — safe

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

