### PR TITLE
fix(cleaners): forward paragraph_split in blank_line_grouper

### DIFF
--- a/unstructured/cleaners/core.py
+++ b/unstructured/cleaners/core.py
@@ -228,7 +228,7 @@ def blank_line_grouper(
     Vestibulum auctor dapibus neque.\n\nNunc dignissim risus id metus.\n\n
 
     """
-    return group_broken_paragraphs(text)
+    return group_broken_paragraphs(text, paragraph_split=paragraph_split)
 
 
 def auto_paragraph_grouper(


### PR DESCRIPTION
### Summary

`blank_line_grouper(text, paragraph_split=…)` accepted a custom pattern but its body was just `return group_broken_paragraphs(text)` — the pattern was silently ignored even though `group_broken_paragraphs` accepts it. Forwards the parameter.

### Checklist

- [x] Conventional Commit title
- [x] No test references `blank_line_grouper` directly (only `group_broken_paragraphs`)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

