### PR TITLE
fix(metrics): correct error messages and export_name docstring in get_mean_grouping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,7 @@ The following is a list of tasks to be completed before submitting a pull reques
 
 Unstructured open source projects are licensed under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
 
-Include a license at the top of new `setup.py` files:
-
-- [Python license example](https://github.com/Unstructured-IO/unstructured/blob/main/setup.py)
+Include the Apache-2.0 license header at the top of new source files (the project now builds with hatchling via `pyproject.toml`; the old `setup.py` was removed in the uv migration).
 
 
 ## Conventions

--- a/unstructured/metrics/evaluate.py
+++ b/unstructured/metrics/evaluate.py
@@ -517,7 +517,7 @@ def get_mean_grouping(
 ) -> None:
     """Aggregates accuracy and missing metrics by column name 'doctype' or 'connector',
     or 'all' for all rows. Export to TSV.
-    If `all`, passing export_name is recommended.
+    If `all`, passing export_filename is recommended.
 
     Args:
         group_by (str): Grouping category ('doctype' or 'connector' or 'all').
@@ -526,10 +526,10 @@ def get_mean_grouping(
         eval_name (str): Evaluated metric ('text_extraction' or 'element_type').
         agg_name (str, optional): String to use with export filename. Default is `cct` for
             group_by `text_extraction` and `element-type` for `element_type`
-        export_name (str, optional): Export filename.
+        export_filename (str, optional): Export filename.
     """
     if group_by not in ("doctype", "connector") and group_by != "all":
-        raise ValueError("Invalid grouping category. Returning a non-group evaluation.")
+        raise ValueError("Invalid grouping category.")
 
     if eval_name == "text_extraction":
         agg_fields = ["cct-accuracy", "cct-%missing"]
@@ -543,7 +543,7 @@ def get_mean_grouping(
     else:
         raise ValueError(
             f"Unknown metric for eval {eval_name}. "
-            f"Expected `text_extraction` or `element_type` or `table_extraction`."
+            f"Expected `text_extraction`, `element_type` or `object_detection`."
         )
 
     if isinstance(data_input, str):
@@ -556,7 +556,7 @@ def get_mean_grouping(
         elif data_input.endswith(".txt"):
             df = pd.read_csv(data_input, sep="\t", header=None)
         else:
-            raise ValueError("Please provide a .csv or .tsv file.")
+            raise ValueError("Please provide a .csv, .tsv or .txt file.")
     else:
         df = data_input
 
@@ -624,7 +624,7 @@ def filter_metrics(
         elif data_input.endswith(".txt"):
             df = pd.read_csv(data_input, sep="\t", header=None)
         else:
-            raise ValueError("Please provide a .csv or .tsv file.")
+            raise ValueError("Please provide a .csv, .tsv or .txt file.")
     else:
         df = data_input
 
@@ -638,7 +638,7 @@ def filter_metrics(
         elif filter_list.endswith(".txt"):
             filter_df = pd.read_csv(filter_list, sep="\t", header=None)
         else:
-            raise ValueError("Please provide a .csv or .tsv file.")
+            raise ValueError("Please provide a .csv, .tsv or .txt file.")
         filter_list = filter_df.iloc[:, 0].astype(str).values.tolist()
     elif not isinstance(filter_list, list):
         raise ValueError("Please provide a List of strings or path to file.")


### PR DESCRIPTION
### Summary

Message/docstring corrections in `unstructured/metrics/evaluate.py`, each verified against the code:

1. "Invalid grouping category. **Returning** a non-group evaluation." — the code raises; it does not return.
2. The unknown-metric message listed `table_extraction` as valid while the accepted branches are `text_extraction`, `element_type` and `object_detection` (table_extraction is rejected); added the missing `object_detection`.
3. The ".csv or .tsv" messages (3 sites) omitted `.txt`, which the preceding line accepts; updated to ".csv, .tsv or .txt".
4. The docstring documented `export_name`; the parameter is `export_filename` (following it raised `TypeError`). Summary reference updated too.

### Checklist

- [x] Existing tests assert only `pytest.raises(ValueError)`, no message matching
- [x] Conventional Commit title

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

