### PR TITLE
fix: recognize single-block list items as ListItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+- **Recognize HTML and Markdown loose-list items.** A list item containing a single ordinary text block (such as `<li><p>text</p></li>`) now produces a `ListItem`, preserving inline annotations and list depth. Multi-paragraph items and specialized blocks retain their existing behavior. Resolves #3499.
+
 - **`partition_doc()` and `partition_ppt()` no longer fail on a document whose name contains multi-byte characters.** `convert_office_doc()` decoded `soffice` stdout and stderr with a strict UTF-8 decode purely to log them and to check whether stdout was empty. LibreOffice echoes the input path using the console encoding, which on Windows is the locale codepage, so a document whose name or path contains multi-byte characters raised `UnicodeDecodeError` and aborted a conversion that would otherwise have succeeded. All three decode sites now go through one helper using `errors="backslashreplace"`, which keeps the message pure ASCII -- readable, still loggable by a handler using the locale codepage, and showing the offending bytes. Resolves #3652.
 
 - **A stray processing instruction no longer crashes HTML partitioning.** `partition_html` (and formats that route through it, such as `.md`) raised `AttributeError: 'lxml.etree._ProcessingInstruction' object has no attribute 'is_phrasing'` when the HTML contained a processing-instruction node like a `<?xml ...?>` declaration. The parser now drops processing instructions at parse time, the same way it already drops comments.

--- a/test_unstructured/partition/html/test_parser.py
+++ b/test_unstructured/partition/html/test_parser.py
@@ -374,6 +374,80 @@ class Describe_PreElementAccumulator:
 # -- FLOW (BLOCK-ITEM) ELEMENTS ------------------------------------------------------------------
 
 
+class DescribeListItemBlock:
+    @pytest.mark.parametrize("tag", ["p", "div", "blockquote"])
+    @pytest.mark.parametrize("text", ["list item one.", "A", "* literal bullet"])
+    def it_adopts_a_single_text_block(self, tag: str, text: str):
+        root = etree.fromstring(f"<ul><li>\n<{tag}>{text}</{tag}>\n</li></ul>", html_parser)
+
+        (element,) = root.find("body").iter_elements()
+
+        assert element == ListItem(text)
+        assert element.metadata.category_depth == 1
+
+    def it_preserves_annotations_and_nested_list_depth(self):
+        root = etree.fromstring(
+            '<ul><li>outer<ul><li data-page-number="3"><p>'
+            '<a href="https://example.com">link</a> <b>bold</b>'
+            "</p></li></ul></li></ul>",
+            html_parser,
+        )
+
+        outer, inner = root.find("body").iter_elements()
+
+        assert outer == ListItem("outer")
+        assert inner == ListItem("link bold")
+        assert inner.metadata.category_depth == 2
+        assert inner.metadata.page_number == 3
+        assert inner.metadata.link_texts == ["link"]
+        assert inner.metadata.link_urls == ["https://example.com"]
+        assert inner.metadata.emphasized_text_contents == ["bold"]
+        assert inner.metadata.emphasized_text_tags == ["b"]
+
+    def it_preserves_child_page_number_and_following_text(self):
+        root = etree.fromstring(
+            '<ul data-page-number="2"><li><p data-page-number="3">'
+            "first<br>second</p></li>following text</ul>",
+            html_parser,
+        )
+
+        item, following = root.find("body").iter_elements()
+
+        assert item == ListItem("first second")
+        assert item.metadata.page_number == 3
+        assert following.text == "following text"
+        assert following.metadata.page_number == 2
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "<p>first paragraph</p><p>second paragraph</p>",
+            "prefix<p>paragraph text</p>",
+            "<p>paragraph text</p>suffix",
+            "<b>prefix</b><p>paragraph text</p>",
+            "<div><p>first paragraph</p><p>second paragraph</p></div>",
+            "<div><span><p>first paragraph</p><p>second paragraph</p></span></div>",
+            "<ul><li>nested item</li></ul>",
+            "<pre>  code\n  block</pre>",
+            "<h2>heading text</h2>",
+            "<table><tr><td>cell text</td></tr></table>",
+            '<img src="https://example.com/image.png" alt="picture">',
+            "<figure>ignored text</figure>",
+            "<p> </p>",
+            "plain list item",
+        ],
+    )
+    def it_retains_normal_traversal_for_other_content(self, content: str):
+        root = etree.fromstring(f"<ul><li>{content}</li></ul>", html_parser)
+        li = root.xpath(".//li")[0]
+
+        actual = list(li.iter_elements())
+        expected = list(Flow.iter_elements(li))
+
+        assert actual == expected
+        assert [e.metadata.to_dict() for e in actual] == [e.metadata.to_dict() for e in expected]
+
+
 class DescribeFlow:
     """Isolated unit-test suite for `unstructured.partition.html.parser.Flow`.
 

--- a/test_unstructured/partition/test_md.py
+++ b/test_unstructured/partition/test_md.py
@@ -14,6 +14,18 @@ from unstructured.partition.md import partition_md
 from unstructured.partition.utils.constants import UNSTRUCTURED_INCLUDE_DEBUG_METADATA
 
 
+@pytest.mark.parametrize("marker", ["1.", "-"])
+@pytest.mark.parametrize("separator", ["\n", "\n\n"])
+def test_partition_md_recognizes_loose_and_tight_lists(marker: str, separator: str):
+    text = separator.join(f"{marker} list item {word}." for word in ["one", "two", "three"])
+
+    elements = partition_md(text=text, languages=[""])
+
+    assert [e.category for e in elements] == ["ListItem"] * 3
+    assert [e.text for e in elements] == [f"list item {word}." for word in ["one", "two", "three"]]
+    assert [e.metadata.category_depth for e in elements] == [1, 1, 1]
+
+
 def test_partition_md_from_filename():
     filename = example_doc_path("README.md")
     elements = partition_md(filename=filename)

--- a/unstructured/partition/html/parser.py
+++ b/unstructured/partition/html/parser.py
@@ -480,6 +480,28 @@ class ListItemBlock(Flow):
 
     _ElementCls = ListItem
 
+    def iter_elements(self) -> Iterator[Element]:
+        """Adopt a sole text block, as produced by Markdown loose lists."""
+        if len(self) == 1 and not (self.text or "").strip():
+            child = self[0]
+            # Only unwrap ordinary text blocks, not tables, images, headings, or code.
+            # Multiple paragraphs (including those nested inside inline markup) retain
+            # normal traversal rather than being collapsed into a single list item.
+            if (
+                type(child) in (Flow, BlockItem)
+                and not (child.tail or "").strip()
+                and all(node.is_phrasing for node in child.iterdescendants())
+            ):
+                # Use the list item's accumulator to retain its list-nesting depth.
+                for element in self._element_from_text_or_tail(
+                    child.text or "", deque(child), ListItem
+                ):
+                    element.metadata.page_number = child._page_number
+                    yield element
+                return
+
+        yield from super().iter_elements()
+
 
 class Pre(BlockItem):
     """Custom element-class for `<pre>` element.


