### PR TITLE
docs: update CONTRIBUTING license step for the removed setup.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,7 @@ The following is a list of tasks to be completed before submitting a pull reques
 
 Unstructured open source projects are licensed under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
 
-Include a license at the top of new `setup.py` files:
-
-- [Python license example](https://github.com/Unstructured-IO/unstructured/blob/main/setup.py)
+Include the Apache-2.0 license header at the top of new source files (the project now builds with hatchling via `pyproject.toml`; the old `setup.py` was removed in the uv migration).
 
 
 ## Conventions


### PR DESCRIPTION
### Summary

The License section of CONTRIBUTING.md still instructed contributors to copy a license header from `setup.py` — a file deleted in the uv migration (69770c65), so the link 404s and the instruction is obsolete. Updated to reference source-file headers / `pyproject.toml`.

### Checklist

- [x] Conventional Commit title
- [x] Docs-only change

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

