### PR TITLE
fix: preserve MathML content in HTML partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.27.6
+
+### Fixes
+
+- **Stop duplicating merged-cell text in DOCX `text_as_html`.** A merged cell (`gridSpan`/`vMerge`) was repeated into every `<td>` its merge visually covered, with no `colspan`/`rowspan` attribute marking the merge; merged cells are now emitted once, with `colspan`/`rowspan` reflecting the true geometry. Since DOCX tables can now carry real spans, table chunking was also made rowspan-aware, so a chunk boundary can no longer split a table in a way that misattributes a spanned cell's rows to the wrong columns.
+
 ## 0.27.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **Stop duplicating merged-cell text in DOCX `text_as_html`.** A merged cell (`gridSpan`/`vMerge`) was repeated into every `<td>` its merge visually covered, with no `colspan`/`rowspan` attribute marking the merge; merged cells are now emitted once, with `colspan`/`rowspan` reflecting the true geometry. Since DOCX tables can now carry real spans, table chunking was also made rowspan-aware, so a chunk boundary can no longer split a table in a way that misattributes a spanned cell's rows to the wrong columns.
 
+### Enhancements
+
+- **Add basic MathML support.** `<math>` elements now extract a textual representation from alttext or supported TeX/LaTeX `<annotation>` values, including case-insensitive annotation encodings. Inline math remains part of surrounding text, while display="block" math is emitted as a separate element boundary. KaTeX's paired MathML/HTML output is also handled without duplicating the same expression.
+
 ## 0.27.5
 
 ### Fixes

--- a/test_unstructured/chunking/test_base.py
+++ b/test_unstructured/chunking/test_base.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import io
 import logging
 from typing import Any, Sequence
 
@@ -28,6 +29,7 @@ from unstructured.chunking.base import (
     is_title,
 )
 from unstructured.chunking.dispatch import reconstruct_table_from_chunks
+from unstructured.chunking.title import chunk_by_title
 from unstructured.common.html_table import HtmlCell, HtmlRow, HtmlTable
 from unstructured.documents.elements import (
     CheckBox,
@@ -1576,7 +1578,14 @@ class Describe_TableChunker:
             repeat_table_headers=True,
         )
 
+        # -- Region's rowspan="2" legitimately reaches into Northwest's row, its own group, so
+        # -- both land in the leading chunk together --
         assert len(chunks) == 3
+        original_html = chunks[0].metadata.text_as_html
+        assert original_html is not None
+        original_table = fragment_fromstring(original_html)
+        assert original_table.xpath("./tr[1]/td[1]/@rowspan") == ["2"]
+
         continuation_html = chunks[1].metadata.text_as_html
         assert continuation_html is not None
         continuation_table = fragment_fromstring(continuation_html)
@@ -1584,7 +1593,9 @@ class Describe_TableChunker:
         assert continuation_table.xpath("./thead/tr[1]/@data-role") == ["header-row"]
         assert continuation_table.xpath("./thead/tr[1]/th[1]/@scope") == ["col"]
         assert continuation_table.xpath("./thead/tr[1]/th[1]/@abbr") == ["region-code"]
-        assert continuation_table.xpath("./thead/tr[1]/th[1]/@rowspan") == ["2"]
+        # -- only one header row is ever prepended, so a repeated copy's rowspan="2" -- which
+        # -- would otherwise reach into the continuation's own body row -- is clipped away --
+        assert continuation_table.xpath("./thead/tr[1]/th[1]/@rowspan") == []
         assert continuation_table.xpath("./thead/tr[1]/th[2]/@class") == ["sales-cell"]
         assert continuation_table.xpath("./thead/tr[1]/th[2]/@data-k") == ["1"]
         assert continuation_table.xpath("./thead/tr[1]/th[2]/@colspan") == ["2"]
@@ -2452,7 +2463,10 @@ class Describe_TableChunker:
         assert reconstructed.xpath("./thead/tr[1]/th[1]/@abbr") == ["region-code"]
         assert reconstructed.xpath("./thead/tr[1]/th[2]/@colspan") == ["2"]
         assert reconstructed.xpath("./thead/tr[2]/th[1]/@headers") == ["sales-group"]
-        assert reconstructed.xpath("./thead/tr[2]/th[2]/@rowspan") == ["2"]
+        # -- "Revenue"'s rowspan="2" reaches one row past the header block into the first body
+        # -- row (Northwest's); only 2 header rows are ever carried into a repeated copy, so that
+        # -- reach is clipped away rather than claiming an arbitrary continuation's body row --
+        assert reconstructed.xpath("./thead/tr[2]/th[2]/@rowspan") == []
         assert reconstructed.xpath("./tr[1]/th") == []
         assert self._row_texts(table.metadata.text_as_html) == expected_rows
 
@@ -2995,6 +3009,70 @@ class Describe_HtmlTableSplitter:
             ),
         ]
 
