### PR TITLE
docs(metrics): document export_filename, not the nonexistent export_name

### DIFF
--- a/unstructured/metrics/evaluate.py
+++ b/unstructured/metrics/evaluate.py
@@ -526,7 +526,7 @@ def get_mean_grouping(
         eval_name (str): Evaluated metric ('text_extraction' or 'element_type').
         agg_name (str, optional): String to use with export filename. Default is `cct` for
             group_by `text_extraction` and `element-type` for `element_type`
-        export_name (str, optional): Export filename.
+        export_filename (str, optional): Export filename.
     """
     if group_by not in ("doctype", "connector") and group_by != "all":
         raise ValueError("Invalid grouping category. Returning a non-group evaluation.")


### PR DESCRIPTION
`get_mean_grouping`'s docstring documents an `export_name (str, optional)` parameter. No such parameter exists — the signature and body use `export_filename`. One-line docstring fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