### PR DESCRIPTION
### Summary

Resolves #3499.

A `<li>` whose only content is a single ordinary text block (`<li><p>text</p></li>`) now produces a `ListItem`. This is the HTML that Markdown *loose lists* (items separated by blank lines) compile to, with both `markdown` and `markdown-it-py`, so `partition_md()` on a loose list returned `Text`/`NarrativeText`/`Title` elements instead of `ListItem`s.

This implements the approach proposed in the issue thread: when a `<li>` contains exactly one block element, adopt that block's content as the list item's text.

### Change

`ListItemBlock.iter_elements()` in `unstructured/partition/html/parser.py` adopts the child block only when all of the following hold, otherwise it falls through to the existing `Flow.iter_elements()` traversal:

- the `<li>` has no text of its own and exactly one child element,
- the child is a plain `Flow`/`BlockItem` (`<p>`, `<div>`, `<blockquote>`) — not a heading, `<pre>`, image, table, or nested list,
- the child has no tail text and contains only phrasing content (so multi-paragraph items, including paragraphs nested inside inline markup, keep their current behavior).

The adopted element is built with the `<li>`'s own accumulator, so `category_depth` reflects list nesting, and inline annotations (links, emphasis) and `data-page-number` on the child are preserved.

### Before / after

```python
from unstructured.partition.md import partition_md

loose = "1. list item one.\n\n2. list item two.\n\n3. list item three.\n"
for el in partition_md(text=loose):
    print(f"{el.category}: {el}")
```

Before:
```
UncategorizedText: list item one.
UncategorizedText: list item two.
UncategorizedText: list item three.
```

After:
```
ListItem: list item one.
ListItem: list item two.
ListItem: list item three.
```

Tight lists are unchanged.

### Testing

- `test_unstructured/partition/html/test_parser.py::DescribeListItemBlock` — adoption for `<p>`/`<div>`/`<blockquote>`, annotation and nested-depth preservation, page-number inheritance, and 14 cases that must keep normal traversal (multiple paragraphs, prefix/suffix text, nested list, `<pre>`, heading, table, image, `<figure>`, whitespace-only block, plain text).
- `test_unstructured/partition/test_md.py::test_partition_md_recognizes_loose_and_tight_lists` — end-to-end for ordered and unordered lists, tight and loose.
- Full `test_unstructured/partition/html` + `test_md.py` suites pass locally; the broader `test_unstructured` run has the same result set as `main` in my environment.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured/pull/4484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