+    def and_it_preserves_colspan_when_splitting_an_oversized_cell(self):
+        opts = ChunkingOptions(max_characters=50)
+        words = " ".join(["word"] * 30)
+        html_table = HtmlTable.from_html_text(
+            f'<table><tr><td colspan="2">{words}</td></tr></table>'
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert len(chunks) > 1
+        for _, html in chunks:
+            assert html.startswith('<table><tr><td colspan="2">')
+            assert len(html) <= 50
+
+    def and_it_accounts_for_a_large_colspan_attributes_own_overhead_when_splitting(self):
+        """A `colspan` attribute is real characters ("` colspan="100""), on top of the plain
+        `<td></td>` overhead a fixed constant would assume -- a cell with a large `colspan` must
+        reserve more room for it, not just for the text content."""
+        opts = ChunkingOptions(max_characters=50)
+        words = " ".join(["word"] * 30)
+        html_table = HtmlTable.from_html_text(
+            f'<table><tr><td colspan="100">{words}</td></tr></table>'
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert len(chunks) > 1
+        for _, html in chunks:
+            assert html.startswith('<table><tr><td colspan="100">')
+            assert len(html) <= 50
+
+    def and_it_accounts_for_html_escaping_when_splitting_an_oversized_cell(self):
+        """Cell text is HTML-escaped (`&` -> `&amp;`, etc.) when formatted, which can make the
+        formatted fragment longer than the raw text a word-boundary split was budgeted for."""
+        opts = ChunkingOptions(max_characters=50)
+        text = " & ".join(["x"] * 20)
+        html_table = HtmlTable.from_html_text(f"<table><tr><td>{text}</td></tr></table>")
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert len(chunks) > 1
+        for _, html in chunks:
+            assert len(html) <= 50
+        # -- no text lost or duplicated across the split --
+        assert " ".join(text for text, _ in chunks).replace(" & ", " ").split() == ["x"] * 20
+        # -- the escape itself actually landed in the emitted HTML, not just the parallel text --
+        assert any("&amp;" in html for _, html in chunks)
+
+    def and_it_accounts_for_colspan_and_escaping_together_when_splitting_an_oversized_cell(self):
+        """A large `colspan` and heavy escaping both eat into a cell's usable content budget at
+        once -- neither can be handled in isolation from the other."""
+        opts = ChunkingOptions(max_characters=80)
+        text = " & ".join(["word"] * 20)
+        html_table = HtmlTable.from_html_text(
+            f'<table><tr><td colspan="20">{text}</td></tr></table>'
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert len(chunks) > 1
+        for _, html in chunks:
+            assert html.startswith('<table><tr><td colspan="20">')
+            assert len(html) <= 80
+
     def and_it_uses_the_configured_measurement_units_for_row_fitting(
         self, monkeypatch: pytest.MonkeyPatch
     ):
@@ -3018,6 +3096,705 @@ class Describe_HtmlTableSplitter:
                 "</table>",
             ),
         ]
+
+    def and_it_splits_an_oversized_rowspan_bound_group_instead_of_emitting_it_whole(self):
+        """A rowspan-bound group too big to fit even an empty chunking window is split on a row
+        boundary, like an ordinary oversized row, rather than emitted whole in violation of
+        `max_characters`. The covering cell's `rowspan` is rewritten in the first fragment to the
+        rows it actually contains there, and re-materialized -- with its own rewritten `rowspan`
+        -- in the next fragment, which doesn't include the row that originally declared it."""
+        pd = pytest.importorskip("pandas")
+        opts = ChunkingOptions(max_characters=50)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tr><td rowspan="3">AAAAA</td><td>xxxxxxxxxxxxxxxxxxxx</td></tr>
+              <tr><td>yyyyyyyyyyyyyyyyyyyy</td></tr>
+              <tr><td>zzzzzzzzzzzzzzzzzzzz</td></tr>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert chunks == [
+            (
+                "AAAAA xxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyyy",
+                "<table>"
+                '<tr><td rowspan="2">AAAAA</td><td>xxxxxxxxxxxxxxxxxxxx</td></tr>'
+                "<tr><td>yyyyyyyyyyyyyyyyyyyy</td></tr>"
+                "</table>",
+            ),
+            (
+                "AAAAA zzzzzzzzzzzzzzzzzzzz",
+                "<table><tr><td>AAAAA</td><td>zzzzzzzzzzzzzzzzzzzz</td></tr></table>",
+            ),
+        ]
+        for text, _ in chunks:
+            assert len(text) <= 50
+        for _, html in chunks:
+            grid = pd.read_html(io.StringIO(html))[0].to_numpy().tolist()
+            for row in grid:
+                assert row[0] == "AAAAA"
+
+    def and_it_splits_a_hallucinated_rowspan_that_reaches_the_tables_last_row(self):
+        """A model/OCR-hallucinated `rowspan` (e.g. "20" on a cell whose real span is more like
+        2-3 rows) is bound by finding-1's fix to its true reach -- the table's last row -- rather
+        than to its own row-group, so the resulting group is now realistically bigger than
+        before. When that bigger group doesn't fit even an empty chunking window, splitting it
+        must still honor `max_characters`/`max_tokens`, not fall back to emitting it whole."""
+        pd = pytest.importorskip("pandas")
+        opts = ChunkingOptions(max_characters=60)
+        body_rows = "".join(
+            f"<tr><td>row{i} extra padding text here</td></tr>" for i in range(1, 8)
+        )
+        html_table = HtmlTable.from_html_text(
+            f"""
+            <table>
+              <tr>
+                <td rowspan="20">covering cell text here padding</td>
+                <td>row0 extra padding</td>
+              </tr>
+              {body_rows}
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        # (a) every emitted chunk is at or below `max_characters` --
+        for text, _ in chunks:
+            assert len(text) <= 60
+        # (b) every emitted chunk is well-formed, parseable HTML, and (d) each fragment's
+        # -- rewritten `rowspan` reflects only the rows actually present in that fragment --
+        # -- (a fragment with N rows never declares a covering `rowspan` bigger than N) --
+        for _, html in chunks:
+            reparsed = HtmlTable.from_html_text(html)
+            rows = list(reparsed.iter_rows())
+            assert rows, f"chunk has no rows: {html}"
+            for idx, row in enumerate(rows):
+                if row.max_rowspan is not None:
+                    assert idx + row.max_rowspan - 1 < len(rows)
+        # -- the covering cell's own text correctly lands in every row it claims to cover --
+        for _, html in chunks:
+            grid = pd.read_html(io.StringIO(html))[0].to_numpy().tolist()
+            for row in grid:
+                assert row[0] == "covering cell text here padding"
+        # (c) no cell text is silently dropped across the full set of fragments -- every row's
+        # -- own (non-covering) text appears exactly once --
+        combined_text = " ".join(text for text, _ in chunks)
+        for i in range(1, 8):
+            assert combined_text.count(f"row{i} extra padding text here") == 1
+        assert combined_text.count("row0 extra padding") == 1
+
+    def and_it_keeps_a_fully_consumed_continuation_row_with_its_rowspan_origin(self):
+        """The empty `<tr>` a fully-consumed continuation row emits (so a `rowspan` still counts
+        actual `<tr>` elements) must never be separated from the row whose `rowspan` covers it,
+        and a later, independent row may still join the same chunk when there's room."""
+        opts = ChunkingOptions(max_characters=70)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tr><td colspan="2" rowspan="2">BIGMERGEBIGMERGEBIGMERGE</td></tr>
+              <tr></tr>
+              <tr><td>pppppppppppppppppppp</td><td>qqqqqqqqqqqqqqqqqqqq</td></tr>
+              <tr><td>rrrrrrrrrrrrrrrrrrrr</td><td>ssssssssssssssssssss</td></tr>
+              <tr><td>tttttttttttttttttttt</td><td>uuuuuuuuuuuuuuuuuuuu</td></tr>
+            </table>
+            """
+        )
+
+        assert list(_HtmlTableSplitter.iter_subtables(html_table, opts)) == [
+            (
+                "BIGMERGEBIGMERGEBIGMERGE pppppppppppppppppppp qqqqqqqqqqqqqqqqqqqq",
+                "<table>"
+                '<tr><td colspan="2" rowspan="2">BIGMERGEBIGMERGEBIGMERGE</td></tr>'
+                "<tr/>"
+                "<tr><td>pppppppppppppppppppp</td><td>qqqqqqqqqqqqqqqqqqqq</td></tr>"
+                "</table>",
+            ),
+            (
+                "rrrrrrrrrrrrrrrrrrrr ssssssssssssssssssss",
+                "<table><tr><td>rrrrrrrrrrrrrrrrrrrr</td><td>ssssssssssssssssssss</td></tr></table>",
+            ),
+            (
+                "tttttttttttttttttttt uuuuuuuuuuuuuuuuuuuu",
+                "<table><tr><td>tttttttttttttttttttt</td><td>uuuuuuuuuuuuuuuuuuuu</td></tr></table>",
+            ),
+        ]
+
+    def and_it_does_not_drop_a_rowspan_that_reaches_past_the_last_row(self):
+        """A malformed but browser-tolerated `rowspan` naming more rows than the table has must
+        still yield its rows, not disappear because the group-closing index it names is never
+        reached -- and, since the group is too big to fit even an empty chunking window here,
+        each fragment's `rowspan` is rewritten to only the rows it actually contains, with the
+        covering cell's text re-materialized into the fragment that doesn't include the row that
+        originally declared it."""
+        opts = ChunkingOptions(max_characters=25)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tr><td rowspan="3">A</td><td>xxxxxxxxxxxxxxxxxxxx</td></tr>
+              <tr><td>yyyyyyyyyyyyyyyyyyyy</td></tr>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert chunks == [
+            (
+                "A xxxxxxxxxxxxxxxxxxxx",
+                "<table><tr><td>A</td><td>xxxxxxxxxxxxxxxxxxxx</td></tr></table>",
+            ),
+            (
+                "A yyyyyyyyyyyyyyyyyyyy",
+                "<table><tr><td>A</td><td>yyyyyyyyyyyyyyyyyyyy</td></tr></table>",
+            ),
+        ]
+        for text, _ in chunks:
+            assert len(text) <= 25
+
+    def and_it_treats_rowspan_0_as_spanning_every_remaining_row(self):
+        """`rowspan="0"` is HTML's spelling for "spans every remaining row in the row group" —
+        the largest possible span, not the absence of one. This model doesn't track
+        `<thead>`/`<tbody>`/`<tfoot>` boundaries here (no explicit sections), so it resolves to
+        the rest of the table, binding both rows into one rowspan-bound group. The window here is
+        too small even for the first row's own cells, so the group degrades all the way to
+        cell-level splitting -- the same tolerance already granted a single oversized cell --
+        rather than being emitted whole in violation of `max_characters`."""
+        opts = ChunkingOptions(max_characters=15)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tr><td rowspan="0">Region</td><td>xxxxxxxxxxxxx</td></tr>
+              <tr><td>yyyyyyyyyyyyy</td></tr>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert chunks == [
+            ("Region", "<table><tr><td>Region</td></tr></table>"),
+            ("xxxxxxxxxxxxx", "<table><tr><td>xxxxxxxxxxxxx</td></tr></table>"),
+            ("yyyyyyyyyyyyy", "<table><tr><td>yyyyyyyyyyyyy</td></tr></table>"),
+        ]
+        # -- no cell text lost or duplicated across the whole set of chunks --
+        combined_text = " ".join(text for text, _ in chunks)
+        for word in ("Region", "xxxxxxxxxxxxx", "yyyyyyyyyyyyy"):
+            assert combined_text.count(word) == 1
+
+    def and_it_bounds_a_rowspan_0_header_to_its_own_thead_instead_of_the_whole_table(self):
+        """`rowspan="0"` spans every remaining row in its OWN row-group, not the whole table. A
+        one-row `<thead>` closes the header's span there; the following `<tbody>` must still
+        chunk normally instead of being swallowed into one unbounded group with the header."""
+        opts = ChunkingOptions(max_characters=200)
+        body_rows = "".join(f"<tr><td>{i:040d}</td></tr>" for i in range(50))
+        html_table = HtmlTable.from_html_text(
+            f"""
+            <table>
+              <thead><tr><th rowspan="0">Header</th></tr></thead>
+              <tbody>{body_rows}</tbody>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert len(chunks) > 1
+        for _, html in chunks:
+            assert len(html) < 300
+        # -- the header's one-row group is emitted alone, with an implicit rowspan (no attribute) --
+        assert chunks[0][1] == "<table><tr><td>Header</td></tr></table>"
+        assert chunks[0][1].count("<tr>") == 1
+
+    def and_it_bounds_a_rowspan_0_header_even_when_a_huge_window_would_otherwise_merge_sections(
+        self,
+    ):
+        """The row-group boundary must hold even when the character budget alone would happily
+        pack the header and every body row into one chunk -- it is model-derived, not a lucky
+        side-effect of a small `max_characters` accidentally forcing separate chunks."""
+        opts = ChunkingOptions(max_characters=100_000)
+        body_rows = "".join(f"<tr><td>{i:040d}</td></tr>" for i in range(50))
+        html_table = HtmlTable.from_html_text(
+            f"""
+            <table>
+              <thead><tr><th rowspan="0">Header</th></tr></thead>
+              <tbody>{body_rows}</tbody>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert len(chunks) == 2
+        assert chunks[0][1] == "<table><tr><td>Header</td></tr></table>"
+        assert chunks[1][1].count("<tr>") == 50
+
+    def and_no_emitted_chunk_lets_a_span_reparse_across_its_source_row_group(self):
+        """General invariant check: reparsing each emitted chunk must never reveal a `rowspan`
+        binding rows that came from two different source row-groups -- if it did, the chunk's
+        own `rowspan` count would exceed the rows the chunk actually has (or would have, on a
+        different split), silently reintroducing the corruption this whole feature prevents."""
+        opts = ChunkingOptions(max_characters=200)
+        body_rows = "".join(f"<tr><td>{i:040d}</td></tr>" for i in range(50))
+        html_table = HtmlTable.from_html_text(
+            f"""
+            <table>
+              <thead><tr><th rowspan="0">Header</th></tr></thead>
+              <tbody>{body_rows}</tbody>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        for _, html in chunks:
+            reparsed = HtmlTable.from_html_text(html)
+            rows = list(reparsed.iter_rows())
+            for idx, row in enumerate(rows):
+                if row.max_rowspan is not None:
+                    assert idx + row.max_rowspan - 1 < len(rows)
+
+    def and_it_lets_a_positive_rowspan_reach_from_one_tbody_into_a_following_tfoot(self):
+        """A positive `rowspan` declared inside one `<tbody>` may legitimately reach into a
+        following `<tbody>` or `<tfoot>` -- that is valid HTML, the continuation row in the next
+        section omits the covered column, relying on the earlier section's cell to still cover
+        it. The overdeclared "5" is rewritten to "3", the table's actual total row count, since
+        that is as far as it can truly reach, not to the tbody's own 2-row count."""
+        opts = ChunkingOptions(max_characters=70)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tbody>
+                <tr><td rowspan="5">AAAAAAAAAAAAAAAAAAAA</td><td>xxxxxxxxxxxxxxxxxxxx</td></tr>
+                <tr><td>yyyyyyyyyyyyyyyyyyyy</td></tr>
+              </tbody>
+              <tfoot>
+                <tr><td>zzzzzzzzzzzzzzzzzzzz</td></tr>
+              </tfoot>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        # -- the merged group (tbody + tfoot) is bigger than `max_characters`, so it's split on a
+        # -- row boundary; the covering cell is re-materialized (rowspan="1") in the tfoot's own
+        # -- fragment, which doesn't include the row that originally declared the span --
+        assert chunks == [
+            (
+                "AAAAAAAAAAAAAAAAAAAA xxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyyy",
+                "<table>"
+                '<tr><td rowspan="2">AAAAAAAAAAAAAAAAAAAA</td><td>xxxxxxxxxxxxxxxxxxxx</td></tr>'
+                "<tr><td>yyyyyyyyyyyyyyyyyyyy</td></tr>"
+                "</table>",
+            ),
+            (
+                "AAAAAAAAAAAAAAAAAAAA zzzzzzzzzzzzzzzzzzzz",
+                "<table><tr><td>AAAAAAAAAAAAAAAAAAAA</td><td>zzzzzzzzzzzzzzzzzzzz</td></tr></table>",
+            ),
+        ]
+
+    def and_it_merges_tbody_and_tfoot_into_one_chunk_when_a_huge_window_allows_it(self):
+        """A positive `rowspan`'s reach across a `<tbody>`/`<tfoot>` boundary is not an artifact
+        of a tight character budget -- with a window large enough to hold every row, the whole
+        table (tbody + tfoot) is emitted as a single chunk, and the overdeclared "5" is rewritten
+        to "4", the table's actual total row count."""
+        opts = ChunkingOptions(max_characters=100_000)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tbody>
+                <tr><td rowspan="5">AAAAAAAAAAAAAAAAAAAA</td><td>xxxxxxxxxxxxxxxxxxxx</td></tr>
+                <tr><td>yyyyyyyyyyyyyyyyyyyy</td></tr>
+              </tbody>
+              <tfoot>
+                <tr><td>zzzzzzzzzzzzzzzzzzzz</td></tr>
+                <tr><td>wwwwwwwwwwwwwwwwwwww</td></tr>
+              </tfoot>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert chunks == [
+            (
+                "AAAAAAAAAAAAAAAAAAAA xxxxxxxxxxxxxxxxxxxx yyyyyyyyyyyyyyyyyyyy "
+                "zzzzzzzzzzzzzzzzzzzz wwwwwwwwwwwwwwwwwwww",
+                "<table>"
+                '<tr><td rowspan="4">AAAAAAAAAAAAAAAAAAAA</td><td>xxxxxxxxxxxxxxxxxxxx</td></tr>'
+                "<tr><td>yyyyyyyyyyyyyyyyyyyy</td></tr>"
+                "<tr><td>zzzzzzzzzzzzzzzzzzzz</td></tr>"
+                "<tr><td>wwwwwwwwwwwwwwwwwwww</td></tr>"
+                "</table>",
+            ),
+        ]
+
+    def and_it_splits_a_tbody_tfoot_spanning_group_through_the_public_chunk_by_title_path(self):
+        """Same tbody-into-tfoot reach, exercised through the public `chunk_by_title()` entry
+        point with a window too small to hold the whole merged group: every emitted chunk must
+        still respect `max_characters`, and no cell text may be lost across the whole set."""
+        pd = pytest.importorskip("pandas")
+        html = (
+            "<table>"
+            "<tbody>"
+            '<tr><td rowspan="5">alpha bravo charlie</td><td>delta echo foxtrot</td></tr>'
+            "<tr><td>golf hotel india</td></tr>"
+            "</tbody>"
+            "<tfoot>"
+            "<tr><td>juliet kilo lima</td></tr>"
+            "<tr><td>mike november oscar</td></tr>"
+            "</tfoot>"
+            "</table>"
+        )
+        text = (
+            "alpha bravo charlie delta echo foxtrot golf hotel india "
+            "juliet kilo lima mike november oscar"
+        )
+        table = Table(text, metadata=ElementMetadata(text_as_html=html))
+
+        chunks = chunk_by_title([table], max_characters=75)
+
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert isinstance(chunk, TableChunk)
+            assert len(chunk.text) <= 75
+            html_out = chunk.metadata.text_as_html
+            assert html_out is not None
+            assert html_out.startswith("<table>")
+            assert html_out.endswith("</table>")
+            # -- the covering cell ("alpha bravo charlie") is re-materialized into whichever
+            # -- fragment doesn't hold its origin row, so every row -- tbody or tfoot -- keeps
+            # -- its correct column 0 value in every chunk that contains it --
+            grid = pd.read_html(io.StringIO(html_out))[0].to_numpy().tolist()
+            for row in grid:
+                if row[1] in ("golf hotel india", "juliet kilo lima", "mike november oscar"):
+                    assert row[0] == "alpha bravo charlie"
+        # -- no cell text lost across the whole set of chunks -- the covering cell's own text is
+        # -- allowed to repeat, once per fragment it spans, per the class docstring --
+        combined_text = " ".join(chunk.text for chunk in chunks)
+        for word in ("delta", "golf", "juliet", "mike"):
+            assert combined_text.count(word) == 1
+
+    def and_an_exactly_fitting_positive_rowspan_is_emitted_unchanged(self):
+        """A `rowspan` whose declared value already matches its own row-group's row count is
+        never rewritten -- the self-correction is a no-op whenever the declared value was
+        already honest, so ordinary, correct tables see no behavior change at all."""
+        opts = ChunkingOptions(max_characters=100)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tr><td rowspan="2">A</td><td>B</td></tr>
+              <tr><td>C</td></tr>
+            </table>
+            """
+        )
+
+        assert list(_HtmlTableSplitter.iter_subtables(html_table, opts)) == [
+            (
+                "A B C",
+                '<table><tr><td rowspan="2">A</td><td>B</td></tr><tr><td>C</td></tr></table>',
+            ),
+        ]
+
+    def and_it_lets_a_positive_thead_rowspan_reach_into_the_tbody_regardless_of_repetition(self):
+        """A `<thead>` row's positive `rowspan` reaching into the `<tbody>` is valid HTML whether
+        or not header repetition is configured -- `repeat_table_headers` only governs a
+        *repeated copy* injected on a continuation chunk (see `_prepend_repeated_headers`), never
+        the header's own original occurrence, which is bound by its true reach like any other
+        row. Here that reach ("3") exactly matches the table's total row count, so nothing is
+        clipped at all."""
+        pd = pytest.importorskip("pandas")
+        opts = ChunkingOptions(max_characters=200)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <thead><tr><th rowspan="3">Header</th><th>HX</th></tr></thead>
+              <tbody>
+                <tr><td>A</td><td>B</td></tr>
+                <tr><td>C</td><td>D</td></tr>
+              </tbody>
+            </table>
+            """
+        )
+
+        # -- header_row_count=0 (the default) means no repeat-header injection applies here --
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert chunks == [
+            (
+                "Header HX A B C D",
+                "<table>"
+                '<tr><td rowspan="3">Header</td><td>HX</td></tr>'
+                "<tr><td>A</td><td>B</td></tr>"
+                "<tr><td>C</td><td>D</td></tr>"
+                "</table>",
+            ),
+        ]
+        grid = pd.read_html(io.StringIO(chunks[0][1]))[0].to_numpy().tolist()
+        assert [row[0] for row in grid] == ["Header"] * 3
+
+    def and_it_lets_a_positive_span_from_a_tbody_bind_a_later_direct_row_of_the_same_key(self):
+        """A `rowspan` declared inside an explicit `<tbody>` may legitimately reach into a
+        following direct (sectionless) row -- valid HTML, and no different from reaching into
+        another `<tbody>` or `<tfoot>`. Here the declared "2" already matches its true reach
+        (the `<tbody>` row plus the one direct row after it), so nothing is clipped, and the two
+        rows are packed into the same chunk as the unrelated leading "Lead" row since there's
+        room for all three."""
+        pd = pytest.importorskip("pandas")
+        opts = ChunkingOptions(max_characters=200)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tr><td>Lead</td><td>X</td></tr>
+              <tbody><tr><td rowspan="2">Scoped</td><td>Inside</td></tr></tbody>
+              <tr><td>After</td><td>Y</td></tr>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert chunks == [
+            (
+                "Lead X Scoped Inside After Y",
+                "<table>"
+                "<tr><td>Lead</td><td>X</td></tr>"
+                '<tr><td rowspan="2">Scoped</td><td>Inside</td></tr>'
+                "<tr><td>After</td><td>Y</td></tr>"
+                "</table>",
+            ),
+        ]
+        grid = pd.read_html(io.StringIO(chunks[0][1]))[0].to_numpy().tolist()
+        assert grid[1][0] == "Scoped"
+        assert grid[2][:2] == ["Scoped", "After"]
+
+    def and_it_does_not_let_a_clipped_span_bind_a_later_direct_row_of_the_same_key(self):
+        """`_RowAccumulator` must compare a candidate group's row-group identity against the
+        MOST RECENTLY accumulated row-group, not the first one ever added to this accumulator --
+        a direct (sectionless) row before and after an explicit `<tbody>` both key by the same
+        `<table>` element, so comparing against the first accumulated row can mistake a real
+        transition (leaving the clipped tbody group) for "no change", letting the clipped span
+        bind the trailing direct row it was never meant to cover. `rowspan="0"` is used here
+        since it is the one span variety that still clips to its own row-group's end."""
+        opts = ChunkingOptions(max_characters=200)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tr><td>Lead</td><td>X</td></tr>
+              <tbody><tr><td rowspan="0">Scoped</td><td>Inside</td></tr></tbody>
+              <tr><td>After</td><td>Y</td></tr>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert len(chunks) == 2
+        for _, html in chunks:
+            reparsed = HtmlTable.from_html_text(html)
+            rows = list(reparsed.iter_rows())
+            for idx, row in enumerate(rows):
+                if row.max_rowspan is not None:
+                    assert idx + row.max_rowspan - 1 < len(rows)
+        # -- "Scoped"'s rowspan="0" is clipped to "1" (its own tbody has one row) --
+        assert (
+            chunks[0][1] == "<table><tr><td>Lead</td><td>X</td></tr>"
+            "<tr><td>Scoped</td><td>Inside</td></tr></table>"
+        )
+        assert chunks[1][1] == "<table><tr><td>After</td><td>Y</td></tr></table>"
+
+    def and_it_preserves_non_text_cell_content_when_correcting_a_clipped_rowspan(self):
+        """`HtmlRow.html_clipped_to_rows()` must only ever touch the `rowspan` attribute -- a
+        nested table, a hyperlink, an image-only cell, and any other cell attribute must survive
+        a correction completely unchanged."""
+        opts = ChunkingOptions(max_characters=100_000)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tbody>
+                <tr>
+                  <td rowspan="0">Group</td>
+                  <td data-note="keep-me">
+                    <table><tr><td>Q1</td><td>100</td></tr></table>
+                    <a href="https://example.com/details">details</a>
+                  </td>
+                  <td><img src="chart.png" alt="Chart"/></td>
+                </tr>
+                <tr><td>Other</td><td>row</td><td>content</td></tr>
+              </tbody>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        # -- rowspan="0" always goes through the correction path, exercising this cell's
+        # -- non-text content on every run, not only when a chunk boundary forces it --
+        assert chunks == [
+            (
+                "Group Q1100details Other row content",
+                "<table>"
+                '<tr><td rowspan="2">Group</td>'
+                "<td><table><tr><td>Q1</td><td>100</td></tr></table><a>details</a></td>"
+                "<td><img/></td></tr>"
+                "<tr><td>Other</td><td>row</td><td>content</td></tr>"
+                "</table>",
+            )
+        ]
+
+    def and_it_lets_the_theads_own_occurrence_bind_body_rows_it_legitimately_reaches(
+        self,
+    ):
+        """`Region`'s `rowspan="3"` legitimately reaches from its own `<thead>` into the first
+        two `<tbody>` rows -- valid HTML, and no different from any other cross-row-group reach.
+        Those two rows share a chunk with it; the third (`Midwest Territory`) lands in its own
+        continuation chunk with a REPEATED header copy that `_prepend_repeated_headers` injects
+        (a separate artifact built from `row.source_html`/`row.html`, wrapped in its own real
+        `<thead>`) -- and since only one header row is ever carried, that copy's `rowspan` is
+        clipped away rather than reaching into `Midwest Territory`'s row.
+
+        Verified by reparsing each chunk's own emitted HTML with `pandas.read_html` (which
+        correctly honors `rowspan`/`colspan` when building a grid) and checking that no body
+        value has been shifted into the wrong column -- a genuine geometry check, not just a
+        string/row-count comparison."""
+        pd = pytest.importorskip("pandas")
+        html = (
+            "<table>"
+            "<thead>"
+            '<tr><th rowspan="3">Region</th><th>Quarter</th></tr>'
+            "</thead>"
+            "<tbody>"
+            "<tr><td>NW</td><td>Q1</td></tr>"
+            "<tr><td>Southwest Territory</td><td>Q2</td></tr>"
+            "<tr><td>Midwest Territory</td><td>Q3</td></tr>"
+            "</tbody>"
+            "</table>"
+        )
+        text = "Region Quarter NW Q1 Southwest Territory Q2 Midwest Territory Q3"
+        table = Table(text, metadata=ElementMetadata(text_as_html=html))
+
+        chunks = chunk_by_title([table], max_characters=60, repeat_table_headers=True)
+
+        assert len(chunks) > 1
+        for chunk in chunks:
+            html_out = chunk.metadata.text_as_html
+            assert html_out is not None
+            grid = pd.read_html(io.StringIO(html_out))[0].to_numpy().tolist()
+            for row in grid:
+                if "NW" in row:
+                    assert row[0] == "Region"
+                    assert row[1] == "NW"
+                    assert row[2] == "Q1"
+                if "Southwest Territory" in row:
+                    assert row[0] == "Region"
+                    assert row[1] == "Southwest Territory"
+                    assert row[2] == "Q2"
+                if "Midwest Territory" in row:
+                    # -- the repeated header's own rowspan was clipped away, so this row is not
+                    # -- shifted by a stray "Region" column --
+                    assert row[0] == "Midwest Territory"
+                    assert row[1] == "Q3"
+        # -- no cell text lost or duplicated across the whole set of chunks --
+        combined_text = " ".join(chunk.text for chunk in chunks)
+        for word in ("NW", "Southwest", "Midwest"):
+            assert combined_text.count(word) == 1
+
+    def and_it_bounds_a_positive_rowspan_whose_own_row_is_oversized_even_alone(self):
+        """`Region`'s `rowspan="3"` exactly reaches the table's last row, so it opens a 3-row
+        group (thead + both tbody rows), not a singleton -- but its own row alone (with the huge
+        second cell) is too big to fit even by itself, so the group degrades all the way to
+        `_CellAccumulator`, which serializes a cell's real `.html` including its original
+        `rowspan`. That span must be bounded before reaching the row splitter, or it survives
+        uncorrected into the sub-chunk even though `Region` is now emitted alone."""
+        opts = ChunkingOptions(max_characters=20)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <thead>
+                <tr>
+                  <th rowspan="3">Region</th><th>zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr><td>NW</td><td>Q1</td></tr>
+                <tr><td>SW</td><td>Q2</td></tr>
+              </tbody>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        # -- "Region"'s own cell-level sub-chunk carries no rowspan claim at all --
+        assert chunks[0] == ("Region", "<table><tr><td>Region</td></tr></table>")
+
+    def and_it_bounds_a_rowspan_0_in_a_multi_cell_oversized_singleton_row(self):
+        """Same reachable gap as the positive-rowspan case above, for `rowspan="0"` specifically
+        -- HTML's own "spans every remaining row" form, which this codebase always treats as
+        clipped (there is no literal count to fall back on)."""
+        opts = ChunkingOptions(max_characters=20)
+        html_table = HtmlTable.from_html_text(
+            """
+            <table>
+              <tbody>
+                <tr>
+                  <td rowspan="0">Region</td><td>zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz</td>
+                </tr>
+              </tbody>
+            </table>
+            """
+        )
+
+        chunks = list(_HtmlTableSplitter.iter_subtables(html_table, opts))
+
+        assert chunks[0] == ("Region", "<table><tr><td>Region</td></tr></table>")
+
+    def and_it_bounds_a_singleton_oversized_rows_span_through_chunk_by_title_and_reconstruction(
+        self,
+    ):
+        """End-to-end through the public `chunk_by_title()` entry point, then back through
+        `reconstruct_table_from_chunks()` -- the actual round-trip a caller performs -- reparsing
+        the reconstructed table with `pandas.read_html()` (which honors `rowspan`/`colspan` when
+        building a grid) to catch real column-shift corruption, not just inspect chunk strings."""
+        pd = pytest.importorskip("pandas")
+        html = (
+            "<table>"
+            "<thead>"
+            '<tr><th rowspan="3">Region</th><th>' + "z" * 150 + "</th></tr>"
+            "</thead>"
+            "<tbody>"
+            "<tr><td>NW</td><td>Q1</td></tr>"
+            "<tr><td>Southwest Territory</td><td>Q2</td></tr>"
+            "</tbody>"
+            "</table>"
+        )
+        text = "Region " + "z" * 150 + " NW Q1 Southwest Territory Q2"
+        table = Table(text, metadata=ElementMetadata(text_as_html=html))
+
+        chunks = chunk_by_title([table], max_characters=50, repeat_table_headers=False)
+        [reconstructed] = reconstruct_table_from_chunks(chunks)
+
+        html_out = reconstructed.metadata.text_as_html
+        assert html_out is not None
+        grid = pd.read_html(io.StringIO(html_out))[0].to_numpy().tolist()
+        # -- an uncorrected rowspan="3" reaches 3 rows deep, so check the rows immediately
+        # -- following "Region" rather than the much-later NW/Southwest Territory rows --
+        assert grid[0][0] == "Region"
+        for row in grid[1:9]:
+            assert row[0] != "Region", f"a later row still carries Region's uncorrected span: {row}"
+        for row in grid:
+            if "NW" in row:
+                assert row == ["NW", "Q1"]
+            if "Southwest Territory" in row:
+                assert row == ["Southwest Territory", "Q2"]
+        # -- no cell text lost or duplicated across the whole reconstructed table --
+        combined_text = reconstructed.text
+        for word in ("Region", "NW", "Southwest"):
+            assert combined_text.count(word) == 1
 
 
 class Describe_TextSplitter:
@@ -3217,7 +3994,7 @@ class Describe_RowAccumulator:
         accum = _RowAccumulator(maxlen=100)
         row = HtmlRow(fragment_fromstring("<tr><td>foo</td><td>bar</td></tr>"))
 
-        accum.add_row(row)
+        accum.add_rows([row])
 
         assert accum._rows == [row]
         assert accum._row_text_len == len("foo bar")
@@ -3226,8 +4003,8 @@ class Describe_RowAccumulator:
         accum = _RowAccumulator(maxlen=3, measure=lambda text: len(text.split()))
         row = HtmlRow(fragment_fromstring("<tr><td>supercalifragilisticexpialidocious</td></tr>"))
 
-        assert accum.will_fit(row) is True
-        accum.add_row(row)
+        assert accum.will_fit([row]) is True
+        accum.add_rows([row])
 
         # -- one token of text plus one separator leaves one token of space --
         assert accum._remaining_space == 1
@@ -3251,7 +4028,7 @@ class Describe_RowAccumulator:
         accum = _RowAccumulator(maxlen=21)
         row = HtmlRow(fragment_fromstring(row_html))
 
-        assert accum.will_fit(row) is expected_value
+        assert accum.will_fit([row]) is expected_value
 
     @pytest.mark.parametrize(
         ("row_html", "expected_value"),
@@ -3270,15 +4047,17 @@ class Describe_RowAccumulator:
     ):
         """There is no overhead beyond row HTML for additional rows."""
         accum = _RowAccumulator(maxlen=48)
-        accum.add_row(HtmlRow(fragment_fromstring("<tr><td>abcdefghijklmnopqrstuvwxyz</td></tr>")))
+        accum.add_rows(
+            [HtmlRow(fragment_fromstring("<tr><td>abcdefghijklmnopqrstuvwxyz</td></tr>"))]
+        )
         # -- remaining space is 48 - 26 = 21 --
         row = HtmlRow(fragment_fromstring(row_html))
 
-        assert accum.will_fit(row) is expected_value
+        assert accum.will_fit([row]) is expected_value
 
     def it_generates_a_TextAndHtml_pair_and_resets_itself_to_empty_when_flushed(self):
         accum = _RowAccumulator(maxlen=100)
-        accum.add_row(HtmlRow(fragment_fromstring("<tr><td>abcde fghij klmno</td></tr>")))
+        accum.add_rows([HtmlRow(fragment_fromstring("<tr><td>abcde fghij klmno</td></tr>"))])
 
         text, html = next(accum.flush())
 
@@ -3289,8 +4068,8 @@ class Describe_RowAccumulator:
 
     def and_the_HTML_contains_as_many_rows_as_were_accumulated(self):
         accum = _RowAccumulator(maxlen=100)
-        accum.add_row(HtmlRow(fragment_fromstring("<tr><td>abcde fghij klmno</td></tr>")))
-        accum.add_row(HtmlRow(fragment_fromstring("<tr><td>pqrst uvwxy z</td></tr>")))
+        accum.add_rows([HtmlRow(fragment_fromstring("<tr><td>abcde fghij klmno</td></tr>"))])
+        accum.add_rows([HtmlRow(fragment_fromstring("<tr><td>pqrst uvwxy z</td></tr>"))])
 
         text, html = next(accum.flush())
 

--- a/test_unstructured/common/test_html_table.py
+++ b/test_unstructured/common/test_html_table.py
@@ -11,7 +11,9 @@ from unstructured.common.html_table import (
     HtmlCell,
     HtmlRow,
     HtmlTable,
+    collapse_matrix_of_keyed_cells_to_spans,
     htmlify_matrix_of_cell_texts,
+    htmlify_matrix_of_spanned_cell_texts,
 )
 
 
@@ -41,6 +43,112 @@ class Describe_htmlify_matrix_of_cell_texts:
 
     def test_htmlify_matrix_handles_empty_matrix(self):
         assert htmlify_matrix_of_cell_texts([]) == ""
+
+
+class Describe_htmlify_matrix_of_spanned_cell_texts:
+    """Unit-test suite for `html_table.htmlify_matrix_of_spanned_cell_texts()`."""
+
+    def it_emits_plain_cells_when_no_span_is_greater_than_1(self):
+        assert htmlify_matrix_of_spanned_cell_texts(
+            [[("a", 1, 1), ("b", 1, 1)], [("c", 1, 1), ("d", 1, 1)]]
+        ) == ("<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>")
+
+    def it_emits_colspan_and_rowspan_attributes_only_when_greater_than_1(self):
+        assert htmlify_matrix_of_spanned_cell_texts([[("a", 2, 3)], [("b", 1, 1)]]) == (
+            '<table><tr><td colspan="2" rowspan="3">a</td></tr><tr><td>b</td></tr></table>'
+        )
+
+    def it_emits_a_void_td_for_an_empty_spanned_cell(self):
+        assert htmlify_matrix_of_spanned_cell_texts([[("", 2, 1)]]) == (
+            '<table><tr><td colspan="2"/></tr></table>'
+        )
+
+    def it_emits_an_empty_tr_for_a_row_entirely_consumed_by_a_rowspan(self):
+        """A row with no originating cells still needs its own `<tr>`.
+
+        HTML `rowspan` counts actual `<tr>` elements, not "rows that happened to have content";
+        dropping this row would shift the column-placement of every row after it.
+        """
+        assert htmlify_matrix_of_spanned_cell_texts([[("a", 1, 2)], [], [("b", 1, 1)]]) == (
+            '<table><tr><td rowspan="2">a</td></tr><tr></tr><tr><td>b</td></tr></table>'
+        )
+
+    def it_handles_an_empty_matrix(self):
+        assert htmlify_matrix_of_spanned_cell_texts([]) == ""
+
+    def it_renders_a_full_width_vertical_merge_via_the_full_collapse_and_render_pipeline(self):
+        """Regression: `collapse_matrix_of_keyed_cells_to_spans()` and
+        `htmlify_matrix_of_spanned_cell_texts()` were each unit-tested individually, but their
+        interaction was not -- the collapse step legitimately produces an empty row for a grid-row
+        entirely covered by a multi-column `rowspan`, and the render step must still emit a `<tr>`
+        for it rather than suppressing it.
+        """
+        keyed_matrix = [
+            [("a", "M"), ("a", "M")],
+            [("a", "M"), ("a", "M")],
+            [("c", "C1"), ("d", "C2")],
+        ]
+        spanned_matrix = collapse_matrix_of_keyed_cells_to_spans(keyed_matrix)
+        assert spanned_matrix == [[("a", 2, 2)], [], [("c", 1, 1), ("d", 1, 1)]]
+        assert htmlify_matrix_of_spanned_cell_texts(spanned_matrix) == (
+            '<table><tr><td colspan="2" rowspan="2">a</td></tr>'
+            "<tr></tr>"
+            "<tr><td>c</td><td>d</td></tr></table>"
+        )
+
+
+class Describe_collapse_matrix_of_keyed_cells_to_spans:
+    """Unit-test suite for `html_table.collapse_matrix_of_keyed_cells_to_spans()`."""
+
+    def it_leaves_a_matrix_with_no_repeated_keys_unchanged(self):
+        matrix = [[("a", 1), ("b", 2)], [("c", 3), ("d", 4)]]
+        assert collapse_matrix_of_keyed_cells_to_spans(matrix) == [
+            [("a", 1, 1), ("b", 1, 1)],
+            [("c", 1, 1), ("d", 1, 1)],
+        ]
+
+    def it_collapses_a_horizontal_run_of_matching_keys_into_a_colspan(self):
+        matrix = [[("a", 1), ("a", 1), ("b", 2)]]
+        assert collapse_matrix_of_keyed_cells_to_spans(matrix) == [[("a", 2, 1), ("b", 1, 1)]]
+
+    def it_collapses_a_vertical_run_of_matching_keys_into_a_rowspan(self):
+        matrix = [[("a", 1)], [("a", 1)], [("b", 2)]]
+        assert collapse_matrix_of_keyed_cells_to_spans(matrix) == [
+            [("a", 1, 2)],
+            [],
+            [("b", 1, 1)],
+        ]
+
+    def it_collapses_a_rectangular_region_into_a_single_cell_with_colspan_and_rowspan(self):
+        """Reproduces the docx-tables.docx merged-cell fixture geometry.
+
+        +---+-------+
+        | a | b     |
+        |   +---+---+
+        |   | c | d |
+        +---+---+   |
+        | e     |   |
+        +-------+---+
+        """
+        matrix = [
+            [("a", 1), ("b", 2), ("b", 2)],
+            [("a", 1), ("c", 3), ("d", 4)],
+            [("e", 5), ("e", 5), ("d", 4)],
+        ]
+        assert collapse_matrix_of_keyed_cells_to_spans(matrix) == [
+            [("a", 1, 2), ("b", 2, 1)],
+            [("c", 1, 1), ("d", 1, 2)],
+            [("e", 2, 1)],
+        ]
+
+    def it_treats_distinct_keys_as_never_merged_even_when_their_text_matches(self):
+        matrix = [[("", 1), ("", 2)]]
+        assert collapse_matrix_of_keyed_cells_to_spans(matrix) == [
+            [("", 1, 1), ("", 1, 1)],
+        ]
+
+    def it_handles_an_empty_matrix(self):
+        assert collapse_matrix_of_keyed_cells_to_spans([]) == []
 
 
 class DescribeHtmlTable:
@@ -288,6 +396,10 @@ class DescribeHtmlCell:
         assert HtmlCell(fragment_fromstring("<td><a href='#'>Category Link</a></td>")).html == (
             '<td><a href="#">Category Link</a></td>'
         )
+
+    def and_it_preserves_colspan_and_rowspan_on_an_empty_cell(self):
+        cell = HtmlCell(fragment_fromstring('<td colspan="2" rowspan="3"></td>'))
+        assert cell.html == '<td colspan="2" rowspan="3"/>'
 
     @pytest.mark.parametrize(
         ("cell_html", "expected_value"),

--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -1551,3 +1551,168 @@ def test_partition_html_leaves_page_number_None_when_not_present():
     html_text = "<html><body><p>No page markup.</p></body></html>"
     elements = partition_html(text=html_text)
     assert all(e.metadata.page_number is None for e in elements)
+
+@pytest.mark.parametrize(
+    "encoding",
+    (
+        "application/x-tex",
+        "TeX",
+        "latex",
+        "application/x-latex",
+    ),
+)
+def test_partition_html_preserves_tex_math_annotations(encoding: str):
+    html = f"""
+    <html>
+      <body>
+        <p>
+          The value is
+          <math>
+            <semantics>
+              <mrow>
+                <msup>
+                  <mi>x</mi>
+                  <mn>2</mn>
+                </msup>
+              </mrow>
+              <annotation encoding="{encoding}">x^{{2}}</annotation>
+            </semantics>
+          </math>
+          units.
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert len(elements) == 1
+    assert elements[0].text == "The value is x^{2} units."
+
+def test_partition_html_uses_math_alttext_when_tex_annotation_is_absent():
+    html = r"""
+    <html>
+      <body>
+        <p>
+          The value is
+          <math alttext="\sqrt{2}">
+            <mrow>
+              <msqrt>
+                <mn>2</mn>
+              </msqrt>
+            </mrow>
+          </math>
+          approximately.
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert len(elements) == 1
+    assert elements[0].text == r"The value is \sqrt{2} approximately."
+
+def test_partition_html_prefers_tex_annotation_over_math_alttext():
+    html = r"""
+    <html>
+      <body>
+        <p>
+          Value:
+          <math alttext="wrong fallback">
+            <semantics>
+              <mrow>
+                <mi>x</mi>
+              </mrow>
+              <annotation encoding="application/x-tex">x^{2}</annotation>
+            </semantics>
+          </math>
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert len(elements) == 1
+    assert elements[0].text == r"Value: x^{2}"
+
+def test_partition_html_falls_back_to_math_alttext_when_tex_annotation_is_empty():
+    html = r"""
+    <html>
+      <body>
+        <p>
+          Value:
+          <math alttext="x^{2}">
+            <semantics>
+              <mrow>
+                <mi>x</mi>
+              </mrow>
+              <annotation encoding="application/x-tex">   </annotation>
+            </semantics>
+          </math>
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert len(elements) == 1
+    assert elements[0].text == r"Value: x^{2}"
+
+def test_partition_html_preserves_text_after_math_element():
+    html = r"""
+    <html>
+      <body>
+        <p>Before <math alttext="x^{2}"></math> after the equation.</p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert len(elements) == 1
+    assert elements[0].text == r"Before x^{2} after the equation."
+
+def test_partition_html_preserves_multiple_inline_math_elements():
+    html = r"""
+    <html>
+      <body>
+        <p>
+          Complexity decreases from
+          <math alttext="O(n^2)"></math>
+          to
+          <math alttext="O(n^2/r)"></math>.
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert len(elements) == 1
+    assert elements[0].text == "Complexity decreases from O(n^2) to O(n^2/r)."
+
+def test_partition_html_ignores_unrecognized_math_annotation_encoding():
+    html = r"""
+    <html>
+      <body>
+        <p>
+          Value:
+          <math alttext="x^{2}">
+            <semantics>
+              <annotation encoding="application/x-some-proprietary-format">
+                garbage
+              </annotation>
+            </semantics>
+          </math>
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert len(elements) == 1
+    assert elements[0].text == r"Value: x^{2}"

--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -1615,7 +1615,7 @@ def test_partition_html_uses_math_alttext_when_tex_annotation_is_absent():
     assert len(elements) == 1
     assert elements[0].text == r"The value is \sqrt{2} approximately."
 
-def test_partition_html_prefers_math_alttext_over_tex_annotation():
+def test_partition_html_prefers_tex_annotation_over_math_alttext():
     html = r"""
     <html>
       <body>
@@ -1637,7 +1637,88 @@ def test_partition_html_prefers_math_alttext_over_tex_annotation():
     elements = partition_html(text=html)
 
     assert len(elements) == 1
-    assert elements[0].text == "Value: preferred alttext"
+    assert elements[0].text == r"Value: x^{2}"
+
+
+@pytest.mark.parametrize(
+    "math_contents",
+    (
+        # -- the semantics node only describes the first part of the root expression --
+        """
+        <semantics>
+          <mi>x</mi>
+          <annotation encoding="tex">x</annotation>
+        </semantics>
+        <mo>+</mo>
+        <mi>y</mi>
+        """,
+        # -- the semantics node only describes the last part of the root expression --
+        """
+        <mi>x</mi>
+        <mo>+</mo>
+        <semantics>
+          <mi>y</mi>
+          <annotation encoding="tex">y</annotation>
+        </semantics>
+        """,
+        # -- multiple semantics children cannot each represent the complete root expression --
+        """
+        <semantics>
+          <mi>x</mi>
+          <annotation encoding="tex">x</annotation>
+        </semantics>
+        <semantics>
+          <mi>y</mi>
+          <annotation encoding="tex">y</annotation>
+        </semantics>
+        """,
+    ),
+)
+def test_partition_html_uses_math_alttext_when_semantics_does_not_cover_root_expression(
+    math_contents: str,
+):
+    html = f"""
+    <html>
+      <body>
+        <p>
+          Value:
+          <math alttext="x+y">
+            {math_contents}
+          </math>
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Value: x+y"]
+
+
+@pytest.mark.parametrize(
+    ("before_semantics", "after_semantics"),
+    (("x+", ""), ("", "+y")),
+)
+def test_partition_html_uses_math_alttext_when_semantics_has_root_text_outside_it(
+    before_semantics: str, after_semantics: str
+):
+    html = f"""
+    <html>
+      <body>
+        <p>
+          Value:
+          <math alttext="x+y">{before_semantics}<semantics>
+            <mi>x</mi>
+            <annotation encoding="tex">x</annotation>
+          </semantics>{after_semantics}</math>
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Value: x+y"]
 
 def test_partition_html_falls_back_to_math_alttext_when_tex_annotation_is_empty():
     html = r"""
@@ -1834,6 +1915,34 @@ def test_partition_html_preserves_page_number_on_display_math():
 
     assert [element.text for element in elements] == ["Before", "x=1", "After"]
     assert [element.metadata.page_number for element in elements] == [7, 7, 7]
+
+
+def test_partition_html_preserves_katex_visual_fallback_in_table_cells():
+    html = r"""
+    <html>
+      <body>
+        <table>
+          <tr>
+            <td>
+              <span class="katex">
+                <span class="katex-mathml">
+                  <math alttext="x^2"></math>
+                </span>
+                <span class="katex-html" aria-hidden="true">
+                  <span class="base"><span>x</span><span>2</span></span>
+                </span>
+              </span>
+            </td>
+          </tr>
+        </table>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert elements == [Table("x 2")]
+    assert elements[0].metadata.text_as_html == "<table><tr><td>x 2</td></tr></table>"
 
 
 def test_partition_html_does_not_duplicate_paired_katex_output():

--- a/test_unstructured/partition/html/test_partition.py
+++ b/test_unstructured/partition/html/test_partition.py
@@ -1557,6 +1557,8 @@ def test_partition_html_leaves_page_number_None_when_not_present():
     (
         "application/x-tex",
         "TeX",
+        "tex",
+        "TEX",
         "latex",
         "application/x-latex",
     ),
@@ -1613,13 +1615,13 @@ def test_partition_html_uses_math_alttext_when_tex_annotation_is_absent():
     assert len(elements) == 1
     assert elements[0].text == r"The value is \sqrt{2} approximately."
 
-def test_partition_html_prefers_tex_annotation_over_math_alttext():
+def test_partition_html_prefers_math_alttext_over_tex_annotation():
     html = r"""
     <html>
       <body>
         <p>
           Value:
-          <math alttext="wrong fallback">
+          <math alttext="preferred alttext">
             <semantics>
               <mrow>
                 <mi>x</mi>
@@ -1635,7 +1637,7 @@ def test_partition_html_prefers_tex_annotation_over_math_alttext():
     elements = partition_html(text=html)
 
     assert len(elements) == 1
-    assert elements[0].text == r"Value: x^{2}"
+    assert elements[0].text == "Value: preferred alttext"
 
 def test_partition_html_falls_back_to_math_alttext_when_tex_annotation_is_empty():
     html = r"""
@@ -1716,3 +1718,253 @@ def test_partition_html_ignores_unrecognized_math_annotation_encoding():
 
     assert len(elements) == 1
     assert elements[0].text == r"Value: x^{2}"
+
+
+def test_partition_html_uses_outer_math_annotation_not_nested_semantics_annotation():
+    html = r"""
+    <html>
+      <body>
+        <p>
+          Value:
+          <math>
+            <semantics>
+              <mrow>
+                <math>
+                  <semantics>
+                    <mi>x</mi>
+                    <annotation encoding="tex">INNER</annotation>
+                  </semantics>
+                </math>
+              </mrow>
+              <annotation encoding="tex">OUTER</annotation>
+            </semantics>
+          </math>
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Value: OUTER"]
+
+
+def test_partition_html_skips_empty_math_annotation_and_uses_later_supported_annotation():
+    html = r"""
+    <html>
+      <body>
+        <p>
+          Value:
+          <math>
+            <semantics>
+              <mi>x</mi>
+              <annotation encoding="application/x-tex">   </annotation>
+              <annotation encoding="tex">x^{2}</annotation>
+            </semantics>
+          </math>
+        </p>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == [r"Value: x^{2}"]
+
+
+@pytest.mark.parametrize("display", ["block", "BLOCK", "Block"])
+def test_partition_html_emits_display_math_as_element_boundary(display: str):
+    html = f"""
+    <html>
+      <body>
+        <div>Before<math display="{display}" alttext="x=1"></math>After</div>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Before", "x=1", "After"]
+
+
+def test_partition_html_keeps_adjacent_display_math_as_separate_elements():
+    html = """
+    <html>
+      <body>
+        <div>
+          <math display="block" alttext="x=1"></math>
+          <math display="block" alttext="y=2"></math>
+        </div>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["x=1", "y=2"]
+
+
+@pytest.mark.parametrize("display_attribute", ["", ' display="inline"'])
+def test_partition_html_keeps_non_display_math_inline(display_attribute: str):
+    html = (
+        "<html><body><div>Before "
+        f'<math{display_attribute} alttext="x=1"></math>'
+        " After</div></body></html>"
+    )
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Before x=1 After"]
+
+
+def test_partition_html_preserves_page_number_on_display_math():
+    html = """
+    <html>
+      <body>
+        <div data-page-number="7">
+          Before
+          <math display="block" alttext="x=1"></math>
+          After
+        </div>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Before", "x=1", "After"]
+    assert [element.metadata.page_number for element in elements] == [7, 7, 7]
+
+
+def test_partition_html_does_not_duplicate_paired_katex_output():
+    html = r"""
+    <html>
+      <body>
+        <div>
+          Before
+          <span class="katex">
+            <span class="katex-mathml">
+              <math alttext="x^2">
+                <semantics>
+                  <msup><mi>x</mi><mn>2</mn></msup>
+                  <annotation encoding="application/x-tex">x^2</annotation>
+                </semantics>
+              </math>
+            </span>
+            <span class="katex-html" aria-hidden="true">
+              <span class="base"><span>x</span><span>2</span></span>
+            </span>
+          </span>
+          After
+        </div>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Before x^2 After"]
+    assert elements[0].text.count("x^2") == 1
+
+
+def test_partition_html_keeps_katex_html_when_mathml_is_unusable():
+    html = """
+    <html>
+      <body>
+        <div>
+          Before
+          <span class="katex">
+            <span class="katex-mathml">
+              <math>
+                <semantics><mi>x</mi></semantics>
+              </math>
+            </span>
+            <span class="katex-html" aria-hidden="true">
+              <span class="base"><span>x</span><span>2</span></span>
+            </span>
+          </span>
+          After
+        </div>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Before x2 After"]
+
+
+def test_partition_html_keeps_katex_html_only_output():
+    html = """
+    <html>
+      <body>
+        <div>
+          Before
+          <span class="katex">
+            <span class="katex-html" aria-hidden="true">
+              <span class="base"><span>x</span><span>2</span></span>
+            </span>
+          </span>
+          After
+        </div>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Before x2 After"]
+
+
+def test_partition_html_keeps_katex_mathml_only_output():
+    html = r"""
+    <html>
+      <body>
+        <div>
+          Before
+          <span class="katex">
+            <span class="katex-mathml">
+              <math alttext="x^2">
+                <semantics>
+                  <msup><mi>x</mi><mn>2</mn></msup>
+                  <annotation encoding="application/x-tex">x^2</annotation>
+                </semantics>
+              </math>
+            </span>
+          </span>
+          After
+        </div>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Before x^2 After"]
+
+
+def test_partition_html_keeps_two_separate_identical_katex_equations():
+    html = """
+    <html>
+      <body>
+        <div>
+          Before
+          <span class="katex">
+            <span class="katex-mathml"><math alttext="2"></math></span>
+            <span class="katex-html" aria-hidden="true"><span>2</span></span>
+          </span>
+          and
+          <span class="katex">
+            <span class="katex-mathml"><math alttext="2"></math></span>
+            <span class="katex-html" aria-hidden="true"><span>2</span></span>
+          </span>
+          After
+        </div>
+      </body>
+    </html>
+    """
+
+    elements = partition_html(text=html)
+
+    assert [element.text for element in elements] == ["Before 2 and 2 After"]
+    assert elements[0].text.count("2") == 2

--- a/test_unstructured/partition/test_docx.py
+++ b/test_unstructured/partition/test_docx.py
@@ -149,6 +149,134 @@ def test_partition_docx_processes_table():
     assert elements[0].metadata.filename == "fake_table.docx"
 
 
+def test_partition_docx_table_with_merged_cells_reports_spans_instead_of_duplicating_text():
+    """A merged cell's text must appear in exactly one `<td>`, marked with colspan/rowspan.
+
+    Fixture table is:
+
+        +---+-------+
+        | a | b     |
+        |   +---+---+
+        |   | c | d |
+        +---+---+   |
+        | e     |   |
+        +-------+---+
+    """
+    elements = partition_docx(example_doc_path("docx-tables.docx"), infer_table_structure=True)
+    tables = [e for e in elements if isinstance(e, Table)]
+    table = next(t for t in tables if t.text == "a b c d e")
+
+    assert table.metadata.text_as_html == (
+        "<table>"
+        '<tr><td rowspan="2">a</td><td colspan="2">b</td></tr>'
+        '<tr><td>c</td><td rowspan="2">d</td></tr>'
+        '<tr><td colspan="2">e</td></tr>'
+        "</table>"
+    )
+    # -- no cell's text is duplicated across more than one `<td>` --
+    for letter in "abcde":
+        assert table.metadata.text_as_html.count(f">{letter}<") == 1
+
+
+def test_partition_docx_table_with_full_width_vertical_merge_reports_a_tr_for_every_row(tmp_path):
+    """A grid-row entirely covered by a `rowspan` (no originating cells of its own) still needs
+    its own `<tr>` in the output. HTML `rowspan` counts actual `<tr>` elements, not "rows that
+    happened to have content" -- suppressing this row would shift the column-placement of every
+    row after it.
+
+        +---+
+        | A |
+        |   |
+        +---+
+        | B |
+        +---+
+    """
+    document = docx.Document()
+    table = document.add_table(rows=3, cols=1)
+    table.cell(0, 0).merge(table.cell(1, 0)).text = "A"
+    table.cell(2, 0).text = "B"
+    docx_path = tmp_path / "vertical-merge.docx"
+    document.save(str(docx_path))
+
+    elements = partition_docx(str(docx_path), infer_table_structure=True)
+    table_element = next(e for e in elements if isinstance(e, Table))
+
+    assert table_element.metadata.text_as_html == (
+        '<table><tr><td rowspan="2">A</td></tr><tr></tr><tr><td>B</td></tr></table>'
+    )
+
+
+def test_partition_docx_table_with_merged_cell_in_nested_table_does_not_duplicate_its_text(
+    tmp_path,
+):
+    """A merged cell in a table nested inside another table's cell contributes its text once.
+
+    Nested tables are flattened to plain text rather than nested `<table>` HTML, but that
+    flattening must still collapse a merged cell to a single occurrence of its text.
+    """
+    document = docx.Document()
+    outer_table = document.add_table(rows=1, cols=1)
+    nested_table = outer_table.cell(0, 0).add_table(rows=2, cols=2)
+    nested_table.cell(0, 0).merge(nested_table.cell(0, 1)).text = "MERGEDNESTED"
+    nested_table.cell(1, 0).text = "foo"
+    nested_table.cell(1, 1).text = "bar"
+    docx_path = tmp_path / "nested-merged-cell.docx"
+    document.save(str(docx_path))
+
+    elements = partition_docx(str(docx_path), infer_table_structure=True)
+    table_element = next(e for e in elements if isinstance(e, Table))
+
+    assert table_element.text == "MERGEDNESTED foo bar"
+    assert table_element.metadata.text_as_html == (
+        "<table><tr><td>MERGEDNESTED foo bar</td></tr></table>"
+    )
+
+
+def test_partition_docx_merged_cell_table_chunks_without_corrupting_rowspan_geometry(tmp_path):
+    """A DOCX table with a real vertical merge, partitioned then chunked with a small window,
+    must never split between rows an active `rowspan` still covers without correcting for it --
+    doing so would leave a continuation `TableChunk` with cells shifted into the wrong column.
+    Splitting is fine as long as the covering cell's `rowspan` is rewritten to match, and
+    re-materialized in whichever fragment doesn't hold the row that originally declared it."""
+    document = docx.Document()
+    table = document.add_table(rows=4, cols=2)
+    table.cell(0, 0).merge(table.cell(1, 0)).merge(table.cell(2, 0)).text = "REGIONWIDE TOTAL"
+    table.cell(0, 1).text = "alpha bravo charlie"
+    table.cell(1, 1).text = "delta echo foxtrot"
+    table.cell(2, 1).text = "golf hotel india"
+    table.cell(3, 0).text = "juliet"
+    table.cell(3, 1).text = "kilo lima mike"
+    docx_path = tmp_path / "merged-cell-chunking.docx"
+    document.save(str(docx_path))
+
+    elements = partition_docx(str(docx_path), infer_table_structure=True)
+    table_element = next(e for e in elements if isinstance(e, Table))
+    assert 'rowspan="3"' in table_element.metadata.text_as_html
+
+    chunks = chunk_by_title([table_element], max_characters=60)
+
+    assert len(chunks) == 3, "fixture should be oversized enough to actually require a split"
+    assert all(isinstance(chunk, TableChunk) for chunk in chunks)
+    assert all(len(chunk.text) <= 60 for chunk in chunks)
+    # -- the rowspan-3 group is itself too big for the window, so it's split on a row boundary;
+    # -- the covering cell's rowspan is rewritten to the rows present in the first fragment --
+    assert chunks[0].metadata.text_as_html == (
+        "<table>"
+        '<tr><td rowspan="2">REGIONWIDE TOTAL</td><td>alpha bravo charlie</td></tr>'
+        "<tr><td>delta echo foxtrot</td></tr>"
+        "</table>"
+    )
+    # -- the covering cell is re-materialized (rowspan="1") in the next fragment, which doesn't
+    # -- include the row that originally declared the span, keeping columns aligned --
+    assert chunks[1].metadata.text_as_html == (
+        "<table><tr><td>REGIONWIDE TOTAL</td><td>golf hotel india</td></tr></table>"
+    )
+    # -- the final row lands in its own chunk with both its cells correctly positioned --
+    assert chunks[2].metadata.text_as_html == (
+        "<table><tr><td>juliet</td><td>kilo lima mike</td></tr></table>"
+    )
+
+
 def test_partition_docx_grabs_header_and_footer():
     elements = partition_docx(example_doc_path("handbook-1p.docx"))
 
@@ -1072,6 +1200,31 @@ class Describe_DocxPartitioner:
         table = docx.Document(example_doc_path("docx-tables.docx")).tables[2]
         assert " ".join(_DocxPartitioner(opts)._iter_table_texts(table)) == "a b c d e"
 
+    def and_the_html_of_a_merged_cell_carries_colspan_and_rowspan_instead_of_repeating_text(
+        self, opts_args: dict[str, Any]
+    ):
+        """
+        Fixture table is:
+
+            +---+-------+
+            | a | b     |
+            |   +---+---+
+            |   | c | d |
+            +---+---+   |
+            | e     |   |
+            +-------+---+
+        """
+        opts = DocxPartitionerOptions(**opts_args)
+        table = docx.Document(example_doc_path("docx-tables.docx")).tables[2]
+
+        assert _DocxPartitioner(opts)._convert_table_to_html(table) == (
+            "<table>"
+            '<tr><td rowspan="2">a</td><td colspan="2">b</td></tr>'
+            '<tr><td>c</td><td rowspan="2">d</td></tr>'
+            '<tr><td colspan="2">e</td></tr>'
+            "</table>"
+        )
+
     def it_can_partition_tables_with_incomplete_rows(self):
         """DOCX permits table rows to start late and end early.
 
@@ -1128,7 +1281,7 @@ class Describe_DocxPartitioner:
         assert e.text == "a b c d", f"actual {e.text=}"
         assert e.metadata.text_as_html == (
             "<table>"
-            "<tr><td>a</td><td>a</td><td/></tr>"
+            '<tr><td colspan="2">a</td><td/></tr>'
             "<tr><td>b</td><td>c</td><td>d</td></tr>"
             "</table>"
         ), f"actual {e.metadata.text_as_html=}"
@@ -1143,8 +1296,8 @@ class Describe_DocxPartitioner:
         assert e.text == "a b c d", f"actual {e.text=}"
         assert e.metadata.text_as_html == (
             "<table>"
-            "<tr><td>a</td><td>b</td><td/></tr>"
-            "<tr><td>a</td><td>c</td><td>d</td></tr>"
+            '<tr><td rowspan="2">a</td><td>b</td><td/></tr>'
+            "<tr><td>c</td><td>d</td></tr>"
             "</table>"
         ), f"actual {e.metadata.text_as_html=}"
         # -- late-start, early-end, and >2 rows vertical span --
@@ -1162,10 +1315,10 @@ class Describe_DocxPartitioner:
         assert e.text == "a b c d e f", f"actual {e.text=}"
         assert e.metadata.text_as_html == (
             "<table>"
-            "<tr><td>a</td><td>a</td><td>b</td><td>c</td></tr>"
-            "<tr><td/><td>d</td><td>d</td><td/></tr>"
-            "<tr><td>e</td><td>d</td><td>d</td><td>f</td></tr>"
-            "<tr><td/><td>d</td><td>d</td><td/></tr>"
+            '<tr><td colspan="2">a</td><td>b</td><td>c</td></tr>'
+            '<tr><td/><td colspan="2" rowspan="3">d</td><td/></tr>'
+            "<tr><td>e</td><td>f</td></tr>"
+            "<tr><td/><td/></tr>"
             "</table>"
         ), f"actual {e.metadata.text_as_html=}"
         # --
@@ -1175,14 +1328,14 @@ class Describe_DocxPartitioner:
         assert e.text == "Data More Dato WTF? Strange Format", f"actual {e.text=}"
         assert e.metadata.text_as_html == (
             "<table>"
-            "<tr><td>Data</td><td>Data</td><td/></tr>"
-            "<tr><td>Data</td><td>Data</td><td/></tr>"
-            "<tr><td>Data</td><td>Data</td><td/></tr>"
+            '<tr><td colspan="2" rowspan="3">Data</td><td/></tr>'
+            "<tr><td/></tr>"
+            "<tr><td/></tr>"
             "<tr><td/><td>More</td><td/></tr>"
             "<tr><td>Dato</td><td/></tr>"
-            "<tr><td>WTF?</td><td>WTF?</td><td/></tr>"
-            "<tr><td>Strange</td><td>Strange</td><td/></tr>"
-            "<tr><td/><td>Format</td><td>Format</td></tr>"
+            '<tr><td colspan="2">WTF?</td><td/></tr>'
+            '<tr><td colspan="2">Strange</td><td/></tr>'
+            '<tr><td/><td colspan="2">Format</td></tr>'
             "</table>"
         ), f"actual {e.metadata.text_as_html=}"
 

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.5"  # pragma: no cover
+__version__ = "0.27.6"  # pragma: no cover

--- a/unstructured/chunking/base.py
+++ b/unstructured/chunking/base.py
@@ -6,14 +6,14 @@ import collections
 import copy
 import uuid
 from functools import cached_property
-from typing import Any, Callable, DefaultDict, Iterable, Iterator, cast
+from typing import Any, Callable, DefaultDict, Iterable, Iterator, NamedTuple, Sequence, cast
 
 import regex
 from lxml.etree import ParserError, tostring
 from lxml.html import fragment_fromstring
 from typing_extensions import Self, TypeAlias
 
-from unstructured.common.html_table import HtmlCell, HtmlRow, HtmlTable
+from unstructured.common.html_table import HtmlCell, HtmlRow, HtmlTable, _format_td
 from unstructured.documents.elements import (
     CodeSnippet,
     CompositeElement,
@@ -1211,6 +1211,16 @@ class _TableChunker:
 # ================================================================================================
 
 
+class _OpenSpan(NamedTuple):
+    """A `rowspan` still active at some row past the one that declared it."""
+
+    col: int
+    colspan: int
+    text: str
+    reach_idx: int
+    """Last row-index (relative to the containing rowspan-bound group) this span still covers."""
+
+
 class _HtmlTableSplitter:
     """Produces (text, html) pairs for a `<table>` HtmlElement.
 
@@ -1240,26 +1250,58 @@ class _HtmlTableSplitter:
     def _iter_subtables(self) -> Iterator[TextAndHtml]:
         """Generate (text, html) pairs containing as many whole rows as will fit in window.
 
-        Falls back to splitting rows into whole cells when a single row is by itself too big to
-        fit in the chunking window.
+        Rows joined by an active `rowspan` are kept together as one atomic group, since splitting
+        them would leave a `rowspan` overclaiming rows and misplace every following row's columns.
+        Falls back to splitting into whole cells when a single row (or rowspan-bound group) is by
+        itself too big to fit in the chunking window.
         """
         is_first_chunk = True
         accum = _RowAccumulator(maxlen=self._maxlen(is_first_chunk), measure=self._opts.measure)
 
-        for row in self._table_element.iter_rows():
-            # -- if row won't fit, any WIP chunk is done, send it on its way --
-            if not accum.will_fit(row):
+        for group, group_bounds, group_is_clipped in self._iter_rowspan_bound_row_groups():
+            # -- flush before crossing a row-group boundary only if a clipped span is already
+            # -- accumulated (see `crosses_a_row_group_unsafely_if_extended`); `group_bounds`
+            # -- below is what actually guarantees an emitted rowspan can never overreach --
+            if (
+                accum.last_row_group_key is not None
+                and group[0].row_group_key is not accum.last_row_group_key
+                and accum.crosses_a_row_group_unsafely_if_extended
+            ):
                 for text, html in accum.flush():
                     yield self._prepend_repeated_headers(text, html, is_first_chunk)
                     is_first_chunk = False
                 accum = _RowAccumulator(
                     maxlen=self._maxlen(is_first_chunk), measure=self._opts.measure
                 )
-            # -- if row fits, add it to accumulator --
-            if accum.will_fit(row):
-                accum.add_row(row)
-            else:  # -- otherwise, single row is bigger than chunking window --
-                for text, html in self._iter_row_splits(row, maxlen=self._maxlen(is_first_chunk)):
+            if not accum.will_fit(group):
+                for text, html in accum.flush():
+                    yield self._prepend_repeated_headers(text, html, is_first_chunk)
+                    is_first_chunk = False
+                accum = _RowAccumulator(
+                    maxlen=self._maxlen(is_first_chunk), measure=self._opts.measure
+                )
+            if accum.will_fit(group):
+                accum.add_rows(group, group_bounds, is_clipped=group_is_clipped)
+            elif len(group) == 1:  # -- a single row is bigger than the chunking window --
+                # -- bound the span even though this row is emitted alone: a caller reassembling
+                # -- chunks later (`reconstruct_table_from_chunks()`) would otherwise see it reach
+                # -- into whatever rows follow in the reassembled table --
+                bounded_row = group[0].row_clipped_to_rows(group_bounds[0])
+                for text, html in self._iter_row_splits(
+                    bounded_row, maxlen=self._maxlen(is_first_chunk)
+                ):
+                    yield self._prepend_repeated_headers(text, html, is_first_chunk)
+                    is_first_chunk = False
+                accum = _RowAccumulator(
+                    maxlen=self._maxlen(is_first_chunk), measure=self._opts.measure
+                )
+            else:
+                # -- A rowspan-bound group doesn't fit even in an empty chunking window; split it
+                # -- like an ordinary oversized row, re-materializing any covered column a
+                # -- fragment boundary separates from the row whose rowspan declares it.
+                for text, html in self._iter_oversized_group_splits(
+                    group, maxlen=self._maxlen(is_first_chunk)
+                ):
                     yield self._prepend_repeated_headers(text, html, is_first_chunk)
                     is_first_chunk = False
                 accum = _RowAccumulator(
@@ -1269,6 +1311,183 @@ class _HtmlTableSplitter:
         for text, html in accum.flush():
             yield self._prepend_repeated_headers(text, html, is_first_chunk)
             is_first_chunk = False
+
+    def _iter_rowspan_bound_row_groups(
+        self,
+    ) -> Iterator[tuple[tuple[HtmlRow, ...], tuple[int, ...], bool]]:
+        """Group consecutive rows that a `rowspan` binds together.
+
+        A row whose cell declares `rowspan=N` binds the next `N-1` rows to it, since splitting
+        them across chunks would misplace their cells or overclaim the span's row count. A
+        positive `rowspan` is bound by its true reach, clamped only to the table's last row --
+        HTML allows a span to cross a `<thead>`/`<tbody>`/`<tfoot>` boundary, with the
+        continuation rows in the next row-group omitting the covered column. `rowspan="0"` (HTML's
+        "span every remaining row") has no literal count to reach with, so it clips to its own
+        row-group's last row instead (see `_group_last_idx`). A group's far edge is the max reach
+        of every span opened within it (standard overlapping-interval merge); a clipped span is
+        always yielded rather than dropped.
+
+        Yields, per group: the rows, a same-length tuple of per-row safe rowspan bounds (consumed
+        by `HtmlRow.html_clipped_to_rows()` so an emitted rowspan can never claim a row that isn't
+        actually present in its chunk), and a bool for whether the group's far edge was clipped
+        (used by `_RowAccumulator.crosses_a_row_group_unsafely_if_extended` to avoid packing a
+        clipped group together with a different row-group's rows).
+        """
+        rows = list(self._table_element.iter_rows())
+        n = len(rows)
+        group_last_idx = self._group_last_idx(rows)
+        reach = [0] * n
+        clipped = [False] * n
+        for idx, row in enumerate(rows):
+            if row.max_rowspan is None:
+                reach[idx] = group_last_idx[idx]
+                clipped[idx] = True
+            else:
+                declared_reach = idx + row.max_rowspan - 1
+                reach[idx] = min(declared_reach, n - 1)
+                clipped[idx] = declared_reach > n - 1
+
+        group_start = 0
+        group_end = -1  # -- index of the furthest row any span opened so far reaches --
+        for idx in range(n):
+            group_end = max(group_end, reach[idx])
+            if idx == group_end:
+                bound = tuple(group_end - i + 1 for i in range(group_start, idx + 1))
+                yield (
+                    tuple(rows[group_start : idx + 1]),
+                    bound,
+                    any(clipped[group_start : idx + 1]),
+                )
+                group_start = idx + 1
+
+    @staticmethod
+    def _group_last_idx(rows: Sequence[HtmlRow]) -> list[int]:
+        """For each row-index in `rows`, the index of the last row sharing its row-group.
+
+        Rows are grouped by identity of `HtmlRow.row_group_key`. Used only to bound a
+        `rowspan="0"` cell, the one span variety that is scoped to its own row-group rather than
+        bound by a literal count.
+        """
+        n = len(rows)
+        last_idx = [0] * n
+        i = 0
+        while i < n:
+            key = rows[i].row_group_key
+            j = i
+            while j + 1 < n and rows[j + 1].row_group_key is key:
+                j += 1
+            for k in range(i, j + 1):
+                last_idx[k] = j
+            i = j + 1
+        return last_idx
+
+    def _iter_oversized_group_splits(
+        self, group: tuple[HtmlRow, ...], maxlen: int
+    ) -> Iterator[TextAndHtml]:
+        """Split a rowspan-bound `group` too big to fit even an empty chunking window.
+
+        Rows are packed in order like an ordinary sequence, falling back to `_iter_row_splits`
+        for a single row still too big alone. A column covered only by an earlier row's
+        `rowspan` -- and so absent from a later row's own `<tr>` -- is re-materialized as a fresh
+        cell repeating the covering cell's text whenever a fragment boundary separates that row
+        from the row declaring the span, with the copy's `rowspan` set to only the rows of that
+        span actually present in the fragment. This unavoidably repeats the covering cell's text
+        across fragments, the accepted trade-off for honoring the hard size limit.
+        """
+        n = len(group)
+        active: list[_OpenSpan] = []
+        fragment_cells: list[list[str]] = []
+        fragment_texts: list[list[str]] = []
+
+        def build_row(
+            row: HtmlRow, idx: int, active: list[_OpenSpan], materialize: bool
+        ) -> tuple[list[str], list[str], list[_OpenSpan]]:
+            cells: list[str] = []
+            texts: list[str] = []
+            new_active: list[_OpenSpan] = []
+            spans = iter(sorted((s for s in active if s.reach_idx >= idx), key=lambda s: s.col))
+            next_span = next(spans, None)
+            own_cells = list(row.iter_cells())
+            own_idx = 0
+            col = 0
+            while True:
+                if next_span is not None and next_span.col == col:
+                    if materialize:
+                        remaining = next_span.reach_idx - idx + 1
+                        cells.append(_format_td(next_span.text, next_span.colspan, remaining))
+                        if next_span.text:
+                            texts.append(next_span.text)
+                    if next_span.reach_idx > idx:
+                        new_active.append(next_span)
+                    col += next_span.colspan
+                    next_span = next(spans, None)
+                    continue
+                if own_idx < len(own_cells):
+                    cell = own_cells[own_idx]
+                    own_idx += 1
+                    cells.append(cell.html)
+                    if cell.text:
+                        texts.append(cell.text)
+                    cell_reach = (
+                        n - 1 if cell.rowspan is None else min(idx + cell.rowspan - 1, n - 1)
+                    )
+                    if cell_reach > idx:
+                        new_active.append(_OpenSpan(col, cell.colspan, cell.text, cell_reach))
+                    col += cell.colspan
+                    continue
+                break
+            return cells, texts, new_active
+
+        def fits(texts: Sequence[str]) -> bool:
+            candidate = fragment_texts + [list(texts)]
+            joined = " ".join(t for row_texts in candidate for t in row_texts)
+            return self._opts.measure(joined) <= maxlen
+
+        def flush_fragment() -> Iterator[TextAndHtml]:
+            nonlocal fragment_cells, fragment_texts
+            if not fragment_cells:
+                return
+            m = len(fragment_cells)
+            trs: list[str] = []
+            for k, cells in enumerate(fragment_cells):
+                bound = m - k
+                tr = _HtmlTableSplitter._parse_row_fragment(f"<tr>{''.join(cells)}</tr>")
+                row = HtmlRow(tr)
+                trs.append(
+                    row.html_clipped_to_rows(bound)
+                    if row.max_rowspan is None or row.max_rowspan > bound
+                    else row.html
+                )
+            text = " ".join(t for row_texts in fragment_texts for t in row_texts)
+            html = f"<table>{''.join(trs)}</table>"
+            fragment_cells, fragment_texts = [], []
+            yield text, html
+
+        for idx, row in enumerate(group):
+            active = [s for s in active if s.reach_idx >= idx]
+            cells, texts, next_active = build_row(row, idx, active, materialize=False)
+            if fragment_cells and fits(texts):
+                fragment_cells.append(cells)
+                fragment_texts.append(texts)
+                active = next_active
+                continue
+
+            yield from flush_fragment()
+
+            mat_cells, mat_texts, mat_active = build_row(row, idx, active, materialize=True)
+            if self._opts.measure(" ".join(mat_texts)) <= maxlen:
+                fragment_cells, fragment_texts = [mat_cells], [mat_texts]
+                active = mat_active
+            else:
+                # -- even this single row, with its covered columns materialized, is too big to
+                # -- fit alone; fall back to cell-level splitting, the same tolerance granted an
+                # -- ordinary oversized row -- it can't span beyond itself, so bound it to 1 --
+                tr = _HtmlTableSplitter._parse_row_fragment(f"<tr>{''.join(mat_cells)}</tr>")
+                bounded_row = HtmlRow(tr).row_clipped_to_rows(1)
+                yield from self._iter_row_splits(bounded_row, maxlen=maxlen)
+                active = []
+
+        yield from flush_fragment()
 
     def _iter_row_splits(self, row: HtmlRow, maxlen: int) -> Iterator[TextAndHtml]:
         """Split oversized row into (text, html) pairs containing as many cells as will fit."""
@@ -1288,9 +1507,6 @@ class _HtmlTableSplitter:
 
     def _iter_cell_splits(self, cell: HtmlCell, maxlen: int) -> Iterator[TextAndHtml]:
         """Split a single oversized cell into sub-sub-sub-table HTML fragments."""
-        # -- 33 is len("<table><tr><td></td></tr></table>"), HTML overhead beyond text content --
-        # -- For token-based chunking, we subtract 33 chars worth of overhead but still use tokens
-        # -- for the actual content limit. For character-based, we use the reduced character limit.
         if self._opts.use_token_counting:
             # -- In token mode, keep token limit but account for HTML overhead in char terms --
             # -- The HTML tags themselves are usually ~10-15 tokens, so we reduce by a small amount
@@ -1298,17 +1514,87 @@ class _HtmlTableSplitter:
                 max_tokens=max(1, maxlen - 10),
                 tokenizer=self._opts._kwargs.get("tokenizer"),
             )
-        else:
-            opts = ChunkingOptions(max_characters=max(1, maxlen - 33))
-        split = _TextSplitter(opts)
+            split = _TextSplitter(opts)
 
-        text, remainder = split(cell.text)
-        yield text, f"<table><tr><td>{text}</td></tr></table>"
+            text, remainder = split(cell.text)
+            yield text, f"<table><tr>{_format_td(text, cell.colspan, rowspan=1)}</tr></table>"
 
-        # -- an oversized cell will have a remainder, split that up into additional chunks.
-        while remainder:
-            text, remainder = split(remainder)
-            yield text, f"<table><tr><td>{text}</td></tr></table>"
+            while remainder:
+                text, remainder = split(remainder)
+                yield text, f"<table><tr>{_format_td(text, cell.colspan, rowspan=1)}</tr></table>"
+            return
+
+        # -- overhead depends on this cell's own colspan, so derive it from an empty wrapper --
+        empty_td = _format_td("", cell.colspan, rowspan=1)
+        empty_fragment_len = len(f"<table><tr>{empty_td}</tr></table>")
+        budget = max(1, maxlen - empty_fragment_len)
+
+        remaining = cell.text
+        while True:
+            text, html, remaining = self._split_cell_fragment(
+                remaining, cell.colspan, maxlen, budget
+            )
+            yield text, html
+            if not remaining:
+                return
+
+    @staticmethod
+    def _split_cell_fragment(
+        text: str, colspan: int, maxlen: int, budget: int
+    ) -> tuple[str, str, str]:
+        """Split `text` at a word boundary and format it as a `<td>` fragment, guaranteeing
+        `len(html) <= maxlen`.
+
+        `budget` is only an upper bound on the raw-text length handed to the word-boundary
+        splitter -- escaping (`&`, `<`, `>`) can expand a raw character into several, so the
+        actual formatted length isn't known until after splitting. Binary-searches `budget` for
+        the largest word-boundary split whose formatted fragment still fits (valid because a
+        larger budget only ever grows the selected raw text, and escaping never shrinks it, so
+        formatted length is non-decreasing in `budget`). Falls back to a raw, non-word-boundary
+        truncation if even a single raw character can't fit (e.g. a lone `&` whose escaped form
+        alone is longer than the room left). Returns `(split_text, html, remainder)`.
+        """
+        lo, hi, best = 1, budget, None
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            split = _TextSplitter(ChunkingOptions(max_characters=mid))
+            split_text, remainder = split(text)
+            html = f"<table><tr>{_format_td(split_text, colspan, rowspan=1)}</tr></table>"
+            if len(html) <= maxlen:
+                best = (split_text, html, remainder)
+                lo = mid + 1
+            else:
+                hi = mid - 1
+
+        return (
+            best
+            if best is not None
+            else _HtmlTableSplitter._truncate_cell_fragment(text, colspan, maxlen)
+        )
+
+    @staticmethod
+    def _truncate_cell_fragment(text: str, colspan: int, maxlen: int) -> tuple[str, str, str]:
+        """Binary-search the longest raw-text prefix of `text` whose escaped, formatted `<td>`
+        fragment fits within `maxlen`, ignoring word boundaries.
+
+        `html.escape()` never shrinks a character, so formatted length is non-decreasing in
+        prefix length, making the search valid. A one-character prefix is used even if it still
+        overflows (a fixed `colspan` attribute makes the wrapper itself too large for `maxlen`)
+        so the caller always makes forward progress on `text`.
+        """
+        lo, hi, best = 0, len(text), 0
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            candidate = f"<table><tr>{_format_td(text[:mid], colspan, rowspan=1)}</tr></table>"
+            if len(candidate) <= maxlen:
+                best, lo = mid, mid + 1
+            else:
+                hi = mid - 1
+        best = max(best, 1) if text else 0
+
+        split_text = text[:best]
+        html = f"<table><tr>{_format_td(split_text, colspan, rowspan=1)}</tr></table>"
+        return split_text, html, text[best:]
 
     @cached_property
     def _header_text(self) -> str:
@@ -1334,7 +1620,11 @@ class _HtmlTableSplitter:
         if not self._header_rows:
             return ""
 
-        rows_html = "".join(self._as_header_row_html(row) for row in self._header_rows)
+        n = len(self._header_rows)
+        rows_html = "".join(
+            self._as_header_row_html(row, max_rowspan=n - i)
+            for i, row in enumerate(self._header_rows)
+        )
         return f"<thead>{rows_html}</thead>"
 
     @cached_property
@@ -1385,16 +1675,27 @@ class _HtmlTableSplitter:
         return chunk_text, chunk_html
 
     @staticmethod
-    def _as_header_row_html(row: HtmlRow) -> str:
-        """Serialize `row` preserving source HTML while converting direct-child `<td>` to `<th>`."""
+    def _as_header_row_html(row: HtmlRow, max_rowspan: int) -> str:
+        """Serialize `row` preserving source HTML while converting direct-child `<td>` to `<th>`.
+
+        Clips any cell's `rowspan` down to `max_rowspan` -- the number of header rows actually
+        being prepended -- so a repeated header can never claim rows beyond its own synthetic
+        `<thead>` and reach into the continuation chunk's body.
+        """
         row_html = row.source_html or row.html
         tr = _HtmlTableSplitter._parse_row_fragment(row_html)
         if tr is None and row.source_html:
             tr = _HtmlTableSplitter._parse_row_fragment(row.html)
         if tr is None:
-            return row.html
+            return row.html_clipped_to_rows(max_rowspan)
 
         for cell in tr:
+            rowspan = HtmlCell(cell).rowspan
+            if rowspan is None or rowspan > max_rowspan:
+                if max_rowspan <= 1:
+                    cell.attrib.pop("rowspan", None)
+                else:
+                    cell.attrib["rowspan"] = str(max_rowspan)
             if getattr(cell, "tag", None) == "td":
                 cell.tag = "th"
 
@@ -1705,27 +2006,69 @@ class _RowAccumulator:
         self._maxlen = maxlen
         self._measure = measure
         self._rows: list[HtmlRow] = []
+        self._bounds: list[int | None] = []
         self._row_text_len = 0
+        self._has_clipped_group = False
 
-    def add_row(self, row: HtmlRow) -> None:
-        """Add `row` to this accumulation. Caller is responsible for ensuring it will fit."""
-        self._rows.append(row)
-        self._row_text_len += self._measured_row_text_len(row)
+    def add_rows(
+        self,
+        rows: Sequence[HtmlRow],
+        bounds: Sequence[int | None] | None = None,
+        is_clipped: bool = False,
+    ) -> None:
+        """Add `rows` (a rowspan-bound group, possibly of length 1) to this accumulation.
+
+        `bounds` is `rows`' own per-row safe-rowspan-bound (see `_iter_rowspan_bound_row_groups`),
+        carried so `flush()` can rewrite an overreaching cell's `rowspan` to match; `None` means no
+        bound applies and every declared span is trusted as-is. `is_clipped` marks whether the
+        group's far edge was clipped by its own row-group boundary; once set for this accumulation
+        it stays set (see `crosses_a_row_group_unsafely_if_extended`).
+
+        Caller is responsible for ensuring the group will fit.
+        """
+        self._rows.extend(rows)
+        self._bounds.extend(bounds if bounds is not None else (None,) * len(rows))
+        self._row_text_len += self._measured_rows_text_len(rows)
+        self._has_clipped_group = self._has_clipped_group or is_clipped
 
     def flush(self) -> Iterator[TextAndHtml]:
         """Generate zero-or-one (text, html) pairs for accumulated sub-table."""
         if not self._rows:
             return
         text = " ".join(self._iter_cell_texts())
-        trs_str = "".join(r.html for r in self._rows)
+        trs_str = "".join(
+            row.html_clipped_to_rows(bound)
+            if bound is not None and (row.max_rowspan is None or row.max_rowspan > bound)
+            else row.html
+            for row, bound in zip(self._rows, self._bounds)
+        )
         html = f"<table>{trs_str}</table>"
         self._rows.clear()
+        self._bounds.clear()
         self._row_text_len = 0
+        self._has_clipped_group = False
         yield text, html
 
-    def will_fit(self, row: HtmlRow) -> bool:
-        """True when `row` will fit within remaining space left by accummulated rows."""
-        return self._remaining_space >= self._measured_row_text_len(row)
+    def will_fit(self, rows: Sequence[HtmlRow]) -> bool:
+        """True when `rows` (a rowspan-bound group) will fit in space left by accumulated rows."""
+        return self._remaining_space >= self._measured_rows_text_len(rows)
+
+    @property
+    def last_row_group_key(self) -> object | None:
+        """Row-group identity of the most recently accumulated row, `None` if empty."""
+        return self._rows[-1].row_group_key if self._rows else None
+
+    @property
+    def crosses_a_row_group_unsafely_if_extended(self) -> bool:
+        """True when appending a row from a different row-group would blend unrelated content.
+
+        A semantic boundary, not a correctness one -- `flush()`'s bounds-based rewrite already
+        guarantees column placement can't corrupt. Only true once a clipped group (one whose far
+        edge didn't reflect its span's literal declared value) has been accumulated; an unclipped
+        span is safe to extend across a row-group boundary, since its literal value already stops
+        at the right row regardless of what follows.
+        """
+        return self._has_clipped_group
 
     def _iter_cell_texts(self) -> Iterator[str]:
         """Generate contents of each row cell as a separate string.
@@ -1743,9 +2086,12 @@ class _RowAccumulator:
         separators_len = len(self._rows)
         return self._maxlen - separators_len - self._row_text_len
 
-    def _measured_row_text_len(self, row: HtmlRow) -> int:
-        """Length of `row` text in configured chunk-size units."""
-        return self._measure(" ".join(row.iter_cell_texts()))
+    def _measured_rows_text_len(self, rows: Sequence[HtmlRow]) -> int:
+        """Length of the joined cell text of `rows` in configured chunk-size units."""
+        texts: list[str] = []
+        for row in rows:
+            texts.extend(row.iter_cell_texts())
+        return self._measure(" ".join(texts))
 
 
 # ================================================================================================

--- a/unstructured/common/html_table.py
+++ b/unstructured/common/html_table.py
@@ -5,15 +5,43 @@ Used during partitioning as well as chunking.
 
 from __future__ import annotations
 
+import copy
 import html
 from functools import cached_property
 from typing import TYPE_CHECKING, Iterator, Sequence, cast
 
 from lxml import etree
 from lxml.html import fragment_fromstring
+from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     from lxml.html import HtmlElement
+
+# -- (cell_text, colspan, rowspan) for one HTML `<td>` --
+SpannedCell: TypeAlias = "tuple[str, int, int]"
+
+
+def _format_td(cell_text: str, colspan: int = 1, rowspan: int = 1) -> str:
+    """Format a single `<td>` element, escaping and normalizing `cell_text`.
+
+    `colspan`/`rowspan` attributes are only emitted when greater than 1 (the implicit default),
+    to minimize character overhead in the common no-span case.
+    """
+    # -- take care of things like '<' and '>' in the text --
+    s = html.escape(cell_text)
+    # -- substitute <br/> elements for line-feeds in the text --
+    s = "<br/>".join(s.split("\n"))
+    # -- normalize whitespace in cell --
+    text = " ".join(s.split())
+
+    attrs = ""
+    if colspan > 1:
+        attrs += f' colspan="{colspan}"'
+    if rowspan > 1:
+        attrs += f' rowspan="{rowspan}"'
+
+    # -- emit void `<td/>` when cell text is empty string --
+    return f"<td{attrs}>{text}</td>" if text else f"<td{attrs}/>"
 
 
 def htmlify_matrix_of_cell_texts(matrix: Sequence[Sequence[str]]) -> str:
@@ -32,20 +60,82 @@ def htmlify_matrix_of_cell_texts(matrix: Sequence[Sequence[str]]) -> str:
             # -- suppress emission of rows with no cells --
             if not row_cell_strs:
                 continue
-            yield f"<tr>{''.join(iter_tds(row_cell_strs))}</tr>"
-
-    def iter_tds(row_cell_strs: Sequence[str]) -> Iterator[str]:
-        for s in row_cell_strs:
-            # -- take care of things like '<' and '>' in the text --
-            s = html.escape(s)
-            # -- substitute <br/> elements for line-feeds in the text --
-            s = "<br/>".join(s.split("\n"))
-            # -- normalize whitespace in cell --
-            cell_text = " ".join(s.split())
-            # -- emit void `<td/>` when cell text is empty string --
-            yield f"<td>{cell_text}</td>" if cell_text else "<td/>"
+            yield f"<tr>{''.join(_format_td(s) for s in row_cell_strs)}</tr>"
 
     return f"<table>{''.join(iter_trs(matrix))}</table>" if matrix else ""
+
+
+def _tr_html(cells: Sequence[SpannedCell]) -> str:
+    """Serialize one `<tr>` from `(cell_text, colspan, rowspan)` triples."""
+    tds = (_format_td(text, colspan, rowspan) for text, colspan, rowspan in cells)
+    return f"<tr>{''.join(tds)}</tr>"
+
+
+def htmlify_matrix_of_spanned_cell_texts(matrix: Sequence[Sequence[SpannedCell]]) -> str:
+    """Like `htmlify_matrix_of_cell_texts()` but each cell can also carry a colspan/rowspan.
+
+    Each row of `matrix` is a sequence of `(cell_text, colspan, rowspan)` triples for each
+    grid-position that is the top-left corner of a cell; a caller must omit any grid-position
+    covered by an earlier cell's colspan/rowspan.
+    """
+
+    def iter_trs(rows: Sequence[Sequence[SpannedCell]]) -> Iterator[str]:
+        for row in rows:
+            # -- an empty row is a real grid-row fully covered by a prior row's rowspan, and must
+            # -- still emit a `<tr>` to keep the rowspan's row-count accounting correct --
+            yield _tr_html(row)
+
+    return f"<table>{''.join(iter_trs(matrix))}</table>" if matrix else ""
+
+
+def collapse_matrix_of_keyed_cells_to_spans(
+    matrix: Sequence[Sequence[tuple[str, object]]],
+) -> list[list[SpannedCell]]:
+    """Collapse a full row/column grid of `(cell_text, merge_key)` cells into merged spans.
+
+    `matrix` must cover every grid-position of the table, including ones covered by a merge.
+    Grid-positions sharing an `==`-equal `merge_key` belong to the same merged region; give an
+    unmerged position a `merge_key` unique to itself (e.g. a fresh `object()`). Only rectangular
+    merged regions are supported.
+
+    Returns one row per row of `matrix`, each holding a `(cell_text, colspan, rowspan)` triple for
+    every cell that originates a region (or unmerged 1x1 cell); covered positions are omitted.
+    """
+    n_rows = len(matrix)
+    consumed = [[False] * len(row) for row in matrix]
+    spanned_rows: list[list[SpannedCell]] = []
+
+    for r, row in enumerate(matrix):
+        spanned_row: list[SpannedCell] = []
+        for c, (text, key) in enumerate(row):
+            if consumed[r][c]:
+                continue
+            consumed[r][c] = True
+
+            # -- extend rightward while the merge-key matches --
+            colspan = 1
+            while c + colspan < len(row) and row[c + colspan][1] == key:
+                consumed[r][c + colspan] = True
+                colspan += 1
+
+            # -- extend downward while the same colspan-wide run of merge-keys matches --
+            rowspan = 1
+            next_r = r + 1
+            while next_r < n_rows:
+                next_row = matrix[next_r]
+                if c + colspan > len(next_row):
+                    break
+                if any(next_row[c + i][1] != key for i in range(colspan)):
+                    break
+                for i in range(colspan):
+                    consumed[next_r][c + i] = True
+                rowspan += 1
+                next_r += 1
+
+            spanned_row.append((text, colspan, rowspan))
+        spanned_rows.append(spanned_row)
+
+    return spanned_rows
 
 
 class HtmlTable:
@@ -56,10 +146,12 @@ class HtmlTable:
         table: HtmlElement,
         header_row_idxs: set[int] | None = None,
         source_row_htmls: Sequence[str] | None = None,
+        row_group_keys: Sequence[object] | None = None,
     ):
         self._table = table
         self._header_row_idxs = header_row_idxs or set()
         self._source_row_htmls = tuple(source_row_htmls or ())
+        self._row_group_keys = tuple(row_group_keys or ())
 
     @classmethod
     def from_html_text(cls, html_text: str) -> HtmlTable:
@@ -70,7 +162,8 @@ class HtmlTable:
             raise ValueError("`html_text` contains no `<table>` element")
         table = tables[0]
 
-        # -- capture header semantics and source row HTML before compactification strips details --
+        # -- capture header semantics, source row HTML, and row-group identity before
+        # -- compactification strips those details --
         rows = cast("list[HtmlElement]", table.xpath("./tr | ./thead/tr | ./tbody/tr | ./tfoot/tr"))
         source_row_htmls = tuple(etree.tostring(tr, encoding=str) for tr in rows)
         header_row_idxs = {
@@ -78,6 +171,9 @@ class HtmlTable:
             for idx, tr in enumerate(rows)
             if tr.getparent().tag == "thead" or bool(tr.xpath("./th"))
         }
+        # -- row-group identity is each row's parent element (a `<thead>`/`<tbody>`/`<tfoot>`, or
+        # -- the `<table>` itself); captured now since it survives `.drop_tag()` below --
+        row_group_keys = tuple(tr.getparent() for tr in rows)
 
         # -- remove `<thead>`, `<tbody>`, and `<tfoot>` noise elements when present --
         noise_elements = table.xpath(".//thead | .//tbody | .//tfoot")
@@ -118,7 +214,12 @@ class HtmlTable:
                     suffix = " " if e.tail[-1].isspace() else ""
                     e.tail = prefix + " ".join(parts) + suffix
 
-        return cls(table, header_row_idxs=header_row_idxs, source_row_htmls=source_row_htmls)
+        return cls(
+            table,
+            header_row_idxs=header_row_idxs,
+            source_row_htmls=source_row_htmls,
+            row_group_keys=row_group_keys,
+        )
 
     @cached_property
     def html(self) -> str:
@@ -136,7 +237,13 @@ class HtmlTable:
         rows = cast("list[HtmlElement]", self._table.xpath("./tr"))
         for idx, tr in enumerate(rows):
             source_html = self._source_row_htmls[idx] if idx < len(self._source_row_htmls) else None
-            yield HtmlRow(tr, is_header=(idx in self._header_row_idxs), source_html=source_html)
+            row_group_key = self._row_group_keys[idx] if idx < len(self._row_group_keys) else None
+            yield HtmlRow(
+                tr,
+                is_header=(idx in self._header_row_idxs),
+                source_html=source_html,
+                row_group_key=row_group_key,
+            )
 
     @cached_property
     def text(self) -> str:
@@ -149,10 +256,17 @@ class HtmlTable:
 class HtmlRow:
     """A `<tr>` element."""
 
-    def __init__(self, tr: HtmlElement, is_header: bool = False, source_html: str | None = None):
+    def __init__(
+        self,
+        tr: HtmlElement,
+        is_header: bool = False,
+        source_html: str | None = None,
+        row_group_key: object = None,
+    ):
         self._tr = tr
         self._is_header = is_header
         self._source_html = source_html
+        self._row_group_key = row_group_key
 
     @cached_property
     def html(self) -> str:
@@ -173,6 +287,15 @@ class HtmlRow:
         """Original source `<tr>` HTML captured before compactification, when available."""
         return self._source_html
 
+    @property
+    def row_group_key(self) -> object:
+        """Identity of this row's containing row-group, for `rowspan` grouping purposes.
+
+        `None` when unknown (e.g. an `HtmlRow` constructed directly rather than via
+        `HtmlTable.iter_rows()`), in which case all such rows are treated as one group.
+        """
+        return self._row_group_key
+
     def iter_cell_texts(self) -> Iterator[str]:
         """Generate contents of each cell of this row as a separate string.
 
@@ -189,6 +312,54 @@ class HtmlRow:
         """Length of the normalized text, as it would appear in `element.text`."""
         return len(" ".join(self.iter_cell_texts()))
 
+    @cached_property
+    def max_rowspan(self) -> int | None:
+        """Largest `rowspan` declared by any cell in this row, `1` when none span multiple rows.
+
+        `None` when any cell in this row declares `rowspan="0"` (HTML's "span every remaining
+        row"), since it reaches farther than any positive count could name.
+        """
+        spans = [cell.rowspan for cell in self.iter_cells()]
+        if any(span is None for span in spans):
+            return None
+        return max((span for span in spans if span is not None), default=1)
+
+    def _clipped_tr(self, max_rowspan: int) -> HtmlElement:
+        """A deep-copied `<tr>` with any over-reaching cell `rowspan` clipped to `max_rowspan`.
+
+        `max_rowspan` is the number of rows, including this one, actually present starting here in
+        the emitted fragment. Only an over-reaching cell's `rowspan` attribute is rewritten (or
+        removed, when the correction is `1`); everything else is preserved unchanged.
+        """
+        tr = copy.deepcopy(self._tr)
+        for td in tr:
+            rowspan = HtmlCell(td).rowspan
+            if rowspan is not None and rowspan <= max_rowspan:
+                continue  # -- already fits; leave this cell untouched --
+            if max_rowspan <= 1:
+                td.attrib.pop("rowspan", None)
+            else:
+                td.attrib["rowspan"] = str(max_rowspan)
+        return tr
+
+    def html_clipped_to_rows(self, max_rowspan: int) -> str:
+        """Serialize this row's `<tr>`, clipping any cell's `rowspan` down to `max_rowspan` when
+        its declared value (or `rowspan="0"`, HTML's "spans every remaining row") would otherwise
+        claim more rows than `max_rowspan` names. See `_clipped_tr()` for the clipping rules.
+        """
+        return etree.tostring(self._clipped_tr(max_rowspan), encoding=str)
+
+    def row_clipped_to_rows(self, max_rowspan: int) -> "HtmlRow":
+        """This row, with any over-reaching cell `rowspan` clipped to `max_rowspan`, as a fresh
+        `HtmlRow` -- for callers that need a row object rather than a serialized string.
+        """
+        return HtmlRow(
+            self._clipped_tr(max_rowspan),
+            is_header=self._is_header,
+            source_html=self._source_html,
+            row_group_key=self._row_group_key,
+        )
+
 
 class HtmlCell:
     """A `<td>` element."""
@@ -199,9 +370,38 @@ class HtmlCell:
     @cached_property
     def html(self) -> str:
         """Like  "<td>foo bar baz</td>"."""
-        return etree.tostring(self._td, encoding=str) if self.text else "<td/>"
+        if self.text:
+            return etree.tostring(self._td, encoding=str)
+        return _format_td("", self.colspan, self.rowspan or 1)
 
     @cached_property
     def text(self) -> str:
         """Text inside `<td>` element, empty string when no text."""
         return " ".join(self._td.text_content().split())
+
+    @cached_property
+    def rowspan(self) -> int | None:
+        """Declared `rowspan` for this cell, `1` when absent or unparseable.
+
+        `None` for `rowspan="0"`, HTML's spelling for "spans every remaining row in the
+        containing row group." This model doesn't track `<thead>`/`<tbody>`/`<tfoot>`
+        boundaries (see `HtmlTable`), so that resolves to the end of the table.
+        """
+        try:
+            value = int(self._td.attrib.get("rowspan", 1))
+        except (TypeError, ValueError):
+            return 1
+        return None if value == 0 else max(1, value)
+
+    @cached_property
+    def colspan(self) -> int:
+        """Declared `colspan` for this cell, `1` when absent, unparseable, or non-positive.
+
+        Unlike `rowspan`, HTML gives `colspan="0"` no special "spans every remaining column"
+        meaning, so it is simply treated as the default of `1`.
+        """
+        try:
+            value = int(self._td.attrib.get("colspan", 1))
+        except (TypeError, ValueError):
+            return 1
+        return max(1, value)

--- a/unstructured/partition/docx.py
+++ b/unstructured/partition/docx.py
@@ -27,7 +27,10 @@ from typing_extensions import TypeAlias
 
 from unstructured.chunking import add_chunking_strategy
 from unstructured.cleaners.core import clean_bullets
-from unstructured.common.html_table import htmlify_matrix_of_cell_texts
+from unstructured.common.html_table import (
+    collapse_matrix_of_keyed_cells_to_spans,
+    htmlify_matrix_of_spanned_cell_texts,
+)
 from unstructured.documents.elements import (
     Address,
     Element,
@@ -496,6 +499,10 @@ class _DocxPartitioner:
             </tbody>
             </table>
 
+        A merged cell (`gridSpan` and/or `vMerge`) is emitted as a single `<td>` carrying the
+        appropriate `colspan`/`rowspan` attribute rather than being repeated into every grid
+        position it visually covers.
+
         `is_nested` is used for recursive calls when a nested table is encountered. Certain
         behaviors are different in that case, but the caller can safely ignore that parameter and
         allow it to take its default value.
@@ -512,36 +519,59 @@ class _DocxPartitioner:
                     # -- structure only
                     yield paragraph.text
                 elif isinstance(table := block_item, DocxTable):
+                    seen_tcs: set[Any] = set()
                     for row in table.rows:
-                        yield from iter_row_cells_as_text(row)
+                        for text, nested_cell in iter_row_cells(row):
+                            if nested_cell is not None:
+                                if nested_cell._tc in seen_tcs:
+                                    continue
+                                seen_tcs.add(nested_cell._tc)
+                            yield text
 
-        def iter_row_cells_as_text(row: _Row) -> Iterator[str]:
-            """Generate the normalized text of each cell in `row` as a separate string.
+        def cell_text(cell: _Cell) -> str:
+            """The normalized text of `cell`, including that of any table nested in it."""
+            text = " ".join(iter_cell_block_items(cell))
+            return " ".join(text.split())
 
-            The text of each paragraph within a cell is not separated. A table nested in a cell is
-            converted to a normalized string of its contents and combined with the text of the
-            cell that contains the table.
+        def iter_row_cells(row: _Row) -> Iterator[tuple[str, _Cell | None]]:
+            """Generate (cell_text, cell) for each layout-grid position in `row`.
+
+            `cell` is `None` for a grid-position with no `tc` element -- the (rare) case of a row
+            that starts late or ends early, or one where `row.cells` raises because the table has
+            merged or malformed cells; `cell_text` is the empty string in each such case.
             """
             # -- Each omitted cell at the start of the row (pretty rare) gets the empty string.
             # -- This preserves column alignment when one or more initial cells are omitted.
             for _ in range(row.grid_cols_before):
-                yield ""
+                yield "", None
 
             try:
                 # -- row.cells may introduce `ValueError: no tc element at grid_offset=X` if the
                 # -- table has merged or malformed cells. always wrap in try/except.
                 for cell in row.cells:
-                    cell_text = " ".join(iter_cell_block_items(cell))
-                    yield " ".join(cell_text.split())
+                    yield cell_text(cell), cell
             except Exception as e:
-                logging.warning(f"Skipping cell in _iter_row_cells_as_text due to: {e}")
-                yield ""
+                logging.warning(f"Skipping cell in _convert_table_to_html due to: {e}")
+                yield "", None
 
             # -- Each omitted cell at the end of the row (also rare) gets the empty string. --
             for _ in range(row.grid_cols_after):
-                yield ""
+                yield "", None
 
-        return htmlify_matrix_of_cell_texts([list(iter_row_cells_as_text(r)) for r in table.rows])
+        def iter_row_merge_keyed_texts(row: _Row) -> Iterator[tuple[str, object]]:
+            """Generate (cell_text, merge_key) for each layout-grid position in `row`.
+
+            `merge_key` is shared by every grid-position spanned by the same merged cell (DOCX
+            resolves both `gridSpan` and `vMerge="continue"` to the same underlying `tc` element),
+            and is otherwise unique, so it can be fed to `collapse_matrix_of_keyed_cells_to_spans()`
+            to recover the original merge geometry.
+            """
+            for text, cell in iter_row_cells(row):
+                yield text, (cell._tc if cell is not None else object())
+
+        matrix = [list(iter_row_merge_keyed_texts(row)) for row in table.rows]
+        spanned_matrix = collapse_matrix_of_keyed_cells_to_spans(matrix)
+        return htmlify_matrix_of_spanned_cell_texts(spanned_matrix)
 
     @cached_property
     def _document(self) -> Document:

--- a/unstructured/partition/html/parser.py
+++ b/unstructured/partition/html/parser.py
@@ -107,6 +107,13 @@ from unstructured.partition.text_type import (
     is_us_city_state_zip,
 )
 
+TEX_ENCODINGS = (
+    "application/x-tex",
+    "TeX",
+    "latex",
+    "application/x-latex",
+)
+
 # ------------------------------------------------------------------------------------------------
 # DOMAIN MODEL
 # ------------------------------------------------------------------------------------------------
@@ -686,6 +693,29 @@ class Phrasing(etree.ElementBase):
             yield from e.iter_text_segments(emphasis)
 
 
+class Math(Phrasing):
+    def iter_text_segments(self, enclosing_emphasis: str = "") -> Iterator[TextSegment | Element]:
+        latex = None
+
+        for encoding in TEX_ENCODINGS:
+            annotations_latex = self.find(f".//annotation[@encoding='{encoding}']")
+            if annotations_latex is not None:
+                latex = annotations_latex.text
+                break
+
+        if not latex or not latex.strip():
+            alt_text = self.get("alttext")
+            if alt_text is not None:
+                latex = alt_text
+
+        if latex:
+            yield TextSegment(
+                latex.strip(),
+                self._annotation(latex, enclosing_emphasis),
+            )
+
+        yield from self._iter_tail_segment(enclosing_emphasis)
+
 class Anchor(Phrasing):
     """Custom element-class for `<a>` element.
 
@@ -983,6 +1013,8 @@ element_class_lookup.get_namespace(None).update(
         "img": ImageBlock,
         # -- table --
         "table": TableBlock,
+        # -- math --
+        "math": Math,
         # -- annotated phrasing --
         "a": Anchor,
         "b": Bold,

--- a/unstructured/partition/html/parser.py
+++ b/unstructured/partition/html/parser.py
@@ -113,6 +113,12 @@ TEX_ENCODINGS = (
     "latex",
     "application/x-latex",
 )
+"""TeX/LaTeX annotation encodings recognized in MathML `<annotation>` elements.
+
+The order is significant. More specific MIME-style encodings are preferred over
+legacy shorthand values when multiple supported annotations are present.
+"""
+
 
 # ------------------------------------------------------------------------------------------------
 # DOMAIN MODEL
@@ -694,7 +700,25 @@ class Phrasing(etree.ElementBase):
 
 
 class Math(Phrasing):
+    """Custom element-class for `<math>` element.
+
+    Provides basic math annotations.
+    """
+
     def iter_text_segments(self, enclosing_emphasis: str = "") -> Iterator[TextSegment | Element]:
+        """Generate a text segment for the mathematical expression and its tail.
+
+        The mathematical representation is selected in this order:
+
+        1. The first non-empty `<annotation>` whose ``encoding`` is one of the
+           supported TeX/LaTeX encodings.
+        2. The `<math>` element's ``alttext`` attribute.
+
+        No mathematical text segment is emitted when neither representation is
+        available. Tail text is always preserved according to normal
+        :class:`Phrasing` behavior.
+        """
+
         latex = None
 
         for encoding in TEX_ENCODINGS:

--- a/unstructured/partition/html/parser.py
+++ b/unstructured/partition/html/parser.py
@@ -109,7 +109,7 @@ from unstructured.partition.text_type import (
 
 TEX_ENCODINGS = (
     "application/x-tex",
-    "TeX",
+    "tex",
     "latex",
     "application/x-latex",
 )
@@ -699,46 +699,105 @@ class Phrasing(etree.ElementBase):
             yield from e.iter_text_segments(emphasis)
 
 
-class Math(Phrasing):
+class Math(Flow, Phrasing):
     """Custom element-class for `<math>` element.
 
     Provides basic math annotations.
     """
 
-    def iter_text_segments(self, enclosing_emphasis: str = "") -> Iterator[TextSegment | Element]:
-        """Generate a text segment for the mathematical expression and its tail.
+    @property
+    def is_phrasing(self) -> bool:
+        return (self.get("display") or "").strip().lower() != "block"
 
-        The mathematical representation is selected in this order:
+    @property
+    def _latex(self) -> str | None:
+        semantics = self.find("./semantics")
+        if semantics is not None:
+            for child in semantics:
+                if child.tag != "annotation":
+                    continue
+                
+                encoding = child.get("encoding")
 
-        1. The first non-empty `<annotation>` whose ``encoding`` is one of the
-           supported TeX/LaTeX encodings.
-        2. The `<math>` element's ``alttext`` attribute.
+                if encoding is None:
+                    continue
 
-        No mathematical text segment is emitted when neither representation is
-        available. Tail text is always preserved according to normal
-        :class:`Phrasing` behavior.
-        """
+                encoding = encoding.strip().lower()
+                if encoding not in TEX_ENCODINGS:
+                    continue
 
-        latex = None
+                annotations_latex = child.text
 
-        for encoding in TEX_ENCODINGS:
-            annotations_latex = self.find(f".//annotation[@encoding='{encoding}']")
-            if annotations_latex is not None:
-                latex = annotations_latex.text
-                break
-
-        if not latex or not latex.strip():
-            alt_text = self.get("alttext")
-            if alt_text is not None:
-                latex = alt_text
-
-        if latex:
+                if annotations_latex is not None and annotations_latex.strip():
+                    return annotations_latex.strip()
+        
+        alt_text = self.get("alttext")
+        if alt_text is not None and alt_text.strip():
+            return alt_text
+        
+        return None
+        
+    def iter_text_segments(
+        self, enclosing_emphasis: str = ""
+    ) -> Iterator[TextSegment | Element]:
+        """Emit inline math as phrasing content."""
+        if latex := self._latex:
             yield TextSegment(
-                latex.strip(),
+                latex,
                 self._annotation(latex, enclosing_emphasis),
             )
 
         yield from self._iter_tail_segment(enclosing_emphasis)
+
+    def iter_elements(self) -> Iterator[Element]:
+        """Emit display math as its own document element."""
+        if latex := self._latex:
+            yield Text(
+                latex,
+                metadata=ElementMetadata(page_number=self._page_number),
+            )
+
+    @staticmethod
+    def _normalize_katex(root: etree._Element) -> None:
+        """Remove redundant KaTeX visual HTML when usable MathML is present."""\
+        
+        for katex in root.xpath(
+            ".//*[contains(concat(' ', normalize-space(@class), ' '), ' katex ')]"
+        ):
+            mathml = None
+            visual = None
+
+            for child in katex:
+                classes = child.get("class")
+                if classes is None:
+                    continue
+
+                classes = classes.split()
+
+                if "katex-mathml" in classes:
+                    mathml = child
+                elif "katex-html" in classes:
+                    visual = child
+                    
+            if mathml is None or visual is None:
+                continue
+
+            math = mathml.find(".//math")
+
+            if math is None or not math._latex:
+                continue
+
+            tail = visual.tail
+            previous = visual.getprevious()
+
+            katex.remove(visual)
+
+            if tail:
+                if previous is not None:
+                    previous.tail = (previous.tail or "") + tail
+                else:
+                    katex.text = (katex.text or "") + tail
+
 
 class Anchor(Phrasing):
     """Custom element-class for `<a>` element.

--- a/unstructured/partition/html/parser.py
+++ b/unstructured/partition/html/parser.py
@@ -711,32 +711,33 @@ class Math(Flow, Phrasing):
 
     @property
     def _latex(self) -> str | None:
-        semantics = self.find("./semantics")
-        if semantics is not None:
-            for child in semantics:
-                if child.tag != "annotation":
-                    continue
-                
-                encoding = child.get("encoding")
+        if len(self) == 1 and not (self.text or "").strip() and not (self[0].tail or "").strip():
+            semantics = self.find("./semantics")
+            if semantics is not None:
+                for child in semantics:
+                    if child.tag != "annotation":
+                        continue
+                    
+                    encoding = child.get("encoding")
 
-                if encoding is None:
-                    continue
+                    if encoding is None:
+                        continue
 
-                encoding = encoding.strip().lower()
-                if encoding not in TEX_ENCODINGS:
-                    continue
+                    encoding = encoding.strip().lower()
+                    if encoding not in TEX_ENCODINGS:
+                        continue
 
-                annotations_latex = child.text
+                    annotations_latex = child.text
 
-                if annotations_latex is not None and annotations_latex.strip():
-                    return annotations_latex.strip()
-        
+                    if annotations_latex is not None and annotations_latex.strip():
+                        return annotations_latex.strip()
+
         alt_text = self.get("alttext")
         if alt_text is not None and alt_text.strip():
             return alt_text
-        
+
         return None
-        
+
     def iter_text_segments(
         self, enclosing_emphasis: str = ""
     ) -> Iterator[TextSegment | Element]:
@@ -778,8 +779,11 @@ class Math(Flow, Phrasing):
                     mathml = child
                 elif "katex-html" in classes:
                     visual = child
-                    
+
             if mathml is None or visual is None:
+                continue
+
+            if katex.xpath("ancestor::table"):
                 continue
 
             math = mathml.find(".//math")

--- a/unstructured/partition/html/partition.py
+++ b/unstructured/partition/html/partition.py
@@ -14,7 +14,7 @@ from unstructured.documents.elements import Element, ElementType
 from unstructured.file_utils.encoding import read_txt_file
 from unstructured.file_utils.model import FileType
 from unstructured.partition.common.metadata import apply_metadata, get_last_modified_date
-from unstructured.partition.html.parser import Flow, html_parser
+from unstructured.partition.html.parser import Flow, Math, html_parser
 from unstructured.partition.html.transformations import (
     ontology_to_unstructured_elements,
     parse_html_to_ontology,
@@ -260,6 +260,8 @@ class _HtmlPartitioner:
             root = etree.fromstring(html_text, html_parser)
         except ValueError:
             root = etree.fromstring(html_text.encode("utf-8"), html_parser)
+
+        Math._normalize_katex(root)
 
         # -- remove a variety of HTML element types like <script> and <style> that we prefer not
         # -- to encounter while parsing.


### PR DESCRIPTION
## Summary

This PR adds support for preserving inline MathML content in the v1 HTML parser used by `partition_html()`.

Previously, `<math>` was not assigned a custom element class. As a result, it fell back to `DefaultElement`, whose contents are intentionally skipped. This could silently remove mathematical expressions from otherwise valid extracted text.

For example, HTML such as:

```html
<p>
    The error rate is
    <math>
        <semantics>
            <annotation encoding="application/x-tex">
                10^{-4}
            </annotation>
        </semantics>
    </math>
    per token.
</p>
```

could be extracted as:

```text
The error rate is per token.
```

This PR introduces a `Math` phrasing element that preserves a textual representation of the expression when one is available.

## Changes

* Adds a `Math` class derived from `Phrasing`.
* Registers `<math>` elements with the v1 HTML parser.
* Searches for recognized TeX/LaTeX annotations within the MathML subtree.
* Supports the following annotation encodings:

  * `application/x-tex`
  * `tex`
  * `latex`
  * `application/x-latex`
* Falls back to the `<math>` element's `alttext` attribute when no supported TeX annotation is available.
* Preserves text following the closing `</math>` element by emitting the element tail using the existing phrasing behavior.

The parser prefers an explicit TeX representation because flattening presentation MathML with `itertext()` can lose mathematical structure. For example, a superscript expression such as `10^-4` could otherwise be flattened into ambiguous plain text such as `10-4`.

## Why

The HTML parser's documented principle is that the browser rendering is the document.

However, before this change, standards-based MathML content could be rendered correctly by a browser while being completely removed during HTML partitioning because `<math>` was treated as an unrecognized element.

This is especially problematic because the failure is silent. Surrounding paragraph text remains intact, so consumers of `partition_html()` may receive syntactically valid but incomplete text.

Treating `<math>` as a specialized phrasing element allows mathematical content to participate naturally in surrounding paragraph text without requiring the parser to understand every individual Presentation MathML element such as `<mrow>`, `<msup>`, `<mfrac>`, `<mi>`, or `<mn>`.

## Scope

This PR intentionally does not attempt to implement a complete MathML-to-text converter.

It currently preserves mathematical content when a reliable textual representation is directly available through:

1. a recognized TeX/LaTeX `<annotation>`, or
2. the `<math>` element's `alttext` attribute.

Other representations, such as Content MathML, arbitrary `annotation-xml` formats, OpenMath, SVG, or unsupported custom annotation encodings, are outside the scope of this change.

## Example

Input:

```html
<p>
    Complexity decreases from
    <math alttext="O(n^2)"></math>
    to
    <math>
        <semantics>
            <annotation encoding="application/x-tex">
                O(n^2/r)
            </annotation>
        </semantics>
    </math>.
</p>
```

Before:

```text
Complexity decreases from to .
```

After:

```text
Complexity decreases from O(n^2) to O(n^2/r).
```

## Testing

Tests have been added for MathML behavior including:

* extracting `application/x-tex` annotations,
* supported TeX/LaTeX encoding variants,
* falling back to `alttext`,
* preferring a supported TeX annotation when both annotation and `alttext` are present,
* preserving surrounding and tail text,
* multiple inline `<math>` elements in one paragraph,
* ignoring unsupported annotation encodings,
* realistic nested Presentation MathML,
* interaction with existing phrasing/emphasis behavior,
* and regression coverage for ordinary phrasing elements.

Reviewer verification can also be performed with:

```python
from unstructured.partition.html import partition_html

html = r"""
<p>
    The loss difference is on the order of
    <math>
        <semantics>
            <annotation encoding="application/x-tex">
                10^{-4}
            </annotation>
        </semantics>
    </math>.
</p>
"""

elements = partition_html(text=html)

for element in elements:
    print(element.text)
```

Expected output:

```text
The loss difference is on the order of 10^{-4}.
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

