### PR TITLE
fix: ignore processing instructions in HTML partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.27.7-dev0
+
+### Fixes
+
+- **A stray processing instruction no longer crashes HTML partitioning.** `partition_html` (and formats that route through it, such as `.md`) raised `AttributeError: 'lxml.etree._ProcessingInstruction' object has no attribute 'is_phrasing'` when the HTML contained a processing-instruction node like a `<?xml ...?>` declaration. The parser now drops processing instructions at parse time, the same way it already drops comments.
+
 ## 0.27.6
 
 ### Fixes

--- a/test_unstructured/partition/html/test_parser.py
+++ b/test_unstructured/partition/html/test_parser.py
@@ -439,6 +439,19 @@ class DescribeFlow:
         with pytest.raises(StopIteration):
             e = next(elements)
 
+    def it_ignores_a_processing_instruction_node(self):
+        """A stray `<?xml ...?>` in the HTML must not break element iteration (issue #4358).
+
+        `remove_pis=True` on the parser drops the processing-instruction node, so it never
+        reaches the traversal as a bare `_ProcessingInstruction` (which has no `.is_phrasing`).
+        """
+        html_text = '<div><p>before</p><?xml version="1.0"?><p>after</p></div>'
+        div = etree.fromstring(html_text, html_parser).xpath(".//div")[0]
+
+        elements = list(div.iter_elements())
+
+        assert elements == [Text("before"), Text("after")]
+
     # -- ._page_number ----------------------------------------------------
 
     def it_returns_None_when_no_data_page_number_in_tree(self):

--- a/unstructured/__version__.py
+++ b/unstructured/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.27.6"  # pragma: no cover
+__version__ = "0.27.7-dev0"  # pragma: no cover

--- a/unstructured/partition/html/parser.py
+++ b/unstructured/partition/html/parser.py
@@ -943,7 +943,12 @@ def derive_element_type_from_text(text: str) -> type[Text] | None:
 # ------------------------------------------------------------------------------------------------
 
 
-html_parser = etree.HTMLParser(remove_comments=True)
+# NOTE(VSathveek): `remove_pis=True` drops processing-instruction nodes (e.g. a
+# stray `<?xml ...?>` declaration) at parse time, just as `remove_comments` drops
+# comments. Without it such a node reaches the element traversal as a bare `lxml`
+# `_ProcessingInstruction`, which has no `is_phrasing` and raises AttributeError
+# (issue #4358).
+html_parser = etree.HTMLParser(remove_comments=True, remove_pis=True)
 # -- elements that don't have a registered class get DefaultElement --
 fallback = etree.ElementDefaultClassLookup(element=DefaultElement)
 # -- elements that do have a registered class are assigned that class via lookup --


### PR DESCRIPTION
DO NOT MERGE

(authored by codex)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

