### PR TITLE
fix(cleaners): prevent UnboundLocalError in _get_indexed_match when pattern is absent

### DIFF
--- a/test_unstructured/cleaners/test_extract.py
+++ b/test_unstructured/cleaners/test_extract.py
@@ -15,8 +15,23 @@ def test_get_indexed_match_raises_with_bad_index():
 
 
 def test_get_indexed_match_raises_with_index_too_high():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="The largest index was 2"):
         extract._get_indexed_match("BLAH BLAH BLAH", "BLAH", 4)
+
+
+def test_get_indexed_match_raises_when_no_matches_found():
+    with pytest.raises(ValueError, match="No matches were found"):
+        extract._get_indexed_match("BLAH BLAH BLAH", "XYZ", 0)
+
+
+def test_extract_text_before_raises_when_pattern_absent():
+    with pytest.raises(ValueError, match="No matches were found"):
+        extract.extract_text_before("hello world", "xyz")
+
+
+def test_extract_text_after_raises_when_pattern_absent():
+    with pytest.raises(ValueError, match="No matches were found"):
+        extract.extract_text_after("hello world", "xyz")
 
 
 def test_extract_text_before():

--- a/unstructured/cleaners/extract.py
+++ b/unstructured/cleaners/extract.py
@@ -18,12 +18,18 @@ def _get_indexed_match(text: str, pattern: str, index: int = 0) -> re.Match:
         raise ValueError(f"The index is {index}. Index must be a non-negative integer.")
 
     regex_match = None
+    largest_index = -1
     for i, result in enumerate(re.finditer(pattern, text)):
+        largest_index = i
         if i == index:
             regex_match = result
 
     if regex_match is None:
-        raise ValueError(f"Result with index {index} was not found. The largest index was {i}.")
+        if largest_index < 0:
+            raise ValueError(f"Result with index {index} was not found. No matches were found.")
+        raise ValueError(
+            f"Result with index {index} was not found. The largest index was {largest_index}."
+        )
 
     return regex_match
 


### PR DESCRIPTION
Closes #4427

### Problem
When `extract_text_before()` or `extract_text_after()` was called with a pattern that had no matches in the input string, the loop in `_get_indexed_match()` never ran. As a result, the loop variable `i` was never bound, causing `UnboundLocalError` when building the `ValueError` message instead of raising the intended descriptive `ValueError`.

### Solution
1. Initialized `largest_index = -1` before the iteration loop.
2. In the error message construction when `regex_match is None`, check if `largest_index < 0` and raise a clear `ValueError("Result with index {index} was not found. No matches were found.")`.
3. Added unit tests for zero-match cases across `_get_indexed_match`, `extract_text_before`, and `extract_text_after` in `test_unstructured/cleaners/test_extract.py`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

